### PR TITLE
feat: Viewer multi-role Time/Usage/provenance + ACP usage 归一化（#27 #30）

### DIFF
--- a/apps/viewer/src/lib/api.ts
+++ b/apps/viewer/src/lib/api.ts
@@ -60,10 +60,34 @@ export type Trial = {
     agent: string;
     model?: string | null;
     profile_id?: string;
+    invokes?: number;
+    latency_ms_sum?: number | null;
+    /** e.g. "8.3s (1)" — sum of inv latency_ms */
+    time_label?: string | null;
+    usage?: {
+      input_tokens?: number | null;
+      output_tokens?: number | null;
+      total_tokens?: number | null;
+      cached_read_tokens?: number | null;
+      cache_hit_rate?: number | null;
+      cost_amount?: number | null;
+      cost_currency?: string | null;
+      context_used?: number | null;
+      context_size?: number | null;
+      label?: string | null;
+    } | null;
+    /** e.g. "in 11.4K / out 140 · cache 75% · $0.012" (observational ≠ PASS) */
+    usage_label?: string | null;
   }>;
   agent_label?: string | null;
   model_label?: string | null;
   executor_kind?: string | null;
+  /** Full lock provenance when present */
+  provenance?: Record<string, unknown> | null;
+  /** lock.provenance.upstream.url for top-bar link */
+  upstream_url?: string | null;
+  upstream_name?: string | null;
+  upstream_ref?: string | null;
   note?: string | null;
 };
 
@@ -72,6 +96,9 @@ export type TreeEntry = {
   name: string;
   type: "file" | "dir";
   size?: number | null;
+  /** Present on agent/invocations/* entries when metadata has profile_id */
+  profile_id?: string | null;
+  invocation?: string | null;
 };
 
 export type TrajectoryStep = {
@@ -85,6 +112,9 @@ export type TrajectoryStep = {
   error?: string | null;
   invocation?: string;
   invocation_id?: string;
+  /** Package role profile (actors key); not message role user/assistant */
+  profile_id?: string | null;
+  model?: string | null;
   line?: number;
   usage?: Record<string, unknown> | null;
   metadata?: Record<string, unknown> | null;
@@ -179,6 +209,12 @@ export function fetchTrialTree(
     run_id: string;
     scope: string;
     entries: TreeEntry[];
+    /** Virtual profile groups for Agent tab (paths stay real) */
+    groups?: Array<{
+      key: string;
+      profile_id?: string | null;
+      label?: string;
+    }> | null;
     truncated?: boolean;
     note?: string;
   }>(`${trialBase(jobId, taskId, runId)}/tree?${q}`);

--- a/apps/viewer/src/pages/TrialDetailPage.tsx
+++ b/apps/viewer/src/pages/TrialDetailPage.tsx
@@ -69,6 +69,9 @@ export function TrialDetailPage() {
   const [trajLoading, setTrajLoading] = useState(false);
 
   const [tree, setTree] = useState<TreeEntry[]>([]);
+  const [treeGroups, setTreeGroups] = useState<
+    Array<{ key: string; profile_id?: string | null; label?: string }> | null
+  >(null);
   const [treeLoading, setTreeLoading] = useState(false);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [fileContent, setFileContent] = useState<string | null>(null);
@@ -163,11 +166,13 @@ export function TrialDetailPage() {
     setSelectedPath(null);
     setFileContent(null);
     setFileNote(null);
+    setTreeGroups(null);
     fetchTrialTree(jobId, taskId, runId, scope)
       .then((data) => {
         if (cancelled) return;
         const files = (data.entries || []).filter((e) => e.type === "file");
         setTree(files);
+        setTreeGroups(data.groups || null);
         // Auto-open a sensible default file
         const preferred =
           files.find((f) => f.name === "lock.json") ||
@@ -244,7 +249,7 @@ export function TrialDetailPage() {
             <h1 className="text-2xl font-semibold tracking-tight text-ink font-mono truncate">
               {runId}
             </h1>
-            {/* Same mute/body style: task · framework · docker(if any) */}
+            {/* Same mute/body style: task · framework · docker · upstream(if any) */}
             <p className="text-sm text-mute mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
               <span>
                 task{" "}
@@ -268,6 +273,22 @@ export function TrialDetailPage() {
                   <span className="text-body font-medium font-mono text-[13px]">
                     {trial.docker}
                   </span>
+                </>
+              ) : null}
+              {trial?.upstream_url ? (
+                <>
+                  <span className="text-mute select-none" aria-hidden>
+                    ·
+                  </span>
+                  <a
+                    href={trial.upstream_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-link hover:text-link-deep font-mono text-[13px] truncate max-w-[min(48ch,100%)]"
+                    title={trial.upstream_name || trial.upstream_url}
+                  >
+                    {trial.upstream_url}
+                  </a>
                 </>
               ) : null}
             </p>
@@ -331,33 +352,54 @@ export function TrialDetailPage() {
               </p>
             ) : null}
 
-            {/* Actors: role · agent · model — above Trajectory tabs */}
+            {/* Actors: Role | Agent | Model | Time | Usage — observational ≠ PASS */}
             {trial.actors && trial.actors.length > 0 ? (
-              <div className="rounded-[8px] border border-hairline overflow-hidden">
-                <Table>
-                  <TableHeader>
-                    <TableRow className="hover:bg-transparent">
-                      <TableHead>Role</TableHead>
-                      <TableHead>Agent</TableHead>
-                      <TableHead>Model</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {trial.actors.map((a) => (
-                      <TableRow key={a.profile_id || `${a.role}-${a.agent}`}>
-                        <TableCell className="font-medium font-mono text-[13px]">
-                          {a.role}
-                        </TableCell>
-                        <TableCell className="font-mono text-[13px] text-body">
-                          {a.agent}
-                        </TableCell>
-                        <TableCell className="font-mono text-[13px] text-mute">
-                          {a.model || "-"}
-                        </TableCell>
+              <div className="space-y-1.5">
+                <div className="rounded-[8px] border border-hairline overflow-hidden overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow className="hover:bg-transparent">
+                        <TableHead>Role</TableHead>
+                        <TableHead>Agent</TableHead>
+                        <TableHead>Model</TableHead>
+                        <TableHead>Time</TableHead>
+                        <TableHead>Usage</TableHead>
                       </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
+                    </TableHeader>
+                    <TableBody>
+                      {trial.actors.map((a) => (
+                        <TableRow key={a.profile_id || `${a.role}-${a.agent}`}>
+                          <TableCell className="font-medium font-mono text-[13px]">
+                            {a.role}
+                          </TableCell>
+                          <TableCell className="font-mono text-[13px] text-body">
+                            {a.agent}
+                          </TableCell>
+                          <TableCell className="font-mono text-[13px] text-mute">
+                            {a.model || "-"}
+                          </TableCell>
+                          <TableCell className="font-mono text-[13px] tabular text-body">
+                            {a.time_label || "-"}
+                          </TableCell>
+                          <TableCell
+                            className="font-mono text-[12px] text-mute max-w-[36ch]"
+                            title={
+                              a.usage_label
+                                ? "Observational usage (tokens/cost); not PASS authority. Cache hit = cached_read / input when present. Session-last invoke for cumulative fields."
+                                : undefined
+                            }
+                          >
+                            {a.usage_label || "-"}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+                <p className="text-[11px] text-mute">
+                  Time sums inv latency. Usage is last-invoke session snapshot
+                  (tokens/cost); trajectory and usage are not PASS.
+                </p>
               </div>
             ) : null}
 
@@ -398,6 +440,7 @@ export function TrialDetailPage() {
                     steps={steps}
                     note={trajNote}
                     result={result}
+                    actors={trial.actors || []}
                   />
                 )}
 
@@ -410,6 +453,9 @@ export function TrialDetailPage() {
                     fileContent={fileContent}
                     fileLoading={fileLoading}
                     fileNote={fileNote}
+                    groupByProfile={activeTab === "agent"}
+                    actors={trial.actors || []}
+                    apiGroups={treeGroups}
                   />
                 )}
               </div>
@@ -445,17 +491,49 @@ function Outcome({
   );
 }
 
+type ActorRow = NonNullable<Trial["actors"]>[number];
+
+function actorLabel(a: ActorRow | undefined, profileId: string): string {
+  if (!a) return profileId;
+  const bits = [a.role || profileId];
+  if (a.agent) bits.push(String(a.agent));
+  if (a.model) bits.push(String(a.model));
+  return bits.join(" · ");
+}
+
 function TrajectoryPanel({
   loading,
   steps,
   note,
   result,
+  actors,
 }: {
   loading: boolean;
   steps: TrajectoryStep[];
   note: string | null;
   result: Record<string, unknown> | null;
+  actors: ActorRow[];
 }) {
+  const groups = useMemo(() => {
+    const actorByPid = new Map(
+      actors.map((a) => [a.profile_id || `${a.role}-${a.agent}`, a]),
+    );
+    const order: string[] = [];
+    const byProfile = new Map<string, TrajectoryStep[]>();
+    for (const s of steps) {
+      const key =
+        (typeof s.profile_id === "string" && s.profile_id) ||
+        "__ungrouped__";
+      if (!byProfile.has(key)) {
+        byProfile.set(key, []);
+        order.push(key);
+      }
+      byProfile.get(key)!.push(s);
+    }
+    const multi = order.filter((k) => k !== "__ungrouped__").length >= 2;
+    return { order, byProfile, actorByPid, multi };
+  }, [steps, actors]);
+
   if (loading) return <p className="text-sm text-mute">Loading trajectory…</p>;
   if (!steps.length) {
     return (
@@ -469,11 +547,11 @@ function TrajectoryPanel({
       </div>
     );
   }
-  return (
-    <div className="space-y-2">
-      {note ? <p className="text-xs text-mute">{note}</p> : null}
-      <ol className="space-y-2 max-h-[70vh] overflow-y-auto pr-1">
-        {steps.map((s, i) => {
+
+  function renderSteps(list: TrajectoryStep[], showProfileBadge: boolean) {
+    return (
+      <ol className="space-y-2">
+        {list.map((s, i) => {
           const role = (s.role || s.type || "event").toString();
           const isUser = role === "user";
           const isAsst = role === "assistant";
@@ -497,6 +575,11 @@ function TrajectoryPanel({
                 >
                   {role}
                 </span>
+                {showProfileBadge && s.profile_id ? (
+                  <span className="rounded bg-canvas-soft border border-hairline px-1.5 py-0 font-mono text-[11px] text-body">
+                    {s.profile_id}
+                  </span>
+                ) : null}
                 {s.turn_index != null ? <span>turn {s.turn_index}</span> : null}
                 {s.invocation ? (
                   <span className="font-mono truncate max-w-[24ch]">{s.invocation}</span>
@@ -517,6 +600,45 @@ function TrajectoryPanel({
           );
         })}
       </ol>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {note ? <p className="text-xs text-mute">{note}</p> : null}
+      <p className="text-[11px] text-mute">
+        Trajectory is observational only; independent evaluator owns PASS.
+      </p>
+      {groups.multi ? (
+        <div className="space-y-4 max-h-[70vh] overflow-y-auto pr-1">
+          {groups.order.map((pid) => {
+            const list = groups.byProfile.get(pid) || [];
+            const actor =
+              pid === "__ungrouped__"
+                ? undefined
+                : groups.actorByPid.get(pid);
+            const title =
+              pid === "__ungrouped__"
+                ? "ungrouped"
+                : actorLabel(actor, pid);
+            return (
+              <section key={pid} className="space-y-2">
+                <h3 className="text-xs font-medium text-ink sticky top-0 bg-canvas/95 backdrop-blur-sm py-1 border-b border-hairline font-mono">
+                  {title}
+                  <span className="text-mute font-normal ml-2">
+                    {list.length} step{list.length === 1 ? "" : "s"}
+                  </span>
+                </h3>
+                {renderSteps(list, false)}
+              </section>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="max-h-[70vh] overflow-y-auto pr-1">
+          {renderSteps(steps, false)}
+        </div>
+      )}
     </div>
   );
 }
@@ -529,6 +651,9 @@ function FileSplitPanel({
   fileContent,
   fileLoading,
   fileNote,
+  groupByProfile = false,
+  actors = [],
+  apiGroups = null,
 }: {
   tree: TreeEntry[];
   treeLoading: boolean;
@@ -537,7 +662,55 @@ function FileSplitPanel({
   fileContent: string | null;
   fileLoading: boolean;
   fileNote: string | null;
+  groupByProfile?: boolean;
+  actors?: ActorRow[];
+  apiGroups?: Array<{
+    key: string;
+    profile_id?: string | null;
+    label?: string;
+  }> | null;
 }) {
+  // Virtual profile folders for multi-role Agent tab (real paths preserved).
+  const groupedTree = useMemo(() => {
+    if (!groupByProfile || tree.length === 0) return null;
+    const profileKeys = new Set(
+      tree.map((e) => e.profile_id).filter((p): p is string => !!p),
+    );
+    if (profileKeys.size < 2) return null;
+
+    const actorByPid = new Map(
+      actors.map((a) => [a.profile_id || "", a] as const),
+    );
+    const order: string[] = [];
+    if (apiGroups && apiGroups.length > 0) {
+      for (const g of apiGroups) {
+        if (g.key && !order.includes(g.key)) order.push(g.key);
+      }
+    }
+    for (const e of tree) {
+      const key = e.profile_id || "__ungrouped__";
+      if (!order.includes(key)) order.push(key);
+    }
+
+    const byKey = new Map<string, TreeEntry[]>();
+    for (const e of tree) {
+      const key = e.profile_id || "__ungrouped__";
+      if (!byKey.has(key)) byKey.set(key, []);
+      byKey.get(key)!.push(e);
+    }
+
+    const labels = new Map<string, string>();
+    for (const key of order) {
+      if (key === "__ungrouped__") {
+        labels.set(key, "other");
+        continue;
+      }
+      const actor = actorByPid.get(key);
+      labels.set(key, actor ? actorLabel(actor, key) : key);
+    }
+    return { order, byKey, labels };
+  }, [tree, groupByProfile, actors, apiGroups]);
+
   return (
     <div
       className={cn(
@@ -558,6 +731,38 @@ function FileSplitPanel({
           <p className="text-xs text-mute p-3">Loading tree…</p>
         ) : tree.length === 0 ? (
           <p className="text-xs text-mute p-3">No files in this scope.</p>
+        ) : groupedTree ? (
+          <div className="py-1 min-h-[140px] md:min-h-[380px]">
+            {groupedTree.order.map((key) => (
+              <div key={key} className="mb-1">
+                <div
+                  className="px-3 py-1 text-[11px] font-mono text-mute sticky top-0 bg-canvas-soft border-b border-hairline/60 truncate"
+                  title={groupedTree.labels.get(key)}
+                >
+                  {groupedTree.labels.get(key)}
+                </div>
+                <ul>
+                  {(groupedTree.byKey.get(key) || []).map((e) => (
+                    <li key={e.path}>
+                      <button
+                        type="button"
+                        onClick={() => onSelect(e.path)}
+                        className={cn(
+                          "w-full text-left px-3 py-1.5 text-[12px] font-mono truncate transition-colors",
+                          selectedPath === e.path
+                            ? "bg-canvas text-ink font-medium"
+                            : "text-body hover:bg-canvas/80",
+                        )}
+                        title={e.path}
+                      >
+                        {e.invocation ? `${e.invocation}/${e.name}` : e.path}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
         ) : (
           <ul className="py-1 min-h-[140px] md:min-h-[380px]">
             {tree.map((e) => (

--- a/src/bora/adapters/agent_acp.py
+++ b/src/bora/adapters/agent_acp.py
@@ -777,9 +777,7 @@ class AcpExecutor:
             event_prompt_usage: dict[str, Any] = self._client.prompt_usage
             if prompt_usage_raw is not None and hasattr(prompt_usage_raw, "model_dump"):
                 with contextlib_suppress(Exception):
-                    dumped_prompt = prompt_usage_raw.model_dump(
-                        by_alias=True, exclude_none=True
-                    )
+                    dumped_prompt = prompt_usage_raw.model_dump(by_alias=True, exclude_none=True)
                     if isinstance(dumped_prompt, dict):
                         event_prompt_usage = dumped_prompt
             self._client.events.append(

--- a/src/bora/adapters/agent_acp.py
+++ b/src/bora/adapters/agent_acp.py
@@ -26,6 +26,151 @@ from bora.adapters.agent_contract import AgentResult, parse_validated_text_struc
 ProcessLauncher = Callable[..., Any]
 
 
+def _as_plain_mapping(obj: Any) -> dict[str, Any] | None:
+    """Best-effort dict from pydantic model / mapping (snake_case preferred)."""
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return dict(obj)
+    with contextlib_suppress(Exception):
+        if hasattr(obj, "model_dump"):
+            # exclude_none + no alias → snake_case field names from acp.schema
+            dumped = obj.model_dump(exclude_none=True)
+            if isinstance(dumped, dict):
+                return dumped
+    with contextlib_suppress(Exception):
+        if hasattr(obj, "model_dump"):
+            dumped = obj.model_dump(by_alias=True, exclude_none=True)
+            if isinstance(dumped, dict):
+                return dumped
+    return None
+
+
+def _pick_int(data: Mapping[str, Any], *keys: str) -> int | None:
+    for key in keys:
+        if key not in data:
+            continue
+        val = data[key]
+        if isinstance(val, bool):
+            continue
+        if isinstance(val, int):
+            return val
+        if isinstance(val, float) and val == int(val):
+            return int(val)
+    return None
+
+
+def _pick_number(data: Mapping[str, Any], *keys: str) -> float | int | None:
+    for key in keys:
+        if key not in data:
+            continue
+        val = data[key]
+        if isinstance(val, bool):
+            continue
+        if isinstance(val, (int, float)):
+            return val
+    return None
+
+
+def normalize_acp_usage(
+    prompt_usage: Any = None,
+    usage_update: Any = None,
+) -> dict[str, Any] | None:
+    """Merge ACP dual-source usage into one observational dict (issue #30).
+
+    Two protocol sources with different semantics:
+
+    * ``PromptResponse.usage`` (``Usage``): billable/session **token** counts
+      (``inputTokens`` / ``outputTokens`` / …).
+    * ``sessionUpdate: usage_update`` (``UsageUpdate``): **context occupancy**
+      (``used`` / ``size``) and optional session **cost** — ``used`` is *not*
+      token total.
+
+    Output shape (omit empty sections; no ``uncached_*`` fields)::
+
+        {
+          "input_tokens": int, "output_tokens": int, "total_tokens": int,
+          "thought_tokens": int, "cached_read_tokens": int, "cached_write_tokens": int,
+          "cost": {"amount": number, "currency": "USD"},
+          "context": {"used": int, "size": int},
+          "sources": {"prompt_usage": bool, "usage_update": bool}
+        }
+
+    Missing fields stay absent. Never invents tokens from ``context.used``.
+    Not PASS authority.
+    """
+    prompt_map = _as_plain_mapping(prompt_usage)
+    update_map = _as_plain_mapping(usage_update)
+    out: dict[str, Any] = {}
+    has_prompt = False
+    has_update = False
+
+    if prompt_map:
+        # Accept snake_case (model fields) and camelCase (wire / by_alias dump).
+        token_pairs = (
+            ("input_tokens", ("input_tokens", "inputTokens")),
+            ("output_tokens", ("output_tokens", "outputTokens")),
+            ("total_tokens", ("total_tokens", "totalTokens")),
+            ("thought_tokens", ("thought_tokens", "thoughtTokens")),
+            ("cached_read_tokens", ("cached_read_tokens", "cachedReadTokens")),
+            ("cached_write_tokens", ("cached_write_tokens", "cachedWriteTokens")),
+        )
+        for out_key, aliases in token_pairs:
+            val = _pick_int(prompt_map, *aliases)
+            if val is not None:
+                out[out_key] = val
+                has_prompt = True
+        # Derive total when both sides present and total missing.
+        if "total_tokens" not in out:
+            inp = out.get("input_tokens")
+            outp = out.get("output_tokens")
+            if isinstance(inp, int) and isinstance(outp, int):
+                out["total_tokens"] = inp + outp
+                has_prompt = True
+
+    if update_map:
+        # Context occupancy — never promote used → input_tokens.
+        used = _pick_int(update_map, "used")
+        size = _pick_int(update_map, "size")
+        if used is not None or size is not None:
+            ctx: dict[str, Any] = {}
+            if used is not None:
+                ctx["used"] = used
+            if size is not None:
+                ctx["size"] = size
+            out["context"] = ctx
+            has_update = True
+        cost_raw = update_map.get("cost")
+        cost_map = _as_plain_mapping(cost_raw) if cost_raw is not None else None
+        if cost_map:
+            amount = _pick_number(cost_map, "amount")
+            currency = cost_map.get("currency")
+            cost_out: dict[str, Any] = {}
+            if amount is not None:
+                cost_out["amount"] = amount
+            if isinstance(currency, str) and currency.strip():
+                cost_out["currency"] = currency.strip()
+            if cost_out:
+                out["cost"] = cost_out
+                has_update = True
+        elif used is not None or size is not None:
+            pass  # context already recorded
+        # Bare update with only sessionUpdate marker still counts as source if
+        # we already got context/cost; else ignore empty shell.
+        if not has_update and ("session_update" in update_map or "sessionUpdate" in update_map):
+            # Keep raw empty update out of normalized payload.
+            pass
+
+    if not has_prompt and not has_update:
+        return None
+
+    out["sources"] = {
+        "prompt_usage": has_prompt,
+        "usage_update": has_update,
+    }
+    return out
+
+
 def write_trajectory_jsonl(
     inv_dir: Path,
     *,
@@ -211,11 +356,22 @@ def _auto_approve_permission(options: Sequence[Any]) -> Any:
 
 @dataclass
 class _BoraAcpClient:
-    """Minimal Client: auto-approve permission, decline elicitation, collect updates."""
+    """Minimal Client: auto-approve permission, decline elicitation, collect updates.
+
+    Usage sources are intentionally split (issue #30):
+
+    * ``latest_usage_update`` — raw ``UsageUpdate`` stream (context used/size + cost)
+    * ``prompt_usage`` — set by the executor after ``session/prompt`` returns
+      ``PromptResponse.usage`` (token counts)
+
+    Normalized merge lives in :func:`normalize_acp_usage`; do not treat
+    ``UsageUpdate.used`` as billable tokens.
+    """
 
     events: list[dict[str, Any]] = field(default_factory=list)
     text_chunks: list[str] = field(default_factory=list)
-    usage: dict[str, Any] | None = None
+    latest_usage_update: dict[str, Any] | None = None
+    prompt_usage: dict[str, Any] | None = None
     permission_decisions: list[dict[str, Any]] = field(default_factory=list)
     _conn: Any = None
 
@@ -287,17 +443,29 @@ class _BoraAcpClient:
                 # normalize camelCase keys already in model_dump; keep flat helpers
                 key = "tool_call_id" if attr in {"tool_call_id", "toolCallId"} else attr
                 event[key] = val if not hasattr(val, "value") else str(val)
-        # UsageUpdate
-        if "Usage" in update_type:
-            usage_obj = getattr(update, "usage", None) or update
-            with contextlib_suppress(Exception):
-                if hasattr(usage_obj, "model_dump"):
-                    self.usage = usage_obj.model_dump(by_alias=True, exclude_none=True)
-                elif isinstance(usage_obj, dict):
-                    self.usage = usage_obj
-            if self.usage is not None:
-                event["usage"] = self.usage
-            event["has_usage"] = True
+        # UsageUpdate (context occupancy + cost) — not PromptResponse token Usage.
+        dumped_raw = event.get("update")
+        dumped_update: dict[str, Any] = dumped_raw if isinstance(dumped_raw, dict) else {}
+        session_upd = (
+            getattr(update, "session_update", None)
+            or dumped_update.get("sessionUpdate")
+            or dumped_update.get("session_update")
+        )
+        is_usage_update = (
+            update_type in {"UsageUpdate", "_UsageUpdate"}
+            or "UsageUpdate" in update_type
+            or (isinstance(session_upd, str) and session_upd.lower() == "usage_update")
+        )
+        if is_usage_update:
+            raw_update = _as_plain_mapping(update)
+            if raw_update is None and isinstance(event.get("update"), dict):
+                raw_update = dict(event["update"])
+            if raw_update is not None:
+                self.latest_usage_update = raw_update
+                event["usage_update"] = raw_update
+                # Keep legacy key for older event consumers (raw UsageUpdate shape).
+                event["usage"] = raw_update
+            event["has_usage_update"] = True
         self.events.append(event)
 
     async def write_text_file(
@@ -579,7 +747,8 @@ class AcpExecutor:
         self._client.text_chunks.clear()
         self._client.events.clear()
         self._client.permission_decisions.clear()
-        self._client.usage = None
+        self._client.latest_usage_update = None
+        self._client.prompt_usage = None
 
         try:
             resp = await self._conn.prompt(
@@ -599,6 +768,28 @@ class AcpExecutor:
                 ok=False,
                 error=err,
                 stop=None,
+            )
+
+        # Token authority: PromptResponse.usage (may be absent on older agents).
+        prompt_usage_raw = getattr(resp, "usage", None)
+        self._client.prompt_usage = _as_plain_mapping(prompt_usage_raw)
+        if self._client.prompt_usage is not None:
+            event_prompt_usage: dict[str, Any] = self._client.prompt_usage
+            if prompt_usage_raw is not None and hasattr(prompt_usage_raw, "model_dump"):
+                with contextlib_suppress(Exception):
+                    dumped_prompt = prompt_usage_raw.model_dump(
+                        by_alias=True, exclude_none=True
+                    )
+                    if isinstance(dumped_prompt, dict):
+                        event_prompt_usage = dumped_prompt
+            self._client.events.append(
+                {
+                    "type": "prompt_usage",
+                    "session_id": self._acp_session_id,
+                    "source": "acp",
+                    # Wire-ish camelCase when available for protocol cross-check.
+                    "prompt_usage": event_prompt_usage,
+                }
             )
 
         stop = getattr(resp, "stop_reason", None) or getattr(resp, "stopReason", None)
@@ -632,7 +823,14 @@ class AcpExecutor:
             "integration_mode": self.descriptor.integration_mode,
         }
         events = tuple(self._client.events) if self._client else ()
-        usage = self._client.usage if self._client else None
+        # Dual-source normalize: tokens from PromptResponse.usage; cost/context
+        # from latest UsageUpdate. Never maps context.used → input_tokens.
+        usage = None
+        if self._client is not None:
+            usage = normalize_acp_usage(
+                prompt_usage=self._client.prompt_usage,
+                usage_update=self._client.latest_usage_update,
+            )
         return AgentResult(
             model=str(self._actual_model or self.model),
             text=text,

--- a/src/bora/cli/main.py
+++ b/src/bora/cli/main.py
@@ -893,10 +893,12 @@ def view_command(
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=2) from exc
     except FileNotFoundError as exc:
-        typer.echo(f"invalid_package: {exc}", err=True)
+        typer.echo(f"viewer: {exc}", err=True)
         raise typer.Exit(code=2) from exc
     except OSError as exc:
-        typer.echo(f"invalid_package: {exc}", err=True)
+        # Prefer strerror / args message (serve_viewer embeds host:port on bind fail).
+        detail = exc.strerror or (exc.args[1] if len(exc.args) > 1 else None) or str(exc)
+        typer.echo(f"viewer: {detail}", err=True)
         raise typer.Exit(code=2) from exc
 
 

--- a/src/bora/viewer/server.py
+++ b/src/bora/viewer/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import mimetypes
 import sys
@@ -18,6 +19,35 @@ from bora.viewer import browse, jobs, trials
 # Default bind: loopback only.
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
+
+
+def _bind_url(host: str, port: int) -> str:
+    """Operator-facing bind URL (clickable in most terminals)."""
+    # IPv6 literals need brackets in URLs.
+    if ":" in host and not host.startswith("["):
+        return f"http://[{host}]:{port}/"
+    return f"http://{host}:{port}/"
+
+
+def _raise_bind_error(host: str, port: int, exc: OSError) -> None:
+    """Re-raise bind failures with a concrete URL (OS strerror often omits it)."""
+    url = _bind_url(host, port)
+    en = getattr(exc, "errno", None)
+    if en in {errno.EADDRINUSE, getattr(errno, "WSAEADDRINUSE", -1)}:
+        raise OSError(
+            en,
+            f"address already in use: {url} "
+            f"(stop the other process or pass --port <free>; --port 0 = ephemeral)",
+        ) from exc
+    if en in {errno.EADDRNOTAVAIL, errno.EACCES, getattr(errno, "WSAEACCES", -1)}:
+        raise OSError(
+            en,
+            f"cannot bind {url}: {exc.strerror or exc}",
+        ) from exc
+    raise OSError(
+        en or 0,
+        f"cannot bind {url}: {exc.strerror or exc}",
+    ) from exc
 
 
 def static_dir() -> Path:
@@ -225,7 +255,11 @@ def serve_viewer(
     overview = browse.database_overview(root)
     assets = static_dir()
     handler = make_handler(root, assets)
-    server = ThreadingHTTPServer((host, port), handler)
+    try:
+        server = ThreadingHTTPServer((host, port), handler)
+    except OSError as exc:
+        _raise_bind_error(host, port, exc)
+        raise  # pragma: no cover — _raise_bind_error always raises
     # If port 0, OS assigns.
     actual_host, actual_port = server.server_address[:2]
     url = f"http://{actual_host}:{actual_port}/"

--- a/src/bora/viewer/trials.py
+++ b/src/bora/viewer/trials.py
@@ -400,8 +400,10 @@ def _usage_summary_for_actor(usage: dict[str, Any] | None) -> dict[str, Any] | N
     if context_size is None:
         context_size = _as_int(usage.get("size"))
 
+    # Hit rate only when cached_read is a share of input (0..1). Some vendors
+    # report cumulative/session cached_read >> per-turn input — omit label then.
     cache_hit_rate: float | None = None
-    if inp is not None and inp > 0 and cached_read is not None:
+    if inp is not None and inp > 0 and cached_read is not None and cached_read <= inp:
         cache_hit_rate = cached_read / inp
 
     has_tokens = inp is not None or outp is not None

--- a/src/bora/viewer/trials.py
+++ b/src/bora/viewer/trials.py
@@ -353,12 +353,94 @@ def _as_int(val: Any) -> int | None:
     return None
 
 
+def _cache_hit_heuristic(
+    *,
+    input_tokens: int | None,
+    cached_read_tokens: int | None,
+    total_tokens: int | None = None,
+    cached_write_tokens: int | None = None,
+) -> dict[str, Any]:
+    """Infer cache relation + hit rate from ACP Usage numbers (#30/#27).
+
+    ACP does **not** fix whether ``cachedReadTokens ⊆ inputTokens``. Entries map
+    vendor APIs differently (OpenAI-style inclusion vs Anthropic-style disjoint).
+    Heuristic only — not PASS authority, not protocol law.
+
+    - **inclusion** (``0 < cache ≤ input``): hit = cache / input;
+      display total input stays ``input``.
+    - **disjoint** (``cache > input``): hit = cache / (input + cache [+ write]);
+      display total input = that denominator.
+    - Prefer ``total_tokens`` as a weak corroboration when both models are
+      plausible (not used to invent a third model).
+    - Missing/zero cache → no rate.
+    """
+    empty: dict[str, Any] = {
+        "cache_relation": None,
+        "cache_hit_rate": None,
+        "display_input_tokens": input_tokens,
+    }
+    if input_tokens is None or cached_read_tokens is None:
+        return empty
+    if input_tokens < 0 or cached_read_tokens < 0:
+        return empty
+    if cached_read_tokens == 0:
+        # Explicit zero cache: rate 0% only when we have positive input.
+        if input_tokens > 0:
+            return {
+                "cache_relation": "inclusion",
+                "cache_hit_rate": 0.0,
+                "display_input_tokens": input_tokens,
+            }
+        return empty
+
+    write = (
+        cached_write_tokens
+        if isinstance(cached_write_tokens, int) and cached_write_tokens > 0
+        else 0
+    )
+
+    # Size-based primary split.
+    if cached_read_tokens <= input_tokens and input_tokens > 0:
+        relation = "inclusion"
+        # Weak total check: if total ≈ input+cache, prefer disjoint anyway.
+        if (
+            total_tokens is not None
+            and total_tokens > 0
+            and abs(total_tokens - (input_tokens + cached_read_tokens))
+            <= max(8, int(0.02 * total_tokens))
+            and abs(total_tokens - input_tokens) > max(8, int(0.02 * total_tokens))
+        ):
+            relation = "disjoint"
+    else:
+        # cache > input (or input == 0 with positive cache)
+        relation = "disjoint"
+
+    if relation == "inclusion":
+        rate = cached_read_tokens / input_tokens if input_tokens > 0 else None
+        return {
+            "cache_relation": "inclusion",
+            "cache_hit_rate": rate,
+            "display_input_tokens": input_tokens,
+        }
+
+    # disjoint: Anthropic-style parallel buckets
+    denom = input_tokens + cached_read_tokens + write
+    if denom <= 0:
+        return empty
+    rate = cached_read_tokens / denom
+    return {
+        "cache_relation": "disjoint",
+        "cache_hit_rate": rate,
+        "display_input_tokens": denom,
+    }
+
+
 def _usage_summary_for_actor(usage: dict[str, Any] | None) -> dict[str, Any] | None:
     """Normalize a terminal usage dict into viewer-facing summary fields (#27/#30).
 
     - Prefer normalized keys (input_tokens / output_tokens / cost / context).
     - Never treat legacy ``used`` (context occupancy) as tokens.
-    - Cache hit rate only when input_tokens > 0 and cached_read_tokens present.
+    - Cache hit rate via :func:`_cache_hit_heuristic` (inclusion vs disjoint).
     - Observational only; not PASS authority.
     """
     if not isinstance(usage, dict) or not usage:
@@ -374,6 +456,11 @@ def _usage_summary_for_actor(usage: dict[str, Any] | None) -> dict[str, Any] | N
         usage.get("cached_read_tokens")
         if "cached_read_tokens" in usage
         else usage.get("cachedReadTokens")
+    )
+    cached_write = _as_int(
+        usage.get("cached_write_tokens")
+        if "cached_write_tokens" in usage
+        else usage.get("cachedWriteTokens")
     )
     total = _as_int(
         usage.get("total_tokens") if "total_tokens" in usage else usage.get("totalTokens")
@@ -400,11 +487,17 @@ def _usage_summary_for_actor(usage: dict[str, Any] | None) -> dict[str, Any] | N
     if context_size is None:
         context_size = _as_int(usage.get("size"))
 
-    # Hit rate only when cached_read is a share of input (0..1). Some vendors
-    # report cumulative/session cached_read >> per-turn input — omit label then.
-    cache_hit_rate: float | None = None
-    if inp is not None and inp > 0 and cached_read is not None and cached_read <= inp:
-        cache_hit_rate = cached_read / inp
+    cache_info = _cache_hit_heuristic(
+        input_tokens=inp,
+        cached_read_tokens=cached_read,
+        total_tokens=total,
+        cached_write_tokens=cached_write,
+    )
+    cache_hit_rate = cache_info.get("cache_hit_rate")
+    cache_relation = cache_info.get("cache_relation")
+    display_input = cache_info.get("display_input_tokens")
+    if not isinstance(display_input, int):
+        display_input = inp
 
     has_tokens = inp is not None or outp is not None
     has_cost = cost_amount is not None
@@ -417,16 +510,19 @@ def _usage_summary_for_actor(usage: dict[str, Any] | None) -> dict[str, Any] | N
         "output_tokens": outp,
         "total_tokens": total,
         "cached_read_tokens": cached_read,
+        "cached_write_tokens": cached_write,
         "cache_hit_rate": cache_hit_rate,
+        "cache_relation": cache_relation,
+        "display_input_tokens": display_input,
         "cost_amount": cost_amount,
         "cost_currency": cost_currency,
         "context_used": context_used,
         "context_size": context_size,
         # Human label assembled server-side so SPA stays thin; observational.
         "label": _format_usage_label(
-            input_tokens=inp,
+            input_tokens=display_input,
             output_tokens=outp,
-            cache_hit_rate=cache_hit_rate,
+            cache_hit_rate=cache_hit_rate if isinstance(cache_hit_rate, float) else None,
             cost_amount=cost_amount,
             cost_currency=cost_currency,
         ),
@@ -442,14 +538,19 @@ def _format_usage_label(
     cost_amount: float | int | None,
     cost_currency: str | None,
 ) -> str | None:
-    """Compact Usage column text, e.g. ``in 11.4K / out 140 · cache 75% · $0.012``."""
+    """Compact Usage column text, e.g. ``in 11.4K / out 140 · cache 75% · $0.012``.
+
+    ``input_tokens`` here is the **display** total (inclusion: raw input;
+    disjoint: input + cached_read [+ write]).
+    """
     parts: list[str] = []
     if input_tokens is not None or output_tokens is not None:
         in_s = _fmt_token_count(input_tokens) if input_tokens is not None else "-"
         out_s = _fmt_token_count(output_tokens) if output_tokens is not None else "-"
         parts.append(f"in {in_s} / out {out_s}")
     if cache_hit_rate is not None:
-        parts.append(f"cache {cache_hit_rate * 100:.0f}%")
+        pct = max(0.0, min(1.0, float(cache_hit_rate))) * 100.0
+        parts.append(f"cache {pct:.0f}%")
     if cost_amount is not None:
         cur = (cost_currency or "").upper()
         if cur in {"", "USD"}:

--- a/src/bora/viewer/trials.py
+++ b/src/bora/viewer/trials.py
@@ -316,6 +316,205 @@ def _docker_label(result: dict[str, Any], summary: dict[str, Any]) -> str | None
     return " · ".join(parts)
 
 
+def _read_terminal_usage(traj_path: Path) -> dict[str, Any] | None:
+    """Last terminal.usage object from a trajectory.jsonl (fail-open)."""
+    if not traj_path.is_file():
+        return None
+    last: dict[str, Any] | None = None
+    try:
+        with traj_path.open("r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                raw = line.strip()
+                if not raw:
+                    continue
+                try:
+                    obj = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                if obj.get("type") != "terminal":
+                    continue
+                usage = obj.get("usage")
+                if isinstance(usage, dict) and usage:
+                    last = usage
+    except OSError:
+        return None
+    return last
+
+
+def _as_int(val: Any) -> int | None:
+    if isinstance(val, bool):
+        return None
+    if isinstance(val, int):
+        return val
+    if isinstance(val, float) and val == int(val):
+        return int(val)
+    return None
+
+
+def _usage_summary_for_actor(usage: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Normalize a terminal usage dict into viewer-facing summary fields (#27/#30).
+
+    - Prefer normalized keys (input_tokens / output_tokens / cost / context).
+    - Never treat legacy ``used`` (context occupancy) as tokens.
+    - Cache hit rate only when input_tokens > 0 and cached_read_tokens present.
+    - Observational only; not PASS authority.
+    """
+    if not isinstance(usage, dict) or not usage:
+        return None
+
+    inp = _as_int(
+        usage.get("input_tokens") if "input_tokens" in usage else usage.get("inputTokens")
+    )
+    outp = _as_int(
+        usage.get("output_tokens") if "output_tokens" in usage else usage.get("outputTokens")
+    )
+    cached_read = _as_int(
+        usage.get("cached_read_tokens")
+        if "cached_read_tokens" in usage
+        else usage.get("cachedReadTokens")
+    )
+    total = _as_int(
+        usage.get("total_tokens") if "total_tokens" in usage else usage.get("totalTokens")
+    )
+
+    cost_raw = usage.get("cost")
+    cost_amount: float | int | None = None
+    cost_currency: str | None = None
+    if isinstance(cost_raw, dict):
+        amt = cost_raw.get("amount")
+        if isinstance(amt, (int, float)) and not isinstance(amt, bool):
+            cost_amount = amt
+        cur = cost_raw.get("currency")
+        if isinstance(cur, str) and cur.strip():
+            cost_currency = cur.strip()
+    # Legacy flat cost is rare; ignore non-mapping.
+
+    context_raw = usage.get("context") if isinstance(usage.get("context"), dict) else None
+    context_used = _as_int(context_raw.get("used")) if isinstance(context_raw, dict) else None
+    context_size = _as_int(context_raw.get("size")) if isinstance(context_raw, dict) else None
+    # Old evidence: top-level used/size only — keep as context, never as tokens.
+    if context_used is None:
+        context_used = _as_int(usage.get("used"))
+    if context_size is None:
+        context_size = _as_int(usage.get("size"))
+
+    cache_hit_rate: float | None = None
+    if inp is not None and inp > 0 and cached_read is not None:
+        cache_hit_rate = cached_read / inp
+
+    has_tokens = inp is not None or outp is not None
+    has_cost = cost_amount is not None
+    has_context = context_used is not None or context_size is not None
+    if not has_tokens and not has_cost and not has_context:
+        return None
+
+    summary: dict[str, Any] = {
+        "input_tokens": inp,
+        "output_tokens": outp,
+        "total_tokens": total,
+        "cached_read_tokens": cached_read,
+        "cache_hit_rate": cache_hit_rate,
+        "cost_amount": cost_amount,
+        "cost_currency": cost_currency,
+        "context_used": context_used,
+        "context_size": context_size,
+        # Human label assembled server-side so SPA stays thin; observational.
+        "label": _format_usage_label(
+            input_tokens=inp,
+            output_tokens=outp,
+            cache_hit_rate=cache_hit_rate,
+            cost_amount=cost_amount,
+            cost_currency=cost_currency,
+        ),
+    }
+    return summary
+
+
+def _format_usage_label(
+    *,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    cache_hit_rate: float | None,
+    cost_amount: float | int | None,
+    cost_currency: str | None,
+) -> str | None:
+    """Compact Usage column text, e.g. ``in 11.4K / out 140 · cache 75% · $0.012``."""
+    parts: list[str] = []
+    if input_tokens is not None or output_tokens is not None:
+        in_s = _fmt_token_count(input_tokens) if input_tokens is not None else "-"
+        out_s = _fmt_token_count(output_tokens) if output_tokens is not None else "-"
+        parts.append(f"in {in_s} / out {out_s}")
+    if cache_hit_rate is not None:
+        parts.append(f"cache {cache_hit_rate * 100:.0f}%")
+    if cost_amount is not None:
+        cur = (cost_currency or "").upper()
+        if cur in {"", "USD"}:
+            parts.append(f"${_fmt_cost(cost_amount)}")
+        else:
+            parts.append(f"{_fmt_cost(cost_amount)} {cur}")
+    if not parts:
+        return None
+    return " · ".join(parts)
+
+
+def _fmt_token_count(n: int) -> str:
+    if n >= 1_000_000:
+        v = n / 1_000_000
+        return f"{int(v)}M" if v == int(v) else f"{v:.1f}M"
+    if n >= 1000:
+        v = n / 1000
+        return f"{int(v)}K" if v == int(v) else f"{v:.1f}K"
+    return str(n)
+
+
+def _fmt_cost(amount: float | int) -> str:
+    if isinstance(amount, int) or float(amount) == int(amount):
+        if float(amount) == 0:
+            return "0"
+        return f"{float(amount):.4g}"
+    # Prefer up to 4 significant decimals for small USD amounts.
+    return f"{float(amount):.4g}"
+
+
+def _format_latency_ms(total_ms: float | None, invokes: int) -> str | None:
+    if total_ms is None:
+        return None
+    seconds = total_ms / 1000.0
+    if seconds >= 10:
+        body = f"{seconds:.0f}s"
+    elif seconds >= 1:
+        body = f"{seconds:.1f}s".replace(".0s", "s")
+    else:
+        body = f"{total_ms:.0f}ms"
+    if invokes > 0:
+        return f"{body} ({invokes})"
+    return body
+
+
+def _provenance_surface(lock: dict[str, Any]) -> dict[str, Any]:
+    """Project lock provenance for Attempt top bar (url only when present)."""
+    prov = lock.get("provenance")
+    if not isinstance(prov, dict):
+        return {
+            "provenance": None,
+            "upstream_url": None,
+            "upstream_name": None,
+            "upstream_ref": None,
+        }
+    upstream = prov.get("upstream") if isinstance(prov.get("upstream"), dict) else {}
+    url = upstream.get("url") if isinstance(upstream, dict) else None
+    name = upstream.get("name") if isinstance(upstream, dict) else None
+    ref = upstream.get("ref") if isinstance(upstream, dict) else None
+    return {
+        "provenance": prov,
+        "upstream_url": url if isinstance(url, str) and url.strip() else None,
+        "upstream_name": name if isinstance(name, str) and name.strip() else None,
+        "upstream_ref": ref if isinstance(ref, str) and ref.strip() else None,
+    }
+
+
 def _agent_surface(
     evidence: Path,
     *,
@@ -327,6 +526,9 @@ def _agent_surface(
 
     Missing optional fields stay null; never invents values. Priority:
     lock.profiles for declared rows; invocation metadata overrides model when set.
+
+    Per-profile Time / Usage (#27): sum latency_ms; take **last** invoke usage
+    (session-cumulative tokens/cost — do not sum cumulative fields).
     """
     profiles_raw = [p for p in (lock.get("profiles") or []) if isinstance(p, dict)]
     by_id: dict[str, dict[str, Any]] = {}
@@ -339,6 +541,11 @@ def _agent_surface(
     ordered_ids: list[str] = []
     inv_model: dict[str, str] = {}
     inv_executor: dict[str, str] = {}
+    # Aggregation state per profile_id
+    latency_sum: dict[str, float] = {}
+    invoke_count: dict[str, int] = {}
+    last_usage: dict[str, dict[str, Any]] = {}
+
     inv_root = evidence / "agent" / "invocations"
     if inv_root.is_dir():
         try:
@@ -357,6 +564,14 @@ def _agent_surface(
                 ek = meta.get("executor_kind")
                 if isinstance(ek, str) and ek:
                     inv_executor[pid] = ek
+                invoke_count[pid] = invoke_count.get(pid, 0) + 1
+                lat = meta.get("latency_ms")
+                if isinstance(lat, (int, float)) and not isinstance(lat, bool):
+                    latency_sum[pid] = latency_sum.get(pid, 0.0) + float(lat)
+                usage = _read_terminal_usage(inv / "trajectory.jsonl")
+                if usage is not None:
+                    # Last invoke wins (session cumulative semantics).
+                    last_usage[pid] = usage
     if not ordered_ids:
         ordered_ids = [pid for pid in by_id]
 
@@ -378,12 +593,22 @@ def _agent_surface(
         # agent column = ACP entry when known, else executor kind, else profile id
         agent_col = entry or ex or pid
         role_col = _profile_role(pid, entry) if entry else pid
+        n_inv = invoke_count.get(pid, 0)
+        lat_total = latency_sum.get(pid)
+        usage_summary = _usage_summary_for_actor(last_usage.get(pid))
         actors.append(
             {
                 "role": role_col,
                 "agent": agent_col,
                 "model": model,
                 "profile_id": pid,
+                "invokes": n_inv,
+                "latency_ms_sum": lat_total,
+                "time_label": _format_latency_ms(lat_total, n_inv),
+                "usage": usage_summary,
+                "usage_label": (
+                    usage_summary.get("label") if isinstance(usage_summary, dict) else None
+                ),
             }
         )
 
@@ -396,6 +621,7 @@ def _agent_surface(
         framework = None
 
     docker = _docker_label(result, summary)
+    prov = _provenance_surface(lock)
 
     return {
         "framework": framework,
@@ -406,6 +632,10 @@ def _agent_surface(
         "model_label": actors[0]["model"] if len(actors) == 1 else None,
         "executor_kind": executors[0] if executors else None,
         "profiles": actors,
+        "provenance": prov.get("provenance"),
+        "upstream_url": prov.get("upstream_url"),
+        "upstream_name": prov.get("upstream_name"),
+        "upstream_ref": prov.get("upstream_ref"),
     }
 
 
@@ -456,6 +686,10 @@ def _trial_meta_from_evidence(
         "model_label": surface.get("model_label"),
         "executor_kind": surface.get("executor_kind"),
         "profiles": surface.get("profiles") or [],
+        "provenance": surface.get("provenance"),
+        "upstream_url": surface.get("upstream_url"),
+        "upstream_name": surface.get("upstream_name"),
+        "upstream_ref": surface.get("upstream_ref"),
         "note": None,
     }
 
@@ -803,13 +1037,88 @@ def trial_tree(
         ]
     else:
         entries = _walk_tree(evidence, base, max_entries=MAX_TREE_ENTRIES)
+
+    # Agent scope: attach profile_id / group labels for virtual SPA folders (#27).
+    groups: list[dict[str, Any]] | None = None
+    if scope_norm == "agent":
+        entries, groups = _annotate_agent_tree_profiles(evidence, entries)
+
     return {
         "ok": True,
         "run_id": rid,
         "scope": scope_norm,
         "entries": entries,
+        "groups": groups,
         "truncated": len(entries) >= MAX_TREE_ENTRIES,
     }
+
+
+def _annotate_agent_tree_profiles(
+    evidence: Path,
+    entries: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]] | None]:
+    """Stamp profile_id on agent/invocations/* entries; build group list.
+
+    Disk layout stays flat; groups are read-side only. Real relative paths
+    are preserved for file preview.
+    """
+    inv_root = evidence / "agent" / "invocations"
+    if not inv_root.is_dir():
+        return entries, None
+
+    inv_meta: dict[str, dict[str, Any]] = {}
+    try:
+        inv_dirs = sorted(p for p in inv_root.iterdir() if p.is_dir())
+    except OSError:
+        inv_dirs = []
+    for inv in inv_dirs:
+        meta = _read_json_object(inv / "metadata.json") or {}
+        pid = meta.get("profile_id")
+        inv_meta[inv.name] = {
+            "profile_id": pid if isinstance(pid, str) else None,
+            "model": meta.get("model") or meta.get("locked_model"),
+            "dirname": inv.name,
+        }
+
+    if not inv_meta:
+        return entries, None
+
+    annotated: list[dict[str, Any]] = []
+    for e in entries:
+        path = str(e.get("path") or "")
+        # agent/invocations/<dirname>/...
+        parts = path.split("/")
+        profile_id = None
+        inv_dirname = None
+        if len(parts) >= 3 and parts[0] == "agent" and parts[1] == "invocations":
+            inv_dirname = parts[2]
+            meta = inv_meta.get(inv_dirname) or {}
+            profile_id = meta.get("profile_id")
+        ne = dict(e)
+        if profile_id:
+            ne["profile_id"] = profile_id
+        if inv_dirname:
+            ne["invocation"] = inv_dirname
+        annotated.append(ne)
+
+    # Stable group order: first appearance in inv dir sort order.
+    seen: list[str] = []
+    groups: list[dict[str, Any]] = []
+    for inv_name in sorted(inv_meta.keys()):
+        meta = inv_meta[inv_name]
+        pid = meta.get("profile_id")
+        key = pid if isinstance(pid, str) and pid else inv_name
+        if key in seen:
+            continue
+        seen.append(key)
+        groups.append(
+            {
+                "key": key,
+                "profile_id": pid if isinstance(pid, str) else None,
+                "label": pid if isinstance(pid, str) else inv_name,
+            }
+        )
+    return annotated, groups if groups else None
 
 
 def _walk_tree(evidence: Path, base: Path, *, max_entries: int) -> list[dict[str, Any]]:
@@ -961,6 +1270,7 @@ def trial_trajectory(
             inv_steps: list[dict[str, Any]] = []
             if traj_path.is_file():
                 inv_steps = _parse_trajectory_jsonl(traj_path)
+            profile_id = inv_meta.get("profile_id")
             for step in inv_steps:
                 if len(steps) >= MAX_TRAJECTORY_STEPS:
                     truncated = True
@@ -970,16 +1280,19 @@ def trial_trajectory(
                         **step,
                         "invocation": inv.name,
                         "invocation_id": inv_meta.get("invocation_id") or inv.name,
+                        "profile_id": profile_id,
+                        "model": inv_meta.get("model") or inv_meta.get("locked_model"),
                     }
                 )
             invocations.append(
                 {
                     "dirname": inv.name,
                     "invocation_id": inv_meta.get("invocation_id") or inv.name,
-                    "profile_id": inv_meta.get("profile_id"),
+                    "profile_id": profile_id,
                     "executor_kind": inv_meta.get("executor_kind"),
                     "model": inv_meta.get("model") or inv_meta.get("locked_model"),
                     "status": inv_meta.get("status"),
+                    "latency_ms": inv_meta.get("latency_ms"),
                     "step_count": len(inv_steps),
                     "has_trajectory": traj_path.is_file(),
                 }

--- a/tests/adapters/test_agent_acp.py
+++ b/tests/adapters/test_agent_acp.py
@@ -1,10 +1,10 @@
-"""Focused AcpExecutor unit tests (fixture-free mapping + offline)."""
+"""Focused AcpExecutor unit tests (fixture-free mapping + offline + #30 usage)."""
 
 from __future__ import annotations
 
 import os
 
-from bora.adapters.agent_acp import AcpExecutor
+from bora.adapters.agent_acp import AcpExecutor, normalize_acp_usage
 from bora.adapters.agent_contract import parse_validated_text_structured
 
 
@@ -35,3 +35,76 @@ def test_unknown_entry_raises() -> None:
         raise AssertionError("expected KeyError")
     except KeyError:
         pass
+
+
+def test_normalize_acp_usage_dual_source_merge() -> None:
+    """PromptResponse tokens + UsageUpdate context/cost merge without used→tokens."""
+    out = normalize_acp_usage(
+        prompt_usage={
+            "inputTokens": 11433,
+            "outputTokens": 140,
+            "totalTokens": 11573,
+            "thoughtTokens": 124,
+            "cachedReadTokens": 8576,
+            "cachedWriteTokens": 0,
+        },
+        usage_update={
+            "used": 15925,
+            "size": 1_000_000,
+            "cost": {"amount": 0.012, "currency": "USD"},
+            "sessionUpdate": "usage_update",
+        },
+    )
+    assert out is not None
+    assert out["input_tokens"] == 11433
+    assert out["output_tokens"] == 140
+    assert out["total_tokens"] == 11573
+    assert out["thought_tokens"] == 124
+    assert out["cached_read_tokens"] == 8576
+    assert out["cached_write_tokens"] == 0
+    assert out["context"] == {"used": 15925, "size": 1_000_000}
+    assert out["cost"] == {"amount": 0.012, "currency": "USD"}
+    assert out["sources"] == {"prompt_usage": True, "usage_update": True}
+    # Never invent uncached_* or promote used as tokens.
+    assert "uncached_input_tokens" not in out
+    assert "used" not in out
+    assert out.get("input_tokens") != out["context"]["used"]
+
+
+def test_normalize_acp_usage_only_usage_update() -> None:
+    out = normalize_acp_usage(
+        prompt_usage=None,
+        usage_update={"used": 100, "size": 1000, "cost": {"amount": 0.0, "currency": "USD"}},
+    )
+    assert out is not None
+    assert "input_tokens" not in out
+    assert "output_tokens" not in out
+    assert out["context"] == {"used": 100, "size": 1000}
+    assert out["cost"]["currency"] == "USD"
+    assert out["sources"] == {"prompt_usage": False, "usage_update": True}
+
+
+def test_normalize_acp_usage_only_prompt_usage_snake() -> None:
+    out = normalize_acp_usage(
+        prompt_usage={
+            "input_tokens": 10,
+            "output_tokens": 2,
+            "cached_read_tokens": 8,
+        },
+        usage_update=None,
+    )
+    assert out is not None
+    assert out["input_tokens"] == 10
+    assert out["output_tokens"] == 2
+    assert out["total_tokens"] == 12  # derived
+    assert out["cached_read_tokens"] == 8
+    assert "context" not in out
+    assert out["sources"]["prompt_usage"] is True
+    assert out["sources"]["usage_update"] is False
+    # Cache hit rate is consumer-side: cached_read / input when input > 0.
+    assert out["cached_read_tokens"] / out["input_tokens"] == 0.8
+
+
+def test_normalize_acp_usage_empty() -> None:
+    assert normalize_acp_usage(None, None) is None
+    assert normalize_acp_usage({}, {}) is None

--- a/tests/viewer/test_viewer_browse.py
+++ b/tests/viewer/test_viewer_browse.py
@@ -6,9 +6,9 @@ import json
 import threading
 from http.server import ThreadingHTTPServer
 from pathlib import Path
+from unittest.mock import patch
 from urllib.error import HTTPError
 from urllib.request import urlopen
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/viewer/test_viewer_browse.py
+++ b/tests/viewer/test_viewer_browse.py
@@ -8,11 +8,12 @@ from http.server import ThreadingHTTPServer
 from pathlib import Path
 from urllib.error import HTTPError
 from urllib.request import urlopen
+from unittest.mock import patch
 
 import pytest
 
 from bora.viewer import browse
-from bora.viewer.server import make_handler, static_dir
+from bora.viewer.server import make_handler, serve_viewer, static_dir
 
 REPO = Path(__file__).resolve().parents[2]
 SUITE = REPO / "tests" / "fixtures" / "databases" / "suite-min"
@@ -40,6 +41,34 @@ def test_static_dir_when_built() -> None:
         pytest.skip("apps/viewer/dist not built (run: cd apps/viewer && pnpm build)")
     assert (d / "index.html").is_file()
     assert (d / "assets").is_dir()
+
+
+def test_serve_viewer_bind_in_use_includes_host_port(tmp_path: Path) -> None:
+    """Port conflict must name the bind address (OS strerror often omits it)."""
+    assets = _minimal_spa(tmp_path)
+    holder = ThreadingHTTPServer(("127.0.0.1", 0), make_handler(SUITE, assets))
+    host, port = holder.server_address[:2]
+    thread = threading.Thread(target=holder.serve_forever, daemon=True)
+    thread.start()
+    try:
+        want_url = f"http://{host}:{port}/"
+        with (
+            patch("bora.viewer.server.static_dir", return_value=assets),
+            pytest.raises(OSError, match=r"address already in use: http://") as ei,
+        ):
+            serve_viewer(
+                SUITE,
+                host=str(host),
+                port=int(port),
+                open_browser=False,
+                block=False,
+            )
+        msg = str(ei.value)
+        assert want_url in msg
+        assert "--port" in msg
+    finally:
+        holder.shutdown()
+        holder.server_close()
 
 
 def _minimal_spa(tmp_path: Path) -> Path:

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -472,6 +472,12 @@ def test_multi_role_actors_time_usage_and_provenance(tmp_path: Path) -> None:
     assert usage.get("output_tokens") == 140
     assert usage.get("cache_hit_rate") == pytest.approx(8576 / 11433)
     assert usage.get("cost_amount") == pytest.approx(0.012)
+    # cached_read > input → omit rate (vendor cumulative quirks)
+    assert (
+        trials._usage_summary_for_actor(  # noqa: SLF001
+            {"input_tokens": 100, "cached_read_tokens": 500}
+        ) or {}
+    ).get("cache_hit_rate") is None
     assert usage.get("context_used") == 15925
     label = service.get("usage_label") or ""
     assert "in " in label and "out " in label

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -476,7 +476,8 @@ def test_multi_role_actors_time_usage_and_provenance(tmp_path: Path) -> None:
     assert (
         trials._usage_summary_for_actor(  # noqa: SLF001
             {"input_tokens": 100, "cached_read_tokens": 500}
-        ) or {}
+        )
+        or {}
     ).get("cache_hit_rate") is None
     assert usage.get("context_used") == 15925
     label = service.get("usage_label") or ""

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -470,15 +470,21 @@ def test_multi_role_actors_time_usage_and_provenance(tmp_path: Path) -> None:
     usage = service.get("usage") or {}
     assert usage.get("input_tokens") == 11433
     assert usage.get("output_tokens") == 140
+    # inclusion heuristic: cache ≤ input → hit = cache/input
+    assert usage.get("cache_relation") == "inclusion"
     assert usage.get("cache_hit_rate") == pytest.approx(8576 / 11433)
     assert usage.get("cost_amount") == pytest.approx(0.012)
-    # cached_read > input → omit rate (vendor cumulative quirks)
-    assert (
+    # disjoint heuristic: cache > input → hit = cache/(input+cache)
+    disjoint = (
         trials._usage_summary_for_actor(  # noqa: SLF001
             {"input_tokens": 100, "cached_read_tokens": 500}
         )
         or {}
-    ).get("cache_hit_rate") is None
+    )
+    assert disjoint.get("cache_relation") == "disjoint"
+    assert disjoint.get("cache_hit_rate") == pytest.approx(500 / 600)
+    assert disjoint.get("display_input_tokens") == 600
+    assert "cache 83%" in (disjoint.get("label") or "")
     assert usage.get("context_used") == 15925
     label = service.get("usage_label") or ""
     assert "in " in label and "out " in label

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -122,6 +122,7 @@ def _write_evidence(db: Path, run_id: str, *, task_id: str = "alpha") -> Path:
                 "executor_kind": "acp",
                 "model": "test-model",
                 "status": "completed",
+                "latency_ms": 1234.5,
             },
             indent=2,
         )
@@ -143,6 +144,15 @@ def _write_evidence(db: Path, run_id: str, *, task_id: str = "alpha") -> Path:
             "stop_reason": "end_turn",
             "source": "bora",
             "turn_index": 1,
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+                "cached_read_tokens": 50,
+                "cost": {"amount": 0.001, "currency": "USD"},
+                "context": {"used": 200, "size": 100000},
+                "sources": {"prompt_usage": True, "usage_update": True},
+            },
         },
     ]
     (inv / "trajectory.jsonl").write_text(
@@ -186,6 +196,18 @@ def test_resolve_and_trial_detail(tmp_path: Path) -> None:
     assert actors[0]["role"] == "main"
     assert actors[0]["agent"] == "pi"
     assert actors[0]["model"] == "test-model"
+    assert actors[0]["invokes"] == 1
+    assert actors[0]["latency_ms_sum"] == pytest.approx(1234.5)
+    assert actors[0]["time_label"]
+    assert "1.2s" in actors[0]["time_label"] or "1234ms" in actors[0]["time_label"]
+    usage = actors[0].get("usage") or {}
+    assert usage.get("input_tokens") == 100
+    assert usage.get("output_tokens") == 20
+    assert usage.get("cache_hit_rate") == pytest.approx(0.5)
+    assert usage.get("cost_amount") == pytest.approx(0.001)
+    assert actors[0].get("usage_label")
+    assert "in " in actors[0]["usage_label"]
+    assert detail["trial"].get("upstream_url") is None
 
 
 def test_trajectory_steps(tmp_path: Path) -> None:
@@ -198,6 +220,7 @@ def test_trajectory_steps(tmp_path: Path) -> None:
     roles = [s.get("role") for s in traj["steps"] if s.get("role")]
     assert "user" in roles
     assert "assistant" in roles
+    assert all(s.get("profile_id") == "main" for s in traj["steps"])
 
 
 def test_tree_and_file_and_traversal(tmp_path: Path) -> None:
@@ -303,3 +326,223 @@ def test_missing_evidence_suite_row_ok(tmp_path: Path) -> None:
     assert detail["trial"]["has_evidence"] is False
     assert detail["trial"]["available_tabs"] == []
     assert detail["trial"]["status"] == "FAIL"
+
+
+def _write_multi_role_evidence(db: Path, run_id: str, *, task_id: str = "alpha") -> Path:
+    """Two profiles, multiple invs; last usage per profile wins; old used-only shape."""
+    root = db / ".bora" / "runs" / run_id
+    inv_root = root / "agent" / "invocations"
+    inv_root.mkdir(parents=True, exist_ok=True)
+    (root / "evaluation").mkdir(parents=True, exist_ok=True)
+
+    (root / "lock.json").write_text(
+        json.dumps(
+            {
+                "task_id": task_id,
+                "digest": "sha256:multi",
+                "provenance": {
+                    "kind": "reimplementation",
+                    "upstream": {
+                        "name": "example-upstream",
+                        "url": "https://github.com/example/upstream",
+                        "ref": "main",
+                    },
+                },
+                "profiles": [
+                    {
+                        "id": "user-grok",
+                        "executor": "acp",
+                        "model": "entry-default",
+                        "options": {"entry": "grok"},
+                        "capabilities": {"execution_mode": "acp-stdio"},
+                    },
+                    {
+                        "id": "service-opencode",
+                        "executor": "acp",
+                        "model": "glm-5.2",
+                        "options": {"entry": "opencode"},
+                        "capabilities": {"execution_mode": "acp-stdio"},
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "result.json").write_text(
+        json.dumps({"status": "PASS", "score": 1.0, "agent_invocations": 3}) + "\n",
+        encoding="utf-8",
+    )
+    (root / "summary.json").write_text(
+        json.dumps({"run_id": run_id, "status": "PASS", "score": 1.0}) + "\n",
+        encoding="utf-8",
+    )
+
+    invs = [
+        ("0001-inv_a", "user-grok", "entry-default", 1000.0, None),
+        (
+            "0002-inv_b",
+            "service-opencode",
+            "glm-5.2",
+            2000.0,
+            # legacy UsageUpdate-only shape — must NOT become tokens
+            {"used": 9999, "size": 100000, "cost": {"amount": 0.05, "currency": "USD"}},
+        ),
+        (
+            "0003-inv_c",
+            "service-opencode",
+            "glm-5.2",
+            3000.0,
+            {
+                "input_tokens": 11433,
+                "output_tokens": 140,
+                "cached_read_tokens": 8576,
+                "cost": {"amount": 0.012, "currency": "USD"},
+                "context": {"used": 15925, "size": 1000000},
+            },
+        ),
+    ]
+    for dirname, profile_id, model, latency_ms, usage in invs:
+        inv = inv_root / dirname
+        inv.mkdir(parents=True, exist_ok=True)
+        (inv / "metadata.json").write_text(
+            json.dumps(
+                {
+                    "invocation_id": dirname.split("-", 1)[-1],
+                    "profile_id": profile_id,
+                    "executor_kind": "acp",
+                    "model": model,
+                    "status": "completed",
+                    "latency_ms": latency_ms,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        terminal: dict = {
+            "type": "terminal",
+            "ok": True,
+            "stop_reason": "end_turn",
+            "source": "bora",
+            "turn_index": 1,
+        }
+        if usage is not None:
+            terminal["usage"] = usage
+        lines = [
+            {"type": "turn", "role": "user", "content": "hi", "turn_index": 1},
+            {"type": "turn", "role": "assistant", "content": "ok", "turn_index": 1},
+            terminal,
+        ]
+        (inv / "trajectory.jsonl").write_text(
+            "\n".join(json.dumps(x) for x in lines) + "\n", encoding="utf-8"
+        )
+    return root
+
+
+def test_multi_role_actors_time_usage_and_provenance(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    _write_multi_role_evidence(db, "run_alpha_1", task_id="alpha")
+
+    detail = trials.get_trial(db, job_id, "alpha", "run_alpha_1")
+    trial = detail["trial"]
+    assert trial.get("upstream_url") == "https://github.com/example/upstream"
+    assert trial.get("upstream_name") == "example-upstream"
+    actors = trial.get("actors") or []
+    assert len(actors) == 2
+    by_pid = {a["profile_id"]: a for a in actors}
+
+    user = by_pid["user-grok"]
+    assert user["role"] == "user"
+    assert user["agent"] == "grok"
+    assert user["invokes"] == 1
+    assert user["latency_ms_sum"] == pytest.approx(1000.0)
+    # No usage on user inv → fail-open
+    assert user.get("usage") is None or user.get("usage_label") is None
+
+    service = by_pid["service-opencode"]
+    assert service["role"] == "service"
+    assert service["agent"] == "opencode"
+    assert service["invokes"] == 2
+    assert service["latency_ms_sum"] == pytest.approx(5000.0)
+    # Last invoke wins — normalized tokens, not legacy used=9999
+    usage = service.get("usage") or {}
+    assert usage.get("input_tokens") == 11433
+    assert usage.get("output_tokens") == 140
+    assert usage.get("cache_hit_rate") == pytest.approx(8576 / 11433)
+    assert usage.get("cost_amount") == pytest.approx(0.012)
+    assert usage.get("context_used") == 15925
+    label = service.get("usage_label") or ""
+    assert "in " in label and "out " in label
+    assert "cache " in label
+    assert "$" in label
+    # Never surface bare context used as token total
+    assert "9999" not in label
+
+    traj = trials.trial_trajectory(db, job_id, "alpha", "run_alpha_1")
+    profiles = {s.get("profile_id") for s in traj["steps"]}
+    assert "user-grok" in profiles
+    assert "service-opencode" in profiles
+
+
+def test_legacy_usage_cost_only_no_used_as_tokens(tmp_path: Path) -> None:
+    """Old evidence with only {used,size,cost}: show cost, never used as tokens."""
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    root = db / ".bora" / "runs" / "run_alpha_1"
+    inv = root / "agent" / "invocations" / "0001-inv_x"
+    inv.mkdir(parents=True, exist_ok=True)
+    (root / "lock.json").write_text(
+        json.dumps(
+            {
+                "task_id": "alpha",
+                "profiles": [
+                    {
+                        "id": "main-pi",
+                        "executor": "acp",
+                        "options": {"entry": "pi"},
+                        "capabilities": {"execution_mode": "acp-stdio"},
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "result.json").write_text(json.dumps({"status": "PASS", "score": 1.0}) + "\n")
+    (root / "summary.json").write_text(json.dumps({"status": "PASS"}) + "\n")
+    (inv / "metadata.json").write_text(
+        json.dumps(
+            {
+                "profile_id": "main-pi",
+                "executor_kind": "acp",
+                "model": "m",
+                "latency_ms": 500,
+            }
+        )
+        + "\n"
+    )
+    terminal = {
+        "type": "terminal",
+        "ok": True,
+        "usage": {
+            "used": 16899,
+            "size": 1000000,
+            "cost": {"amount": 0.0, "currency": "USD"},
+            "sessionUpdate": "usage_update",
+        },
+    }
+    (inv / "trajectory.jsonl").write_text(json.dumps(terminal) + "\n", encoding="utf-8")
+
+    detail = trials.get_trial(db, job_id, "alpha", "run_alpha_1")
+    actor = (detail["trial"].get("actors") or [])[0]
+    usage = actor.get("usage") or {}
+    assert usage.get("input_tokens") is None
+    assert usage.get("output_tokens") is None
+    assert usage.get("context_used") == 16899
+    assert usage.get("cost_amount") == 0.0
+    label = actor.get("usage_label") or ""
+    # Cost-only label; no token line
+    assert "in " not in label
+    assert "$" in label or "0" in label


### PR DESCRIPTION
## 摘要

本 PR 相对 `main` 交付 Attempt 用量与多角色可读性：

1. **#30 ACP usage 归一化** — 双源采集 `PromptResponse.usage` + `UsageUpdate`  
2. **#27 Viewer multi-role** — actors Time/Usage、provenance 顶栏、轨迹/Agent 按 profile 分组  
3. 附带：cache hit **启发式**（inclusion vs disjoint）、`bora view` 端口占用时带 URL 的报错

## 功能说明

### ACP 采集（#30）

- tokens ← `PromptResponse.usage`（input/output/total/thought/cached_read/write）  
- cost/context ← 最新 `UsageUpdate`（**不**把 `used` 当 billable tokens）  
- 落盘 terminal / final-response 归一化对象 + `sources`；无 uncached_* 派生字段  
- 单元测试：双源合并、单源、空 usage

### Viewer Attempt 详情（#27）

- actors 五列：Role / Agent / Model / **Time** / **Usage**  
  - Time：profile 下 inv `latency_ms` **求和**  
  - Usage：同 profile **最后一次** inv 的归一化 usage（session 累计语义，勿盲 sum）  
- 顶栏：`task · framework · docker · upstream.url`（有则，可点外链）  
- Trajectory / Agent 树：multi-role 时按 `profile_id` 虚拟分组（磁盘布局不变）  
- 缺字段 fail-open；文案标明观测 ≠ PASS

<img width="1386" height="311" alt="image" src="https://github.com/user-attachments/assets/f9a272a0-527b-4e8f-9506-9b192b34605f" />

<img width="1391" height="580" alt="image" src="https://github.com/user-attachments/assets/59229323-c9bb-44ee-a6e7-b11c76cf5f74" />


### Cache hit 启发式

ACP 未钉死 cache ⊆ input；OpenAI 系多为包含、Anthropic 系多为并列：

- `cache ≤ input` → hit = cache/input  
- `cache > input` → hit = cache/(input+cache)，展示 in 用合计  
- 可用 `total_tokens` 弱校验  

### Viewer 运维

- bind 失败时错误信息含 `http://host:port/`（EADDRINUSE 可辨）

## 测试

本地 core CI 已通过：

- `ruff format --check` / `ruff check` / `pyright`  
- pytest core **311 passed**（无 Docker/L1/真 Agent e2e）  
- `examples/journeys` 全 suite 4/4 PASS（手工 e2e；usage 因 entry 能力而异：opencode 有，pi/grok-build 常无）

```bash
cd apps/viewer && pnpm build   # dist/ 不进 git
uv run bora view examples/journeys
# 若 8765 被占：先停旧进程或 --port 0
```

## 关联

- Closes #30  
- Closes #27  
- Related: #26（Attempt 详情基座）