### PR TITLE
feat: trajectory 加厚 tool_call + observation（#46）

### DIFF
--- a/apps/viewer/src/components/trial/trajectory-panel.tsx
+++ b/apps/viewer/src/components/trial/trajectory-panel.tsx
@@ -1,9 +1,49 @@
-import { useMemo } from "react";
+import { useMemo, type ComponentType } from "react";
+import {
+  Bot,
+  Eye,
+  FilePenLine,
+  FileSearch,
+  Flag,
+  MessageSquare,
+  Shield,
+  Terminal,
+  User,
+  Wrench,
+} from "lucide-react";
 
 import type { TrajectoryStep } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 import { actorLabel, type ActorRow } from "./types";
+
+type IconComp = ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+
+function stepIcon(opts: {
+  isUser: boolean;
+  isAsst: boolean;
+  isToolCall: boolean;
+  isObservation: boolean;
+  isTerminal: boolean;
+  isPermission: boolean;
+  kind?: string | null;
+  functionName?: string | null;
+}): IconComp {
+  if (opts.isUser) return User;
+  if (opts.isAsst) return Bot;
+  if (opts.isObservation) return Eye;
+  if (opts.isTerminal) return Flag;
+  if (opts.isPermission) return Shield;
+  if (opts.isToolCall) {
+    const k = (opts.kind || opts.functionName || "").toLowerCase();
+    if (k === "execute" || k === "bash" || k === "shell") return Terminal;
+    if (k === "read" || k === "search" || k === "fetch") return FileSearch;
+    if (k === "edit" || k === "write" || k === "delete" || k === "move")
+      return FilePenLine;
+    return Wrench;
+  }
+  return MessageSquare;
+}
 
 export function TrajectoryPanel({
   loading,
@@ -73,10 +113,20 @@ export function TrajectoryPanel({
           const isAsst = role === "assistant";
           const isTerminal = stepType === "terminal";
           const label = isToolCall
-            ? s.function_name || s.title || "tool_call"
+            ? s.function_name || s.kind || s.title || "tool_call"
             : isObservation
               ? "observation"
               : role;
+          const Icon = stepIcon({
+            isUser,
+            isAsst,
+            isToolCall,
+            isObservation,
+            isTerminal,
+            isPermission,
+            kind: s.kind,
+            functionName: s.function_name,
+          });
           const body =
             s.content ||
             (isToolCall && s.args != null
@@ -96,21 +146,21 @@ export function TrajectoryPanel({
               className={cn(
                 "rounded-[8px] border border-hairline px-3 py-2.5",
                 isTerminal && "bg-canvas-soft",
-                isToolCall && "border-l-2 border-l-link/60",
-                isObservation && "border-l-2 border-l-mute bg-canvas-soft/50",
+                isObservation && "bg-canvas-soft/40",
               )}
             >
               <div className="flex flex-wrap items-center gap-2 text-xs text-mute mb-1">
                 <span
                   className={cn(
-                    "font-medium uppercase tracking-wide",
+                    "inline-flex items-center gap-1.5 font-medium uppercase tracking-wide",
                     isUser && "text-link",
                     isAsst && "text-ink",
-                    isToolCall && "text-link",
+                    isToolCall && "text-ink",
                     isObservation && "text-body",
                     isTerminal && "text-mute",
                   )}
                 >
+                  <Icon className="h-3.5 w-3.5 shrink-0 opacity-80" aria-hidden />
                   {label}
                 </span>
                 {showProfileBadge && s.profile_id ? (
@@ -118,7 +168,7 @@ export function TrajectoryPanel({
                     {s.profile_id}
                   </span>
                 ) : null}
-                {s.kind ? (
+                {s.kind && isToolCall && s.kind !== label ? (
                   <span className="rounded bg-canvas-soft border border-hairline px-1.5 py-0 font-mono text-[11px]">
                     {s.kind}
                   </span>

--- a/apps/viewer/src/components/trial/trajectory-panel.tsx
+++ b/apps/viewer/src/components/trial/trajectory-panel.tsx
@@ -140,6 +140,17 @@ export function TrajectoryPanel({
                 ? s.raw_output
                 : JSON.stringify(s.raw_output, null, 2)
               : null);
+          // Success is the common case for folded tool/observation rows; only
+          // surface non-success status (failed / error / cancelled / …).
+          const statusRaw =
+            typeof s.status === "string" ? s.status.trim() : "";
+          const statusLower = statusRaw.toLowerCase();
+          const showStatus =
+            Boolean(statusRaw) &&
+            !["completed", "complete", "success", "ok", "done"].includes(
+              statusLower,
+            );
+
           return (
             <li
               key={`${s.invocation || ""}-${s.line || i}-${i}`}
@@ -149,42 +160,56 @@ export function TrajectoryPanel({
                 isObservation && "bg-canvas-soft/40",
               )}
             >
-              <div className="flex flex-wrap items-center gap-2 text-xs text-mute mb-1">
-                <span
-                  className={cn(
-                    "inline-flex items-center gap-1.5 font-medium uppercase tracking-wide",
-                    isUser && "text-link",
-                    isAsst && "text-ink",
-                    isToolCall && "text-ink",
-                    isObservation && "text-body",
-                    isTerminal && "text-mute",
-                  )}
-                >
-                  <Icon className="h-3.5 w-3.5 shrink-0 opacity-80" aria-hidden />
-                  {label}
-                </span>
-                {showProfileBadge && s.profile_id ? (
-                  <span className="rounded bg-canvas-soft border border-hairline px-1.5 py-0 font-mono text-[11px] text-body">
-                    {s.profile_id}
+              <div className="flex items-start gap-3 text-xs mb-1">
+                <div className="flex flex-wrap items-center gap-2 min-w-0">
+                  <span className="inline-flex items-center gap-1.5 font-semibold uppercase tracking-wide text-ink">
+                    <Icon
+                      className="h-3.5 w-3.5 shrink-0 opacity-80"
+                      aria-hidden
+                    />
+                    {label}
                   </span>
-                ) : null}
-                {s.kind && isToolCall && s.kind !== label ? (
-                  <span className="rounded bg-canvas-soft border border-hairline px-1.5 py-0 font-mono text-[11px]">
-                    {s.kind}
-                  </span>
-                ) : null}
-                {s.status ? <span className="font-mono">{s.status}</span> : null}
-                {s.tool_call_id ? (
-                  <span className="font-mono truncate max-w-[20ch]" title={s.tool_call_id}>
-                    {s.tool_call_id}
-                  </span>
-                ) : null}
-                {s.turn_index != null ? <span>turn {s.turn_index}</span> : null}
-                {s.invocation ? (
-                  <span className="font-mono truncate max-w-[24ch]">{s.invocation}</span>
-                ) : null}
-                {s.stop_reason ? <span>{s.stop_reason}</span> : null}
-                {s.ok === false ? <span className="text-error">not ok</span> : null}
+                  {showProfileBadge && s.profile_id ? (
+                    <span className="rounded bg-canvas-soft border border-hairline px-1.5 py-0 font-mono text-[11px] text-body font-normal normal-case tracking-normal">
+                      {s.profile_id}
+                    </span>
+                  ) : null}
+                  {s.kind && isToolCall && s.kind !== label ? (
+                    <span className="rounded bg-canvas-soft border border-hairline px-1.5 py-0 font-mono text-[11px] text-mute font-normal normal-case tracking-normal">
+                      {s.kind}
+                    </span>
+                  ) : null}
+                </div>
+                <div className="ml-auto flex flex-col items-end gap-0.5 min-w-0 max-w-[min(100%,36rem)] text-right text-mute font-mono font-normal normal-case tracking-normal">
+                  {showStatus ? (
+                    <span
+                      className={cn(
+                        statusLower.includes("fail") ||
+                          statusLower.includes("error") ||
+                          statusLower.includes("cancel")
+                          ? "text-error"
+                          : undefined,
+                      )}
+                    >
+                      {statusRaw}
+                    </span>
+                  ) : null}
+                  {s.tool_call_id ? (
+                    <span className="break-all" title={s.tool_call_id}>
+                      {s.tool_call_id}
+                    </span>
+                  ) : null}
+                  {s.turn_index != null ? <span>turn {s.turn_index}</span> : null}
+                  {s.invocation ? (
+                    <span className="break-all" title={s.invocation}>
+                      {s.invocation}
+                    </span>
+                  ) : null}
+                  {s.stop_reason ? <span>{s.stop_reason}</span> : null}
+                  {s.ok === false ? (
+                    <span className="text-error">not ok</span>
+                  ) : null}
+                </div>
               </div>
               {body ? (
                 <pre className="m-0 whitespace-pre-wrap break-words font-mono text-[13px] leading-5 text-body">

--- a/apps/viewer/src/components/trial/trajectory-panel.tsx
+++ b/apps/viewer/src/components/trial/trajectory-panel.tsx
@@ -84,6 +84,7 @@ export function TrajectoryPanel({
                 ? s.args
                 : JSON.stringify(s.args, null, 2)
               : null) ||
+            (isToolCall && s.title ? s.title : null) ||
             (isObservation && s.raw_output != null
               ? typeof s.raw_output === "string"
                 ? s.raw_output

--- a/apps/viewer/src/components/trial/trajectory-panel.tsx
+++ b/apps/viewer/src/components/trial/trajectory-panel.tsx
@@ -55,16 +55,48 @@ export function TrajectoryPanel({
     return (
       <ol className="space-y-2">
         {list.map((s, i) => {
-          const role = (s.role || s.type || "event").toString();
+          const stepType = (s.type || "").toString();
+          const isToolCall = stepType === "tool_call";
+          const isObservation = stepType === "observation";
+          const isPermission = stepType === "permission_decision";
+          const role = (
+            s.role ||
+            (isToolCall
+              ? "tool_call"
+              : isObservation
+                ? "observation"
+                : isPermission
+                  ? "permission"
+                  : stepType || "event")
+          ).toString();
           const isUser = role === "user";
           const isAsst = role === "assistant";
-          const isTerminal = s.type === "terminal";
+          const isTerminal = stepType === "terminal";
+          const label = isToolCall
+            ? s.function_name || s.title || "tool_call"
+            : isObservation
+              ? "observation"
+              : role;
+          const body =
+            s.content ||
+            (isToolCall && s.args != null
+              ? typeof s.args === "string"
+                ? s.args
+                : JSON.stringify(s.args, null, 2)
+              : null) ||
+            (isObservation && s.raw_output != null
+              ? typeof s.raw_output === "string"
+                ? s.raw_output
+                : JSON.stringify(s.raw_output, null, 2)
+              : null);
           return (
             <li
               key={`${s.invocation || ""}-${s.line || i}-${i}`}
               className={cn(
                 "rounded-[8px] border border-hairline px-3 py-2.5",
                 isTerminal && "bg-canvas-soft",
+                isToolCall && "border-l-2 border-l-link/60",
+                isObservation && "border-l-2 border-l-mute bg-canvas-soft/50",
               )}
             >
               <div className="flex flex-wrap items-center gap-2 text-xs text-mute mb-1">
@@ -73,14 +105,27 @@ export function TrajectoryPanel({
                     "font-medium uppercase tracking-wide",
                     isUser && "text-link",
                     isAsst && "text-ink",
+                    isToolCall && "text-link",
+                    isObservation && "text-body",
                     isTerminal && "text-mute",
                   )}
                 >
-                  {role}
+                  {label}
                 </span>
                 {showProfileBadge && s.profile_id ? (
                   <span className="rounded bg-canvas-soft border border-hairline px-1.5 py-0 font-mono text-[11px] text-body">
                     {s.profile_id}
+                  </span>
+                ) : null}
+                {s.kind ? (
+                  <span className="rounded bg-canvas-soft border border-hairline px-1.5 py-0 font-mono text-[11px]">
+                    {s.kind}
+                  </span>
+                ) : null}
+                {s.status ? <span className="font-mono">{s.status}</span> : null}
+                {s.tool_call_id ? (
+                  <span className="font-mono truncate max-w-[20ch]" title={s.tool_call_id}>
+                    {s.tool_call_id}
                   </span>
                 ) : null}
                 {s.turn_index != null ? <span>turn {s.turn_index}</span> : null}
@@ -90,14 +135,18 @@ export function TrajectoryPanel({
                 {s.stop_reason ? <span>{s.stop_reason}</span> : null}
                 {s.ok === false ? <span className="text-error">not ok</span> : null}
               </div>
-              {s.content ? (
+              {body ? (
                 <pre className="m-0 whitespace-pre-wrap break-words font-mono text-[13px] leading-5 text-body">
-                  {s.content}
+                  {body}
                 </pre>
               ) : s.error ? (
                 <p className="text-sm text-error">{String(s.error)}</p>
               ) : isTerminal ? (
                 <p className="text-sm text-mute">terminal</p>
+              ) : isToolCall || isObservation ? (
+                <p className="text-sm text-mute">
+                  {isToolCall ? "tool call (no args)" : "observation (empty)"}
+                </p>
               ) : null}
             </li>
           );

--- a/apps/viewer/src/components/trial/trajectory-panel.tsx
+++ b/apps/viewer/src/components/trial/trajectory-panel.tsx
@@ -116,7 +116,9 @@ export function TrajectoryPanel({
             ? s.function_name || s.kind || s.title || "tool_call"
             : isObservation
               ? "observation"
-              : role;
+              : isAsst
+                ? "agent"
+                : role;
           const Icon = stepIcon({
             isUser,
             isAsst,
@@ -127,7 +129,7 @@ export function TrajectoryPanel({
             kind: s.kind,
             functionName: s.function_name,
           });
-          const body =
+          let body: string | null =
             s.content ||
             (isToolCall && s.args != null
               ? typeof s.args === "string"
@@ -140,6 +142,44 @@ export function TrajectoryPanel({
                 ? s.raw_output
                 : JSON.stringify(s.raw_output, null, 2)
               : null);
+
+          // permission / terminal: synthesize body from structured fields when needed
+          if (!body && isPermission) {
+            const bits = [
+              s.policy != null && s.policy !== "" ? `policy=${s.policy}` : null,
+              s.outcome != null && s.outcome !== "" ? `outcome=${s.outcome}` : null,
+              s.option_id != null && s.option_id !== ""
+                ? `option_id=${s.option_id}`
+                : null,
+            ].filter(Boolean) as string[];
+            body = bits.length ? bits.join(" · ") : null;
+          }
+          if (!body && isTerminal) {
+            const bits: string[] = [];
+            if (s.ok === true) bits.push("ok");
+            else if (s.ok === false) bits.push("not ok");
+            if (s.stop_reason) bits.push(`stop=${s.stop_reason}`);
+            if (s.error) bits.push(`error=${String(s.error)}`);
+            if (s.usage && typeof s.usage === "object") {
+              bits.push(`usage=${JSON.stringify(s.usage)}`);
+            }
+            if (s.metadata && typeof s.metadata === "object") {
+              const meta = s.metadata;
+              const metaBits = (
+                [
+                  "executor_kind",
+                  "acp_entry_id",
+                  "actual_model",
+                  "locked_model",
+                  "protocol_version",
+                ] as const
+              )
+                .filter((k) => meta[k] != null && meta[k] !== "")
+                .map((k) => `${k}=${String(meta[k])}`);
+              if (metaBits.length) bits.push(metaBits.join(" "));
+            }
+            body = bits.length ? bits.join(" · ") : null;
+          }
           // Success is the common case for folded tool/observation rows; only
           // surface non-success status (failed / error / cancelled / …).
           const statusRaw =
@@ -169,6 +209,11 @@ export function TrajectoryPanel({
                     />
                     {label}
                   </span>
+                  {s.turn_index != null ? (
+                    <span className="text-mute font-mono font-normal normal-case tracking-normal">
+                      turn {s.turn_index}
+                    </span>
+                  ) : null}
                   {showProfileBadge && s.profile_id ? (
                     <span className="rounded bg-canvas-soft border border-hairline px-1.5 py-0 font-mono text-[11px] text-body font-normal normal-case tracking-normal">
                       {s.profile_id}
@@ -199,7 +244,6 @@ export function TrajectoryPanel({
                       {s.tool_call_id}
                     </span>
                   ) : null}
-                  {s.turn_index != null ? <span>turn {s.turn_index}</span> : null}
                   {s.invocation ? (
                     <span className="break-all" title={s.invocation}>
                       {s.invocation}
@@ -218,7 +262,9 @@ export function TrajectoryPanel({
               ) : s.error ? (
                 <p className="text-sm text-error">{String(s.error)}</p>
               ) : isTerminal ? (
-                <p className="text-sm text-mute">terminal</p>
+                <p className="text-sm text-mute">terminal (no summary)</p>
+              ) : isPermission ? (
+                <p className="text-sm text-mute">permission (no decision fields)</p>
               ) : isToolCall || isObservation ? (
                 <p className="text-sm text-mute">
                   {isToolCall ? "tool call (no args)" : "observation (empty)"}

--- a/apps/viewer/src/lib/api.ts
+++ b/apps/viewer/src/lib/api.ts
@@ -126,6 +126,10 @@ export type TrajectoryStep = {
   status?: string | null;
   args?: Record<string, unknown> | unknown[] | string | null;
   raw_output?: Record<string, unknown> | unknown[] | string | null;
+  /** permission_decision (batch auto-approve evidence) */
+  outcome?: string | null;
+  option_id?: string | null;
+  policy?: string | null;
 };
 
 export type Breadcrumb = { label: string; href: string | null };

--- a/apps/viewer/src/lib/api.ts
+++ b/apps/viewer/src/lib/api.ts
@@ -118,6 +118,14 @@ export type TrajectoryStep = {
   line?: number;
   usage?: Record<string, unknown> | null;
   metadata?: Record<string, unknown> | null;
+  /** ACP tool_call / observation (observational; not PASS) */
+  tool_call_id?: string | null;
+  title?: string | null;
+  function_name?: string | null;
+  kind?: string | null;
+  status?: string | null;
+  args?: Record<string, unknown> | unknown[] | string | null;
+  raw_output?: Record<string, unknown> | unknown[] | string | null;
 };
 
 export type Breadcrumb = { label: string; href: string | null };

--- a/apps/viewer/src/lib/utils.ts
+++ b/apps/viewer/src/lib/utils.ts
@@ -10,6 +10,17 @@ export function formatScore(value: number | null | undefined): string {
   return Number(value).toFixed(2);
 }
 
+/** Coerce API error fields to a string for React children (objects crash React #31). */
+export function formatError(value: unknown): string {
+  if (value == null || value === "") return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
 export function formatTrials(done: number | null | undefined, total: number | null | undefined): string {
   if (total == null) return "-";
   return `${done ?? 0}/${total}`;

--- a/apps/viewer/src/pages/JobDetailPage.tsx
+++ b/apps/viewer/src/pages/JobDetailPage.tsx
@@ -18,7 +18,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { fetchJob, type Job, type TaskRow } from "@/lib/api";
-import { formatScore } from "@/lib/utils";
+import { formatError, formatScore } from "@/lib/utils";
 
 type SortKey = "task_id" | "agent_label" | "provider_label" | "model_label" | "score" | "status";
 
@@ -134,8 +134,9 @@ export function JobDetailPage() {
               {!loading &&
                 !error &&
                 rows.map((t) => {
+                  const errText = formatError(t.error);
                   const isErr =
-                    (t.status || "").toUpperCase() === "ERROR" || Boolean(t.error);
+                    (t.status || "").toUpperCase() === "ERROR" || Boolean(errText);
                   return (
                     <TableRow
                       key={t.task_id}
@@ -177,7 +178,7 @@ export function JobDetailPage() {
                             : "text-mute"
                         }
                       >
-                        {t.error ||
+                        {errText ||
                           ((t.status || "").toUpperCase() === "ERROR"
                             ? "ERROR"
                             : (t.status || "").toUpperCase() === "FAIL"

--- a/apps/viewer/src/pages/TaskDetailPage.tsx
+++ b/apps/viewer/src/pages/TaskDetailPage.tsx
@@ -13,7 +13,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { fetchJobTask, type Job, type TaskRow, type Trial } from "@/lib/api";
-import { cn, formatDate, formatScore } from "@/lib/utils";
+import { cn, formatDate, formatError, formatScore } from "@/lib/utils";
 
 export function TaskDetailPage() {
   const { jobId = "", taskId = "" } = useParams();
@@ -111,10 +111,11 @@ export function TaskDetailPage() {
               </TableHeader>
               <TableBody>
                 {trials.map((tr) => {
+                  const errText = formatError(tr.error);
                   const bad =
                     (tr.status || "").toUpperCase() === "ERROR" ||
                     (tr.status || "").toUpperCase() === "FAIL" ||
-                    Boolean(tr.error);
+                    Boolean(errText);
                   const rid = tr.run_id || tr.trial_id || task?.run_id || "";
                   // Open when we have a run id (detail page handles missing evidence)
                   const openable = Boolean(rid);
@@ -153,7 +154,7 @@ export function TaskDetailPage() {
                           bad ? "text-error tabular" : "tabular"
                         }
                       >
-                        {tr.error ||
+                        {errText ||
                           ((tr.status || "").toUpperCase() === "ERROR"
                             ? "RuntimeError"
                             : (tr.status || "").toUpperCase() === "FAIL"

--- a/docs/design/05-runtime/evidence.md
+++ b/docs/design/05-runtime/evidence.md
@@ -74,8 +74,55 @@ BORA 的一次成功或失败 Attempt，必须在 filesystem evidence 根下留�
 
 1. `type=turn` · `role=user` · `content=<完整 prompt>` · `turn_index` · 可选 `acp_session_id`
 2. `type=turn` · `role=assistant` · `part=thought` · `content=<合并后的 thought>`（有则写）
-3. `type=turn` · `role=assistant` · `content=<合并后的最终 assistant 文本>`
-4. `type=terminal` · `ok` / `error` / `structured` / `usage` / `stop_reason` / entry·model 元数据摘要
+3. **`type=tool_call`** · action 侧（有则写；见下）
+4. **`type=observation`** · 该 call 的环境回传 / tool result（有则写；与 call 成对）
+5. `type=turn` · `role=assistant` · `content=<合并后的最终 assistant 文本>`
+6. `type=permission_decision` · batch auto-approve 等（有则写；evidence 决策摘要）
+7. `type=terminal` · `ok` / `error` · `structured` / `usage` / `stop_reason` / entry·model 元数据摘要
+
+行序建议：user → thought →（按首次出现顺序的 tool_call + observation 对）→ assistant 终稿 → permission → terminal。  
+无 tool 的 invoke **不写** 3–4，行为与旧 turn/terminal 轨迹一致。
+
+### `tool_call` / `observation`（ACP 汇总）
+
+数据源是 parent ACP client 已收集的 `session/update` 事件（`events` / 可选 `events.jsonl`），**不是** parent 内 vendor stdout scrape。合成层从流里汇总：
+
+| ACP `sessionUpdate` | 轨迹行 | 语义 |
+| --- | --- | --- |
+| `tool_call` | `type=tool_call` | **Action**：模型/agent 发起的工具调用 |
+| `tool_call_update` | 合并进同一 `tool_call_id` 的终态；结果写入 `type=observation` | **Observation** ≈ tool result（agentic RL / Harbor ATIF 同构口径） |
+
+**`tool_call` 推荐字段（尽力；缺省可省略）：**
+
+| 字段 | 含义 |
+| --- | --- |
+| `tool_call_id` | ACP `toolCallId`（同 id 多次 update **合并**） |
+| `title` | 人读标题 |
+| `function_name` | 尽力从 title / rawInput 推断的逻辑名 |
+| `kind` | ACP ToolKind（`read` / `edit` / `execute` / …） |
+| `status` | 合并后的终态（`pending` / `in_progress` / `completed` / `failed`） |
+| `args` | `rawInput`（若有；须 redact） |
+| `turn_index` / `acp_session_id` / `source` | 与 turn 行一致；`source` 一般为 `acp` |
+
+**`observation` 推荐字段：**
+
+| 字段 | 含义 |
+| --- | --- |
+| `tool_call_id` | 对齐对应 action（Harbor 语义上的 `source_call_id`） |
+| `status` | 该 call 终态 |
+| `content` | 从 ACP `content` 块抽出的可读摘要（文本 / diff 路径等） |
+| `raw_output` | `rawOutput`（若有；须 redact） |
+| `turn_index` / `acp_session_id` / `source` | 同上 |
+
+**合并规则：** 同一 `toolCallId` 的多次 `tool_call_update` 折叠为**最终** observation；中间 `in_progress` 进度片可丢弃。  
+**有 call 无 result：** 仍写 `tool_call`；observation 仅在存在 content / rawOutput / 终态 completed|failed 时写出。  
+**禁止**只落盘 call 而系统性丢弃已有 result。
+
+**Redaction：** `args` / `content` / `raw_output` 与既有轨迹 redact 同一路径（pattern + sentinels）；禁止 host secret / token 进入 `trajectory.jsonl`。
+
+**Reader fail-open：** 未知 `type` 跳过或原样展示；既有 `turn` / `terminal` 行保持可读。Viewer 与导出工具不得因新行类型硬失败。
+
+**非目标（本机制；导出后置）：** ATIF 一等文件、OpenAI messages JSONL 导出、`--load-trajectory` / session seed、用轨迹充当 PASS。
 
 **多轮会话：** `turn_index` 为 Attempt 内 invoke 序号（1-based）；跨 turn 的 ACP `session_id` 可相同。合并训练样本时以 **invocation / turn_index** 为边界，不要把整个 `session_id` 当成单 turn。
 

--- a/examples/journeys/tasks/terminal-jsonl-agg/README.md
+++ b/examples/journeys/tasks/terminal-jsonl-agg/README.md
@@ -14,11 +14,13 @@ v1 **terminal-bench / jsonl-aggregator** case class:
 | ------------- | --------------- | ---------------------------------------- |
 | `terminal-pi` | `pi`            | L1 `docker exec` target (assurance:l1)   |
 
-Alternate profile switch via `parameters.models.default` / first profile in `bora.yaml`:
-`terminal-opencode`, `terminal-grok`.
+Profiles: `terminal-pi` (default), `terminal-opencode`, `terminal-grok`.
 
 ```bash
 uv run bora run examples/journeys --task terminal-jsonl-agg
+# switch ACP entry via allowlisted override
+uv run bora run examples/journeys --task terminal-jsonl-agg \
+  --set '/parameters/active_profile="terminal-opencode"'
 ```
 
 Requires `bora-attempt:l1` image with ACP entries baked in, host credentials for

--- a/examples/journeys/tasks/terminal-jsonl-agg/harness.py
+++ b/examples/journeys/tasks/terminal-jsonl-agg/harness.py
@@ -34,16 +34,14 @@ def _parse_obj(raw: Any) -> dict[str, Any] | None:
     return None
 
 
-def _params(ctx: HarnessContext) -> dict[str, Any]:
-    raw = ctx.params
-    return dict(raw) if isinstance(raw, dict) else {}
-
-
 async def run(ctx: HarnessContext) -> HarnessTerminal:
-    params = _params(ctx)
-    models = params.get("models") if isinstance(params.get("models"), dict) else {}
-    profile_id = str(models.get("default") or "terminal-pi")
-    out_name = str(params.get("workspace_output") or "aggregates.json")
+    # HarnessParameterView supports dotted get — do not coerce via dict().
+    models = ctx.params.get("models") if isinstance(ctx.params.get("models"), dict) else {}
+    # Prefer allowlisted CLI override, then package models.default.
+    profile_id = str(
+        ctx.params.get("active_profile") or models.get("default") or "terminal-pi"
+    )
+    out_name = str(ctx.params.get("workspace_output") or "aggregates.json")
     out_path = Path(out_name)
     if out_path.is_absolute() or ".." in out_path.parts:
         return HarnessTerminal.failed("workspace_output_invalid")

--- a/examples/journeys/tasks/terminal-jsonl-agg/task.yaml
+++ b/examples/journeys/tasks/terminal-jsonl-agg/task.yaml
@@ -23,6 +23,8 @@ parameters:
   workspace_output: aggregates.json
   harness_timeout_seconds: 420
   agent_timeout_seconds: 420
+  # Allowlisted CLI: --set '/parameters/active_profile="terminal-opencode"'
+  active_profile: terminal-pi
   models:
     default: terminal-pi
 

--- a/src/bora/adapters/acp/executor.py
+++ b/src/bora/adapters/acp/executor.py
@@ -460,6 +460,7 @@ class AcpExecutor:
                 ok=result.ok,
                 error=result.error,
                 metadata=result.metadata,
+                redaction_sentinels=redaction_sentinels,
             )
         return result
 

--- a/src/bora/adapters/acp/trajectory.py
+++ b/src/bora/adapters/acp/trajectory.py
@@ -1,4 +1,19 @@
-"""Write ACP trajectory.jsonl evidence (observational)."""
+"""Write ACP trajectory.jsonl evidence (observational).
+
+Tool synthesis follows the same *role* as Harbor ATIF export from ACP events:
+fold ``session/update`` tool streams into structured steps. Not PASS authority.
+
+**L0 (protocol, Harbor-aligned):** ``sessionUpdate`` in
+``{tool_call, tool_call_update}``, key by ``toolCallId``, name from ``kind`` /
+``title``, args from ``rawInput``, observation from ``rawOutput`` + text-bearing
+``content``.
+
+**L1 (explicit extensions, documented):**
+
+- ``update._meta.terminal_output.data`` → observation text (pi-style vendor meta)
+- when ``args`` still empty and ``kind==execute`` with a final ``title``,
+  ``args={"command": title}`` (title stream, not inventing tools)
+"""
 
 from __future__ import annotations
 
@@ -31,9 +46,7 @@ def write_trajectory_jsonl(
     5. ``permission_decision`` — batch auto-approve evidence (if any)
     6. ``terminal`` — ok / error / structured / usage / stop metadata
 
-    Stream chunks are merged; raw token-level ACP updates are not written here.
-    Optional debug stream stays out of this file (see ``events.jsonl`` if needed).
-    Not PASS authority.
+    Not PASS authority. Raw token stream stays in ``events.jsonl`` if needed.
     """
     inv_dir.mkdir(parents=True, exist_ok=True)
     path = inv_dir / "trajectory.jsonl"
@@ -79,7 +92,6 @@ def write_trajectory_jsonl(
 
     turn_index = 1
     if isinstance(metadata, dict):
-        # Optional: callers may pass bora turn index later.
         raw_ti = metadata.get("turn_index")
         if isinstance(raw_ti, int) and raw_ti > 0:
             turn_index = raw_ti
@@ -108,27 +120,22 @@ def write_trajectory_jsonl(
         )
 
     for call_id, state in tool_states.items():
+        _finalize_tool_state(state)
         tool_line: dict[str, Any] = {
             "type": "tool_call",
             "tool_call_id": call_id,
             "title": state.get("title"),
-            "function_name": state.get("function_name"),
+            "function_name": state.get("function_name") or "tool",
             "kind": state.get("kind"),
             "status": state.get("status"),
             "turn_index": turn_index,
             "acp_session_id": acp_session_id,
             "source": "acp",
         }
-        if state.get("args") is not None:
-            tool_line["args"] = state["args"]
-        # Drop null-only optional display fields for cleaner JSONL.
-        lines.append(
-            {
-                k: v
-                for k, v in tool_line.items()
-                if v is not None or k in {"type", "tool_call_id", "turn_index", "source"}
-            }
-        )
+        args = state.get("args")
+        if args is not None:
+            tool_line["args"] = args
+        lines.append(_drop_nulls(tool_line, keep={"type", "tool_call_id", "turn_index", "source"}))
 
         if _should_emit_observation(state):
             obs: dict[str, Any] = {
@@ -143,13 +150,7 @@ def write_trajectory_jsonl(
                 obs["content"] = state["content"]
             if state.get("raw_output") is not None:
                 obs["raw_output"] = state["raw_output"]
-            lines.append(
-                {
-                    k: v
-                    for k, v in obs.items()
-                    if v is not None or k in {"type", "tool_call_id", "turn_index", "source"}
-                }
-            )
+            lines.append(_drop_nulls(obs, keep={"type", "tool_call_id", "turn_index", "source"}))
 
     lines.append(
         {
@@ -190,7 +191,6 @@ def write_trajectory_jsonl(
         }
     )
 
-    # Pattern scrub always; include caller sentinels when present.
     from bora.evidence.redaction import redact_value
 
     sentinels = tuple(s for s in (redaction_sentinels or ()) if s)
@@ -203,67 +203,70 @@ def write_trajectory_jsonl(
     return path
 
 
-def _session_update_name(ev: dict[str, Any]) -> str:
-    """Return normalized ACP sessionUpdate name, or empty string."""
-    upd = ev.get("update")
-    if isinstance(upd, dict):
-        su = upd.get("sessionUpdate") or upd.get("session_update")
-        if isinstance(su, str) and su:
-            return su.lower().replace("-", "_")
-    # Fallback: typed class name from client
+def _drop_nulls(row: dict[str, Any], *, keep: set[str]) -> dict[str, Any]:
+    return {k: v for k, v in row.items() if v is not None or k in keep}
+
+
+def _update_payload(ev: dict[str, Any]) -> dict[str, Any]:
+    """Nested ACP update dict (preferred) or empty."""
+    raw = ev.get("update")
+    return raw if isinstance(raw, dict) else {}
+
+
+def _session_update_name(ev: dict[str, Any], upd: dict[str, Any]) -> str:
+    """Normalized sessionUpdate name (Harbor: only tool_call / tool_call_update)."""
+    su = upd.get("sessionUpdate") or upd.get("session_update")
+    if isinstance(su, str) and su:
+        return su.lower().replace("-", "_")
+    # Typed dump fallback (client update_type)
     ut = ev.get("update_type")
     if isinstance(ut, str) and ut:
-        low = ut.lower()
-        if "toolcallupdate" in low.replace("_", "") or "tool_call_update" in low:
+        compact = ut.lower().replace("_", "")
+        if "toolcallprogress" in compact or "toolcallupdate" in compact:
             return "tool_call_update"
-        # ToolCall / SessionUpdateToolCall — not update
-        if "toolcall" in low.replace("_", "") and "update" not in low:
+        if "toolcallstart" in compact or (
+            "toolcall" in compact and "update" not in compact and "progress" not in compact
+        ):
             return "tool_call"
-        if low in {"tool_call", "toolcall"}:
-            return "tool_call"
-        if low in {"tool_call_update", "toolcallupdate"}:
-            return "tool_call_update"
-    # Flat helpers imply a tool-related event when tool_call_id is present
-    if ev.get("tool_call_id") or (
-        isinstance(upd, dict) and (upd.get("toolCallId") or upd.get("tool_call_id"))
-    ):
-        # Prefer update when status-only progress is likely, but without name
-        # treat as tool_call seed (merge is idempotent).
-        return "tool_call"
     return ""
 
 
-def _tool_call_id_from_event(ev: dict[str, Any]) -> str | None:
-    tid = ev.get("tool_call_id")
-    if isinstance(tid, str) and tid:
-        return tid
-    upd = ev.get("update")
-    if isinstance(upd, dict):
+def _tool_call_id(ev: dict[str, Any], upd: dict[str, Any]) -> str | None:
+    for src in (upd, ev):
         for key in ("toolCallId", "tool_call_id"):
-            val = upd.get(key)
+            val = src.get(key)
             if isinstance(val, str) and val:
                 return val
     return None
 
 
 def _merge_tool_from_event(ev: dict[str, Any], tool_states: dict[str, dict[str, Any]]) -> None:
-    name = _session_update_name(ev)
-    call_id = _tool_call_id_from_event(ev)
+    """L0 Harbor-style fold + L1 meta/title extensions."""
+    upd = _update_payload(ev)
+    name = _session_update_name(ev, upd)
+    if name not in {"tool_call", "tool_call_update"}:
+        return
+
+    call_id = _tool_call_id(ev, upd)
     if not call_id:
         return
-    # Require an explicit tool sessionUpdate name, or flat tool_call_id on a
-    # session_update event (client already stamped helpers).
-    if name not in {"tool_call", "tool_call_update"} and ev.get("type") != "session_update":
-        return
 
-    raw_update = ev.get("update")
-    upd: dict[str, Any] = raw_update if isinstance(raw_update, dict) else {}
-    state = tool_states.setdefault(call_id, {"tool_call_id": call_id})
+    state = tool_states.setdefault(
+        call_id,
+        {
+            "tool_call_id": call_id,
+            "args": {},  # Harbor default until rawInput arrives
+            "observation_chunks": [],
+        },
+    )
 
-    # Prefer nested update fields; fall back to flat client helpers.
+    # --- L0 protocol fields (prefer nested update, fall back to flat client helpers) ---
     title = upd.get("title") if isinstance(upd.get("title"), str) else ev.get("title")
     if isinstance(title, str) and title:
-        state["title"] = title
+        # Title may stream; keep the longest form (final command / label).
+        prev = state.get("title")
+        if not isinstance(prev, str) or len(title) >= len(prev):
+            state["title"] = title
 
     kind = upd.get("kind") if upd.get("kind") is not None else ev.get("kind")
     if kind is not None:
@@ -275,96 +278,165 @@ def _merge_tool_from_event(ev: dict[str, Any], tool_states: dict[str, dict[str, 
 
     raw_input = upd.get("rawInput") if "rawInput" in upd else upd.get("raw_input")
     if raw_input is not None:
-        state["args"] = raw_input
+        state["args"] = _normalize_tool_arguments(raw_input)
+        state["args_from_raw_input"] = True
 
     raw_output = upd.get("rawOutput") if "rawOutput" in upd else upd.get("raw_output")
     if raw_output is not None:
         state["raw_output"] = raw_output
 
-    content = upd.get("content")
-    if content is not None:
-        summarized = _summarize_tool_content(content)
-        if summarized:
-            state["content"] = summarized
+    # Harbor: observation from rawOutput and/or text-bearing content
+    obs = _stringify_tool_output(raw_output, upd.get("content"))
+    if obs:
+        chunks: list[str] = state.setdefault("observation_chunks", [])
+        if not chunks or chunks[-1] != obs:
+            chunks.append(obs)
 
-    # Best-effort function_name — re-infer until a non-empty name sticks.
-    if not state.get("function_name"):
-        inferred = _infer_function_name(state)
-        if inferred:
-            state["function_name"] = inferred
+    # --- L1: vendor meta terminal stdout (pi) ---
+    _merge_terminal_meta(upd, state)
+
+    # function_name: Harbor _resolve_tool_name (kind else title first line)
+    if not state.get("function_name") or state.get("function_name") == "tool":
+        state["function_name"] = _resolve_tool_name(upd if upd else state)
 
 
-def _infer_function_name(state: dict[str, Any]) -> str | None:
-    args = state.get("args")
-    if isinstance(args, dict):
-        for key in ("name", "tool", "toolName", "tool_name", "command", "function"):
-            val = args.get(key)
-            if isinstance(val, str) and val.strip():
-                return val.strip()
-    title = state.get("title")
-    if isinstance(title, str) and title.strip():
-        # Use first token / short title as display name
-        return title.strip()[:120]
-    kind = state.get("kind")
-    if isinstance(kind, str) and kind:
+def _normalize_tool_arguments(raw_input: Any) -> dict[str, Any]:
+    """Harbor-compatible args object."""
+    if isinstance(raw_input, dict):
+        return raw_input
+    if raw_input is None:
+        return {}
+    return {"value": raw_input}
+
+
+def _resolve_tool_name(update: dict[str, Any]) -> str:
+    """Harbor: kind (if not other) else title first line else 'tool'."""
+    kind = update.get("kind")
+    if isinstance(kind, str) and kind and kind != "other":
         return kind
-    return None
+    title = update.get("title")
+    if isinstance(title, str) and title.strip():
+        return title.strip().splitlines()[0]
+    return "tool"
 
 
-def _summarize_tool_content(content: Any) -> str | None:
-    """Collapse ACP ToolCallContent[] (or string) into a readable observation string."""
+def _extract_text_from_content(content: Any) -> str:
+    """Harbor-style: walk content tree for text; ignore pure terminal id blocks."""
     if content is None:
-        return None
+        return ""
     if isinstance(content, str):
         return content
-    if not isinstance(content, list):
-        try:
-            return json.dumps(content, ensure_ascii=False)
-        except (TypeError, ValueError):
-            return str(content)
+    if isinstance(content, list):
+        return "".join(_extract_text_from_content(item) for item in content)
+    if isinstance(content, dict):
+        if content.get("type") == "terminal":
+            return ""
+        text = content.get("text")
+        if isinstance(text, str):
+            return text
+        nested = content.get("content")
+        if nested is not None:
+            return _extract_text_from_content(nested)
+        # diff: surface path + newText when present
+        if content.get("type") == "diff" or "newText" in content or "new_text" in content:
+            path = content.get("path") or ""
+            new = content.get("newText") if "newText" in content else content.get("new_text")
+            if isinstance(new, str):
+                return f"[diff {path}]\n{new}"
+            return f"[diff {path}]".strip() if path else ""
+    return ""
 
-    parts: list[str] = []
-    for item in content:
-        if not isinstance(item, dict):
-            parts.append(str(item))
-            continue
-        item_type = item.get("type")
-        if item_type == "content" or "content" in item:
-            inner = item.get("content")
-            if isinstance(inner, dict):
-                text = inner.get("text")
-                if isinstance(text, str):
-                    parts.append(text)
-                else:
-                    try:
-                        parts.append(json.dumps(inner, ensure_ascii=False))
-                    except (TypeError, ValueError):
-                        parts.append(str(inner))
-            elif isinstance(inner, str):
-                parts.append(inner)
-        elif item_type == "diff":
-            path = item.get("path") or ""
-            parts.append(f"[diff {path}]".strip())
-        elif item_type == "terminal":
-            tid = item.get("terminalId") or item.get("terminal_id") or ""
-            parts.append(f"[terminal {tid}]".strip())
-        else:
-            text = item.get("text")
-            if isinstance(text, str):
-                parts.append(text)
-            else:
-                try:
-                    parts.append(json.dumps(item, ensure_ascii=False))
-                except (TypeError, ValueError):
-                    parts.append(str(item))
-    joined = "\n".join(p for p in parts if p)
-    return joined or None
+
+def _stringify_tool_output(raw_output: Any, content: Any) -> str | None:
+    """Harbor _stringify_tool_output."""
+    if isinstance(raw_output, dict):
+        for key in ("output", "formatted_output", "aggregated_output"):
+            value = raw_output.get(key)
+            if isinstance(value, str) and value:
+                return value
+        if any(key in raw_output for key in ("stdout", "stderr", "exit_code", "status")):
+            return json.dumps(raw_output, ensure_ascii=False, sort_keys=True)
+    elif raw_output is not None:
+        return str(raw_output)
+
+    text = _extract_text_from_content(content)
+    return text or None
+
+
+def _merge_terminal_meta(upd: dict[str, Any], state: dict[str, Any]) -> None:
+    """L1: ``_meta.terminal_output.data`` (and terminal_exit) when present."""
+    meta = upd.get("_meta") if isinstance(upd.get("_meta"), dict) else None
+    if meta is None:
+        # alias used by some dumps
+        meta = upd.get("field_meta") if isinstance(upd.get("field_meta"), dict) else None
+    if meta is None:
+        return
+
+    term = meta.get("terminal_output")
+    if isinstance(term, dict):
+        data = term.get("data")
+        if isinstance(data, str) and data:
+            prev = state.get("terminal_output")
+            if (
+                not isinstance(prev, str)
+                or not prev
+                or data.startswith(prev)
+                or len(data) >= len(prev)
+            ):
+                state["terminal_output"] = data
+            elif not prev.endswith(data):
+                state["terminal_output"] = prev + data
+
+    exit_info = meta.get("terminal_exit")
+    if exit_info is not None:
+        state["terminal_exit"] = exit_info
+
+
+def _finalize_tool_state(state: dict[str, Any]) -> None:
+    """Collapse chunks; apply L1 title→command when rawInput never arrived."""
+    # function_name from final kind/title (Harbor)
+    state["function_name"] = _resolve_tool_name(
+        {
+            "kind": state.get("kind"),
+            "title": state.get("title"),
+        }
+    )
+
+    # L1: execute tools often stream command into title without rawInput
+    if not state.get("args_from_raw_input"):
+        title = state.get("title")
+        kind = state.get("kind")
+        kind_l = kind.lower() if isinstance(kind, str) else ""
+        if (
+            isinstance(title, str)
+            and title.strip()
+            and kind_l in {"execute", "other", ""}
+            and (not state.get("args") or state.get("args") == {})
+        ):
+            state["args"] = {"command": title}
+
+    # Observation content: protocol chunks + L1 terminal meta
+    chunks: list[str] = list(state.get("observation_chunks") or [])
+    term_out = state.get("terminal_output")
+    if isinstance(term_out, str) and term_out:
+        if not chunks or all(c.startswith("[terminal ") for c in chunks):
+            chunks = [term_out]
+        elif term_out not in "\n\n".join(chunks):
+            chunks.append(term_out)
+
+    if chunks:
+        state["content"] = "\n\n".join(chunks)
+
+    if state.get("args") is None:
+        state["args"] = {}
 
 
 def _should_emit_observation(state: dict[str, Any]) -> bool:
-    if state.get("content") is not None:
+    if state.get("content"):
         return True
     if state.get("raw_output") is not None:
         return True
+    # Harbor skips empty observation; we still emit on terminal status when
+    # completed/failed so the action chain is visible (status-only).
     status = state.get("status")
     return isinstance(status, str) and status.lower() in {"completed", "failed"}

--- a/src/bora/adapters/acp/trajectory.py
+++ b/src/bora/adapters/acp/trajectory.py
@@ -18,6 +18,7 @@ def write_trajectory_jsonl(
     ok: bool,
     error: str | None,
     metadata: dict[str, Any] | None = None,
+    redaction_sentinels: tuple[str, ...] | list[str] | None = None,
 ) -> Path:
     """Write **turn-level** training trajectory for one BORA invoke.
 
@@ -25,8 +26,10 @@ def write_trajectory_jsonl(
 
     1. ``user`` — full prompt
     2. ``assistant`` (optional ``part=thought``) — merged thought text
-    3. ``assistant`` — merged message text (prefer ``final_text``)
-    4. ``terminal`` — ok / error / structured / usage / stop metadata
+    3. ``tool_call`` / ``observation`` pairs — merged from ACP stream
+    4. ``assistant`` — merged message text (prefer ``final_text``)
+    5. ``permission_decision`` — batch auto-approve evidence (if any)
+    6. ``terminal`` — ok / error / structured / usage / stop metadata
 
     Stream chunks are merged; raw token-level ACP updates are not written here.
     Optional debug stream stays out of this file (see ``events.jsonl`` if needed).
@@ -39,6 +42,8 @@ def write_trajectory_jsonl(
     assistant_parts: list[str] = []
     permission_events: list[dict[str, Any]] = []
     acp_session_id: str | None = None
+    # toolCallId → merged state; insertion order = first appearance
+    tool_states: dict[str, dict[str, Any]] = {}
 
     for ev in events:
         if not isinstance(ev, dict):
@@ -57,6 +62,9 @@ def write_trajectory_jsonl(
                 }
             )
             continue
+
+        _merge_tool_from_event(ev, tool_states)
+
         channel = ev.get("channel")
         text = ev.get("text")
         if not isinstance(text, str):
@@ -98,6 +106,51 @@ def write_trajectory_jsonl(
                 "source": "acp",
             }
         )
+
+    for call_id, state in tool_states.items():
+        tool_line: dict[str, Any] = {
+            "type": "tool_call",
+            "tool_call_id": call_id,
+            "title": state.get("title"),
+            "function_name": state.get("function_name"),
+            "kind": state.get("kind"),
+            "status": state.get("status"),
+            "turn_index": turn_index,
+            "acp_session_id": acp_session_id,
+            "source": "acp",
+        }
+        if state.get("args") is not None:
+            tool_line["args"] = state["args"]
+        # Drop null-only optional display fields for cleaner JSONL.
+        lines.append(
+            {
+                k: v
+                for k, v in tool_line.items()
+                if v is not None or k in {"type", "tool_call_id", "turn_index", "source"}
+            }
+        )
+
+        if _should_emit_observation(state):
+            obs: dict[str, Any] = {
+                "type": "observation",
+                "tool_call_id": call_id,
+                "status": state.get("status"),
+                "turn_index": turn_index,
+                "acp_session_id": acp_session_id,
+                "source": "acp",
+            }
+            if state.get("content") is not None:
+                obs["content"] = state["content"]
+            if state.get("raw_output") is not None:
+                obs["raw_output"] = state["raw_output"]
+            lines.append(
+                {
+                    k: v
+                    for k, v in obs.items()
+                    if v is not None or k in {"type", "tool_call_id", "turn_index", "source"}
+                }
+            )
+
     lines.append(
         {
             "type": "turn",
@@ -136,8 +189,184 @@ def write_trajectory_jsonl(
             "source": "bora",
         }
     )
+
+    sentinels = tuple(s for s in (redaction_sentinels or ()) if s)
+    if sentinels:
+        from bora.evidence.redaction import redact_value
+
+        lines = [redact_value(line, extra_sentinels=sentinels) for line in lines]
+    else:
+        # Still scrub common secret shapes even without explicit sentinels.
+        from bora.evidence.redaction import redact_value
+
+        lines = [redact_value(line) for line in lines]
+
     path.write_text(
         "\n".join(json.dumps(x, ensure_ascii=False, sort_keys=True) for x in lines) + "\n",
         encoding="utf-8",
     )
     return path
+
+
+def _session_update_name(ev: dict[str, Any]) -> str:
+    """Return normalized ACP sessionUpdate name, or empty string."""
+    upd = ev.get("update")
+    if isinstance(upd, dict):
+        su = upd.get("sessionUpdate") or upd.get("session_update")
+        if isinstance(su, str) and su:
+            return su.lower().replace("-", "_")
+    # Fallback: typed class name from client
+    ut = ev.get("update_type")
+    if isinstance(ut, str) and ut:
+        low = ut.lower()
+        if "toolcallupdate" in low.replace("_", "") or "tool_call_update" in low:
+            return "tool_call_update"
+        # ToolCall / SessionUpdateToolCall — not update
+        if "toolcall" in low.replace("_", "") and "update" not in low:
+            return "tool_call"
+        if low in {"tool_call", "toolcall"}:
+            return "tool_call"
+        if low in {"tool_call_update", "toolcallupdate"}:
+            return "tool_call_update"
+    # Flat helpers imply a tool-related event when tool_call_id is present
+    if ev.get("tool_call_id") or (
+        isinstance(upd, dict) and (upd.get("toolCallId") or upd.get("tool_call_id"))
+    ):
+        # Prefer update when status-only progress is likely, but without name
+        # treat as tool_call seed (merge is idempotent).
+        return "tool_call"
+    return ""
+
+
+def _tool_call_id_from_event(ev: dict[str, Any]) -> str | None:
+    tid = ev.get("tool_call_id")
+    if isinstance(tid, str) and tid:
+        return tid
+    upd = ev.get("update")
+    if isinstance(upd, dict):
+        for key in ("toolCallId", "tool_call_id"):
+            val = upd.get(key)
+            if isinstance(val, str) and val:
+                return val
+    return None
+
+
+def _merge_tool_from_event(ev: dict[str, Any], tool_states: dict[str, dict[str, Any]]) -> None:
+    name = _session_update_name(ev)
+    call_id = _tool_call_id_from_event(ev)
+    if not call_id:
+        return
+    # Require an explicit tool sessionUpdate name, or flat tool_call_id on a
+    # session_update event (client already stamped helpers).
+    if name not in {"tool_call", "tool_call_update"} and ev.get("type") != "session_update":
+        return
+
+    upd = ev.get("update") if isinstance(ev.get("update"), dict) else {}
+    state = tool_states.setdefault(call_id, {"tool_call_id": call_id})
+
+    # Prefer nested update fields; fall back to flat client helpers.
+    title = upd.get("title") if isinstance(upd.get("title"), str) else ev.get("title")
+    if isinstance(title, str) and title:
+        state["title"] = title
+
+    kind = upd.get("kind") if upd.get("kind") is not None else ev.get("kind")
+    if kind is not None:
+        state["kind"] = kind if isinstance(kind, str) else str(kind)
+
+    status = upd.get("status") if upd.get("status") is not None else ev.get("status")
+    if status is not None:
+        state["status"] = status if isinstance(status, str) else str(status)
+
+    raw_input = upd.get("rawInput") if "rawInput" in upd else upd.get("raw_input")
+    if raw_input is not None:
+        state["args"] = raw_input
+
+    raw_output = upd.get("rawOutput") if "rawOutput" in upd else upd.get("raw_output")
+    if raw_output is not None:
+        state["raw_output"] = raw_output
+
+    content = upd.get("content")
+    if content is not None:
+        summarized = _summarize_tool_content(content)
+        if summarized:
+            state["content"] = summarized
+
+    # Best-effort function_name
+    if "function_name" not in state:
+        state["function_name"] = _infer_function_name(state)
+
+
+def _infer_function_name(state: dict[str, Any]) -> str | None:
+    args = state.get("args")
+    if isinstance(args, dict):
+        for key in ("name", "tool", "toolName", "tool_name", "command", "function"):
+            val = args.get(key)
+            if isinstance(val, str) and val.strip():
+                return val.strip()
+    title = state.get("title")
+    if isinstance(title, str) and title.strip():
+        # Use first token / short title as display name
+        return title.strip()[:120]
+    kind = state.get("kind")
+    if isinstance(kind, str) and kind:
+        return kind
+    return None
+
+
+def _summarize_tool_content(content: Any) -> str | None:
+    """Collapse ACP ToolCallContent[] (or string) into a readable observation string."""
+    if content is None:
+        return None
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        try:
+            return json.dumps(content, ensure_ascii=False)
+        except (TypeError, ValueError):
+            return str(content)
+
+    parts: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            parts.append(str(item))
+            continue
+        item_type = item.get("type")
+        if item_type == "content" or "content" in item:
+            inner = item.get("content")
+            if isinstance(inner, dict):
+                text = inner.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+                else:
+                    try:
+                        parts.append(json.dumps(inner, ensure_ascii=False))
+                    except (TypeError, ValueError):
+                        parts.append(str(inner))
+            elif isinstance(inner, str):
+                parts.append(inner)
+        elif item_type == "diff":
+            path = item.get("path") or ""
+            parts.append(f"[diff {path}]".strip())
+        elif item_type == "terminal":
+            tid = item.get("terminalId") or item.get("terminal_id") or ""
+            parts.append(f"[terminal {tid}]".strip())
+        else:
+            text = item.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+            else:
+                try:
+                    parts.append(json.dumps(item, ensure_ascii=False))
+                except (TypeError, ValueError):
+                    parts.append(str(item))
+    joined = "\n".join(p for p in parts if p)
+    return joined or None
+
+
+def _should_emit_observation(state: dict[str, Any]) -> bool:
+    if state.get("content") is not None:
+        return True
+    if state.get("raw_output") is not None:
+        return True
+    status = state.get("status")
+    return isinstance(status, str) and status.lower() in {"completed", "failed"}

--- a/src/bora/adapters/acp/trajectory.py
+++ b/src/bora/adapters/acp/trajectory.py
@@ -190,16 +190,11 @@ def write_trajectory_jsonl(
         }
     )
 
+    # Pattern scrub always; include caller sentinels when present.
+    from bora.evidence.redaction import redact_value
+
     sentinels = tuple(s for s in (redaction_sentinels or ()) if s)
-    if sentinels:
-        from bora.evidence.redaction import redact_value
-
-        lines = [redact_value(line, extra_sentinels=sentinels) for line in lines]
-    else:
-        # Still scrub common secret shapes even without explicit sentinels.
-        from bora.evidence.redaction import redact_value
-
-        lines = [redact_value(line) for line in lines]
+    lines = [redact_value(line, extra_sentinels=sentinels) for line in lines]
 
     path.write_text(
         "\n".join(json.dumps(x, ensure_ascii=False, sort_keys=True) for x in lines) + "\n",
@@ -261,7 +256,8 @@ def _merge_tool_from_event(ev: dict[str, Any], tool_states: dict[str, dict[str, 
     if name not in {"tool_call", "tool_call_update"} and ev.get("type") != "session_update":
         return
 
-    upd = ev.get("update") if isinstance(ev.get("update"), dict) else {}
+    raw_update = ev.get("update")
+    upd: dict[str, Any] = raw_update if isinstance(raw_update, dict) else {}
     state = tool_states.setdefault(call_id, {"tool_call_id": call_id})
 
     # Prefer nested update fields; fall back to flat client helpers.
@@ -291,9 +287,11 @@ def _merge_tool_from_event(ev: dict[str, Any], tool_states: dict[str, dict[str, 
         if summarized:
             state["content"] = summarized
 
-    # Best-effort function_name
-    if "function_name" not in state:
-        state["function_name"] = _infer_function_name(state)
+    # Best-effort function_name — re-infer until a non-empty name sticks.
+    if not state.get("function_name"):
+        inferred = _infer_function_name(state)
+        if inferred:
+            state["function_name"] = inferred
 
 
 def _infer_function_name(state: dict[str, Any]) -> str | None:

--- a/src/bora/adapters/credential_projection.py
+++ b/src/bora/adapters/credential_projection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import shutil
 import tempfile
@@ -62,12 +63,16 @@ def project_executor_credentials(*, work_root: Path) -> CredentialProjection:
     allowlisted_files: list[tuple[Path, str]] = [
         (Path.home() / ".pi" / "agent" / "auth.json", "pi_home/agent/auth.json"),
         (Path.home() / ".local" / "share" / "opencode" / "auth.json", "opencode/auth.json"),
+        # Grok Build ACP (Mode 3) host OAuth / session store — not XAI_API_KEY alone.
+        (Path.home() / ".grok" / "auth.json", "grok_home/auth.json"),
     ]
     for src_file, rel in allowlisted_files:
         if src_file.is_file():
             target = root / rel
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src_file, target)
+            with contextlib.suppress(OSError):
+                target.chmod(0o600)
             has = True
             keys.append(rel)
 

--- a/src/bora/adapters/provider_docker/multi_actor.py
+++ b/src/bora/adapters/provider_docker/multi_actor.py
@@ -407,9 +407,7 @@ class DockerMultiActorMixin:
                 f"cp /creds/opencode/auth.json '{home}/.local/share/opencode/auth.json'; "
                 f"chmod 0600 '{home}/.local/share/opencode/auth.json'; fi"
             )
-            lines.append(
-                f"chown -R {b.uid}:{b.gid} '{home}/.local' 2>/dev/null || true"
-            )
+            lines.append(f"chown -R {b.uid}:{b.gid} '{home}/.local' 2>/dev/null || true")
             # Grok Build ACP host login (optional) — $HOME/.grok/auth.json
             lines.append(f"mkdir -p '{home}/.grok'")
             lines.append(

--- a/src/bora/adapters/provider_docker/multi_actor.py
+++ b/src/bora/adapters/provider_docker/multi_actor.py
@@ -392,6 +392,33 @@ class DockerMultiActorMixin:
             )
             lines.append(f"chown -R {b.uid}:{b.gid} '{home}/.codex'")
             lines.append(f"chmod 0700 '{home}/.codex'")
+            # Pi agent auth (optional)
+            lines.append(f"mkdir -p '{home}/.pi/agent'")
+            lines.append(
+                f"if [ -f /creds/pi_home/agent/auth.json ]; then "
+                f"cp /creds/pi_home/agent/auth.json '{home}/.pi/agent/auth.json'; "
+                f"chmod 0600 '{home}/.pi/agent/auth.json'; fi"
+            )
+            lines.append(f"chown -R {b.uid}:{b.gid} '{home}/.pi' 2>/dev/null || true")
+            # OpenCode auth (optional) under XDG_DATA_HOME default
+            lines.append(f"mkdir -p '{home}/.local/share/opencode'")
+            lines.append(
+                f"if [ -f /creds/opencode/auth.json ]; then "
+                f"cp /creds/opencode/auth.json '{home}/.local/share/opencode/auth.json'; "
+                f"chmod 0600 '{home}/.local/share/opencode/auth.json'; fi"
+            )
+            lines.append(
+                f"chown -R {b.uid}:{b.gid} '{home}/.local' 2>/dev/null || true"
+            )
+            # Grok Build ACP host login (optional) — $HOME/.grok/auth.json
+            lines.append(f"mkdir -p '{home}/.grok'")
+            lines.append(
+                f"if [ -f /creds/grok_home/auth.json ]; then "
+                f"cp /creds/grok_home/auth.json '{home}/.grok/auth.json'; "
+                f"chmod 0600 '{home}/.grok/auth.json'; fi"
+            )
+            lines.append(f"chown -R {b.uid}:{b.gid} '{home}/.grok' 2>/dev/null || true")
+            lines.append(f"chmod 0700 '{home}/.grok' 2>/dev/null || true")
             # Create private primary group if needed (numeric chown works without).
             lines.append(f"groupadd -g {b.gid} actor-g-{b.gid} 2>/dev/null || true")
             lines.append(

--- a/src/bora/evidence/store.py
+++ b/src/bora/evidence/store.py
@@ -220,6 +220,7 @@ class InvocationHandle:
                 for name in (
                     "request.json",
                     "events.jsonl",
+                    "trajectory.jsonl",
                     "final-response.json",
                     "stderr.txt",
                 ):

--- a/src/bora/runtime/agent_service_evidence.py
+++ b/src/bora/runtime/agent_service_evidence.py
@@ -137,6 +137,10 @@ def seal_invoke_result(
         from bora.adapters.acp import write_trajectory_jsonl
 
         # Always rewrite with turn_index even if executor already wrote.
+        sentinels = ()
+        store = getattr(handle, "store", None)
+        if store is not None:
+            sentinels = tuple(getattr(store, "sentinels", ()) or ())
         write_trajectory_jsonl(
             handle.directory,
             prompt=prompt,
@@ -149,6 +153,7 @@ def seal_invoke_result(
             ok=bool(result.ok),
             error=result.error,
             metadata=meta,
+            redaction_sentinels=sentinels,
         )
 
     status = "completed" if result.ok else map_error_status(result.error)

--- a/src/bora/viewer/trials/surface.py
+++ b/src/bora/viewer/trials/surface.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -301,6 +302,12 @@ def _trial_meta_from_evidence(
     if score is None:
         score = summary.get("score")
     error = suite_row.get("error") or result.get("error") or summary.get("error")
+    # SPA must receive a string; structured errors (e.g. {phase: ...}) crash React.
+    if error is not None and not isinstance(error, str):
+        try:
+            error = json.dumps(error, ensure_ascii=False, sort_keys=True)
+        except (TypeError, ValueError):
+            error = str(error)
     locked_task = lock.get("task_id") if isinstance(lock.get("task_id"), str) else None
     surface = _agent_surface(evidence, lock=lock, result=result, summary=summary)
 

--- a/src/bora/viewer/trials/trajectory.py
+++ b/src/bora/viewer/trials/trajectory.py
@@ -121,6 +121,25 @@ def _parse_trajectory_jsonl(path: Path) -> list[dict[str, Any]]:
                         content = str(content)
                 if isinstance(content, str) and len(content) > 8_000:
                     content = content[:8_000] + "…[truncated]"
+
+                # tool_call / observation: surface args & raw_output as content when needed
+                args = obj.get("args")
+                raw_output = obj.get("raw_output")
+                if step_type == "tool_call" and content is None and args is not None:
+                    try:
+                        content = json.dumps(args, ensure_ascii=False)
+                    except (TypeError, ValueError):
+                        content = str(args)
+                    if isinstance(content, str) and len(content) > 8_000:
+                        content = content[:8_000] + "…[truncated]"
+                if step_type == "observation" and content is None and raw_output is not None:
+                    try:
+                        content = json.dumps(raw_output, ensure_ascii=False)
+                    except (TypeError, ValueError):
+                        content = str(raw_output)
+                    if isinstance(content, str) and len(content) > 8_000:
+                        content = content[:8_000] + "…[truncated]"
+
                 steps.append(
                     {
                         "type": step_type,
@@ -134,6 +153,16 @@ def _parse_trajectory_jsonl(path: Path) -> list[dict[str, Any]]:
                         "usage": obj.get("usage") if isinstance(obj.get("usage"), dict) else None,
                         "metadata": obj.get("metadata")
                         if isinstance(obj.get("metadata"), dict)
+                        else None,
+                        # tool_call / observation fields (fail-open; unknown types ignore)
+                        "tool_call_id": obj.get("tool_call_id"),
+                        "title": obj.get("title"),
+                        "function_name": obj.get("function_name"),
+                        "kind": obj.get("kind"),
+                        "status": obj.get("status"),
+                        "args": args if isinstance(args, (dict, list, str)) else None,
+                        "raw_output": raw_output
+                        if isinstance(raw_output, (dict, list, str))
                         else None,
                         "line": line_no,
                     }

--- a/src/bora/viewer/trials/trajectory.py
+++ b/src/bora/viewer/trials/trajectory.py
@@ -140,6 +140,55 @@ def _parse_trajectory_jsonl(path: Path) -> list[dict[str, Any]]:
                     if isinstance(content, str) and len(content) > 8_000:
                         content = content[:8_000] + "…[truncated]"
 
+                # permission_decision: decision summary (no tool payload secrets)
+                if step_type == "permission_decision" and content is None:
+                    parts: list[str] = []
+                    for key in ("policy", "outcome", "option_id"):
+                        val = obj.get(key)
+                        if val is not None and val != "":
+                            parts.append(f"{key}={val}")
+                    if parts:
+                        content = " · ".join(parts)
+
+                # terminal: BORA invoke footer (ok / stop / usage / entry meta)
+                if step_type == "terminal" and content is None:
+                    tparts: list[str] = []
+                    if obj.get("ok") is True:
+                        tparts.append("ok")
+                    elif obj.get("ok") is False:
+                        tparts.append("not ok")
+                    stop = obj.get("stop_reason")
+                    if isinstance(stop, str) and stop:
+                        tparts.append(f"stop={stop}")
+                    err = obj.get("error")
+                    if err is not None and err != "":
+                        tparts.append(f"error={err}")
+                    usage = obj.get("usage") if isinstance(obj.get("usage"), dict) else None
+                    if usage:
+                        try:
+                            tparts.append(f"usage={json.dumps(usage, ensure_ascii=False)}")
+                        except (TypeError, ValueError):
+                            tparts.append(f"usage={usage}")
+                    meta = obj.get("metadata") if isinstance(obj.get("metadata"), dict) else None
+                    if meta:
+                        # Compact interesting keys only
+                        bits = []
+                        for k in (
+                            "executor_kind",
+                            "acp_entry_id",
+                            "actual_model",
+                            "locked_model",
+                            "protocol_version",
+                        ):
+                            if k in meta and meta[k] is not None:
+                                bits.append(f"{k}={meta[k]}")
+                        if bits:
+                            tparts.append(" ".join(bits))
+                    if tparts:
+                        content = " · ".join(tparts)
+                        if len(content) > 8_000:
+                            content = content[:8_000] + "…[truncated]"
+
                 steps.append(
                     {
                         "type": step_type,
@@ -164,6 +213,10 @@ def _parse_trajectory_jsonl(path: Path) -> list[dict[str, Any]]:
                         "raw_output": raw_output
                         if isinstance(raw_output, (dict, list, str))
                         else None,
+                        # permission_decision summary fields
+                        "outcome": obj.get("outcome"),
+                        "option_id": obj.get("option_id"),
+                        "policy": obj.get("policy"),
                         "line": line_no,
                     }
                 )

--- a/tests/adapters/test_trajectory_tool_observation.py
+++ b/tests/adapters/test_trajectory_tool_observation.py
@@ -1,0 +1,261 @@
+"""ACP trajectory synthesis: tool_call + observation from session/update events."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bora.adapters.acp.trajectory import write_trajectory_jsonl
+
+
+def _read_lines(path: Path) -> list[dict]:
+    return [
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+
+
+def test_no_tool_events_unchanged_shape(tmp_path: Path) -> None:
+    path = write_trajectory_jsonl(
+        tmp_path / "inv",
+        prompt="hello",
+        events=(
+            {
+                "type": "session_update",
+                "session_id": "s1",
+                "channel": "assistant",
+                "text": "hi ",
+            },
+            {
+                "type": "session_update",
+                "session_id": "s1",
+                "channel": "assistant",
+                "text": "there",
+            },
+        ),
+        final_text="hi there",
+        structured=None,
+        usage={"input_tokens": 1},
+        ok=True,
+        error=None,
+        metadata={"executor_kind": "acp", "turn_index": 1},
+    )
+    lines = _read_lines(path)
+    types = [x["type"] for x in lines]
+    assert types == ["turn", "turn", "terminal"]
+    assert lines[0]["role"] == "user"
+    assert lines[1]["role"] == "assistant"
+    assert lines[1]["content"] == "hi there"
+    assert "tool_call" not in types
+    assert "observation" not in types
+
+
+def test_tool_call_and_update_merged(tmp_path: Path) -> None:
+    events = (
+        {
+            "type": "session_update",
+            "session_id": "sess_1",
+            "update_type": "ToolCall",
+            "tool_call_id": "call_001",
+            "title": "Reading configuration file",
+            "kind": "read",
+            "status": "pending",
+            "update": {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "call_001",
+                "title": "Reading configuration file",
+                "kind": "read",
+                "status": "pending",
+                "rawInput": {"path": "/workspace/config.json"},
+            },
+        },
+        {
+            "type": "session_update",
+            "session_id": "sess_1",
+            "update_type": "ToolCallUpdate",
+            "tool_call_id": "call_001",
+            "status": "in_progress",
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "call_001",
+                "status": "in_progress",
+                "content": [
+                    {
+                        "type": "content",
+                        "content": {"type": "text", "text": "Found 3 configuration files..."},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "session_update",
+            "session_id": "sess_1",
+            "update_type": "ToolCallUpdate",
+            "tool_call_id": "call_001",
+            "status": "completed",
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "call_001",
+                "status": "completed",
+                "content": [
+                    {
+                        "type": "content",
+                        "content": {"type": "text", "text": "Analysis complete. Found 3 issues."},
+                    }
+                ],
+                "rawOutput": {"ok": True, "count": 3},
+            },
+        },
+        {
+            "type": "session_update",
+            "session_id": "sess_1",
+            "channel": "assistant",
+            "text": "Done.",
+        },
+    )
+    path = write_trajectory_jsonl(
+        tmp_path / "inv",
+        prompt="inspect config",
+        events=events,
+        final_text="Done.",
+        structured=None,
+        usage=None,
+        ok=True,
+        error=None,
+        metadata={"executor_kind": "acp", "acp_entry_id": "pi", "turn_index": 2},
+    )
+    lines = _read_lines(path)
+    types = [x["type"] for x in lines]
+    assert types == ["turn", "tool_call", "observation", "turn", "terminal"]
+
+    tool = lines[1]
+    assert tool["tool_call_id"] == "call_001"
+    assert tool["kind"] == "read"
+    assert tool["status"] == "completed"
+    assert tool["args"] == {"path": "/workspace/config.json"}
+    assert tool["title"] == "Reading configuration file"
+    assert tool["function_name"]
+    assert tool["turn_index"] == 2
+    assert tool["acp_session_id"] == "sess_1"
+
+    obs = lines[2]
+    assert obs["type"] == "observation"
+    assert obs["tool_call_id"] == "call_001"
+    assert obs["status"] == "completed"
+    assert "Analysis complete" in (obs.get("content") or "")
+    # Intermediate in_progress text must not be the only residual — final content wins
+    assert "Found 3 configuration files" not in (obs.get("content") or "")
+    assert obs["raw_output"] == {"ok": True, "count": 3}
+
+
+def test_multiple_tool_calls_order_preserved(tmp_path: Path) -> None:
+    events = (
+        {
+            "type": "session_update",
+            "session_id": "s",
+            "tool_call_id": "a",
+            "title": "list",
+            "kind": "search",
+            "status": "completed",
+            "update": {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "a",
+                "title": "list",
+                "kind": "search",
+                "status": "completed",
+                "rawInput": {"q": "x"},
+                "content": [{"type": "content", "content": {"type": "text", "text": "a-out"}}],
+            },
+        },
+        {
+            "type": "session_update",
+            "session_id": "s",
+            "tool_call_id": "b",
+            "title": "run",
+            "kind": "execute",
+            "status": "completed",
+            "update": {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "b",
+                "title": "run",
+                "kind": "execute",
+                "status": "completed",
+                "rawInput": {"cmd": "ls"},
+                "rawOutput": {"stdout": "ok"},
+            },
+        },
+    )
+    path = write_trajectory_jsonl(
+        tmp_path / "inv",
+        prompt="p",
+        events=events,
+        final_text="",
+        structured=None,
+        usage=None,
+        ok=True,
+        error=None,
+    )
+    lines = _read_lines(path)
+    tool_ids = [x["tool_call_id"] for x in lines if x["type"] == "tool_call"]
+    assert tool_ids == ["a", "b"]
+
+
+def test_tool_args_redacted(tmp_path: Path) -> None:
+    sentinel = "TRAJ_TOOL_SECRET_9f3a"
+    events = (
+        {
+            "type": "session_update",
+            "session_id": "s",
+            "tool_call_id": "c1",
+            "title": "fetch",
+            "kind": "fetch",
+            "status": "completed",
+            "update": {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "c1",
+                "title": "fetch",
+                "kind": "fetch",
+                "status": "completed",
+                "rawInput": {"Authorization": f"Bearer {sentinel}", "token": sentinel},
+                "rawOutput": {"body": f"cookie={sentinel}"},
+            },
+        },
+    )
+    path = write_trajectory_jsonl(
+        tmp_path / "inv",
+        prompt=f"use {sentinel}",
+        events=events,
+        final_text="ok",
+        structured=None,
+        usage=None,
+        ok=True,
+        error=None,
+        redaction_sentinels=[sentinel],
+    )
+    blob = path.read_text(encoding="utf-8")
+    assert sentinel not in blob
+    assert "REDACTED" in blob
+
+
+def test_permission_decision_still_emitted(tmp_path: Path) -> None:
+    events = (
+        {
+            "type": "permission_decision",
+            "outcome": "selected",
+            "option_id": "allow-once",
+            "policy": "batch_auto_approve",
+            "source": "acp_client",
+        },
+    )
+    path = write_trajectory_jsonl(
+        tmp_path / "inv",
+        prompt="p",
+        events=events,
+        final_text="",
+        structured=None,
+        usage=None,
+        ok=True,
+        error=None,
+    )
+    lines = _read_lines(path)
+    types = [x["type"] for x in lines]
+    assert "permission_decision" in types

--- a/tests/adapters/test_trajectory_tool_observation.py
+++ b/tests/adapters/test_trajectory_tool_observation.py
@@ -133,7 +133,7 @@ def test_tool_call_and_update_merged(tmp_path: Path) -> None:
     assert tool["status"] == "completed"
     assert tool["args"] == {"path": "/workspace/config.json"}
     assert tool["title"] == "Reading configuration file"
-    assert tool["function_name"]
+    assert tool["function_name"] == "read"  # Harbor: kind when present
     assert tool["turn_index"] == 2
     assert tool["acp_session_id"] == "sess_1"
 
@@ -141,9 +141,8 @@ def test_tool_call_and_update_merged(tmp_path: Path) -> None:
     assert obs["type"] == "observation"
     assert obs["tool_call_id"] == "call_001"
     assert obs["status"] == "completed"
+    # Harbor joins observation chunks (in_progress + completed text)
     assert "Analysis complete" in (obs.get("content") or "")
-    # Intermediate in_progress text must not be the only residual — final content wins
-    assert "Found 3 configuration files" not in (obs.get("content") or "")
     assert obs["raw_output"] == {"ok": True, "count": 3}
 
 
@@ -234,6 +233,95 @@ def test_tool_args_redacted(tmp_path: Path) -> None:
     blob = path.read_text(encoding="utf-8")
     assert sentinel not in blob
     assert "REDACTED" in blob
+
+
+def test_terminal_meta_stdout_and_title_command(tmp_path: Path) -> None:
+    """Pi/ACP path: command in title stream; stdout in update._meta.terminal_output."""
+    events = (
+        {
+            "type": "session_update",
+            "session_id": "s",
+            "update_type": "ToolCallStart",
+            "tool_call_id": "call_term",
+            "title": "bash",
+            "kind": "execute",
+            "status": "pending",
+            "update": {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "call_term",
+                "title": "bash",
+                "kind": "execute",
+                "status": "pending",
+                "content": [{"type": "terminal", "terminalId": "call_term"}],
+            },
+        },
+        {
+            "type": "session_update",
+            "session_id": "s",
+            "update_type": "ToolCallProgress",
+            "tool_call_id": "call_term",
+            "title": "ls -la /attempt/workspace/",
+            "kind": "execute",
+            "status": "pending",
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "call_term",
+                "title": "ls -la /attempt/workspace/",
+                "kind": "execute",
+                "status": "pending",
+            },
+        },
+        {
+            "type": "session_update",
+            "session_id": "s",
+            "update_type": "ToolCallProgress",
+            "tool_call_id": "call_term",
+            "status": "in_progress",
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "call_term",
+                "status": "in_progress",
+                "_meta": {
+                    "terminal_output": {
+                        "data": "total 20\ndrwxr-xr-x 6 actor instruction.md\n",
+                        "terminal_id": "call_term",
+                    }
+                },
+            },
+        },
+        {
+            "type": "session_update",
+            "session_id": "s",
+            "update_type": "ToolCallProgress",
+            "tool_call_id": "call_term",
+            "status": "completed",
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "call_term",
+                "status": "completed",
+                "_meta": {"terminal_exit": {"exit_code": 0}},
+            },
+        },
+    )
+    path = write_trajectory_jsonl(
+        tmp_path / "inv",
+        prompt="list dir",
+        events=events,
+        final_text="done",
+        structured=None,
+        usage=None,
+        ok=True,
+        error=None,
+    )
+    lines = _read_lines(path)
+    tool = next(x for x in lines if x["type"] == "tool_call")
+    obs = next(x for x in lines if x["type"] == "observation")
+    assert tool["args"] == {"command": "ls -la /attempt/workspace/"}
+    assert tool["title"] == "ls -la /attempt/workspace/"
+    assert tool["function_name"] == "execute"  # Harbor: kind over title token
+    assert "total 20" in (obs.get("content") or "")
+    assert "instruction.md" in (obs.get("content") or "")
+    assert "[terminal" not in (obs.get("content") or "")
 
 
 def test_permission_decision_still_emitted(tmp_path: Path) -> None:

--- a/tests/security/test_l1_secret_redaction.py
+++ b/tests/security/test_l1_secret_redaction.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from bora.adapters.credential_projection import project_executor_credentials
 
 
@@ -19,5 +21,30 @@ def test_projection_locator_has_no_raw_secret_in_keys_list(tmp_path: Path) -> No
         # Scoped home for container — never host tree mount marker
         assert (proj.root / "home").is_dir()
         assert "home/" in proj.locator_keys
+    finally:
+        proj.cleanup()
+
+
+def test_projection_copies_grok_auth_when_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """L1 must project host ~/.grok/auth.json for grok-build ACP (OAuth path)."""
+    import bora.adapters.credential_projection as cp
+
+    fake_home = tmp_path / "host-home"
+    grok_auth = fake_home / ".grok" / "auth.json"
+    grok_auth.parent.mkdir(parents=True)
+    grok_auth.write_text('{"token":"test-not-a-real-secret"}\n', encoding="utf-8")
+    monkeypatch.setattr(cp.Path, "home", lambda: fake_home)
+
+    work = tmp_path / "work"
+    work.mkdir()
+    proj = project_executor_credentials(work_root=work)
+    try:
+        projected = proj.root / "grok_home" / "auth.json"
+        assert projected.is_file()
+        assert "grok_home/auth.json" in proj.locator_keys
+        # Locator list must not embed the token value
+        assert "test-not-a-real-secret" not in json.dumps(proj.locator_keys)
     finally:
         proj.cleanup()

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -223,6 +223,55 @@ def test_trajectory_steps(tmp_path: Path) -> None:
     assert all(s.get("profile_id") == "main" for s in traj["steps"])
 
 
+def test_trajectory_tool_call_and_observation_steps(tmp_path: Path) -> None:
+    """Viewer fail-open parses tool_call / observation rows for the panel."""
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    root = _write_evidence(db, "run_alpha_1", task_id="alpha")
+    inv = root / "agent" / "invocations" / "0001-inv_test"
+    traj = [
+        {"type": "turn", "role": "user", "content": "read cfg", "turn_index": 1},
+        {
+            "type": "tool_call",
+            "tool_call_id": "call_1",
+            "title": "read file",
+            "function_name": "read",
+            "kind": "read",
+            "status": "completed",
+            "args": {"path": "/w/a.txt"},
+            "turn_index": 1,
+            "source": "acp",
+        },
+        {
+            "type": "observation",
+            "tool_call_id": "call_1",
+            "status": "completed",
+            "content": "file body",
+            "turn_index": 1,
+            "source": "acp",
+        },
+        {"type": "turn", "role": "assistant", "content": "done", "turn_index": 1},
+        {"type": "terminal", "ok": True, "turn_index": 1},
+    ]
+    (inv / "trajectory.jsonl").write_text(
+        "\n".join(json.dumps(x) for x in traj) + "\n", encoding="utf-8"
+    )
+
+    payload = trials.trial_trajectory(db, job_id, "alpha", "run_alpha_1")
+    types = [s.get("type") for s in payload["steps"]]
+    assert "tool_call" in types
+    assert "observation" in types
+    tool = next(s for s in payload["steps"] if s.get("type") == "tool_call")
+    assert tool.get("tool_call_id") == "call_1"
+    assert tool.get("kind") == "read"
+    assert tool.get("function_name") == "read"
+    # args surfaced as content when no content field
+    assert tool.get("content") and "a.txt" in tool["content"]
+    obs = next(s for s in payload["steps"] if s.get("type") == "observation")
+    assert obs.get("content") == "file body"
+    assert obs.get("tool_call_id") == "call_1"
+
+
 def test_tree_and_file_and_traversal(tmp_path: Path) -> None:
     db = _clean_db(tmp_path)
     job_id = _seed_suite_run(db)


### PR DESCRIPTION
## 摘要

本 PR 相对 `main` 交付 **#46**：在既有 BORA `trajectory.jsonl`（对话 turn）上加厚 **tool_call + observation**，**暂不做 ATIF**。

1. **Design** — `docs/design/05-runtime/evidence.md` 扩展行类型与合并/redact 规则  
2. **ACP 合成** — `write_trajectory_jsonl` 从 ACP events 折叠 tool 动作链（Harbor 同构 L0 + 显式 L1 `_meta`/title）  
3. **Viewer** — 轨迹面板展示 tool/observation；失败 error 字符串化防白屏  
4. **L1** — 投影 `~/.grok/auth.json`，使 `grok-build` 在 attempt 容器可鉴权  

## Screenshot

<img width="2786" height="1230" alt="image" src="https://github.com/user-attachments/assets/df83f455-12f5-4403-9cd2-58e5b75b74c4" />


## 功能说明

### Trajectory 合成（#46）

- 数据源：parent ACP client 已收集的 `session/update`（**不**做 parent 内 vendor scrape）  
- L0：`tool_call` / `tool_call_update` 按 `toolCallId` 合并 → `type=tool_call` + `type=observation`  
- L1：`update._meta.terminal_output.data`；无 `rawInput` 时 execute 用 title 回填 `args.command`  
- Redaction：args/content/raw_output 走既有 `redact_value`；`redaction_failed` 时 scrub `trajectory.jsonl`  
- 无 tool 路径行为不变：`turn` → `terminal`

### Viewer

- 解析 tool 字段；标签 + lucide 图标（user / assistant / execute / read / observation…）  
- 右侧对齐 turn / invocation / tool_call_id；隐藏成功态 `completed`，保留 failed 等  
- 结构化 `error`（如 `{phase:…}`）序列化为字符串，避免 React #31 白屏  

### Journeys / L1

- `terminal-jsonl-agg` 支持 `--set '/parameters/active_profile=…'`（修复 HarnessParameterView 读参）  
- L1 credential projection 增加 `grok_home/auth.json`，bootstrap 到 actor `$HOME/.grok/auth.json`  

## 本地验证

- CI 等价：ruff format/check、pyright、pytest **332 passed**（offline / skip L1 e2e 门禁）  
- 实跑 `examples/journeys --task terminal-jsonl-agg`：  
  - pi / opencode / **grok** 均 PASS，轨迹含 tool_call + observation  
- Grok 先前 `acp_auth_required` 因 L1 未投影 `~/.grok/auth.json`；本 PR 已修  

## 非目标（#46 正文）

- ATIF 一等文件、OpenAI messages 导出、`--load-trajectory`、轨迹当 PASS、parent 内 vendor stdout scrape  

## 关联

Closes #46