### PR TITLE
feat: Attempt 详情（#26）+ package provenance（#18）

### DIFF
--- a/apps/viewer/AGENTS.md
+++ b/apps/viewer/AGENTS.md
@@ -75,9 +75,21 @@ Python API under `/api/*` (see `src/bora/viewer/`):
 | `GET /api/jobs/{id}/tasks/{task_id}` | Task detail + enriched trials list + commands |
 | `GET /api/jobs/{id}/tasks/{task_id}/trials` | Trials list (suite + local evidence) |
 | `GET /api/jobs/{id}/tasks/{task_id}/trials/{run_id}` | Attempt meta + `available_tabs` |
-| `GET .../trials/{run_id}/tree?scope=` | File tree under evidence (`agent`/`verifier`/…) |
+| `GET .../trials/{run_id}/tree?scope=` | File tree under evidence (`agent`/`verifier`/`runtime`/…) |
 | `GET .../trials/{run_id}/file?path=` | File preview (size-capped; secret-like names redacted) |
-| `GET .../trials/{run_id}/trajectory` | Parsed `trajectory.jsonl` steps (**not PASS**) |
+| `GET .../trials/{run_id}/trajectory` | Parsed `trajectory.jsonl` steps (observational) |
+
+Trial meta returns `framework` / `docker` / `actors[]` (role·agent·model) from lock +
+invocation metadata.
+
+| Tab | Disk scope | Meaning |
+| --- | --- | --- |
+| **Artifacts** | `artifacts/`, `harness/`, `agent/artifacts/` | Harness-published product files (JSON results, terminal, etc.) |
+| **Runtime** | root `effects.jsonl`, `cleanup.json`, `summary.json`, `agent.json`, `harness.json` | Attempt bookkeeping — not publishable outputs |
+| **Agent** | `agent/` | Invocation trees, trajectory raw, backend_raw |
+| **Verifier** | `evaluation/`, `eval_staging/`, `result.json` | Evaluator side |
+
+SPA file preview: JSON/JSONL pretty-print + lightweight syntax highlight (no extra deps).
 
 Package-file browse routes (`/api/database`, `/api/tasks/*`, `/api/commands`) were removed with the old SPA.  
 All paths confined to the opened Database root (`job_id` / `task_id` / `run_id` single-segment; file paths fail closed on `..`). No Registry required.  

--- a/apps/viewer/AGENTS.md
+++ b/apps/viewer/AGENTS.md
@@ -21,13 +21,16 @@ When UI conflicts with taste: **DESIGN.md wins**.
    Jobs = local suite runs under `.bora/suite-runs/`
 2. **Job → tasks** — task table with scores / status / agent-model meta
 3. **Task detail** — trials/run row(s), status/error coloring, **copyable CLI**
-4. **Breadcrumb** — `Jobs > jobId > taskId` with `>` separators; click to navigate
+4. **Attempt / trial detail** — `Jobs > job > task > run_id`; Outcome + tabs from
+   real evidence only (Trajectory · Agent · Verifier · Artifacts · Lock · Log)
+5. **Breadcrumb** — `Jobs > jobId > taskId > runId` with `>` separators; click to navigate
 
 **Out of scope unless user asks:**
 
 - Public catalog, OAuth, Postgres, Leaderboard SPA (#22)
 - Package file-tree / task-package browser (removed; Jobs is the product surface)
 - Marketing mesh gradients, dark neon skins, custom CSS component kits
+- Fabricating Harbor-only files or empty evidence tabs
 
 ## Stack (mandatory)
 
@@ -69,10 +72,16 @@ Python API under `/api/*` (see `src/bora/viewer/`):
 | `GET /api/health` | Liveness |
 | `GET /api/jobs` | Suite-run job list (local `.bora/suite-runs`) |
 | `GET /api/jobs/{id}` | Job detail + task rows |
-| `GET /api/jobs/{id}/tasks/{task_id}` | Task / trial detail + commands |
+| `GET /api/jobs/{id}/tasks/{task_id}` | Task detail + enriched trials list + commands |
+| `GET /api/jobs/{id}/tasks/{task_id}/trials` | Trials list (suite + local evidence) |
+| `GET /api/jobs/{id}/tasks/{task_id}/trials/{run_id}` | Attempt meta + `available_tabs` |
+| `GET .../trials/{run_id}/tree?scope=` | File tree under evidence (`agent`/`verifier`/…) |
+| `GET .../trials/{run_id}/file?path=` | File preview (size-capped; secret-like names redacted) |
+| `GET .../trials/{run_id}/trajectory` | Parsed `trajectory.jsonl` steps (**not PASS**) |
 
 Package-file browse routes (`/api/database`, `/api/tasks/*`, `/api/commands`) were removed with the old SPA.  
-All paths confined to the opened Database root. No Registry required.
+All paths confined to the opened Database root (`job_id` / `task_id` / `run_id` single-segment; file paths fail closed on `..`). No Registry required.  
+Evidence roots: `{db}/.bora/runs/{run_id}` or task-local `.bora/runs/`; lock `task_id` must match when present.
 
 ## Build & serve
 

--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { JobDetailPage } from "@/pages/JobDetailPage";
 import { JobsPage } from "@/pages/JobsPage";
 import { TaskDetailPage } from "@/pages/TaskDetailPage";
+import { TrialDetailPage } from "@/pages/TrialDetailPage";
 
 export default function App() {
   return (
@@ -11,6 +12,10 @@ export default function App() {
         <Route path="/" element={<JobsPage />} />
         <Route path="/jobs/:jobId" element={<JobDetailPage />} />
         <Route path="/jobs/:jobId/tasks/:taskId" element={<TaskDetailPage />} />
+        <Route
+          path="/jobs/:jobId/tasks/:taskId/trials/:runId"
+          element={<TrialDetailPage />}
+        />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>

--- a/apps/viewer/src/index.css
+++ b/apps/viewer/src/index.css
@@ -49,14 +49,14 @@
   --viewer-error-soft: #f7d4d6;
   --viewer-warning: #f5a623;
   --viewer-row-hover: #fafafa;
-  --viewer-code-bg: #0b0d12;
-  /* Shell highlight on dark code surface (Vercel/terminal-like) */
-  --viewer-shell-cmd: #79c0ff;
-  --viewer-shell-flag: #d2a8ff;
-  --viewer-shell-string: #a5d6ff;
-  --viewer-shell-path: #7ee787;
-  --viewer-shell-punct: #8b949e;
-  --viewer-shell-plain: #e6edf3;
+  /* Light code surface: soft canvas, dark syntax (CLI strip + JSON preview) */
+  --viewer-code-bg: #f5f5f5;
+  --viewer-shell-cmd: #0761d1;
+  --viewer-shell-flag: #6b4fbb;
+  --viewer-shell-string: #0b6e4f;
+  --viewer-shell-path: #0d7a4f;
+  --viewer-shell-punct: #888888;
+  --viewer-shell-plain: #171717;
 }
 
 /* Dark product chrome */
@@ -75,6 +75,7 @@
   --viewer-error-soft: #3b1414;
   --viewer-warning: #f5a623;
   --viewer-row-hover: #141414;
+  /* Dark code surface (Vercel/terminal-like) */
   --viewer-code-bg: #050505;
   --viewer-shell-cmd: #79c0ff;
   --viewer-shell-flag: #d2a8ff;
@@ -127,13 +128,13 @@
     --viewer-error-soft: #f7d4d6;
     --viewer-warning: #f5a623;
     --viewer-row-hover: #fafafa;
-    --viewer-code-bg: #0b0d12;
-    --viewer-shell-cmd: #79c0ff;
-    --viewer-shell-flag: #d2a8ff;
-    --viewer-shell-string: #a5d6ff;
-    --viewer-shell-path: #7ee787;
-    --viewer-shell-punct: #8b949e;
-    --viewer-shell-plain: #e6edf3;
+    --viewer-code-bg: #f5f5f5;
+    --viewer-shell-cmd: #0761d1;
+    --viewer-shell-flag: #6b4fbb;
+    --viewer-shell-string: #0b6e4f;
+    --viewer-shell-path: #0d7a4f;
+    --viewer-shell-punct: #888888;
+    --viewer-shell-plain: #171717;
   }
 }
 

--- a/apps/viewer/src/lib/api.ts
+++ b/apps/viewer/src/lib/api.ts
@@ -50,6 +50,20 @@ export type Trial = {
   evidence_relpath?: string | null;
   agent_invocations?: number | null;
   harness_kind?: string | null;
+  /** Framework kind, e.g. acp */
+  framework?: string | null;
+  /** Docker placement label when L1/docker, else null */
+  docker?: string | null;
+  /** Per-role rows for the actors table above Trajectory */
+  actors?: Array<{
+    role: string;
+    agent: string;
+    model?: string | null;
+    profile_id?: string;
+  }>;
+  agent_label?: string | null;
+  model_label?: string | null;
+  executor_kind?: string | null;
   note?: string | null;
 };
 

--- a/apps/viewer/src/lib/api.ts
+++ b/apps/viewer/src/lib/api.ts
@@ -45,6 +45,35 @@ export type Trial = {
   error?: string | null;
   run_id?: string | null;
   exit_code?: number | null;
+  has_evidence?: boolean;
+  available_tabs?: string[];
+  evidence_relpath?: string | null;
+  agent_invocations?: number | null;
+  harness_kind?: string | null;
+  note?: string | null;
+};
+
+export type TreeEntry = {
+  path: string;
+  name: string;
+  type: "file" | "dir";
+  size?: number | null;
+};
+
+export type TrajectoryStep = {
+  type?: string;
+  role?: string | null;
+  content?: string | null;
+  turn_index?: number | null;
+  source?: string | null;
+  stop_reason?: string | null;
+  ok?: boolean | null;
+  error?: string | null;
+  invocation?: string;
+  invocation_id?: string;
+  line?: number;
+  usage?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
 };
 
 export type Breadcrumb = { label: string; href: string | null };
@@ -101,4 +130,85 @@ export function fetchJobTask(jobId: string, taskId: string) {
   }>(
     `/api/jobs/${encodeURIComponent(jobId)}/tasks/${encodeURIComponent(taskId)}`,
   );
+}
+
+function trialBase(jobId: string, taskId: string, runId: string) {
+  return `/api/jobs/${encodeURIComponent(jobId)}/tasks/${encodeURIComponent(taskId)}/trials/${encodeURIComponent(runId)}`;
+}
+
+export function fetchTrial(jobId: string, taskId: string, runId: string) {
+  return getJson<{
+    ok: boolean;
+    job: Job;
+    task_id: string;
+    trial: Trial;
+    result?: Record<string, unknown> | null;
+    prev_run_id?: string | null;
+    next_run_id?: string | null;
+    sibling_run_ids?: string[];
+    commands?: Record<string, string>;
+    run_command?: string;
+    breadcrumb: Breadcrumb[];
+    note?: string;
+  }>(trialBase(jobId, taskId, runId));
+}
+
+export function fetchTrialTree(
+  jobId: string,
+  taskId: string,
+  runId: string,
+  scope: string,
+) {
+  const q = new URLSearchParams({ scope });
+  return getJson<{
+    ok: boolean;
+    run_id: string;
+    scope: string;
+    entries: TreeEntry[];
+    truncated?: boolean;
+    note?: string;
+  }>(`${trialBase(jobId, taskId, runId)}/tree?${q}`);
+}
+
+export function fetchTrialFile(
+  jobId: string,
+  taskId: string,
+  runId: string,
+  path: string,
+) {
+  const q = new URLSearchParams({ path });
+  return getJson<{
+    ok: boolean;
+    run_id: string;
+    path: string;
+    name: string;
+    size: number;
+    media_type: string;
+    encoding: string;
+    truncated?: boolean;
+    content?: string | null;
+    note?: string;
+  }>(`${trialBase(jobId, taskId, runId)}/file?${q}`);
+}
+
+export function fetchTrialTrajectory(jobId: string, taskId: string, runId: string) {
+  return getJson<{
+    ok: boolean;
+    run_id: string;
+    task_id: string;
+    steps: TrajectoryStep[];
+    step_count: number;
+    invocations: Array<{
+      dirname: string;
+      invocation_id?: string;
+      profile_id?: string;
+      executor_kind?: string;
+      model?: string;
+      status?: string;
+      step_count?: number;
+      has_trajectory?: boolean;
+    }>;
+    truncated?: boolean;
+    note?: string;
+  }>(`${trialBase(jobId, taskId, runId)}/trajectory`);
 }

--- a/apps/viewer/src/lib/code-highlight.tsx
+++ b/apps/viewer/src/lib/code-highlight.tsx
@@ -1,0 +1,238 @@
+/**
+ * Lightweight JSON / JSONL highlighting for file preview.
+ * Deterministic tokenizer — no full language server, no extra deps.
+ */
+import type { ReactNode } from "react";
+
+type Kind = "key" | "string" | "number" | "bool" | "null" | "punct" | "plain";
+
+type Token = { kind: Kind; text: string };
+
+const KIND_CLASS: Record<Kind, string> = {
+  key: "text-shell-flag",
+  string: "text-shell-string",
+  number: "text-shell-cmd",
+  bool: "text-shell-path",
+  null: "text-shell-path",
+  punct: "text-shell-punct",
+  plain: "text-shell-plain",
+};
+
+function tokenizeJson(src: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  let expectingKey = false;
+  const stack: string[] = []; // track object vs array for key detection
+
+  const peek = () => src[i];
+  const push = (kind: Kind, text: string) => {
+    tokens.push({ kind, text });
+  };
+
+  while (i < src.length) {
+    const ch = peek();
+
+    // whitespace
+    if (/\s/.test(ch)) {
+      let j = i + 1;
+      while (j < src.length && /\s/.test(src[j])) j += 1;
+      push("plain", src.slice(i, j));
+      i = j;
+      continue;
+    }
+
+    // punctuation
+    if (ch === "{" || ch === "}" || ch === "[" || ch === "]" || ch === ":" || ch === ",") {
+      if (ch === "{") {
+        stack.push("obj");
+        expectingKey = true;
+      } else if (ch === "[") {
+        stack.push("arr");
+        expectingKey = false;
+      } else if (ch === "}" || ch === "]") {
+        stack.pop();
+        expectingKey = stack[stack.length - 1] === "obj";
+      } else if (ch === ":") {
+        expectingKey = false;
+      } else if (ch === ",") {
+        expectingKey = stack[stack.length - 1] === "obj";
+      }
+      push("punct", ch);
+      i += 1;
+      continue;
+    }
+
+    // string
+    if (ch === '"') {
+      let j = i + 1;
+      while (j < src.length) {
+        if (src[j] === "\\") {
+          j += 2;
+          continue;
+        }
+        if (src[j] === '"') {
+          j += 1;
+          break;
+        }
+        j += 1;
+      }
+      const text = src.slice(i, j);
+      // key if we are in object and expecting a key
+      const isKey = expectingKey && stack[stack.length - 1] === "obj";
+      push(isKey ? "key" : "string", text);
+      i = j;
+      continue;
+    }
+
+    // number
+    if (/[0-9-]/.test(ch)) {
+      let j = i + 1;
+      while (j < src.length && /[0-9.eE+-]/.test(src[j])) j += 1;
+      push("number", src.slice(i, j));
+      i = j;
+      continue;
+    }
+
+    // true / false / null
+    if (src.startsWith("true", i)) {
+      push("bool", "true");
+      i += 4;
+      continue;
+    }
+    if (src.startsWith("false", i)) {
+      push("bool", "false");
+      i += 5;
+      continue;
+    }
+    if (src.startsWith("null", i)) {
+      push("null", "null");
+      i += 4;
+      continue;
+    }
+
+    // fallback single char
+    push("plain", ch);
+    i += 1;
+  }
+
+  return tokens;
+}
+
+function tryPrettyJson(text: string): string | null {
+  const t = text.trim();
+  if (!t) return null;
+  if (!(t.startsWith("{") || t.startsWith("["))) return null;
+  try {
+    return JSON.stringify(JSON.parse(t), null, 2);
+  } catch {
+    return null;
+  }
+}
+
+function formatJsonl(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => {
+      const s = line.trim();
+      if (!s) return line;
+      try {
+        return JSON.stringify(JSON.parse(s));
+      } catch {
+        return line;
+      }
+    })
+    .join("\n");
+}
+
+export type CodeLang = "json" | "jsonl" | "text";
+
+export function detectLang(path: string | null | undefined, content: string): CodeLang {
+  const lower = (path || "").toLowerCase();
+  if (lower.endsWith(".jsonl")) return "jsonl";
+  if (lower.endsWith(".json")) return "json";
+  // Heuristic for content without extension
+  const t = content.trim();
+  if (t.startsWith("{") || t.startsWith("[")) {
+    try {
+      JSON.parse(t);
+      return "json";
+    } catch {
+      /* fall through */
+    }
+  }
+  // multi-line json objects often jsonl
+  const lines = t.split("\n").filter((l) => l.trim());
+  if (lines.length > 1 && lines.every((l) => l.trim().startsWith("{"))) {
+    return "jsonl";
+  }
+  return "text";
+}
+
+export function preparePreview(
+  path: string | null | undefined,
+  content: string,
+): { lang: CodeLang; text: string } {
+  const lang = detectLang(path, content);
+  if (lang === "json") {
+    const pretty = tryPrettyJson(content);
+    return { lang, text: pretty ?? content };
+  }
+  if (lang === "jsonl") {
+    return { lang, text: formatJsonl(content) };
+  }
+  return { lang: "text", text: content };
+}
+
+export function CodeHighlight({
+  path,
+  content,
+}: {
+  path?: string | null;
+  content: string;
+}): ReactNode {
+  const { lang, text } = preparePreview(path, content);
+
+  if (lang === "text") {
+    return <span className="text-shell-plain">{text}</span>;
+  }
+
+  // jsonl: highlight each non-empty line independently so broken lines stay readable
+  if (lang === "jsonl") {
+    const lines = text.split("\n");
+    return (
+      <>
+        {lines.map((line, li) => {
+          if (!line.trim()) {
+            return (
+              <span key={li} className="text-shell-plain">
+                {"\n"}
+              </span>
+            );
+          }
+          const tokens = tokenizeJson(line);
+          return (
+            <span key={li}>
+              {tokens.map((t, ti) => (
+                <span key={`${li}-${ti}`} className={KIND_CLASS[t.kind]}>
+                  {t.text}
+                </span>
+              ))}
+              {li < lines.length - 1 ? "\n" : null}
+            </span>
+          );
+        })}
+      </>
+    );
+  }
+
+  const tokens = tokenizeJson(text);
+  return (
+    <>
+      {tokens.map((t, idx) => (
+        <span key={`${idx}-${t.kind}`} className={KIND_CLASS[t.kind]}>
+          {t.text}
+        </span>
+      ))}
+    </>
+  );
+}

--- a/apps/viewer/src/pages/TaskDetailPage.tsx
+++ b/apps/viewer/src/pages/TaskDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import { BreadcrumbNav } from "@/components/breadcrumb";
 import { CommandStrip } from "@/components/command-strip";
@@ -13,10 +13,11 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { fetchJobTask, type Job, type TaskRow, type Trial } from "@/lib/api";
-import { formatDate, formatScore } from "@/lib/utils";
+import { cn, formatDate, formatScore } from "@/lib/utils";
 
 export function TaskDetailPage() {
   const { jobId = "", taskId = "" } = useParams();
+  const navigate = useNavigate();
   const [job, setJob] = useState<Job | null>(null);
   const [task, setTask] = useState<TaskRow | null>(null);
   const [trials, setTrials] = useState<Trial[]>([]);
@@ -114,10 +115,37 @@ export function TaskDetailPage() {
                     (tr.status || "").toUpperCase() === "ERROR" ||
                     (tr.status || "").toUpperCase() === "FAIL" ||
                     Boolean(tr.error);
+                  const rid = tr.run_id || tr.trial_id || task?.run_id || "";
+                  const openable = Boolean(rid);
                   return (
-                    <TableRow key={tr.trial_id}>
+                    <TableRow
+                      key={tr.trial_id || rid}
+                      className={cn(openable && "cursor-pointer")}
+                      onClick={() => {
+                        if (!openable) return;
+                        navigate(
+                          `/jobs/${encodeURIComponent(jobId)}/tasks/${encodeURIComponent(taskId)}/trials/${encodeURIComponent(rid)}`,
+                        );
+                      }}
+                      onKeyDown={(e) => {
+                        if (!openable) return;
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          navigate(
+                            `/jobs/${encodeURIComponent(jobId)}/tasks/${encodeURIComponent(taskId)}/trials/${encodeURIComponent(rid)}`,
+                          );
+                        }
+                      }}
+                      tabIndex={openable ? 0 : undefined}
+                      role={openable ? "link" : undefined}
+                    >
                       <TableCell className="font-medium font-mono text-[13px]">
                         {tr.trial_id}
+                        {tr.has_evidence ? (
+                          <span className="ml-2 text-[11px] text-mute font-sans">
+                            evidence
+                          </span>
+                        ) : null}
                       </TableCell>
                       <TableCell
                         className={

--- a/apps/viewer/src/pages/TaskDetailPage.tsx
+++ b/apps/viewer/src/pages/TaskDetailPage.tsx
@@ -116,6 +116,7 @@ export function TaskDetailPage() {
                     (tr.status || "").toUpperCase() === "FAIL" ||
                     Boolean(tr.error);
                   const rid = tr.run_id || tr.trial_id || task?.run_id || "";
+                  // Open when we have a run id (detail page handles missing evidence)
                   const openable = Boolean(rid);
                   return (
                     <TableRow

--- a/apps/viewer/src/pages/TrialDetailPage.tsx
+++ b/apps/viewer/src/pages/TrialDetailPage.tsx
@@ -1,0 +1,514 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+
+import { BreadcrumbNav } from "@/components/breadcrumb";
+import { CommandStrip } from "@/components/command-strip";
+import { Shell } from "@/components/layout";
+import { Button } from "@/components/ui/button";
+import {
+  fetchTrial,
+  fetchTrialFile,
+  fetchTrialTrajectory,
+  fetchTrialTree,
+  type TrajectoryStep,
+  type TreeEntry,
+  type Trial,
+} from "@/lib/api";
+import { cn, formatDate, formatScore } from "@/lib/utils";
+
+type TabId =
+  | "trajectory"
+  | "agent"
+  | "verifier"
+  | "artifacts"
+  | "lock"
+  | "log";
+
+const TAB_LABELS: Record<TabId, string> = {
+  trajectory: "Trajectory",
+  agent: "Agent",
+  verifier: "Verifier",
+  artifacts: "Artifacts",
+  lock: "Lock",
+  log: "Log",
+};
+
+const TREE_SCOPES: Partial<Record<TabId, string>> = {
+  agent: "agent",
+  verifier: "verifier",
+  artifacts: "artifacts",
+  lock: "lock",
+  log: "log",
+};
+
+export function TrialDetailPage() {
+  const { jobId = "", taskId = "", runId = "" } = useParams();
+  const navigate = useNavigate();
+  const [trial, setTrial] = useState<Trial | null>(null);
+  const [result, setResult] = useState<Record<string, unknown> | null>(null);
+  const [runCommand, setRunCommand] = useState("");
+  const [prevId, setPrevId] = useState<string | null>(null);
+  const [nextId, setNextId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState<TabId | null>(null);
+
+  const [steps, setSteps] = useState<TrajectoryStep[]>([]);
+  const [trajNote, setTrajNote] = useState<string | null>(null);
+  const [trajLoading, setTrajLoading] = useState(false);
+
+  const [tree, setTree] = useState<TreeEntry[]>([]);
+  const [treeLoading, setTreeLoading] = useState(false);
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [fileContent, setFileContent] = useState<string | null>(null);
+  const [fileNote, setFileNote] = useState<string | null>(null);
+  const [fileLoading, setFileLoading] = useState(false);
+
+  const availableTabs = useMemo(() => {
+    const raw = (trial?.available_tabs || []) as string[];
+    const order: TabId[] = [
+      "trajectory",
+      "agent",
+      "verifier",
+      "artifacts",
+      "lock",
+      "log",
+    ];
+    return order.filter((t) => raw.includes(t));
+  }, [trial]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setActiveTab(null);
+    setSteps([]);
+    setTree([]);
+    setSelectedPath(null);
+    setFileContent(null);
+    fetchTrial(jobId, taskId, runId)
+      .then((data) => {
+        if (cancelled) return;
+        setTrial(data.trial);
+        setResult(data.result || null);
+        setRunCommand(data.run_command || "");
+        setPrevId(data.prev_run_id || null);
+        setNextId(data.next_run_id || null);
+        setError(null);
+        const tabs = (data.trial.available_tabs || []) as TabId[];
+        const first =
+          (["trajectory", "agent", "verifier", "lock", "log", "artifacts"] as TabId[]).find(
+            (t) => tabs.includes(t),
+          ) || null;
+        setActiveTab(first);
+      })
+      .catch((e: Error) => {
+        if (!cancelled) setError(e.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [jobId, taskId, runId]);
+
+  useEffect(() => {
+    if (!activeTab || !jobId || !taskId || !runId) return;
+    let cancelled = false;
+
+    if (activeTab === "trajectory") {
+      setTrajLoading(true);
+      fetchTrialTrajectory(jobId, taskId, runId)
+        .then((data) => {
+          if (cancelled) return;
+          setSteps(data.steps || []);
+          setTrajNote(data.note || null);
+        })
+        .catch((e: Error) => {
+          if (!cancelled) setTrajNote(e.message);
+        })
+        .finally(() => {
+          if (!cancelled) setTrajLoading(false);
+        });
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const scope = TREE_SCOPES[activeTab];
+    if (!scope) return;
+    setTreeLoading(true);
+    setSelectedPath(null);
+    setFileContent(null);
+    setFileNote(null);
+    fetchTrialTree(jobId, taskId, runId, scope)
+      .then((data) => {
+        if (cancelled) return;
+        const files = (data.entries || []).filter((e) => e.type === "file");
+        setTree(files);
+        // Auto-open a sensible default file
+        const preferred =
+          files.find((f) => f.name === "lock.json") ||
+          files.find((f) => f.name === "result.json") ||
+          files.find((f) => f.name.endsWith(".json")) ||
+          files[0];
+        if (preferred) {
+          setSelectedPath(preferred.path);
+        }
+      })
+      .catch((e: Error) => {
+        if (!cancelled) setFileNote(e.message);
+      })
+      .finally(() => {
+        if (!cancelled) setTreeLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, jobId, taskId, runId]);
+
+  useEffect(() => {
+    if (!selectedPath || !jobId || !taskId || !runId) return;
+    let cancelled = false;
+    setFileLoading(true);
+    fetchTrialFile(jobId, taskId, runId, selectedPath)
+      .then((data) => {
+        if (cancelled) return;
+        setFileContent(data.content ?? null);
+        setFileNote(data.note || (data.truncated ? "truncated preview" : null));
+      })
+      .catch((e: Error) => {
+        if (!cancelled) {
+          setFileContent(null);
+          setFileNote(e.message);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setFileLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedPath, jobId, taskId, runId]);
+
+  const status = (trial?.status || "").toUpperCase();
+  const bad =
+    status === "ERROR" || status === "FAIL" || Boolean(trial?.error);
+
+  function goSibling(id: string | null) {
+    if (!id) return;
+    navigate(
+      `/jobs/${encodeURIComponent(jobId)}/tasks/${encodeURIComponent(taskId)}/trials/${encodeURIComponent(id)}`,
+    );
+  }
+
+  return (
+    <Shell>
+      <div className="space-y-5">
+        <BreadcrumbNav
+          items={[
+            { label: "Jobs", href: "/" },
+            { label: jobId, href: `/jobs/${encodeURIComponent(jobId)}` },
+            {
+              label: taskId,
+              href: `/jobs/${encodeURIComponent(jobId)}/tasks/${encodeURIComponent(taskId)}`,
+            },
+            { label: runId, href: null },
+          ]}
+        />
+
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h1 className="text-2xl font-semibold tracking-tight text-ink font-mono truncate">
+              {runId}
+            </h1>
+            <p className="text-sm text-mute mt-1">
+              Attempt evidence · task{" "}
+              <span className="text-body font-medium">{taskId}</span>
+            </p>
+          </div>
+          <div className="flex items-center gap-1">
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              disabled={!prevId}
+              onClick={() => goSibling(prevId)}
+              aria-label="Previous trial"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              disabled={!nextId}
+              onClick={() => goSibling(nextId)}
+              aria-label="Next trial"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+
+        {runCommand ? <CommandStrip command={runCommand} /> : null}
+
+        {loading && <p className="text-sm text-mute">Loading trial…</p>}
+        {error && <p className="text-sm text-error">{error}</p>}
+
+        {!loading && !error && trial && (
+          <>
+            {/* Outcome strip */}
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 rounded-[8px] border border-hairline p-4">
+              <Outcome label="Status">
+                <span className={bad ? "text-error font-medium" : "text-ink font-medium"}>
+                  {status || "-"}
+                </span>
+              </Outcome>
+              <Outcome label="Score">
+                <span className="tabular">{formatScore(trial.score ?? trial.reward)}</span>
+              </Outcome>
+              <Outcome label="Started">
+                <span className="tabular text-body">{formatDate(trial.started)}</span>
+              </Outcome>
+              <Outcome label="Invocations">
+                <span className="tabular">
+                  {trial.agent_invocations != null ? trial.agent_invocations : "-"}
+                </span>
+              </Outcome>
+            </div>
+            {trial.note ? (
+              <p className="text-xs text-mute">{trial.note}</p>
+            ) : null}
+            {trial.error ? (
+              <p className="text-sm text-error rounded-[8px] bg-error-soft/40 px-3 py-2">
+                {String(trial.error)}
+              </p>
+            ) : null}
+
+            {/* Tabs */}
+            {availableTabs.length === 0 ? (
+              <p className="text-sm text-mute">
+                No evidence files found for this run under the Database root.
+              </p>
+            ) : (
+              <div className="space-y-3">
+                <div
+                  role="tablist"
+                  aria-label="Evidence tabs"
+                  className="flex flex-wrap gap-1 border-b border-hairline pb-0"
+                >
+                  {availableTabs.map((tab) => (
+                    <button
+                      key={tab}
+                      type="button"
+                      role="tab"
+                      aria-selected={activeTab === tab}
+                      onClick={() => setActiveTab(tab)}
+                      className={cn(
+                        "px-3 py-2 text-sm transition-colors border-b-2 -mb-px",
+                        activeTab === tab
+                          ? "border-ink text-ink font-medium"
+                          : "border-transparent text-mute hover:text-body",
+                      )}
+                    >
+                      {TAB_LABELS[tab]}
+                    </button>
+                  ))}
+                </div>
+
+                {activeTab === "trajectory" && (
+                  <TrajectoryPanel
+                    loading={trajLoading}
+                    steps={steps}
+                    note={trajNote}
+                    result={result}
+                  />
+                )}
+
+                {activeTab && activeTab !== "trajectory" && (
+                  <FileSplitPanel
+                    tree={tree}
+                    treeLoading={treeLoading}
+                    selectedPath={selectedPath}
+                    onSelect={setSelectedPath}
+                    fileContent={fileContent}
+                    fileLoading={fileLoading}
+                    fileNote={fileNote}
+                  />
+                )}
+              </div>
+            )}
+
+            <p className="text-xs text-mute">
+              <Link
+                to={`/jobs/${encodeURIComponent(jobId)}/tasks/${encodeURIComponent(taskId)}`}
+                className="text-link hover:text-link-deep"
+              >
+                ← Back to trials
+              </Link>
+            </p>
+          </>
+        )}
+      </div>
+    </Shell>
+  );
+}
+
+function Outcome({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div>
+      <div className="text-xs text-mute mb-0.5">{label}</div>
+      <div className="text-sm">{children}</div>
+    </div>
+  );
+}
+
+function TrajectoryPanel({
+  loading,
+  steps,
+  note,
+  result,
+}: {
+  loading: boolean;
+  steps: TrajectoryStep[];
+  note: string | null;
+  result: Record<string, unknown> | null;
+}) {
+  if (loading) return <p className="text-sm text-mute">Loading trajectory…</p>;
+  if (!steps.length) {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-mute">No trajectory.jsonl steps for this run.</p>
+        {result ? (
+          <pre className="text-[12px] font-mono bg-canvas-soft border border-hairline rounded-[8px] p-3 overflow-auto max-h-64">
+            {JSON.stringify(result, null, 2)}
+          </pre>
+        ) : null}
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-2">
+      {note ? <p className="text-xs text-mute">{note}</p> : null}
+      <ol className="space-y-2 max-h-[70vh] overflow-y-auto pr-1">
+        {steps.map((s, i) => {
+          const role = (s.role || s.type || "event").toString();
+          const isUser = role === "user";
+          const isAsst = role === "assistant";
+          const isTerminal = s.type === "terminal";
+          return (
+            <li
+              key={`${s.invocation || ""}-${s.line || i}-${i}`}
+              className={cn(
+                "rounded-[8px] border border-hairline px-3 py-2.5",
+                isTerminal && "bg-canvas-soft",
+              )}
+            >
+              <div className="flex flex-wrap items-center gap-2 text-xs text-mute mb-1">
+                <span
+                  className={cn(
+                    "font-medium uppercase tracking-wide",
+                    isUser && "text-link",
+                    isAsst && "text-ink",
+                    isTerminal && "text-mute",
+                  )}
+                >
+                  {role}
+                </span>
+                {s.turn_index != null ? <span>turn {s.turn_index}</span> : null}
+                {s.invocation ? (
+                  <span className="font-mono truncate max-w-[24ch]">{s.invocation}</span>
+                ) : null}
+                {s.stop_reason ? <span>{s.stop_reason}</span> : null}
+                {s.ok === false ? <span className="text-error">not ok</span> : null}
+              </div>
+              {s.content ? (
+                <pre className="m-0 whitespace-pre-wrap break-words font-mono text-[13px] leading-5 text-body">
+                  {s.content}
+                </pre>
+              ) : s.error ? (
+                <p className="text-sm text-error">{String(s.error)}</p>
+              ) : isTerminal ? (
+                <p className="text-sm text-mute">terminal</p>
+              ) : null}
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}
+
+function FileSplitPanel({
+  tree,
+  treeLoading,
+  selectedPath,
+  onSelect,
+  fileContent,
+  fileLoading,
+  fileNote,
+}: {
+  tree: TreeEntry[];
+  treeLoading: boolean;
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+  fileContent: string | null;
+  fileLoading: boolean;
+  fileNote: string | null;
+}) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-[240px_1fr] gap-0 rounded-[8px] border border-hairline overflow-hidden min-h-[320px]">
+      <aside className="border-b md:border-b-0 md:border-r border-hairline bg-canvas-soft max-h-[50vh] md:max-h-[70vh] overflow-y-auto">
+        {treeLoading ? (
+          <p className="text-xs text-mute p-3">Loading tree…</p>
+        ) : tree.length === 0 ? (
+          <p className="text-xs text-mute p-3">No files in this scope.</p>
+        ) : (
+          <ul className="py-1">
+            {tree.map((e) => (
+              <li key={e.path}>
+                <button
+                  type="button"
+                  onClick={() => onSelect(e.path)}
+                  className={cn(
+                    "w-full text-left px-3 py-1.5 text-[12px] font-mono truncate transition-colors",
+                    selectedPath === e.path
+                      ? "bg-canvas text-ink font-medium"
+                      : "text-body hover:bg-row-hover",
+                  )}
+                  title={e.path}
+                >
+                  {e.path}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </aside>
+      <div className="p-3 max-h-[70vh] overflow-auto">
+        {fileLoading ? (
+          <p className="text-sm text-mute">Loading file…</p>
+        ) : (
+          <>
+            {fileNote ? <p className="text-xs text-mute mb-2">{fileNote}</p> : null}
+            {fileContent != null ? (
+              <pre className="m-0 whitespace-pre-wrap break-words font-mono text-[12px] leading-5 text-body">
+                {fileContent}
+              </pre>
+            ) : (
+              <p className="text-sm text-mute">Select a file to preview.</p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/viewer/src/pages/TrialDetailPage.tsx
+++ b/apps/viewer/src/pages/TrialDetailPage.tsx
@@ -15,6 +15,15 @@ import {
   type TreeEntry,
   type Trial,
 } from "@/lib/api";
+import { CodeHighlight } from "@/lib/code-highlight";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { cn, formatDate, formatScore } from "@/lib/utils";
 
 type TabId =
@@ -23,7 +32,7 @@ type TabId =
   | "verifier"
   | "artifacts"
   | "lock"
-  | "log";
+  | "runtime";
 
 const TAB_LABELS: Record<TabId, string> = {
   trajectory: "Trajectory",
@@ -31,7 +40,8 @@ const TAB_LABELS: Record<TabId, string> = {
   verifier: "Verifier",
   artifacts: "Artifacts",
   lock: "Lock",
-  log: "Log",
+  // effects / cleanup / summary / agent.json / harness.json — not “log files”
+  runtime: "Runtime",
 };
 
 const TREE_SCOPES: Partial<Record<TabId, string>> = {
@@ -39,7 +49,7 @@ const TREE_SCOPES: Partial<Record<TabId, string>> = {
   verifier: "verifier",
   artifacts: "artifacts",
   lock: "lock",
-  log: "log",
+  runtime: "runtime",
 };
 
 export function TrialDetailPage() {
@@ -73,9 +83,11 @@ export function TrialDetailPage() {
       "verifier",
       "artifacts",
       "lock",
-      "log",
+      "runtime",
     ];
-    return order.filter((t) => raw.includes(t));
+    // Accept legacy API tab id "log" as runtime
+    const normalized = raw.map((t) => (t === "log" ? "runtime" : t));
+    return order.filter((t) => normalized.includes(t));
   }, [trial]);
 
   useEffect(() => {
@@ -95,11 +107,20 @@ export function TrialDetailPage() {
         setPrevId(data.prev_run_id || null);
         setNextId(data.next_run_id || null);
         setError(null);
-        const tabs = (data.trial.available_tabs || []) as TabId[];
+        const tabs = (data.trial.available_tabs || []).map((t) =>
+          t === "log" ? "runtime" : t,
+        ) as TabId[];
         const first =
-          (["trajectory", "agent", "verifier", "lock", "log", "artifacts"] as TabId[]).find(
-            (t) => tabs.includes(t),
-          ) || null;
+          (
+            [
+              "trajectory",
+              "agent",
+              "verifier",
+              "lock",
+              "runtime",
+              "artifacts",
+            ] as TabId[]
+          ).find((t) => tabs.includes(t)) || null;
         setActiveTab(first);
       })
       .catch((e: Error) => {
@@ -219,16 +240,39 @@ export function TrialDetailPage() {
         />
 
         <div className="flex flex-wrap items-start justify-between gap-3">
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1">
             <h1 className="text-2xl font-semibold tracking-tight text-ink font-mono truncate">
               {runId}
             </h1>
-            <p className="text-sm text-mute mt-1">
-              Attempt evidence · task{" "}
-              <span className="text-body font-medium">{taskId}</span>
+            {/* Same mute/body style: task · framework · docker(if any) */}
+            <p className="text-sm text-mute mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+              <span>
+                task{" "}
+                <span className="text-body font-medium">{taskId}</span>
+              </span>
+              {trial?.framework ? (
+                <>
+                  <span className="text-mute select-none" aria-hidden>
+                    ·
+                  </span>
+                  <span className="text-body font-medium font-mono text-[13px]">
+                    {trial.framework}
+                  </span>
+                </>
+              ) : null}
+              {trial?.docker ? (
+                <>
+                  <span className="text-mute select-none" aria-hidden>
+                    ·
+                  </span>
+                  <span className="text-body font-medium font-mono text-[13px]">
+                    {trial.docker}
+                  </span>
+                </>
+              ) : null}
             </p>
           </div>
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-1 shrink-0">
             <Button
               type="button"
               variant="outline"
@@ -285,6 +329,36 @@ export function TrialDetailPage() {
               <p className="text-sm text-error rounded-[8px] bg-error-soft/40 px-3 py-2">
                 {String(trial.error)}
               </p>
+            ) : null}
+
+            {/* Actors: role · agent · model — above Trajectory tabs */}
+            {trial.actors && trial.actors.length > 0 ? (
+              <div className="rounded-[8px] border border-hairline overflow-hidden">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="hover:bg-transparent">
+                      <TableHead>Role</TableHead>
+                      <TableHead>Agent</TableHead>
+                      <TableHead>Model</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {trial.actors.map((a) => (
+                      <TableRow key={a.profile_id || `${a.role}-${a.agent}`}>
+                        <TableCell className="font-medium font-mono text-[13px]">
+                          {a.role}
+                        </TableCell>
+                        <TableCell className="font-mono text-[13px] text-body">
+                          {a.agent}
+                        </TableCell>
+                        <TableCell className="font-mono text-[13px] text-mute">
+                          {a.model || "-"}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
             ) : null}
 
             {/* Tabs */}
@@ -465,14 +539,27 @@ function FileSplitPanel({
   fileNote: string | null;
 }) {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-[240px_1fr] gap-0 rounded-[8px] border border-hairline overflow-hidden min-h-[320px]">
-      <aside className="border-b md:border-b-0 md:border-r border-hairline bg-canvas-soft max-h-[50vh] md:max-h-[70vh] overflow-y-auto">
+    <div
+      className={cn(
+        "grid grid-cols-1 md:grid-cols-[240px_1fr] gap-0",
+        "rounded-[8px] border border-hairline overflow-hidden",
+        /* Keep a stable pane even with 1-file trees (e.g. Lock) */
+        "min-h-[360px] md:min-h-[420px]",
+      )}
+    >
+      <aside
+        className={cn(
+          "border-b md:border-b-0 md:border-r border-hairline bg-canvas-soft",
+          "min-h-[160px] md:min-h-[420px] max-h-[50vh] md:max-h-[70vh]",
+          "overflow-y-auto",
+        )}
+      >
         {treeLoading ? (
           <p className="text-xs text-mute p-3">Loading tree…</p>
         ) : tree.length === 0 ? (
           <p className="text-xs text-mute p-3">No files in this scope.</p>
         ) : (
-          <ul className="py-1">
+          <ul className="py-1 min-h-[140px] md:min-h-[380px]">
             {tree.map((e) => (
               <li key={e.path}>
                 <button
@@ -493,21 +580,43 @@ function FileSplitPanel({
           </ul>
         )}
       </aside>
-      <div className="p-3 max-h-[70vh] overflow-auto">
-        {fileLoading ? (
-          <p className="text-sm text-mute">Loading file…</p>
-        ) : (
-          <>
-            {fileNote ? <p className="text-xs text-mute mb-2">{fileNote}</p> : null}
-            {fileContent != null ? (
-              <pre className="m-0 whitespace-pre-wrap break-words font-mono text-[12px] leading-5 text-body">
-                {fileContent}
-              </pre>
-            ) : (
-              <p className="text-sm text-mute">Select a file to preview.</p>
-            )}
-          </>
+      <div
+        className={cn(
+          "flex flex-col min-h-[200px] md:min-h-[420px]",
+          "max-h-[70vh] overflow-hidden",
         )}
+      >
+        {selectedPath ? (
+          <div className="px-3 py-1.5 border-b border-hairline text-[11px] font-mono text-mute shrink-0 bg-canvas-soft">
+            {selectedPath}
+          </div>
+        ) : null}
+        <div className="p-0 flex-1 min-h-0 overflow-auto">
+          {fileLoading ? (
+            <p className="text-sm text-mute p-3">Loading file…</p>
+          ) : (
+            <>
+              {fileNote ? (
+                <p className="text-xs text-mute px-3 pt-2">{fileNote}</p>
+              ) : null}
+              {fileContent != null ? (
+                <pre
+                  className={cn(
+                    "m-0 p-3 min-h-full overflow-auto",
+                    "whitespace-pre-wrap break-words font-mono text-[12px] leading-5",
+                    "bg-code-bg text-shell-plain",
+                  )}
+                >
+                  <code className="font-mono">
+                    <CodeHighlight path={selectedPath} content={fileContent} />
+                  </code>
+                </pre>
+              ) : (
+                <p className="text-sm text-mute p-3">Select a file to preview.</p>
+              )}
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/docs/design/02-task-package-and-config.md
+++ b/docs/design/02-task-package-and-config.md
@@ -501,6 +501,44 @@ Config Core 至少检查：
 
 Config Core 不校验某个 Planner 会选择哪个 specialist，也不检查 Harness 是否真的调用某个 Tool。前者属于运行时算法，后者由 Harness 和测试确认。
 
+### 6.7. Package provenance（溯源，可选）
+
+复刻 / 移植类 package 应声明 **provenance**，回答「复刻自哪、钉在哪一版」，便于对照 upstream 做流程保真检查。Provenance **不是** Attempt PASS，也**不是** package 质量分（质量审计见后续 issue，不与 evaluator verdict 混写）。
+
+#### 写在哪
+
+| 场景 | 位置 |
+| --- | --- |
+| 整包来自同一 suite | Database 根 `bora.yaml` |
+| 个别 task 是复刻 | 成员 `task.yaml` |
+| 两边都有 | **task 整段覆盖** database 默认（不做字段级 merge） |
+
+#### 最小形态
+
+```yaml
+provenance:
+  kind: port            # port | reimplementation | wrapper | original
+  upstream:
+    name: tau-bench
+    url: https://github.com/example/tau-bench   # 复刻类必填
+    ref: v0.1.0                                 # tag/branch；与 commit 至少填一个
+    commit: abc123def456                        # 建议钉死
+    task_id: airline-001                        # 上游若有 id
+    paper: https://arxiv.org/abs/...            # 可选
+  parity:
+    claims: [protocol, scoring]                 # 声称对齐哪些面
+    known_gaps: []                              # 已知刻意差异
+```
+
+#### 校验规则（fail closed）
+
+- `kind: original`：可省略 `upstream`。
+- `kind` 为 `port` / `reimplementation` / `wrapper`：必须有 `upstream.url`，且 `ref` 或 `commit` 至少一个。
+- 未知键、错误类型 → `invalid_schema`。
+- 字段**完全省略**时不强制（不挡 lock）；作者写了复刻类 `kind` 则按上表强制。
+
+锁定后 provenance 进入 `LockedTaskConfig`（参与 digest），并出现在 `bora lock` 摘要与 Attempt evidence `lock.json`（若本 run 写了 lock summary）。**Attempt PASS 仍只来自独立 evaluator。**
+
 ## 5.x Database Registry 分发（Spec 21）
 
 **Release 单位 = Database 整包**（根 `bora.yaml` + 全部 `tasks/**`）。Registry 是独立服务（`services/registry/`），不进入 Core 五组。

--- a/examples/journeys/tasks/env-postgres-min/task.yaml
+++ b/examples/journeys/tasks/env-postgres-min/task.yaml
@@ -1,6 +1,10 @@
 format: bora.task/1
 task_id: env-postgres-min
 
+# BORA Core env smoke — not an upstream port.
+provenance:
+  kind: original
+
 harness:
   runtime: python
   entrypoint: harness:run

--- a/examples/journeys/tasks/multiagent-env-min/task.yaml
+++ b/examples/journeys/tasks/multiagent-env-min/task.yaml
@@ -1,6 +1,20 @@
 format: bora.task/1
 task_id: multiagent-env-min
 
+# Multi-specialist + planner + reducer over seeded DB (MultiAgentBench / database-52 case class).
+provenance:
+  kind: reimplementation
+  upstream:
+    name: MultiAgentBench (MARBLE)
+    url: https://github.com/ulab-uiuc/MARBLE
+    ref: main
+    paper: https://arxiv.org/abs/2503.01935
+  parity:
+    claims: [protocol]
+    known_gaps:
+      - BORA journey mini-package; not full MultiAgentBench suite
+      - no MultiAgentBenchAdapter; roles via profiles + env tools only
+
 harness:
   runtime: python
   entrypoint: harness:run

--- a/examples/journeys/tasks/tau2-dialog-min/task.yaml
+++ b/examples/journeys/tasks/tau2-dialog-min/task.yaml
@@ -1,6 +1,19 @@
 format: bora.task/1
 task_id: tau2-dialog-min
 
+# Inspired by τ-bench retail dialog (user-sim + service tools); BORA journey mini-package.
+provenance:
+  kind: reimplementation
+  upstream:
+    name: tau2-bench
+    url: https://github.com/sierra-research/tau2-bench
+    ref: main
+  parity:
+    claims: [protocol]
+    known_gaps:
+      - minimal BORA case class, not full tau2 suite or task pin
+      - synthetic retail fixture; not upstream scenario dump
+
 harness:
   runtime: python
   entrypoint: harness:run

--- a/examples/journeys/tasks/terminal-jsonl-agg/task.yaml
+++ b/examples/journeys/tasks/terminal-jsonl-agg/task.yaml
@@ -1,6 +1,19 @@
 format: bora.task/1
 task_id: terminal-jsonl-agg
 
+# Terminal-style workspace file → independent eval (terminal-bench case class, not an adapter).
+provenance:
+  kind: reimplementation
+  upstream:
+    name: terminal-bench
+    url: https://github.com/laude-institute/terminal-bench
+    ref: main
+  parity:
+    claims: [protocol]
+    known_gaps:
+      - single synthetic jsonl-agg task; not Terminal-Bench task suite
+      - no TerminalBenchAdapter; BORA Core surfaces only
+
 harness:
   runtime: python
   entrypoint: harness:run

--- a/skills/bora-config-package/SKILL.md
+++ b/skills/bora-config-package/SKILL.md
@@ -120,10 +120,12 @@ HTTP / non-ACP profile example:
 | `parameters` | Harness `ctx.params` only |
 | envelope / profiles / limits / provider | Runtime |
 | gold under `evaluation/` | Clean evaluator after barrier — **not** Agent/Harness mount |
+| `provenance` | Config / authors / auditors only — **not** PASS |
 
 - Never put API keys or passwords in yaml.
 - Do not branch harness on executor kind / ACP entry for Core behavior; switch profile instead.
 - Adapter modules must stay mechanism-named (`acp`, `postgresql`, docker) — not benchmark names.
+- For **ports / reimplementations**, fill `provenance` (see `references/bora-yaml.md`); Attempt PASS still comes only from the independent evaluator.
 
 ## Which `executor` / ACP `entry` values?
 

--- a/skills/bora-config-package/references/bora-yaml.md
+++ b/skills/bora-config-package/references/bora-yaml.md
@@ -7,6 +7,7 @@
 - `version`: non-empty string
 - `tasks.root`: default `tasks`
 - `defaults` v1 allowlist: only `max_concurrent_tasks` (≥1)
+- Optional `provenance` (suite default; see below)
 - **Forbidden** on root: harness / provider / limits / evaluation / agent_profiles / …
 
 ## Member (`task.yaml`) — top-level required
@@ -20,6 +21,36 @@
 - `agent_profiles`: list of `{id, executor, model}` (+ ACP `options.entry` when applicable)
 - `limits`: wall / agent_invocations / environment_actions / memory_mb
 - `evaluation`: runtime, entrypoint, inputs, output.format
+- Optional `provenance` (fully replaces Database-root default when set)
+
+## Provenance（溯源，可选）
+
+Declare where a package/task was ported from. **Not PASS** and not a quality score.
+
+```yaml
+provenance:
+  kind: port   # port | reimplementation | wrapper | original
+  upstream:
+    name: tau-bench
+    url: https://github.com/example/tau-bench
+    ref: v0.1.0          # and/or commit
+    commit: abc123…
+    task_id: airline-001 # optional
+    paper: https://arxiv.org/abs/…  # optional
+  parity:
+    claims: [protocol, scoring]
+    known_gaps: []
+```
+
+| Rule | Detail |
+| --- | --- |
+| Location | `bora.yaml` (suite default) and/or member `task.yaml` |
+| Override | task block **replaces** database block entirely |
+| `original` | may omit `upstream` |
+| `port` / `reimplementation` / `wrapper` | require `upstream.url` + (`ref` or `commit`) |
+| Lock | enters digest + `bora lock` summary + evidence `lock.json` when written |
+
+Author checklist: for ports, fill provenance before claiming upstream fidelity.
 
 ## Executors (`agent_profiles[].executor`)
 

--- a/src/bora/application/campaign.py
+++ b/src/bora/application/campaign.py
@@ -70,13 +70,14 @@ async def run_campaign(
     """
     from bora.adapters.package_fs import LocalPackageReader
     from bora.config.capabilities import DeclarationCapabilityCatalog
-    from bora.config.database import resolve_task
+    from bora.config.database import load_database_manifest, resolve_task
     from bora.config.load_and_lock import ConfigCore
     from bora.registry.resolve import resolve_database_root
 
     database_root = resolve_database_root(package_root)
     resolved = resolve_task(database_root, task_id)
     task_dir = resolved.task_dir
+    man = load_database_manifest(resolved.database_root)
 
     axes = [parse_matrix_arg(a) for a in matrix_args]
     variants = expand_matrix(axes)
@@ -89,6 +90,7 @@ async def run_campaign(
             task_id,
             overrides=variant if variant else None,
             capabilities=DeclarationCapabilityCatalog(),
+            database_provenance=man.provenance,
         )
         admitted.append(
             {

--- a/src/bora/application/lock_command.py
+++ b/src/bora/application/lock_command.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from bora.config.capabilities import CapabilityCatalog
-from bora.config.database import resolve_task
+from bora.config.database import load_database_manifest, resolve_task
 from bora.config.load_and_lock import ConfigCore, parse_set_override
 from bora.config.model import locked_to_summary
 from bora.registry.resolve import resolve_database_root
@@ -53,6 +53,7 @@ class LockCommand:
 
         root = resolve_database_root(raw)
         resolved = resolve_task(root, task_id)
+        man = load_database_manifest(root)
 
         overrides: dict[str, object] = {}
         for raw in set_overrides:
@@ -65,6 +66,7 @@ class LockCommand:
             variant=variant,
             overrides=overrides or None,
             capabilities=self._capabilities,
+            database_provenance=man.provenance,
         )
         summary = locked_to_summary(locked).as_dict()
         summary["database_id"] = resolved.database_id

--- a/src/bora/application/run_command.py
+++ b/src/bora/application/run_command.py
@@ -39,6 +39,9 @@ async def run_task(
     database_root = resolve_database_root(package_root)
     resolved = resolve_task(database_root, task_id)
     package_root = resolved.task_dir
+    from bora.config.database import load_database_manifest
+
+    man = load_database_manifest(resolved.database_root)
     # Host credential locators from .env (values never enter lock/evidence).
     # Prefer Database-root .env, then task-member .env (later wins on key clash).
     load_host_env_files(package_root=resolved.database_root)
@@ -50,6 +53,7 @@ async def run_task(
             task_id,
             overrides=overrides,
             capabilities=DeclarationCapabilityCatalog(),
+            database_provenance=man.provenance,
         )
     except ConfigError:
         # unknown task etc. before Attempt/evidence
@@ -142,13 +146,14 @@ async def run_task(
                         "execution_mode": cap.execution_mode,
                     }
                 profile_rows.append(row)
-            evidence_store.write_lock_summary(
-                {
-                    "digest": lock.digest,
-                    "task_id": task_id,
-                    "profiles": profile_rows,
-                }
-            )
+            lock_doc: dict[str, Any] = {
+                "digest": lock.digest,
+                "task_id": task_id,
+                "profiles": profile_rows,
+            }
+            if lock.provenance is not None:
+                lock_doc["provenance"] = thaw(lock.provenance)
+            evidence_store.write_lock_summary(lock_doc)
         # Wall hard ceiling from locked limits (design §13.1): pre-effect deadline.
         import time as _time
 

--- a/src/bora/application/run_l1.py
+++ b/src/bora/application/run_l1.py
@@ -161,21 +161,24 @@ def run_l1_sdk_session_attempt(
         run_id=run_ident.value,
     )
     with contextlib.suppress(Exception):
-        evidence_store.write_lock_summary(
-            {
-                "digest": lock.digest,
-                "task_id": lock.task_id,
-                "topology": topology.public_summary(),
-                "profiles": [
-                    {
-                        "id": p.get("id"),
-                        "executor": p.get("executor"),
-                        "model": p.get("model"),
-                    }
-                    for p in profiles
-                ],
-            }
-        )
+        from bora.config.model import thaw as _thaw_lock
+
+        lock_doc: dict[str, Any] = {
+            "digest": lock.digest,
+            "task_id": lock.task_id,
+            "topology": topology.public_summary(),
+            "profiles": [
+                {
+                    "id": p.get("id"),
+                    "executor": p.get("executor"),
+                    "model": p.get("model"),
+                }
+                for p in profiles
+            ],
+        }
+        if lock.provenance is not None:
+            lock_doc["provenance"] = _thaw_lock(lock.provenance)
+        evidence_store.write_lock_summary(lock_doc)
 
     cred = project_executor_credentials(work_root=runtime.workdir_host)
     l1_meta["credential_projection"] = {

--- a/src/bora/config/database.py
+++ b/src/bora/config/database.py
@@ -64,6 +64,8 @@ class DatabaseManifest:
     tasks_root: str
     description: str | None = None
     defaults: DatabaseDefaults | None = None
+    # Optional suite-wide provenance; member task.yaml may fully override.
+    provenance: dict[str, object] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -281,8 +283,22 @@ def _manifest_from_mapping(raw: dict[str, Any]) -> DatabaseManifest:
             )
         defaults_obj = DatabaseDefaults(max_concurrent_tasks=mct)
 
+    provenance_obj: dict[str, object] | None = None
+    if "provenance" in raw:
+        from bora.config.provenance import validate_provenance
+
+        provenance_obj = validate_provenance(raw.get("provenance"), location="/provenance")
+
     # Reject unknown top-level keys beyond the wire schema.
-    allowed = {"format", "database_id", "version", "tasks", "description", "defaults"}
+    allowed = {
+        "format",
+        "database_id",
+        "version",
+        "tasks",
+        "description",
+        "defaults",
+        "provenance",
+    }
     unknown_top = set(raw) - allowed
     if unknown_top:
         raise ConfigError(
@@ -298,6 +314,7 @@ def _manifest_from_mapping(raw: dict[str, Any]) -> DatabaseManifest:
         tasks_root=tasks_root,
         description=description,
         defaults=defaults_obj,
+        provenance=provenance_obj,
     )
 
 

--- a/src/bora/config/load_and_lock.py
+++ b/src/bora/config/load_and_lock.py
@@ -38,6 +38,7 @@ from bora.config.model import (
     freeze,
 )
 from bora.config.ports import PackageReader
+from bora.config.provenance import merge_provenance, validate_provenance
 
 # Package top-level allowlist (design/02). Unknown first-level paths fail closed.
 ALLOWED_TOP_LEVEL_FILES = frozenset(
@@ -281,6 +282,7 @@ class ConfigCore:
         variant: Mapping[str, object] | None = None,
         overrides: Mapping[str, object] | None = None,
         capabilities: CapabilityCatalog,
+        database_provenance: Mapping[str, object] | None = None,
     ) -> LockedTaskConfig:
         """Read, merge, validate, canonicalize, digest, and freeze a task package.
 
@@ -297,6 +299,9 @@ class ConfigCore:
             Explicit overrides as a mapping of JSON Pointer → value (merge step 3).
         capabilities:
             Declaration-only catalog used for kind/format recognition.
+        database_provenance:
+            Optional Database-root ``provenance`` (suite default). Member
+            ``task.yaml`` provenance fully replaces this when present.
         """
         try:
             root = self._reader.resolve_root(package_root)
@@ -383,6 +388,33 @@ class ConfigCore:
         self._validate_document(merged, task_id=task_id, root=root, capabilities=capabilities)
         resolved_refs = self._collect_resolved_references(merged, root)
 
+        # Provenance: task fully replaces Database default; omit when neither set.
+        task_prov_raw = merged.get("provenance")
+        task_prov: dict[str, Any] | None = None
+        if task_prov_raw is not None:
+            task_prov = validate_provenance(task_prov_raw, location="/provenance")
+            resolution.append(
+                ResolutionEntry(
+                    source="task.yaml",
+                    pointer="/provenance",
+                    note="task provenance",
+                )
+            )
+        db_prov: dict[str, Any] | None = None
+        if database_provenance is not None:
+            db_prov = validate_provenance(
+                dict(database_provenance), location="database:/provenance"
+            )
+            if task_prov is None:
+                resolution.append(
+                    ResolutionEntry(
+                        source="database",
+                        pointer="/provenance",
+                        note="database default provenance",
+                    )
+                )
+        effective_prov = merge_provenance(database=db_prov, task=task_prov)
+
         # Freeze section views.
         format_id = str(merged["format"])
         locked_task_id = str(merged["task_id"])
@@ -401,6 +433,7 @@ class ConfigCore:
         limits = freeze(merged["limits"])
         artifacts = freeze(merged["artifacts"])
         evaluation = freeze(merged["evaluation"])
+        provenance_frozen = freeze(effective_prov) if effective_prov is not None else None
         resolution_record = ResolutionRecord(entries=tuple(resolution))
         resolved_references = freeze(resolved_refs)
 
@@ -419,6 +452,7 @@ class ConfigCore:
             resolution=resolution_record,
             digest="",  # filled below
             resolved_references=resolved_references,  # type: ignore[arg-type]
+            provenance=provenance_frozen,  # type: ignore[arg-type]
         )
         payload = provisional.canonical_payload()
         digest = digest_payload(payload)
@@ -437,6 +471,7 @@ class ConfigCore:
             resolution=resolution_record,
             digest=digest,
             resolved_references=resolved_references,  # type: ignore[arg-type]
+            provenance=provenance_frozen,  # type: ignore[arg-type]
         )
 
     def _validate_top_level_layout(self, root: Path) -> None:

--- a/src/bora/config/model.py
+++ b/src/bora/config/model.py
@@ -71,10 +71,12 @@ class LockedTaskConfig:
     digest: str
     # Package-relative resolved references (entrypoints, artifact paths, inputs).
     resolved_references: Mapping[str, Any] = field(default_factory=lambda: freeze({}))
+    # Optional package provenance (溯源); observational — never Attempt PASS.
+    provenance: Mapping[str, Any] | None = None
 
     def canonical_payload(self) -> dict[str, Any]:
         """Payload used for digest: everything except the digest field itself."""
-        return {
+        payload: dict[str, Any] = {
             "format": self.format,
             "task_id": self.task_id,
             "harness": thaw(self.harness),
@@ -88,6 +90,9 @@ class LockedTaskConfig:
             "resolution": self.resolution.as_plain(),
             "resolved_references": thaw(self.resolved_references),
         }
+        if self.provenance is not None:
+            payload["provenance"] = thaw(self.provenance)
+        return payload
 
 
 @dataclass(frozen=True, slots=True)
@@ -99,16 +104,20 @@ class LockSummary:
     resolved_references: Mapping[str, Any]
     resolution: Sequence[Mapping[str, str]]
     digest: str
+    provenance: Mapping[str, Any] | None = None
 
     def as_dict(self) -> dict[str, Any]:
         # Always return plain JSON-serializable dict/list trees (no MappingProxy).
-        return {
+        out: dict[str, Any] = {
             "digest": self.digest,
             "format": self.format,
             "resolution": thaw(list(self.resolution)),
             "resolved_references": thaw(self.resolved_references),
             "task_id": self.task_id,
         }
+        if self.provenance is not None:
+            out["provenance"] = thaw(self.provenance)
+        return out
 
 
 def locked_to_summary(lock: LockedTaskConfig) -> LockSummary:
@@ -119,6 +128,7 @@ def locked_to_summary(lock: LockedTaskConfig) -> LockSummary:
         resolved_references=lock.resolved_references,
         resolution=tuple(freeze(e) for e in lock.resolution.as_plain()),
         digest=lock.digest,
+        provenance=lock.provenance,
     )
 
 

--- a/src/bora/config/provenance.py
+++ b/src/bora/config/provenance.py
@@ -1,0 +1,170 @@
+"""Package provenance (溯源) validation and Database→task merge (#18).
+
+Provenance records *where a package/task came from* for fidelity audits.
+It never participates in Attempt PASS and is not a quality score.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bora.config.errors import ERROR_INVALID_SCHEMA, ConfigError
+
+PROVENANCE_KINDS = frozenset(
+    {
+        "port",
+        "reimplementation",
+        "wrapper",
+        "original",
+    }
+)
+REPLICATE_KINDS = frozenset({"port", "reimplementation", "wrapper"})
+
+_ALLOWED_TOP = frozenset({"kind", "upstream", "parity"})
+_ALLOWED_UPSTREAM = frozenset(
+    {
+        "name",
+        "url",
+        "ref",
+        "commit",
+        "task_id",
+        "paper",
+    }
+)
+_ALLOWED_PARITY = frozenset({"claims", "known_gaps"})
+
+
+def validate_provenance(raw: object, *, location: str = "/provenance") -> dict[str, Any]:
+    """Validate a provenance mapping; return a normalized plain dict.
+
+    Fail closed on unknown keys / wrong types. Replicate kinds require
+    ``upstream.url`` and at least one of ``upstream.ref`` / ``upstream.commit``.
+    ``kind: original`` may omit ``upstream``.
+    """
+    if not isinstance(raw, dict):
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            "provenance must be a mapping",
+            location=location,
+        )
+    unknown = set(raw) - _ALLOWED_TOP
+    if unknown:
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            f"unknown provenance keys: {sorted(unknown)}",
+            location=location,
+        )
+
+    kind = raw.get("kind")
+    if not isinstance(kind, str) or not kind:
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            "provenance.kind is required",
+            location=f"{location}/kind",
+        )
+    if kind not in PROVENANCE_KINDS:
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            f"provenance.kind must be one of {sorted(PROVENANCE_KINDS)}; got {kind!r}",
+            location=f"{location}/kind",
+        )
+
+    out: dict[str, Any] = {"kind": kind}
+
+    upstream_raw = raw.get("upstream")
+    if upstream_raw is not None:
+        if not isinstance(upstream_raw, dict):
+            raise ConfigError(
+                ERROR_INVALID_SCHEMA,
+                "provenance.upstream must be a mapping when set",
+                location=f"{location}/upstream",
+            )
+        unknown_u = set(upstream_raw) - _ALLOWED_UPSTREAM
+        if unknown_u:
+            raise ConfigError(
+                ERROR_INVALID_SCHEMA,
+                f"unknown provenance.upstream keys: {sorted(unknown_u)}",
+                location=f"{location}/upstream",
+            )
+        upstream: dict[str, Any] = {}
+        for key in ("name", "url", "ref", "commit", "task_id", "paper"):
+            val = upstream_raw.get(key)
+            if val is None:
+                continue
+            if not isinstance(val, str) or not val.strip():
+                raise ConfigError(
+                    ERROR_INVALID_SCHEMA,
+                    f"provenance.upstream.{key} must be a non-empty string when set",
+                    location=f"{location}/upstream/{key}",
+                )
+            upstream[key] = val.strip()
+        if upstream:
+            out["upstream"] = upstream
+
+    if kind in REPLICATE_KINDS:
+        upstream_req = out.get("upstream")
+        if not isinstance(upstream_req, dict):
+            raise ConfigError(
+                ERROR_INVALID_SCHEMA,
+                f"provenance.kind={kind!r} requires provenance.upstream",
+                location=f"{location}/upstream",
+            )
+        if not upstream_req.get("url"):
+            raise ConfigError(
+                ERROR_INVALID_SCHEMA,
+                f"provenance.kind={kind!r} requires provenance.upstream.url",
+                location=f"{location}/upstream/url",
+            )
+        if not upstream_req.get("ref") and not upstream_req.get("commit"):
+            raise ConfigError(
+                ERROR_INVALID_SCHEMA,
+                f"provenance.kind={kind!r} requires provenance.upstream.ref "
+                "and/or provenance.upstream.commit",
+                location=f"{location}/upstream",
+            )
+
+    parity_raw = raw.get("parity")
+    if parity_raw is not None:
+        if not isinstance(parity_raw, dict):
+            raise ConfigError(
+                ERROR_INVALID_SCHEMA,
+                "provenance.parity must be a mapping when set",
+                location=f"{location}/parity",
+            )
+        unknown_p = set(parity_raw) - _ALLOWED_PARITY
+        if unknown_p:
+            raise ConfigError(
+                ERROR_INVALID_SCHEMA,
+                f"unknown provenance.parity keys: {sorted(unknown_p)}",
+                location=f"{location}/parity",
+            )
+        parity: dict[str, Any] = {}
+        for key in ("claims", "known_gaps"):
+            val = parity_raw.get(key)
+            if val is None:
+                continue
+            if not isinstance(val, list) or not all(isinstance(x, str) for x in val):
+                raise ConfigError(
+                    ERROR_INVALID_SCHEMA,
+                    f"provenance.parity.{key} must be a list of strings when set",
+                    location=f"{location}/parity/{key}",
+                )
+            parity[key] = list(val)
+        if parity:
+            out["parity"] = parity
+
+    return out
+
+
+def merge_provenance(
+    *,
+    database: dict[str, Any] | None,
+    task: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Task provenance fully replaces Database default when present.
+
+    Returns None when neither layer declares provenance.
+    """
+    if task is not None:
+        return task
+    return database

--- a/src/bora/viewer/jobs.py
+++ b/src/bora/viewer/jobs.py
@@ -17,6 +17,25 @@ from bora.config.errors import ConfigError
 from bora.viewer.browse import commands_for
 
 
+def safe_id_segment(value: str, *, field: str) -> str:
+    """Single path segment (job_id / task_id / run_id); reject traversal."""
+    text = (value or "").strip()
+    if (
+        not text
+        or text in {".", ".."}
+        or "/" in text
+        or "\\" in text
+        or ".." in text
+        or text.startswith(".")
+    ):
+        raise ConfigError(
+            "invalid_package",
+            f"invalid {field}: {value!r}",
+            location=field,
+        )
+    return text
+
+
 def _suite_root(database_root: Path) -> Path:
     return database_root.expanduser().resolve(strict=False) / ".bora" / "suite-runs"
 
@@ -158,7 +177,18 @@ def list_jobs(database_root: Path) -> dict[str, Any]:
 
 def get_job(database_root: Path, job_id: str) -> dict[str, Any]:
     root = database_root.expanduser().resolve(strict=False)
+    job_id = safe_id_segment(job_id, field="job_id")
     suite_dir = _suite_root(root) / job_id
+    # Confine suite dir under database root
+    suite_resolved = suite_dir.resolve(strict=False)
+    try:
+        suite_resolved.relative_to(root)
+    except ValueError as exc:
+        raise ConfigError(
+            "invalid_package",
+            "job path escapes database sandbox",
+            location=job_id,
+        ) from exc
     summary_path = suite_dir / "summary.json"
     if not summary_path.is_file():
         raise ConfigError(
@@ -208,6 +238,7 @@ def get_job(database_root: Path, job_id: str) -> dict[str, Any]:
 
 
 def get_job_task(database_root: Path, job_id: str, task_id: str) -> dict[str, Any]:
+    task_id = safe_id_segment(task_id, field="task_id")
     job_payload = get_job(database_root, job_id)
     match = None
     for row in job_payload["tasks"]:

--- a/src/bora/viewer/server.py
+++ b/src/bora/viewer/server.py
@@ -132,10 +132,32 @@ def make_handler(database_root: Path, assets: Path) -> type[BaseHTTPRequestHandl
                     # Trial-enriched listing (suite summary + local evidence)
                     task_id = parts[2]
                     payload = trials.list_task_trials(root, job_id, task_id)
-                    base = jobs.get_job_task(root, job_id, task_id)
-                    base["trials"] = payload["trials"]
-                    base["note"] = payload.get("note") or base.get("note")
-                    _json(self, 200, base)
+                    _json(
+                        self,
+                        200,
+                        {
+                            "ok": True,
+                            "job": payload["job"],
+                            "task": payload["task"],
+                            "trials": payload["trials"],
+                            "agent_label": payload["task"].get("agent_label")
+                            or payload["job"].get("agent_label"),
+                            "model_label": payload["task"].get("model_label")
+                            or payload["job"].get("model_label"),
+                            "provider_label": payload["task"].get("provider_label")
+                            or payload["job"].get("provider_label"),
+                            "dataset": payload["task"].get("dataset")
+                            or payload["job"].get("source"),
+                            "commands": payload.get("commands"),
+                            "run_command": payload.get("run_command"),
+                            "breadcrumb": [
+                                {"label": "Jobs", "href": "/"},
+                                {"label": job_id, "href": f"/jobs/{job_id}"},
+                                {"label": task_id, "href": None},
+                            ],
+                            "note": payload.get("note"),
+                        },
+                    )
                     return
                 if len(parts) >= 4 and parts[1] == "tasks" and parts[3] == "trials":
                     task_id = parts[2]

--- a/src/bora/viewer/server.py
+++ b/src/bora/viewer/server.py
@@ -13,7 +13,7 @@ from typing import Any
 from urllib.parse import unquote, urlparse
 
 from bora.config.errors import ConfigError
-from bora.viewer import browse, jobs
+from bora.viewer import browse, jobs, trials
 
 # Default bind: loopback only.
 DEFAULT_HOST = "127.0.0.1"
@@ -113,19 +113,70 @@ def make_handler(database_root: Path, assets: Path) -> type[BaseHTTPRequestHandl
         def _api_jobs(self, path: str) -> None:
             # /api/jobs/{job_id}
             # /api/jobs/{job_id}/tasks/{task_id}
+            # /api/jobs/{job_id}/tasks/{task_id}/trials
+            # /api/jobs/{job_id}/tasks/{task_id}/trials/{run_id}
+            # /api/jobs/{job_id}/tasks/{task_id}/trials/{run_id}/tree|file|trajectory
             rest = path[len("/api/jobs/") :]
             parts = [p for p in rest.split("/") if p]
             if not parts:
                 _error(self, 404, "not_found", "job id required")
                 return
             job_id = parts[0]
+            query = urlparse(self.path).query
+            q = trials.parse_query(query)
             try:
                 if len(parts) == 1:
                     _json(self, 200, jobs.get_job(root, job_id))
                     return
                 if len(parts) == 3 and parts[1] == "tasks":
-                    _json(self, 200, jobs.get_job_task(root, job_id, parts[2]))
+                    # Trial-enriched listing (suite summary + local evidence)
+                    task_id = parts[2]
+                    payload = trials.list_task_trials(root, job_id, task_id)
+                    base = jobs.get_job_task(root, job_id, task_id)
+                    base["trials"] = payload["trials"]
+                    base["note"] = payload.get("note") or base.get("note")
+                    _json(self, 200, base)
                     return
+                if len(parts) >= 4 and parts[1] == "tasks" and parts[3] == "trials":
+                    task_id = parts[2]
+                    if len(parts) == 4:
+                        _json(self, 200, trials.list_task_trials(root, job_id, task_id))
+                        return
+                    run_id = parts[4]
+                    if len(parts) == 5:
+                        _json(self, 200, trials.get_trial(root, job_id, task_id, run_id))
+                        return
+                    if len(parts) == 6 and parts[5] == "tree":
+                        _json(
+                            self,
+                            200,
+                            trials.trial_tree(
+                                root,
+                                job_id,
+                                task_id,
+                                run_id,
+                                scope=q.get("scope", "root"),
+                            ),
+                        )
+                        return
+                    if len(parts) == 6 and parts[5] == "file":
+                        rel = q.get("path") or ""
+                        if not rel:
+                            _error(self, 400, "invalid_package", "path query required")
+                            return
+                        _json(
+                            self,
+                            200,
+                            trials.trial_file(root, job_id, task_id, run_id, relpath=rel),
+                        )
+                        return
+                    if len(parts) == 6 and parts[5] == "trajectory":
+                        _json(
+                            self,
+                            200,
+                            trials.trial_trajectory(root, job_id, task_id, run_id),
+                        )
+                        return
             except ConfigError as exc:
                 status = 404 if "unknown" in exc.error_code else 400
                 _error(self, status, exc.error_code, str(exc))

--- a/src/bora/viewer/trials.py
+++ b/src/bora/viewer/trials.py
@@ -1,0 +1,775 @@
+"""Attempt / trial evidence APIs for the local viewer (issue #26).
+
+Resolves ``run_id`` → evidence root under the opened Database sandox and exposes
+read-only meta, file tree, file preview, and trajectory steps. Tabs are derived
+from files that exist — never fabricated. Trajectory is observational, not PASS.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import mimetypes
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs
+
+from bora.config.database import load_database_manifest
+from bora.config.errors import ConfigError
+from bora.viewer.browse import commands_for
+from bora.viewer.jobs import get_job, get_job_task
+
+# Preview / enumeration caps (operator-facing local tool, not bulk export).
+MAX_FILE_BYTES = 512 * 1024
+MAX_TREE_ENTRIES = 800
+MAX_TRAJECTORY_STEPS = 2_000
+MAX_JSONL_LINE = 256 * 1024
+
+_TEXT_SUFFIXES = {
+    ".json",
+    ".jsonl",
+    ".txt",
+    ".md",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".py",
+    ".sh",
+    ".log",
+    ".csv",
+    ".tsv",
+    ".xml",
+    ".html",
+    ".css",
+    ".js",
+    ".ts",
+    ".tsx",
+    ".jsx",
+    ".env",
+    ".ini",
+    ".cfg",
+    ".conf",
+}
+
+
+def _safe_run_id(run_id: str) -> str:
+    rid = (run_id or "").strip()
+    if not rid or rid in {".", ".."} or "/" in rid or "\\" in rid or ".." in rid:
+        raise ConfigError(
+            "invalid_package",
+            f"invalid run_id: {run_id!r}",
+            location="run_id",
+        )
+    return rid
+
+
+def _safe_under(root: Path, relative: str) -> Path:
+    """Resolve *relative* under *root*; reject traversal and escape."""
+    if not relative or relative.startswith(("/", "\\")):
+        raise ConfigError(
+            "invalid_package",
+            "path must be relative",
+            location=relative or ".",
+        )
+    parts = Path(relative).parts
+    if ".." in parts:
+        raise ConfigError(
+            "invalid_package",
+            "path traversal rejected",
+            location=relative,
+        )
+    root_resolved = root.resolve(strict=False)
+    candidate = (root / relative).resolve(strict=False)
+    try:
+        candidate.relative_to(root_resolved)
+    except ValueError as exc:
+        raise ConfigError(
+            "invalid_package",
+            "path escapes sandbox",
+            location=relative,
+        ) from exc
+    return candidate
+
+
+def _read_json_object(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def resolve_evidence_root(
+    database_root: Path,
+    run_id: str,
+    *,
+    task_id: str | None = None,
+) -> Path:
+    """Locate Attempt evidence for *run_id* under the Database root sandbox.
+
+    Lookup order:
+    1. ``{database}/.bora/runs/{run_id}``
+    2. ``{database}/{tasks_root}/{task_id}/.bora/runs/{run_id}`` when task_id given
+    3. Scan ``{database}/**/ .bora/runs/{run_id}`` (depth-limited)
+    """
+    root = database_root.expanduser().resolve(strict=False)
+    rid = _safe_run_id(run_id)
+
+    primary = root / ".bora" / "runs" / rid
+    if primary.is_dir():
+        return primary
+
+    tasks_root_name = "tasks"
+    with contextlib.suppress(ConfigError):
+        man = load_database_manifest(root)
+        tasks_root_name = man.tasks_root or "tasks"
+
+    if task_id:
+        tid = task_id.strip()
+        if tid and ".." not in tid and "/" not in tid and "\\" not in tid:
+            task_local = root / tasks_root_name / tid / ".bora" / "runs" / rid
+            if task_local.is_dir():
+                return task_local
+
+    # Bounded scan: only under tasks/*/.bora/runs and root .bora/runs (already checked).
+    tasks_dir = root / tasks_root_name
+    if tasks_dir.is_dir():
+        for child in tasks_dir.iterdir():
+            if not child.is_dir():
+                continue
+            cand = child / ".bora" / "runs" / rid
+            if cand.is_dir():
+                return cand
+
+    raise ConfigError(
+        "unknown_task",
+        f"evidence root not found for run_id={rid!r}",
+        location=str(primary),
+    )
+
+
+def _has_any_file(path: Path) -> bool:
+    if not path.exists():
+        return False
+    if path.is_file():
+        return True
+    try:
+        for p in path.rglob("*"):
+            if p.is_file():
+                return True
+    except OSError:
+        return False
+    return False
+
+
+def _available_tabs(evidence: Path) -> list[str]:
+    tabs: list[str] = []
+    # Trajectory: any trajectory.jsonl under agent/invocations
+    inv = evidence / "agent" / "invocations"
+    has_traj = False
+    if inv.is_dir():
+        try:
+            has_traj = any(p.name == "trajectory.jsonl" for p in inv.rglob("trajectory.jsonl"))
+        except OSError:
+            has_traj = False
+    if has_traj:
+        tabs.append("trajectory")
+    if (evidence / "agent").is_dir() and _has_any_file(evidence / "agent"):
+        tabs.append("agent")
+    if (
+        _has_any_file(evidence / "evaluation")
+        or _has_any_file(evidence / "eval_staging")
+        or (evidence / "result.json").is_file()
+    ):
+        tabs.append("verifier")
+    # Artifacts: harness publish tree or common artifact dirs
+    art_candidates = [
+        evidence / "harness",
+        evidence / "artifacts",
+        evidence / "agent" / "artifacts",
+    ]
+    # Prefer a dedicated tab only when files exist under artifact-ish trees
+    if any(
+        p.is_dir() and any(x.is_file() for x in p.rglob("*") if x.is_file())
+        for p in art_candidates
+        if p.exists()
+    ):
+        tabs.append("artifacts")
+    if (evidence / "lock.json").is_file():
+        tabs.append("lock")
+    if (
+        (evidence / "effects.jsonl").is_file()
+        or (evidence / "cleanup.json").is_file()
+        or (evidence / "summary.json").is_file()
+    ):
+        tabs.append("log")
+    return tabs
+
+
+def _trial_meta_from_evidence(
+    evidence: Path,
+    *,
+    run_id: str,
+    task_id: str | None,
+    suite_row: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    result = _read_json_object(evidence / "result.json") or {}
+    summary = _read_json_object(evidence / "summary.json") or {}
+    lock = _read_json_object(evidence / "lock.json") or {}
+    suite_row = suite_row or {}
+
+    status = suite_row.get("status") or result.get("status") or summary.get("status") or None
+    if isinstance(status, str):
+        status = status.upper()
+    score = suite_row.get("score")
+    if score is None:
+        score = result.get("score")
+    if score is None:
+        score = summary.get("score")
+    error = suite_row.get("error") or result.get("error") or summary.get("error")
+    locked_task = lock.get("task_id") if isinstance(lock.get("task_id"), str) else None
+
+    return {
+        "trial_id": run_id,
+        "run_id": run_id,
+        "task_id": task_id or locked_task or suite_row.get("task_id"),
+        "status": status,
+        "score": score,
+        "reward": score,
+        "error": error,
+        "exit_code": suite_row.get("exit_code") or result.get("exit_code"),
+        "duration": suite_row.get("duration"),
+        "started": summary.get("started_at") or suite_row.get("started"),
+        "evidence_relpath": None,  # filled by caller
+        "has_evidence": True,
+        "available_tabs": _available_tabs(evidence),
+        "agent_invocations": result.get("agent_invocations") or summary.get("agent_invocations"),
+        "harness_kind": result.get("harness_kind") or summary.get("harness_kind"),
+        "note": "trajectory and harness status are not PASS; PASS is per-task evaluator only",
+    }
+
+
+def list_task_trials(
+    database_root: Path,
+    job_id: str,
+    task_id: str,
+) -> dict[str, Any]:
+    """List trials for a task within a suite job, enriched with local evidence when present."""
+    root = database_root.expanduser().resolve(strict=False)
+    task_payload = get_job_task(root, job_id, task_id)
+    job = task_payload["job"]
+    suite_trials = list(task_payload.get("trials") or [])
+
+    by_run: dict[str, dict[str, Any]] = {}
+    for tr in suite_trials:
+        rid = tr.get("run_id") or tr.get("trial_id")
+        if not rid:
+            continue
+        rid_s = str(rid)
+        by_run[rid_s] = {
+            "trial_id": rid_s,
+            "run_id": rid_s,
+            "task_id": task_id,
+            "status": tr.get("status"),
+            "score": tr.get("score") if tr.get("score") is not None else tr.get("reward"),
+            "reward": tr.get("reward") if tr.get("reward") is not None else tr.get("score"),
+            "error": tr.get("error"),
+            "exit_code": tr.get("exit_code"),
+            "duration": tr.get("duration"),
+            "started": tr.get("started") or job.get("started"),
+            "has_evidence": False,
+            "available_tabs": [],
+            "note": "from suite summary",
+        }
+
+    # Scan database-level and task-local runs matching this task_id via lock.json
+    candidates: list[Path] = []
+    db_runs = root / ".bora" / "runs"
+    if db_runs.is_dir():
+        candidates.extend(p for p in db_runs.iterdir() if p.is_dir())
+    tasks_root_name = "tasks"
+    with contextlib.suppress(ConfigError):
+        man = load_database_manifest(root)
+        tasks_root_name = man.tasks_root or "tasks"
+    task_runs = root / tasks_root_name / task_id / ".bora" / "runs"
+    if task_runs.is_dir():
+        candidates.extend(p for p in task_runs.iterdir() if p.is_dir())
+
+    for run_dir in candidates:
+        rid = run_dir.name
+        lock = _read_json_object(run_dir / "lock.json") or {}
+        locked_task = lock.get("task_id")
+        # Enrich suite-listed runs always; only *add* new runs when lock matches task.
+        if rid not in by_run and locked_task != task_id:
+            continue
+        suite_row = by_run.get(rid, {})
+        meta = _trial_meta_from_evidence(
+            run_dir,
+            run_id=rid,
+            task_id=task_id,
+            suite_row=suite_row,
+        )
+        try:
+            rel = str(run_dir.resolve(strict=False).relative_to(root))
+        except ValueError:
+            rel = str(run_dir)
+        meta["evidence_relpath"] = rel
+        meta["started"] = meta.get("started") or suite_row.get("started") or job.get("started")
+        by_run[rid] = meta
+
+    trials = sorted(
+        by_run.values(),
+        key=lambda t: (t.get("started") or "", t.get("run_id") or ""),
+        reverse=True,
+    )
+    cmds = commands_for(root, task_id=task_id)
+    return {
+        "ok": True,
+        "job": job,
+        "task": task_payload["task"],
+        "trials": trials,
+        "count": len(trials),
+        "commands": cmds,
+        "run_command": cmds.get("run_task") or cmds.get("run_suite"),
+        "breadcrumb": [
+            {"label": "Jobs", "href": "/"},
+            {"label": job_id, "href": f"/jobs/{job_id}"},
+            {"label": task_id, "href": f"/jobs/{job_id}/tasks/{task_id}"},
+            {"label": "trials", "href": None},
+        ],
+        "note": "per-task evaluator verdicts only; trajectory is not PASS",
+    }
+
+
+def get_trial(
+    database_root: Path,
+    job_id: str,
+    task_id: str,
+    run_id: str,
+) -> dict[str, Any]:
+    root = database_root.expanduser().resolve(strict=False)
+    rid = _safe_run_id(run_id)
+    job_payload = get_job(root, job_id)
+    job = job_payload["job"]
+    suite_row: dict[str, Any] = {}
+    for row in job_payload.get("tasks") or []:
+        if row.get("task_id") == task_id and str(row.get("run_id") or "") == rid:
+            suite_row = row
+            break
+
+    evidence = resolve_evidence_root(root, rid, task_id=task_id)
+    meta = _trial_meta_from_evidence(evidence, run_id=rid, task_id=task_id, suite_row=suite_row)
+    try:
+        meta["evidence_relpath"] = str(evidence.resolve(strict=False).relative_to(root))
+    except ValueError:
+        meta["evidence_relpath"] = str(evidence)
+
+    # Sibling runs for prev/next navigation
+    listed = list_task_trials(root, job_id, task_id)
+    sibling_ids = [str(t.get("run_id")) for t in listed["trials"] if t.get("run_id")]
+    try:
+        idx = sibling_ids.index(rid)
+    except ValueError:
+        idx = -1
+    prev_id = sibling_ids[idx - 1] if idx > 0 else None
+    next_id = sibling_ids[idx + 1] if 0 <= idx < len(sibling_ids) - 1 else None
+
+    cmds = commands_for(root, task_id=task_id)
+    result_preview = _read_json_object(evidence / "result.json")
+    # Strip huge nested blobs if any
+    if result_preview and "metrics" in result_preview:
+        metrics = result_preview.get("metrics")
+        if isinstance(metrics, dict) and len(json.dumps(metrics)) > 8_000:
+            result_preview = {**result_preview, "metrics": {"_truncated": True}}
+
+    return {
+        "ok": True,
+        "job": job,
+        "task_id": task_id,
+        "trial": meta,
+        "result": result_preview,
+        "prev_run_id": prev_id,
+        "next_run_id": next_id,
+        "sibling_run_ids": sibling_ids,
+        "commands": cmds,
+        "run_command": cmds.get("run_task") or cmds.get("run_suite"),
+        "breadcrumb": [
+            {"label": "Jobs", "href": "/"},
+            {"label": job_id, "href": f"/jobs/{job_id}"},
+            {"label": task_id, "href": f"/jobs/{job_id}/tasks/{task_id}"},
+            {"label": rid, "href": None},
+        ],
+        "note": meta.get("note"),
+    }
+
+
+def _scope_base(evidence: Path, scope: str) -> Path:
+    scope = (scope or "root").strip().lower()
+    mapping = {
+        "root": evidence,
+        "agent": evidence / "agent",
+        "eval": evidence / "evaluation",
+        "evaluation": evidence / "evaluation",
+        "verifier": evidence / "evaluation",
+        "artifacts": evidence / "harness",
+        "harness": evidence / "harness",
+        "lock": evidence,  # single file handled by caller
+    }
+    if scope not in mapping:
+        raise ConfigError(
+            "invalid_package",
+            f"unknown tree scope: {scope!r}",
+            location="scope",
+        )
+    return mapping[scope]
+
+
+def trial_tree(
+    database_root: Path,
+    job_id: str,  # noqa: ARG001 — reserved for auth/scoping consistency
+    task_id: str,
+    run_id: str,
+    *,
+    scope: str = "root",
+) -> dict[str, Any]:
+    root = database_root.expanduser().resolve(strict=False)
+    rid = _safe_run_id(run_id)
+    evidence = resolve_evidence_root(root, rid, task_id=task_id)
+    scope_norm = (scope or "root").strip().lower()
+
+    # Special multi-root scopes for verifier
+    if scope_norm in {"verifier", "eval", "evaluation"}:
+        entries: list[dict[str, Any]] = []
+        for sub in (
+            evidence / "evaluation",
+            evidence / "eval_staging",
+            evidence / "result.json",
+        ):
+            if sub.is_file():
+                st = sub.stat()
+                rel = sub.name if sub.parent == evidence else str(sub.relative_to(evidence))
+                entries.append(
+                    {
+                        "path": rel,
+                        "name": sub.name,
+                        "type": "file",
+                        "size": st.st_size,
+                    }
+                )
+            elif sub.is_dir():
+                remain = MAX_TREE_ENTRIES - len(entries)
+                entries.extend(_walk_tree(evidence, sub, max_entries=remain))
+        return {
+            "ok": True,
+            "run_id": rid,
+            "scope": "verifier",
+            "entries": entries[:MAX_TREE_ENTRIES],
+            "truncated": len(entries) > MAX_TREE_ENTRIES,
+        }
+
+    if scope_norm == "artifacts":
+        entries = []
+        for sub_name in ("harness", "artifacts"):
+            sub = evidence / sub_name
+            if sub.is_dir():
+                entries.extend(
+                    _walk_tree(evidence, sub, max_entries=MAX_TREE_ENTRIES - len(entries))
+                )
+        return {
+            "ok": True,
+            "run_id": rid,
+            "scope": "artifacts",
+            "entries": entries[:MAX_TREE_ENTRIES],
+            "truncated": len(entries) > MAX_TREE_ENTRIES,
+        }
+
+    if scope_norm == "lock":
+        lock_path = evidence / "lock.json"
+        entries = []
+        if lock_path.is_file():
+            entries.append(
+                {
+                    "path": "lock.json",
+                    "name": "lock.json",
+                    "type": "file",
+                    "size": lock_path.stat().st_size,
+                }
+            )
+        return {"ok": True, "run_id": rid, "scope": "lock", "entries": entries, "truncated": False}
+
+    if scope_norm == "log":
+        entries = []
+        for name in ("effects.jsonl", "cleanup.json", "summary.json", "agent.json", "harness.json"):
+            p = evidence / name
+            if p.is_file():
+                entries.append(
+                    {
+                        "path": name,
+                        "name": name,
+                        "type": "file",
+                        "size": p.stat().st_size,
+                    }
+                )
+        return {"ok": True, "run_id": rid, "scope": "log", "entries": entries, "truncated": False}
+
+    base = _scope_base(evidence, scope_norm)
+    if not base.exists():
+        return {
+            "ok": True,
+            "run_id": rid,
+            "scope": scope_norm,
+            "entries": [],
+            "truncated": False,
+            "note": f"no files under scope {scope_norm!r}",
+        }
+    if base.is_file():
+        entries = [
+            {
+                "path": str(base.relative_to(evidence)),
+                "name": base.name,
+                "type": "file",
+                "size": base.stat().st_size,
+            }
+        ]
+    else:
+        entries = _walk_tree(evidence, base, max_entries=MAX_TREE_ENTRIES)
+    return {
+        "ok": True,
+        "run_id": rid,
+        "scope": scope_norm,
+        "entries": entries,
+        "truncated": len(entries) >= MAX_TREE_ENTRIES,
+    }
+
+
+def _walk_tree(evidence: Path, base: Path, *, max_entries: int) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    if max_entries <= 0:
+        return out
+    try:
+        paths = sorted(base.rglob("*"), key=lambda p: str(p).lower())
+    except OSError:
+        return out
+    for p in paths:
+        if len(out) >= max_entries:
+            break
+        try:
+            rel = str(p.relative_to(evidence))
+            if p.is_dir():
+                out.append({"path": rel, "name": p.name, "type": "dir", "size": None})
+            elif p.is_file():
+                out.append(
+                    {
+                        "path": rel,
+                        "name": p.name,
+                        "type": "file",
+                        "size": p.stat().st_size,
+                    }
+                )
+        except (OSError, ValueError):
+            continue
+    return out
+
+
+def trial_file(
+    database_root: Path,
+    job_id: str,  # noqa: ARG001
+    task_id: str,
+    run_id: str,
+    *,
+    relpath: str,
+) -> dict[str, Any]:
+    root = database_root.expanduser().resolve(strict=False)
+    rid = _safe_run_id(run_id)
+    evidence = resolve_evidence_root(root, rid, task_id=task_id)
+    path = _safe_under(evidence, relpath)
+    if not path.is_file():
+        raise ConfigError(
+            "unknown_task",
+            f"file not found: {relpath}",
+            location=relpath,
+        )
+    size = path.stat().st_size
+    mime, _ = mimetypes.guess_type(str(path))
+    mime = mime or "application/octet-stream"
+    suffix = path.suffix.lower()
+    is_text = (
+        suffix in _TEXT_SUFFIXES
+        or mime.startswith("text/")
+        or mime in {"application/json", "application/xml", "application/x-yaml"}
+    )
+    if not is_text:
+        return {
+            "ok": True,
+            "run_id": rid,
+            "path": relpath,
+            "name": path.name,
+            "size": size,
+            "media_type": mime,
+            "encoding": "binary",
+            "truncated": False,
+            "content": None,
+            "note": "binary file; preview not shown",
+        }
+    if size > MAX_FILE_BYTES:
+        raw = path.read_bytes()[:MAX_FILE_BYTES]
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            text = raw.decode("utf-8", errors="replace")
+        return {
+            "ok": True,
+            "run_id": rid,
+            "path": relpath,
+            "name": path.name,
+            "size": size,
+            "media_type": mime,
+            "encoding": "utf-8",
+            "truncated": True,
+            "content": text,
+            "note": f"truncated to first {MAX_FILE_BYTES} bytes",
+        }
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    return {
+        "ok": True,
+        "run_id": rid,
+        "path": relpath,
+        "name": path.name,
+        "size": size,
+        "media_type": mime,
+        "encoding": "utf-8",
+        "truncated": False,
+        "content": text,
+    }
+
+
+def trial_trajectory(
+    database_root: Path,
+    job_id: str,  # noqa: ARG001
+    task_id: str,
+    run_id: str,
+) -> dict[str, Any]:
+    root = database_root.expanduser().resolve(strict=False)
+    rid = _safe_run_id(run_id)
+    evidence = resolve_evidence_root(root, rid, task_id=task_id)
+    inv_root = evidence / "agent" / "invocations"
+    steps: list[dict[str, Any]] = []
+    invocations: list[dict[str, Any]] = []
+    truncated = False
+
+    if inv_root.is_dir():
+        inv_dirs = sorted(
+            [p for p in inv_root.iterdir() if p.is_dir()],
+            key=lambda p: p.name,
+        )
+        for inv in inv_dirs:
+            inv_meta = _read_json_object(inv / "metadata.json") or {}
+            traj_path = inv / "trajectory.jsonl"
+            inv_steps: list[dict[str, Any]] = []
+            if traj_path.is_file():
+                inv_steps = _parse_trajectory_jsonl(traj_path)
+            for step in inv_steps:
+                if len(steps) >= MAX_TRAJECTORY_STEPS:
+                    truncated = True
+                    break
+                steps.append(
+                    {
+                        **step,
+                        "invocation": inv.name,
+                        "invocation_id": inv_meta.get("invocation_id") or inv.name,
+                    }
+                )
+            invocations.append(
+                {
+                    "dirname": inv.name,
+                    "invocation_id": inv_meta.get("invocation_id") or inv.name,
+                    "profile_id": inv_meta.get("profile_id"),
+                    "executor_kind": inv_meta.get("executor_kind"),
+                    "model": inv_meta.get("model") or inv_meta.get("locked_model"),
+                    "status": inv_meta.get("status"),
+                    "step_count": len(inv_steps),
+                    "has_trajectory": traj_path.is_file(),
+                }
+            )
+            if truncated:
+                break
+
+    return {
+        "ok": True,
+        "run_id": rid,
+        "task_id": task_id,
+        "steps": steps,
+        "step_count": len(steps),
+        "invocations": invocations,
+        "truncated": truncated,
+        "note": "trajectory is observational evidence; not PASS",
+    }
+
+
+def _parse_trajectory_jsonl(path: Path) -> list[dict[str, Any]]:
+    steps: list[dict[str, Any]] = []
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as fh:
+            for line_no, line in enumerate(fh, start=1):
+                if len(steps) >= MAX_TRAJECTORY_STEPS:
+                    break
+                raw = line.strip()
+                if not raw:
+                    continue
+                if len(raw) > MAX_JSONL_LINE:
+                    raw = raw[:MAX_JSONL_LINE]
+                try:
+                    obj = json.loads(raw)
+                except json.JSONDecodeError:
+                    steps.append(
+                        {
+                            "type": "parse_error",
+                            "line": line_no,
+                            "content": raw[:500],
+                        }
+                    )
+                    continue
+                if not isinstance(obj, dict):
+                    steps.append({"type": "raw", "line": line_no, "content": str(obj)[:500]})
+                    continue
+                role = obj.get("role")
+                step_type = obj.get("type") or ("turn" if role else "event")
+                content = obj.get("content")
+                if content is not None and not isinstance(content, str):
+                    try:
+                        content = json.dumps(content, ensure_ascii=False)
+                    except (TypeError, ValueError):
+                        content = str(content)
+                if isinstance(content, str) and len(content) > 8_000:
+                    content = content[:8_000] + "…[truncated]"
+                steps.append(
+                    {
+                        "type": step_type,
+                        "role": role,
+                        "content": content,
+                        "turn_index": obj.get("turn_index"),
+                        "source": obj.get("source"),
+                        "stop_reason": obj.get("stop_reason"),
+                        "ok": obj.get("ok"),
+                        "error": obj.get("error"),
+                        "usage": obj.get("usage") if isinstance(obj.get("usage"), dict) else None,
+                        "metadata": obj.get("metadata")
+                        if isinstance(obj.get("metadata"), dict)
+                        else None,
+                        "line": line_no,
+                    }
+                )
+    except OSError:
+        return steps
+    return steps
+
+
+def parse_query(query: str) -> dict[str, str]:
+    """Parse URL query string into first-value map."""
+    qs = parse_qs(query or "", keep_blank_values=False)
+    return {k: v[0] for k, v in qs.items() if v}

--- a/src/bora/viewer/trials.py
+++ b/src/bora/viewer/trials.py
@@ -370,7 +370,8 @@ def _agent_surface(
             ex = inv_executor.get(pid)
         if isinstance(ex, str) and ex and ex not in executors:
             executors.append(ex)
-        caps = p.get("capabilities") if isinstance(p.get("capabilities"), dict) else {}
+        caps_raw = p.get("capabilities")
+        caps: dict[str, Any] = caps_raw if isinstance(caps_raw, dict) else {}
         if caps.get("execution_mode") == "acp-stdio" and "acp" not in executors:
             executors.append("acp")
         model = inv_model.get(pid) or (p.get("model") if isinstance(p.get("model"), str) else None)
@@ -727,7 +728,7 @@ def trial_tree(
                     _walk_tree(evidence, sub, max_entries=MAX_TREE_ENTRIES - len(entries))
                 )
             elif sub.is_file():
-                try:
+                with contextlib.suppress(OSError, ValueError):
                     entries.append(
                         {
                             "path": str(sub.relative_to(evidence)),
@@ -736,8 +737,6 @@ def trial_tree(
                             "size": sub.stat().st_size,
                         }
                     )
-                except (OSError, ValueError):
-                    pass
         return {
             "ok": True,
             "run_id": rid,

--- a/src/bora/viewer/trials.py
+++ b/src/bora/viewer/trials.py
@@ -17,7 +17,7 @@ from urllib.parse import parse_qs
 from bora.config.database import load_database_manifest
 from bora.config.errors import ConfigError
 from bora.viewer.browse import commands_for
-from bora.viewer.jobs import get_job, get_job_task
+from bora.viewer.jobs import get_job, get_job_task, safe_id_segment
 
 # Preview / enumeration caps (operator-facing local tool, not bulk export).
 MAX_FILE_BYTES = 512 * 1024
@@ -45,7 +45,6 @@ _TEXT_SUFFIXES = {
     ".ts",
     ".tsx",
     ".jsx",
-    ".env",
     ".ini",
     ".cfg",
     ".conf",
@@ -53,14 +52,7 @@ _TEXT_SUFFIXES = {
 
 
 def _safe_run_id(run_id: str) -> str:
-    rid = (run_id or "").strip()
-    if not rid or rid in {".", ".."} or "/" in rid or "\\" in rid or ".." in rid:
-        raise ConfigError(
-            "invalid_package",
-            f"invalid run_id: {run_id!r}",
-            location="run_id",
-        )
-    return rid
+    return safe_id_segment(run_id, field="run_id")
 
 
 def _safe_under(root: Path, relative: str) -> Path:
@@ -101,51 +93,104 @@ def _read_json_object(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
+def _assert_under_database(root: Path, path: Path, *, location: str) -> Path:
+    """Resolve *path* and ensure it stays under Database *root*."""
+    root_r = root.resolve(strict=False)
+    cand = path.resolve(strict=False)
+    try:
+        cand.relative_to(root_r)
+    except ValueError as exc:
+        raise ConfigError(
+            "invalid_package",
+            "path escapes database sandbox",
+            location=location,
+        ) from exc
+    return cand
+
+
+def _evidence_matches_task(evidence: Path, task_id: str | None) -> bool:
+    """If lock.json has task_id, require match; missing lock is ok without require."""
+    if not task_id:
+        return True
+    lock = _read_json_object(evidence / "lock.json")
+    if lock is None:
+        # No lock: allow only when caller already scoped via suite membership.
+        return True
+    locked = lock.get("task_id")
+    if locked is None:
+        return True
+    return str(locked) == task_id
+
+
 def resolve_evidence_root(
     database_root: Path,
     run_id: str,
     *,
     task_id: str | None = None,
+    require_task_match: bool = True,
 ) -> Path:
     """Locate Attempt evidence for *run_id* under the Database root sandbox.
 
     Lookup order:
     1. ``{database}/.bora/runs/{run_id}``
     2. ``{database}/{tasks_root}/{task_id}/.bora/runs/{run_id}`` when task_id given
-    3. Scan ``{database}/**/ .bora/runs/{run_id}`` (depth-limited)
+    3. Scan ``{database}/tasks/*/.bora/runs/{run_id}`` (bounded)
+
+    When *require_task_match* and *task_id* are set, lock.json ``task_id`` must match
+    if present (fail closed on mismatch).
     """
     root = database_root.expanduser().resolve(strict=False)
     rid = _safe_run_id(run_id)
+    tid = safe_id_segment(task_id, field="task_id") if task_id else None
 
+    candidates: list[Path] = []
     primary = root / ".bora" / "runs" / rid
     if primary.is_dir():
-        return primary
+        candidates.append(primary)
 
     tasks_root_name = "tasks"
     with contextlib.suppress(ConfigError):
         man = load_database_manifest(root)
         tasks_root_name = man.tasks_root or "tasks"
+    # tasks_root may be multi-segment but must not escape (validated at load).
+    if ".." in Path(tasks_root_name).parts or tasks_root_name.startswith(("/", "\\")):
+        tasks_root_name = "tasks"
 
-    if task_id:
-        tid = task_id.strip()
-        if tid and ".." not in tid and "/" not in tid and "\\" not in tid:
-            task_local = root / tasks_root_name / tid / ".bora" / "runs" / rid
-            if task_local.is_dir():
-                return task_local
+    if tid:
+        task_local = root / tasks_root_name / tid / ".bora" / "runs" / rid
+        if task_local.is_dir():
+            candidates.append(task_local)
 
-    # Bounded scan: only under tasks/*/.bora/runs and root .bora/runs (already checked).
+    # Bounded scan under tasks/*/.bora/runs (single-segment task ids only)
     tasks_dir = root / tasks_root_name
     if tasks_dir.is_dir():
         for child in tasks_dir.iterdir():
             if not child.is_dir():
                 continue
+            try:
+                safe_id_segment(child.name, field="task_id")
+            except ConfigError:
+                continue
             cand = child / ".bora" / "runs" / rid
             if cand.is_dir():
-                return cand
+                candidates.append(cand)
+
+    seen: set[Path] = set()
+    for cand in candidates:
+        try:
+            resolved = _assert_under_database(root, cand, location=str(cand))
+        except ConfigError:
+            continue
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if require_task_match and tid and not _evidence_matches_task(resolved, tid):
+            continue
+        return resolved
 
     raise ConfigError(
         "unknown_task",
-        f"evidence root not found for run_id={rid!r}",
+        f"evidence root not found for run_id={rid!r}" + (f" task_id={tid!r}" if tid else ""),
         location=str(primary),
     )
 
@@ -191,12 +236,11 @@ def _available_tabs(evidence: Path) -> list[str]:
         evidence / "agent" / "artifacts",
     ]
     # Prefer a dedicated tab only when files exist under artifact-ish trees
-    if any(
-        p.is_dir() and any(x.is_file() for x in p.rglob("*") if x.is_file())
-        for p in art_candidates
-        if p.exists()
-    ):
-        tabs.append("artifacts")
+    try:
+        if any(_has_any_file(p) for p in art_candidates):
+            tabs.append("artifacts")
+    except OSError:
+        pass
     if (evidence / "lock.json").is_file():
         tabs.append("lock")
     if (
@@ -258,6 +302,8 @@ def list_task_trials(
 ) -> dict[str, Any]:
     """List trials for a task within a suite job, enriched with local evidence when present."""
     root = database_root.expanduser().resolve(strict=False)
+    job_id = safe_id_segment(job_id, field="job_id")
+    task_id = safe_id_segment(task_id, field="task_id")
     task_payload = get_job_task(root, job_id, task_id)
     job = task_payload["job"]
     suite_trials = list(task_payload.get("trials") or [])
@@ -350,6 +396,8 @@ def get_trial(
     run_id: str,
 ) -> dict[str, Any]:
     root = database_root.expanduser().resolve(strict=False)
+    job_id = safe_id_segment(job_id, field="job_id")
+    task_id = safe_id_segment(task_id, field="task_id")
     rid = _safe_run_id(run_id)
     job_payload = get_job(root, job_id)
     job = job_payload["job"]
@@ -359,30 +407,59 @@ def get_trial(
             suite_row = row
             break
 
-    evidence = resolve_evidence_root(root, rid, task_id=task_id)
-    meta = _trial_meta_from_evidence(evidence, run_id=rid, task_id=task_id, suite_row=suite_row)
-    try:
-        meta["evidence_relpath"] = str(evidence.resolve(strict=False).relative_to(root))
-    except ValueError:
-        meta["evidence_relpath"] = str(evidence)
+    evidence: Path | None = None
+    with contextlib.suppress(ConfigError):
+        evidence = resolve_evidence_root(root, rid, task_id=task_id, require_task_match=True)
 
-    # Sibling runs for prev/next navigation
+    result_preview: dict[str, Any] | None = None
+    if evidence is None:
+        if not suite_row:
+            raise ConfigError(
+                "unknown_task",
+                f"trial {rid!r} not found for task {task_id!r} in job {job_id!r}",
+                location=rid,
+            )
+        status = suite_row.get("status")
+        meta = {
+            "trial_id": rid,
+            "run_id": rid,
+            "task_id": task_id,
+            "status": str(status).upper() if status else None,
+            "score": suite_row.get("score"),
+            "reward": suite_row.get("score"),
+            "error": suite_row.get("error"),
+            "exit_code": suite_row.get("exit_code"),
+            "duration": suite_row.get("duration"),
+            "started": suite_row.get("started") or job.get("started"),
+            "evidence_relpath": None,
+            "has_evidence": False,
+            "available_tabs": [],
+            "note": "no local evidence tree for this run_id; files/trajectory unavailable "
+            "(not PASS)",
+        }
+    else:
+        meta = _trial_meta_from_evidence(evidence, run_id=rid, task_id=task_id, suite_row=suite_row)
+        try:
+            meta["evidence_relpath"] = str(evidence.resolve(strict=False).relative_to(root))
+        except ValueError:
+            meta["evidence_relpath"] = str(evidence)
+        result_preview = _read_json_object(evidence / "result.json")
+        if result_preview and "metrics" in result_preview:
+            metrics = result_preview.get("metrics")
+            if isinstance(metrics, dict) and len(json.dumps(metrics)) > 8_000:
+                result_preview = {**result_preview, "metrics": {"_truncated": True}}
+
     listed = list_task_trials(root, job_id, task_id)
     sibling_ids = [str(t.get("run_id")) for t in listed["trials"] if t.get("run_id")]
+    if rid not in sibling_ids:
+        sibling_ids.insert(0, rid)
     try:
         idx = sibling_ids.index(rid)
     except ValueError:
         idx = -1
     prev_id = sibling_ids[idx - 1] if idx > 0 else None
     next_id = sibling_ids[idx + 1] if 0 <= idx < len(sibling_ids) - 1 else None
-
     cmds = commands_for(root, task_id=task_id)
-    result_preview = _read_json_object(evidence / "result.json")
-    # Strip huge nested blobs if any
-    if result_preview and "metrics" in result_preview:
-        metrics = result_preview.get("metrics")
-        if isinstance(metrics, dict) and len(json.dumps(metrics)) > 8_000:
-            result_preview = {**result_preview, "metrics": {"_truncated": True}}
 
     return {
         "ok": True,
@@ -428,15 +505,19 @@ def _scope_base(evidence: Path, scope: str) -> Path:
 
 def trial_tree(
     database_root: Path,
-    job_id: str,  # noqa: ARG001 — reserved for auth/scoping consistency
+    job_id: str,
     task_id: str,
     run_id: str,
     *,
     scope: str = "root",
 ) -> dict[str, Any]:
     root = database_root.expanduser().resolve(strict=False)
+    safe_id_segment(job_id, field="job_id")
+    task_id = safe_id_segment(task_id, field="task_id")
     rid = _safe_run_id(run_id)
-    evidence = resolve_evidence_root(root, rid, task_id=task_id)
+    # Ensure job exists (sandbox + membership)
+    get_job(root, job_id)
+    evidence = resolve_evidence_root(root, rid, task_id=task_id, require_task_match=True)
     scope_norm = (scope or "root").strip().lower()
 
     # Special multi-root scopes for verifier
@@ -575,15 +656,18 @@ def _walk_tree(evidence: Path, base: Path, *, max_entries: int) -> list[dict[str
 
 def trial_file(
     database_root: Path,
-    job_id: str,  # noqa: ARG001
+    job_id: str,
     task_id: str,
     run_id: str,
     *,
     relpath: str,
 ) -> dict[str, Any]:
     root = database_root.expanduser().resolve(strict=False)
+    safe_id_segment(job_id, field="job_id")
+    task_id = safe_id_segment(task_id, field="task_id")
     rid = _safe_run_id(run_id)
-    evidence = resolve_evidence_root(root, rid, task_id=task_id)
+    get_job(root, job_id)
+    evidence = resolve_evidence_root(root, rid, task_id=task_id, require_task_match=True)
     path = _safe_under(evidence, relpath)
     if not path.is_file():
         raise ConfigError(
@@ -595,6 +679,20 @@ def trial_file(
     mime, _ = mimetypes.guess_type(str(path))
     mime = mime or "application/octet-stream"
     suffix = path.suffix.lower()
+    # Never preview env/secret-like basenames even if under evidence
+    if path.name in {".env", ".env.local", ".env.production"} or path.name.startswith(".env."):
+        return {
+            "ok": True,
+            "run_id": rid,
+            "path": relpath,
+            "name": path.name,
+            "size": size,
+            "media_type": mime,
+            "encoding": "redacted",
+            "truncated": False,
+            "content": None,
+            "note": "secret-like filename; content not shown",
+        }
     is_text = (
         suffix in _TEXT_SUFFIXES
         or mime.startswith("text/")
@@ -650,13 +748,16 @@ def trial_file(
 
 def trial_trajectory(
     database_root: Path,
-    job_id: str,  # noqa: ARG001
+    job_id: str,
     task_id: str,
     run_id: str,
 ) -> dict[str, Any]:
     root = database_root.expanduser().resolve(strict=False)
+    safe_id_segment(job_id, field="job_id")
+    task_id = safe_id_segment(task_id, field="task_id")
     rid = _safe_run_id(run_id)
-    evidence = resolve_evidence_root(root, rid, task_id=task_id)
+    get_job(root, job_id)
+    evidence = resolve_evidence_root(root, rid, task_id=task_id, require_task_match=True)
     inv_root = evidence / "agent" / "invocations"
     steps: list[dict[str, Any]] = []
     invocations: list[dict[str, Any]] = []

--- a/src/bora/viewer/trials.py
+++ b/src/bora/viewer/trials.py
@@ -243,13 +243,169 @@ def _available_tabs(evidence: Path) -> list[str]:
         pass
     if (evidence / "lock.json").is_file():
         tabs.append("lock")
+    # Runtime facts: effects / cleanup / summary (not agent trajectory, not artifacts)
     if (
         (evidence / "effects.jsonl").is_file()
         or (evidence / "cleanup.json").is_file()
         or (evidence / "summary.json").is_file()
+        or (evidence / "agent.json").is_file()
+        or (evidence / "harness.json").is_file()
     ):
-        tabs.append("log")
+        tabs.append("runtime")
     return tabs
+
+
+# Known ACP registry entry ids — longest match first when stripping from profile ids.
+_ACP_ENTRY_SUFFIXES = (
+    "claude-code",
+    "grok-build",
+    "opencode",
+    "codex",
+    "grok",
+    "pi",
+)
+
+
+def _profile_entry(profile: dict[str, Any]) -> str | None:
+    opts = profile.get("options") if isinstance(profile.get("options"), dict) else {}
+    entry = opts.get("entry") if isinstance(opts, dict) else None
+    if isinstance(entry, str) and entry.strip():
+        return entry.strip()
+    pid = profile.get("id")
+    if not isinstance(pid, str) or not pid:
+        return None
+    lower = pid.lower()
+    for suf in _ACP_ENTRY_SUFFIXES:
+        if lower == suf or lower.endswith("-" + suf) or lower.endswith("_" + suf):
+            return suf
+    return None
+
+
+def _profile_role(profile_id: str, entry: str | None) -> str:
+    """Role label: profile id with trailing entry suffix removed when present."""
+    if entry:
+        for sep in ("-", "_"):
+            suffix = sep + entry
+            if profile_id.lower().endswith(suffix.lower()) and len(profile_id) > len(suffix):
+                return profile_id[: -len(suffix)]
+    return profile_id
+
+
+def _docker_label(result: dict[str, Any], summary: dict[str, Any]) -> str | None:
+    """Short docker placement label when this Attempt used Docker/L1; else None."""
+    runtime_kind = str(result.get("runtime_kind") or summary.get("runtime_kind") or "")
+    assurance = str(result.get("assurance") or summary.get("assurance") or "")
+    l1 = result.get("l1") if isinstance(result.get("l1"), dict) else None
+    if l1 is None:
+        l1 = summary.get("l1") if isinstance(summary.get("l1"), dict) else None
+    is_docker = "docker" in runtime_kind.lower() or assurance.lower() == "l1" or l1 is not None
+    if not is_docker:
+        return None
+    parts: list[str] = ["docker"]
+    if isinstance(l1, dict):
+        platform = l1.get("platform")
+        if isinstance(platform, str) and platform:
+            parts.append(platform)
+        iso = l1.get("isolation") if isinstance(l1.get("isolation"), dict) else {}
+        net = iso.get("network") if isinstance(iso, dict) else None
+        if isinstance(net, str) and net:
+            parts.append(net)
+        loc = l1.get("execution_location")
+        if isinstance(loc, str) and loc and loc not in parts:
+            parts.append(loc)
+    return " · ".join(parts)
+
+
+def _agent_surface(
+    evidence: Path,
+    *,
+    lock: dict[str, Any],
+    result: dict[str, Any],
+    summary: dict[str, Any],
+) -> dict[str, Any]:
+    """Deterministic agent surface from lock profiles + invocation metadata.
+
+    Missing optional fields stay null; never invents values. Priority:
+    lock.profiles for declared rows; invocation metadata overrides model when set.
+    """
+    profiles_raw = [p for p in (lock.get("profiles") or []) if isinstance(p, dict)]
+    by_id: dict[str, dict[str, Any]] = {}
+    for p in profiles_raw:
+        pid = p.get("id")
+        if isinstance(pid, str) and pid:
+            by_id[pid] = p
+
+    # Order of appearance: first from invocations (actual use), else lock order.
+    ordered_ids: list[str] = []
+    inv_model: dict[str, str] = {}
+    inv_executor: dict[str, str] = {}
+    inv_root = evidence / "agent" / "invocations"
+    if inv_root.is_dir():
+        try:
+            inv_dirs = sorted(p for p in inv_root.iterdir() if p.is_dir())
+        except OSError:
+            inv_dirs = []
+        for inv in inv_dirs:
+            meta = _read_json_object(inv / "metadata.json") or {}
+            pid = meta.get("profile_id")
+            if isinstance(pid, str) and pid:
+                if pid not in ordered_ids:
+                    ordered_ids.append(pid)
+                mid = meta.get("model")
+                if isinstance(mid, str) and mid:
+                    inv_model[pid] = mid
+                ek = meta.get("executor_kind")
+                if isinstance(ek, str) and ek:
+                    inv_executor[pid] = ek
+    if not ordered_ids:
+        ordered_ids = [pid for pid in by_id]
+
+    actors: list[dict[str, Any]] = []
+    executors: list[str] = []
+    for pid in ordered_ids:
+        p = by_id.get(pid, {"id": pid})
+        entry = _profile_entry(p)
+        ex = p.get("executor") if isinstance(p.get("executor"), str) else None
+        if not ex:
+            ex = inv_executor.get(pid)
+        if isinstance(ex, str) and ex and ex not in executors:
+            executors.append(ex)
+        caps = p.get("capabilities") if isinstance(p.get("capabilities"), dict) else {}
+        if caps.get("execution_mode") == "acp-stdio" and "acp" not in executors:
+            executors.append("acp")
+        model = inv_model.get(pid) or (p.get("model") if isinstance(p.get("model"), str) else None)
+        # agent column = ACP entry when known, else executor kind, else profile id
+        agent_col = entry or ex or pid
+        role_col = _profile_role(pid, entry) if entry else pid
+        actors.append(
+            {
+                "role": role_col,
+                "agent": agent_col,
+                "model": model,
+                "profile_id": pid,
+            }
+        )
+
+    # Framework: unified ACP client → "acp"; else first executor kind.
+    if any(a.get("agent") in _ACP_ENTRY_SUFFIXES for a in actors) or "acp" in executors:
+        framework = "acp"
+    elif executors:
+        framework = executors[0]
+    else:
+        framework = None
+
+    docker = _docker_label(result, summary)
+
+    return {
+        "framework": framework,
+        "docker": docker,
+        "actors": actors,
+        # Keep thin aliases for older clients / tests
+        "agent_label": actors[0]["role"] if len(actors) == 1 else None,
+        "model_label": actors[0]["model"] if len(actors) == 1 else None,
+        "executor_kind": executors[0] if executors else None,
+        "profiles": actors,
+    }
 
 
 def _trial_meta_from_evidence(
@@ -274,6 +430,7 @@ def _trial_meta_from_evidence(
         score = summary.get("score")
     error = suite_row.get("error") or result.get("error") or summary.get("error")
     locked_task = lock.get("task_id") if isinstance(lock.get("task_id"), str) else None
+    surface = _agent_surface(evidence, lock=lock, result=result, summary=summary)
 
     return {
         "trial_id": run_id,
@@ -291,7 +448,14 @@ def _trial_meta_from_evidence(
         "available_tabs": _available_tabs(evidence),
         "agent_invocations": result.get("agent_invocations") or summary.get("agent_invocations"),
         "harness_kind": result.get("harness_kind") or summary.get("harness_kind"),
-        "note": "trajectory and harness status are not PASS; PASS is per-task evaluator only",
+        "framework": surface.get("framework"),
+        "docker": surface.get("docker"),
+        "actors": surface.get("actors") or [],
+        "agent_label": surface.get("agent_label"),
+        "model_label": surface.get("model_label"),
+        "executor_kind": surface.get("executor_kind"),
+        "profiles": surface.get("profiles") or [],
+        "note": None,
     }
 
 
@@ -385,7 +549,7 @@ def list_task_trials(
             {"label": task_id, "href": f"/jobs/{job_id}/tasks/{task_id}"},
             {"label": "trials", "href": None},
         ],
-        "note": "per-task evaluator verdicts only; trajectory is not PASS",
+        "note": None,
     }
 
 
@@ -434,8 +598,7 @@ def get_trial(
             "evidence_relpath": None,
             "has_evidence": False,
             "available_tabs": [],
-            "note": "no local evidence tree for this run_id; files/trajectory unavailable "
-            "(not PASS)",
+            "note": "no local evidence tree for this run_id",
         }
     else:
         meta = _trial_meta_from_evidence(evidence, run_id=rid, task_id=task_id, suite_row=suite_row)
@@ -551,19 +714,38 @@ def trial_tree(
         }
 
     if scope_norm == "artifacts":
+        # Publishable / harness-produced product files — not root runtime bookkeeping.
+        # Prefer package artifacts/ then harness/ subtree (e.g. terminal.json, published JSON).
         entries = []
-        for sub_name in ("harness", "artifacts"):
-            sub = evidence / sub_name
+        for sub in (
+            evidence / "artifacts",
+            evidence / "harness",
+            evidence / "agent" / "artifacts",
+        ):
             if sub.is_dir():
                 entries.extend(
                     _walk_tree(evidence, sub, max_entries=MAX_TREE_ENTRIES - len(entries))
                 )
+            elif sub.is_file():
+                try:
+                    entries.append(
+                        {
+                            "path": str(sub.relative_to(evidence)),
+                            "name": sub.name,
+                            "type": "file",
+                            "size": sub.stat().st_size,
+                        }
+                    )
+                except (OSError, ValueError):
+                    pass
         return {
             "ok": True,
             "run_id": rid,
             "scope": "artifacts",
             "entries": entries[:MAX_TREE_ENTRIES],
             "truncated": len(entries) > MAX_TREE_ENTRIES,
+            "note": "publishable outputs under artifacts/ and harness/; "
+            "runtime bookkeeping is under Runtime tab",
         }
 
     if scope_norm == "lock":
@@ -580,7 +762,7 @@ def trial_tree(
             )
         return {"ok": True, "run_id": rid, "scope": "lock", "entries": entries, "truncated": False}
 
-    if scope_norm == "log":
+    if scope_norm in {"runtime", "log"}:  # "log" accepted as alias
         entries = []
         for name in ("effects.jsonl", "cleanup.json", "summary.json", "agent.json", "harness.json"):
             p = evidence / name
@@ -593,7 +775,13 @@ def trial_tree(
                         "size": p.stat().st_size,
                     }
                 )
-        return {"ok": True, "run_id": rid, "scope": "log", "entries": entries, "truncated": False}
+        return {
+            "ok": True,
+            "run_id": rid,
+            "scope": "runtime",
+            "entries": entries,
+            "truncated": False,
+        }
 
     base = _scope_base(evidence, scope_norm)
     if not base.exists():
@@ -808,7 +996,7 @@ def trial_trajectory(
         "step_count": len(steps),
         "invocations": invocations,
         "truncated": truncated,
-        "note": "trajectory is observational evidence; not PASS",
+        "note": None,
     }
 
 

--- a/tests/config/test_provenance.py
+++ b/tests/config/test_provenance.py
@@ -1,0 +1,227 @@
+"""Package provenance field validation, lock inclusion, Database→task merge (#18)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from bora.adapters.package_fs import LocalPackageReader
+from bora.config.capabilities import DeclarationCapabilityCatalog
+from bora.config.database import load_database_manifest
+from bora.config.errors import ConfigError
+from bora.config.load_and_lock import ConfigCore
+from bora.config.model import thaw
+from bora.config.provenance import merge_provenance, validate_provenance
+
+REPO = Path(__file__).resolve().parents[2]
+MINIMAL = REPO / "examples" / "core" / "tasks" / "config-minimal"
+
+
+def _minimal_task_yaml(*, extra: str = "", task_id: str = "config-minimal") -> str:
+    base = (MINIMAL / "task.yaml").read_text(encoding="utf-8")
+    if not extra:
+        return base
+    # Append provenance (or other) block after task document.
+    return base.rstrip() + "\n\n" + textwrap.dedent(extra).lstrip() + "\n"
+
+
+def _write_task_pkg(tmp: Path, *, yaml_text: str, task_id: str = "config-minimal") -> Path:
+    pkg = tmp / task_id
+    pkg.mkdir(parents=True)
+    (pkg / "task.yaml").write_text(yaml_text, encoding="utf-8")
+    (pkg / "harness.py").write_text("#\n", encoding="utf-8")
+    (pkg / "evaluator.py").write_text("#\n", encoding="utf-8")
+    return pkg
+
+
+@pytest.fixture
+def core() -> ConfigCore:
+    return ConfigCore(package_reader=LocalPackageReader())
+
+
+@pytest.fixture
+def catalog() -> DeclarationCapabilityCatalog:
+    return DeclarationCapabilityCatalog()
+
+
+def test_validate_original_minimal() -> None:
+    out = validate_provenance({"kind": "original"})
+    assert out == {"kind": "original"}
+
+
+def test_validate_port_requires_url_and_pin() -> None:
+    with pytest.raises(ConfigError) as ei:
+        validate_provenance({"kind": "port"})
+    assert ei.value.error_code == "invalid_schema"
+
+    with pytest.raises(ConfigError):
+        validate_provenance(
+            {
+                "kind": "port",
+                "upstream": {"url": "https://github.com/example/repo"},
+            }
+        )
+
+    ok = validate_provenance(
+        {
+            "kind": "port",
+            "upstream": {
+                "name": "tau-bench",
+                "url": "https://github.com/example/tau-bench",
+                "commit": "abc123def",
+                "task_id": "airline-001",
+            },
+            "parity": {"claims": ["protocol"], "known_gaps": ["tool names"]},
+        }
+    )
+    assert ok["kind"] == "port"
+    assert ok["upstream"]["commit"] == "abc123def"
+    assert ok["parity"]["claims"] == ["protocol"]
+
+
+def test_merge_task_overrides_database() -> None:
+    db = {"kind": "port", "upstream": {"url": "https://a.example", "ref": "v1"}}
+    task = {"kind": "original"}
+    assert merge_provenance(database=db, task=task) == task
+    assert merge_provenance(database=db, task=None) == db
+    assert merge_provenance(database=None, task=None) is None
+
+
+def test_lock_includes_task_provenance(
+    core: ConfigCore, catalog: DeclarationCapabilityCatalog, tmp_path: Path
+) -> None:
+    yaml = _minimal_task_yaml(
+        extra="""
+        provenance:
+          kind: original
+        """
+    )
+    pkg = _write_task_pkg(tmp_path, yaml_text=yaml)
+    locked = core.load_and_lock(pkg, "config-minimal", capabilities=catalog)
+    assert thaw(locked.provenance) == {"kind": "original"}
+    assert "provenance" in locked.canonical_payload()
+    # Digest changes vs no-provenance baseline from examples/core
+    base = core.load_and_lock(MINIMAL, "config-minimal", capabilities=catalog)
+    assert locked.digest != base.digest
+
+
+def test_database_default_applied(
+    core: ConfigCore, catalog: DeclarationCapabilityCatalog, tmp_path: Path
+) -> None:
+    pkg = _write_task_pkg(tmp_path, yaml_text=_minimal_task_yaml())
+    locked = core.load_and_lock(
+        pkg,
+        "config-minimal",
+        capabilities=catalog,
+        database_provenance={
+            "kind": "wrapper",
+            "upstream": {
+                "url": "https://github.com/example/suite",
+                "ref": "v0.2.0",
+            },
+        },
+    )
+    prov = thaw(locked.provenance)
+    assert prov["kind"] == "wrapper"
+    assert prov["upstream"]["ref"] == "v0.2.0"
+    sources = [e.source for e in locked.resolution.entries]
+    assert "database" in sources
+
+
+def test_task_provenance_overrides_database(
+    core: ConfigCore, catalog: DeclarationCapabilityCatalog, tmp_path: Path
+) -> None:
+    yaml = _minimal_task_yaml(
+        extra="""
+        provenance:
+          kind: original
+        """
+    )
+    pkg = _write_task_pkg(tmp_path, yaml_text=yaml)
+    locked = core.load_and_lock(
+        pkg,
+        "config-minimal",
+        capabilities=catalog,
+        database_provenance={
+            "kind": "port",
+            "upstream": {
+                "url": "https://github.com/example/x",
+                "commit": "deadbeef",
+            },
+        },
+    )
+    assert thaw(locked.provenance) == {"kind": "original"}
+
+
+def test_invalid_port_fails_lock(
+    core: ConfigCore, catalog: DeclarationCapabilityCatalog, tmp_path: Path
+) -> None:
+    yaml = _minimal_task_yaml(
+        extra="""
+        provenance:
+          kind: port
+          upstream:
+            name: incomplete
+        """
+    )
+    pkg = _write_task_pkg(tmp_path, yaml_text=yaml)
+    with pytest.raises(ConfigError) as ei:
+        core.load_and_lock(pkg, "config-minimal", capabilities=catalog)
+    assert ei.value.error_code == "invalid_schema"
+
+
+def test_database_manifest_accepts_provenance(tmp_path: Path) -> None:
+    root = tmp_path / "db"
+    root.mkdir()
+    (root / "bora.yaml").write_text(
+        textwrap.dedent(
+            """
+            format: bora.database/1
+            database_id: test/prov-db
+            version: "0.1.0"
+            tasks:
+              root: tasks
+            provenance:
+              kind: original
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    (root / "tasks" / "alpha").mkdir(parents=True)
+    (root / "tasks" / "alpha" / "task.yaml").write_text(
+        textwrap.dedent(
+            """
+            format: bora.task/1
+            task_id: alpha
+            harness:
+              runtime: python
+              entrypoint: harness:run
+            provider:
+              kind: local
+            agent_profiles: []
+            limits:
+              wall_time_seconds: 60
+              agent_invocations: 0
+              environment_actions: 0
+              memory_mb: 256
+            artifacts:
+              publishable: []
+            evaluation:
+              runtime: python
+              entrypoint: evaluator:evaluate
+              network: none
+              inputs: []
+              output:
+                format: json
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    (root / "tasks" / "alpha" / "harness.py").write_text("#\n", encoding="utf-8")
+    (root / "tasks" / "alpha" / "evaluator.py").write_text("#\n", encoding="utf-8")
+
+    man = load_database_manifest(root)
+    assert man.provenance is not None
+    assert man.provenance["kind"] == "original"

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -244,3 +244,43 @@ def test_missing_run_raises(tmp_path: Path) -> None:
     _seed_suite_run(db)
     with pytest.raises(ConfigError):
         trials.resolve_evidence_root(db, "does_not_exist")
+
+
+def test_path_ids_reject_traversal(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    with pytest.raises(ConfigError):
+        jobs.get_job(db, "../etc")
+    with pytest.raises(ConfigError):
+        jobs.get_job_task(db, job_id, "../alpha")
+    with pytest.raises(ConfigError):
+        trials.resolve_evidence_root(db, "run_alpha_1/../x", task_id="alpha")
+    with pytest.raises(ConfigError):
+        trials.trial_file(
+            db,
+            job_id,
+            "alpha",
+            "run_alpha_1",
+            relpath="/etc/passwd",
+        )
+
+
+def test_cross_task_evidence_rejected(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    # Evidence locked to alpha, requested under beta
+    _write_evidence(db, "run_alpha_1", task_id="alpha")
+    with pytest.raises(ConfigError):
+        trials.resolve_evidence_root(db, "run_alpha_1", task_id="beta", require_task_match=True)
+    with pytest.raises(ConfigError):
+        trials.trial_trajectory(db, job_id, "beta", "run_alpha_1")
+
+
+def test_missing_evidence_suite_row_ok(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    # suite has run_beta_1 but no on-disk evidence
+    detail = trials.get_trial(db, job_id, "beta", "run_beta_1")
+    assert detail["trial"]["has_evidence"] is False
+    assert detail["trial"]["available_tabs"] == []
+    assert detail["trial"]["status"] == "FAIL"

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -1,0 +1,246 @@
+"""Attempt / trial evidence API tests for local viewer (#26)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from bora.config.errors import ConfigError
+from bora.viewer import jobs, trials
+
+REPO = Path(__file__).resolve().parents[2]
+SUITE = REPO / "tests" / "fixtures" / "databases" / "suite-min"
+
+
+def _seed_suite_run(db: Path, job_id: str = "suite_demo_job_001") -> str:
+    suite_dir = db / ".bora" / "suite-runs" / job_id
+    suite_dir.mkdir(parents=True, exist_ok=True)
+    summary = {
+        "schema": "bora.suite.summary/1",
+        "suite_run_id": job_id,
+        "database_id": "test/suite-min",
+        "database_version": "0.1.0",
+        "agent_label": "codex",
+        "model_label": "gpt-test",
+        "provider_label": "openai",
+        "environment": "local",
+        "created_at": "2026-07-14T19:46:20Z",
+        "tasks": [
+            {"task_id": "alpha", "status": "PASS", "score": 1.0, "run_id": "run_alpha_1"},
+            {"task_id": "beta", "status": "FAIL", "score": 0.0, "run_id": "run_beta_1"},
+        ],
+        "task_refs": [
+            {"task_id": "alpha", "status": "PASS", "score": 1.0, "run_id": "run_alpha_1"},
+            {"task_id": "beta", "status": "FAIL", "score": 0.0, "run_id": "run_beta_1"},
+        ],
+        "metrics": {
+            "pass_rate": 0.5,
+            "mean_score": 0.5,
+            "n_tasks": 2,
+            "n_pass": 1,
+            "n_fail": 1,
+            "n_error": 0,
+            "missing_score_as": 0.0,
+        },
+        "exit_code": 1,
+        "note": "per-task evaluator verdicts only; no suite-level PASS",
+    }
+    (suite_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    return job_id
+
+
+def _write_evidence(db: Path, run_id: str, *, task_id: str = "alpha") -> Path:
+    root = db / ".bora" / "runs" / run_id
+    inv = root / "agent" / "invocations" / "0001-inv_test"
+    inv.mkdir(parents=True, exist_ok=True)
+    (root / "evaluation").mkdir(parents=True, exist_ok=True)
+    (root / "harness").mkdir(parents=True, exist_ok=True)
+
+    (root / "lock.json").write_text(
+        json.dumps({"task_id": task_id, "digest": "sha256:deadbeef"}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    (root / "result.json").write_text(
+        json.dumps(
+            {
+                "status": "PASS",
+                "score": 1.0,
+                "error": None,
+                "agent_invocations": 1,
+                "harness_kind": "completed",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "summary.json").write_text(
+        json.dumps(
+            {
+                "schema": "bora.evidence.summary/1",
+                "run_id": run_id,
+                "status": "PASS",
+                "score": 1.0,
+                "agent_invocations": 1,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "effects.jsonl").write_text(
+        json.dumps({"kind": "effect", "ok": True}) + "\n", encoding="utf-8"
+    )
+    (root / "cleanup.json").write_text(json.dumps({"ok": True}) + "\n", encoding="utf-8")
+    (root / "evaluation" / "raw.json").write_text(
+        json.dumps({"verdict": "PASS", "score": 1.0}) + "\n", encoding="utf-8"
+    )
+    (inv / "metadata.json").write_text(
+        json.dumps(
+            {
+                "invocation_id": "inv_test",
+                "profile_id": "main",
+                "executor_kind": "acp",
+                "model": "test-model",
+                "status": "completed",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    traj = [
+        {"type": "turn", "role": "user", "content": "hello", "turn_index": 1, "source": "bora"},
+        {
+            "type": "turn",
+            "role": "assistant",
+            "content": "world",
+            "turn_index": 1,
+            "source": "acp",
+        },
+        {
+            "type": "terminal",
+            "ok": True,
+            "stop_reason": "end_turn",
+            "source": "bora",
+            "turn_index": 1,
+        },
+    ]
+    (inv / "trajectory.jsonl").write_text(
+        "\n".join(json.dumps(x) for x in traj) + "\n", encoding="utf-8"
+    )
+    (inv / "final-response.json").write_text(
+        json.dumps({"content": "world"}) + "\n", encoding="utf-8"
+    )
+    return root
+
+
+def _clean_db(tmp_path: Path) -> Path:
+    db = tmp_path / "db"
+    shutil.copytree(SUITE, db, ignore=shutil.ignore_patterns(".bora"))
+    return db
+
+
+def test_resolve_and_trial_detail(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    _write_evidence(db, "run_alpha_1", task_id="alpha")
+
+    evidence = trials.resolve_evidence_root(db, "run_alpha_1", task_id="alpha")
+    assert evidence.is_dir()
+    assert (evidence / "lock.json").is_file()
+
+    detail = trials.get_trial(db, job_id, "alpha", "run_alpha_1")
+    assert detail["ok"] is True
+    assert detail["trial"]["run_id"] == "run_alpha_1"
+    assert detail["trial"]["status"] == "PASS"
+    tabs = detail["trial"]["available_tabs"]
+    assert "trajectory" in tabs
+    assert "agent" in tabs
+    assert "verifier" in tabs
+    assert "lock" in tabs
+    assert "log" in tabs
+    assert "PASS" not in (detail["trial"].get("note") or "") or "not PASS" in (
+        detail["trial"].get("note") or ""
+    )
+
+
+def test_trajectory_steps(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    _write_evidence(db, "run_alpha_1", task_id="alpha")
+
+    traj = trials.trial_trajectory(db, job_id, "alpha", "run_alpha_1")
+    assert traj["step_count"] >= 3
+    roles = [s.get("role") for s in traj["steps"] if s.get("role")]
+    assert "user" in roles
+    assert "assistant" in roles
+    assert "not PASS" in (traj.get("note") or "")
+
+
+def test_tree_and_file_and_traversal(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    _write_evidence(db, "run_alpha_1", task_id="alpha")
+
+    tree = trials.trial_tree(db, job_id, "alpha", "run_alpha_1", scope="agent")
+    paths = {e["path"] for e in tree["entries"]}
+    assert any("trajectory.jsonl" in p for p in paths)
+
+    file_payload = trials.trial_file(
+        db,
+        job_id,
+        "alpha",
+        "run_alpha_1",
+        relpath="lock.json",
+    )
+    assert file_payload["encoding"] == "utf-8"
+    assert "task_id" in (file_payload.get("content") or "")
+
+    with pytest.raises(ConfigError):
+        trials.trial_file(
+            db,
+            job_id,
+            "alpha",
+            "run_alpha_1",
+            relpath="../escape.txt",
+        )
+
+
+def test_list_trials_enriches_evidence(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    _write_evidence(db, "run_alpha_1", task_id="alpha")
+    # Extra local run for same task (not in suite summary)
+    _write_evidence(db, "run_alpha_extra", task_id="alpha")
+
+    listed = trials.list_task_trials(db, job_id, "alpha")
+    run_ids = {t["run_id"] for t in listed["trials"]}
+    assert "run_alpha_1" in run_ids
+    assert "run_alpha_extra" in run_ids
+    alpha1 = next(t for t in listed["trials"] if t["run_id"] == "run_alpha_1")
+    assert alpha1["has_evidence"] is True
+    assert "trajectory" in alpha1["available_tabs"]
+
+
+def test_task_page_uses_enriched_trials(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    _write_evidence(db, "run_beta_1", task_id="beta")
+    # Server path logic: merge list into get_job_task shape
+    base = jobs.get_job_task(db, job_id, "beta")
+    listed = trials.list_task_trials(db, job_id, "beta")
+    base["trials"] = listed["trials"]
+    assert len(base["trials"]) >= 1
+    assert base["trials"][0]["run_id"] == "run_beta_1"
+    assert base["trials"][0].get("has_evidence") is True
+
+
+def test_missing_run_raises(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    _seed_suite_run(db)
+    with pytest.raises(ConfigError):
+        trials.resolve_evidence_root(db, "does_not_exist")

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -60,7 +60,23 @@ def _write_evidence(db: Path, run_id: str, *, task_id: str = "alpha") -> Path:
     (root / "harness").mkdir(parents=True, exist_ok=True)
 
     (root / "lock.json").write_text(
-        json.dumps({"task_id": task_id, "digest": "sha256:deadbeef"}, indent=2) + "\n",
+        json.dumps(
+            {
+                "task_id": task_id,
+                "digest": "sha256:deadbeef",
+                "profiles": [
+                    {
+                        "id": "main",
+                        "executor": "acp",
+                        "model": "test-model",
+                        "options": {"entry": "pi"},
+                        "capabilities": {"execution_mode": "acp-stdio"},
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
         encoding="utf-8",
     )
     (root / "result.json").write_text(
@@ -162,10 +178,14 @@ def test_resolve_and_trial_detail(tmp_path: Path) -> None:
     assert "agent" in tabs
     assert "verifier" in tabs
     assert "lock" in tabs
-    assert "log" in tabs
-    assert "PASS" not in (detail["trial"].get("note") or "") or "not PASS" in (
-        detail["trial"].get("note") or ""
-    )
+    assert "runtime" in tabs
+    assert detail["trial"].get("framework") == "acp"
+    assert detail["trial"].get("docker") is None
+    actors = detail["trial"].get("actors") or []
+    assert len(actors) == 1
+    assert actors[0]["role"] == "main"
+    assert actors[0]["agent"] == "pi"
+    assert actors[0]["model"] == "test-model"
 
 
 def test_trajectory_steps(tmp_path: Path) -> None:
@@ -178,7 +198,6 @@ def test_trajectory_steps(tmp_path: Path) -> None:
     roles = [s.get("role") for s in traj["steps"] if s.get("role")]
     assert "user" in roles
     assert "assistant" in roles
-    assert "not PASS" in (traj.get("note") or "")
 
 
 def test_tree_and_file_and_traversal(tmp_path: Path) -> None:


### PR DESCRIPTION
## 摘要

本 PR 相对 `main` 交付两块能力（实现于 `dev`，含 follow-up 打磨）：

1. **#26 本地 Viewer Attempt 详情** — Jobs → task → trial/run 可钻取 evidence  
2. **#18 package provenance** — 配置契约 + lock 摘要；journeys 示例已填

## 功能说明

### Viewer / Attempt 详情（#26）

- 路由：`/jobs/:jobId/tasks/:taskId/trials/:runId`
- 只读 API：trial 列表 / meta / tree / file / trajectory  
- Tabs 按磁盘是否有文件出现：Trajectory · Agent · Verifier · Artifacts · Lock · Runtime  
- 顶栏：`task · framework · docker`；actors 表：Role / Agent / Model  
- 文件预览：JSON/JSONL 高亮；亮色主题 code 区浅底  
- 路径沙箱：`job_id` / `task_id` / `run_id` 单段；文件 `..` fail-closed  
- 无本地 evidence 时仍可看 suite meta（空 tabs）

<img width="1459" height="972" alt="image" src="https://github.com/user-attachments/assets/3d645d9a-60e1-4bb3-aedd-e4f85265ff18" />

<img width="1432" height="829" alt="image" src="https://github.com/user-attachments/assets/8e28d6bc-6cc8-43e2-8445-2e0139aff5c0" />


### Provenance（#18）

- 可选字段：`bora.yaml` / `task.yaml`；task 整段覆盖 database 默认  
- `port` / `reimplementation` / `wrapper` 需 `upstream.url` + `ref|commit`  
- 进入 lock digest / `bora lock` 摘要；agent 路径可写入 evidence `lock.json`  
- design §6.7 + `bora-config-package` skill 已同步  
- `examples/journeys` 四个 task 已标注 original / reimplementation  

## 测试

- `uv run pytest tests/viewer tests/config -q`
- `apps/viewer`：`pnpm build`（`dist/` 不进 git）

## 关联

- Closes #26  
- Closes #18  
- Related #27  