### PR TITLE
feat: Registry org model, result share, Hub orgs + browser OAuth (#51–#55)

### DIFF
--- a/apps/hub/README.md
+++ b/apps/hub/README.md
@@ -3,6 +3,9 @@
 Registry **Dataset catalog** SPA (Epic #22): list public/private packages, open
 README + tasks, preview package files, Task Jobs list, Leaderboard (#40).
 
+Also: **Organizations** browse (membership, org datasets, shared suite results)
+and **GitHub browser login** (Authorization Code → Registry token).
+
 **Not** the local results viewer (`apps/viewer` / `bora view`).
 
 ## Stack
@@ -13,8 +16,10 @@ Visual tokens: inherit [`apps/viewer/DESIGN.md`](../viewer/DESIGN.md).
 ## Dev
 
 ```bash
-# Terminal A — Registry (example)
+# Terminal A — Registry (must expose OAuth + org APIs)
 # see services/registry/README.md
+export VITE_REGISTRY_PROXY_TARGET=http://127.0.0.1:8700   # recommended local port
+uv run --extra registry python -m services.registry.app --host 127.0.0.1 --port 8700
 
 # Terminal B
 cd apps/hub
@@ -25,19 +30,35 @@ pnpm dev   # http://127.0.0.1:5174  — proxies /v1 → registry
 | Env | Meaning |
 | --- | --- |
 | `VITE_REGISTRY_URL` | Absolute Registry origin (production SPA). Empty = same origin (dev proxy). |
-| `VITE_REGISTRY_PROXY_TARGET` | Dev proxy target (default `http://127.0.0.1:8080`). |
+| `VITE_REGISTRY_PROXY_TARGET` | Dev proxy target (default `http://127.0.0.1:8080` — set to **8700** for local Registry). |
+
+### Login (browser OAuth)
+
+Hub uses **Authorization Code** (not Device Flow). Configure the GitHub OAuth App
+callback URL:
+
+- `http://127.0.0.1:5174/login/callback`
+- `http://localhost:5174/login/callback` (if you open Hub that way)
+
+Flow: **Sign in with GitHub** → GitHub Authorize → `/login/callback` → Registry
+token in `localStorage` (avatar + display name in the header when returned).
+
+CLI remains Device Flow: `bora login` (see `services/registry/README.md`).
 
 ## Routes
 
 | Path | Page |
 | --- | --- |
-| `/datasets` | Dataset list |
+| `/datasets` | Dataset list (**Your organizations** / **Explore**) |
 | `/datasets/:id` | README · Tasks · Leaderboard |
 | `/datasets/:id/tasks/:task` | README · Files · Jobs (list only) |
-| `/login` | GitHub device login shell |
+| `/organizations` | Orgs you belong to |
+| `/organizations/:orgId` | Members · Datasets · Shared results · Settings placeholder |
+| `/login` | Start browser OAuth |
+| `/login/callback` | OAuth redirect target |
 
-`:id` is URL-encoded `org/name` (`encodeURIComponent`).
+`:id` is URL-encoded `database_id` (`encodeURIComponent`).
 
 ## Related issues
 
-- Epic #22 · files API #38 · browse #39 · Leaderboard #40 · Jobs click-through #43 (out of scope)
+- Epic #22 · files API #38 · browse #39 · Leaderboard #40 · org/share #51–#55 · Jobs deep-link #43 (out of scope)

--- a/apps/hub/src/App.tsx
+++ b/apps/hub/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 
 import { DatasetDetailPage } from "@/pages/DatasetDetailPage";
 import { DatasetsPage } from "@/pages/DatasetsPage";
+import { LoginCallbackPage } from "@/pages/LoginCallbackPage";
 import { LoginPage } from "@/pages/LoginPage";
 import { OrganizationDetailPage } from "@/pages/OrganizationDetailPage";
 import { OrganizationsPage } from "@/pages/OrganizationsPage";
@@ -24,6 +25,7 @@ export default function App() {
           element={<OrganizationDetailPage />}
         />
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/login/callback" element={<LoginCallbackPage />} />
         <Route path="*" element={<Navigate to="/datasets" replace />} />
       </Routes>
     </BrowserRouter>

--- a/apps/hub/src/App.tsx
+++ b/apps/hub/src/App.tsx
@@ -3,6 +3,8 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { DatasetDetailPage } from "@/pages/DatasetDetailPage";
 import { DatasetsPage } from "@/pages/DatasetsPage";
 import { LoginPage } from "@/pages/LoginPage";
+import { OrganizationDetailPage } from "@/pages/OrganizationDetailPage";
+import { OrganizationsPage } from "@/pages/OrganizationsPage";
 import { TaskDetailPage } from "@/pages/TaskDetailPage";
 
 export default function App() {
@@ -15,6 +17,11 @@ export default function App() {
         <Route
           path="/datasets/:datasetId/tasks/:taskId"
           element={<TaskDetailPage />}
+        />
+        <Route path="/organizations" element={<OrganizationsPage />} />
+        <Route
+          path="/organizations/:orgId"
+          element={<OrganizationDetailPage />}
         />
         <Route path="/login" element={<LoginPage />} />
         <Route path="*" element={<Navigate to="/datasets" replace />} />

--- a/apps/hub/src/components/layout.tsx
+++ b/apps/hub/src/components/layout.tsx
@@ -3,7 +3,13 @@ import { Link, NavLink } from "react-router-dom";
 
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
-import { clearToken, getGithubUser, getToken } from "@/lib/auth";
+import {
+  clearToken,
+  getGithubAvatar,
+  getGithubName,
+  getGithubUser,
+  getToken,
+} from "@/lib/auth";
 import { cn } from "@/lib/utils";
 
 function navClass({ isActive }: { isActive: boolean }) {
@@ -22,6 +28,9 @@ export function Shell({
 }) {
   const token = getToken();
   const githubUser = getGithubUser();
+  const githubName = getGithubName();
+  const githubAvatar = getGithubAvatar();
+  const displayName = githubName || githubUser;
 
   return (
     <div className="min-h-full flex flex-col bg-canvas">
@@ -42,9 +51,23 @@ export function Shell({
         {meta}
         {token ? (
           <>
-            {githubUser ? (
-              <span className="text-xs text-mute font-mono hidden sm:inline">
-                @{githubUser}
+            {displayName ? (
+              <span className="hidden sm:inline-flex items-center gap-2 min-w-0 max-w-[14rem]">
+                {githubAvatar || githubUser ? (
+                  <img
+                    src={
+                      githubAvatar ||
+                      `https://github.com/${encodeURIComponent(githubUser || "")}.png?size=64`
+                    }
+                    alt=""
+                    width={28}
+                    height={28}
+                    className="h-7 w-7 rounded-full border border-hairline bg-canvas-soft object-cover shrink-0"
+                  />
+                ) : null}
+                <span className="text-sm text-body truncate" title={githubUser || undefined}>
+                  {displayName}
+                </span>
               </span>
             ) : null}
             <Button

--- a/apps/hub/src/components/layout.tsx
+++ b/apps/hub/src/components/layout.tsx
@@ -1,9 +1,17 @@
 import type { ReactNode } from "react";
-import { Link } from "react-router-dom";
+import { Link, NavLink } from "react-router-dom";
 
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
-import { clearToken, getToken } from "@/lib/auth";
+import { clearToken, getGithubUser, getToken } from "@/lib/auth";
+import { cn } from "@/lib/utils";
+
+function navClass({ isActive }: { isActive: boolean }) {
+  return cn(
+    "text-sm transition-colors px-1 py-0.5",
+    isActive ? "text-ink font-medium" : "text-body hover:text-ink",
+  );
+}
 
 export function Shell({
   children,
@@ -13,6 +21,7 @@ export function Shell({
   meta?: ReactNode;
 }) {
   const token = getToken();
+  const githubUser = getGithubUser();
 
   return (
     <div className="min-h-full flex flex-col bg-canvas">
@@ -21,25 +30,35 @@ export function Shell({
           BORA
         </Link>
         <span className="text-mute text-sm">hub</span>
-        <nav className="flex items-center gap-3 text-sm">
-          <Link to="/datasets" className="text-body hover:text-ink transition-colors">
+        <nav className="flex items-center gap-4 text-sm ml-2">
+          <NavLink to="/datasets" className={navClass} end={false}>
             Datasets
-          </Link>
+          </NavLink>
+          <NavLink to="/organizations" className={navClass}>
+            Organizations
+          </NavLink>
         </nav>
         <div className="flex-1" />
         {meta}
         {token ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => {
-              clearToken();
-              window.location.reload();
-            }}
-          >
-            Sign out
-          </Button>
+          <>
+            {githubUser ? (
+              <span className="text-xs text-mute font-mono hidden sm:inline">
+                @{githubUser}
+              </span>
+            ) : null}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                clearToken();
+                window.location.reload();
+              }}
+            >
+              Sign out
+            </Button>
+          </>
         ) : (
           <Button asChild variant="outline" size="sm">
             <Link to="/login">Sign in</Link>

--- a/apps/hub/src/components/leaderboard-table.tsx
+++ b/apps/hub/src/components/leaderboard-table.tsx
@@ -137,6 +137,11 @@ export function LeaderboardTable({
                 </TableCell>
                 <TableCell className="text-sm text-body">
                   {s.visibility || "—"}
+                  {s.uploaded_by ? (
+                    <span className="ml-2 font-mono text-[11px] text-mute">
+                      by {s.uploaded_by}
+                    </span>
+                  ) : null}
                 </TableCell>
                 <TableCell className="font-mono text-[11px]">
                   {s.suite_run_id}

--- a/apps/hub/src/lib/api.ts
+++ b/apps/hub/src/lib/api.ts
@@ -9,6 +9,7 @@ export type PackageRelease = {
   size: number;
   media_type?: string;
   created_at?: number;
+  org_id?: string;
 };
 
 export type FileItem = {
@@ -54,6 +55,7 @@ export type SuiteRow = {
   exit_code?: number | null;
   created_at?: number | string;
   note?: string;
+  uploaded_by?: string;
 };
 
 export class RegistryHttpError extends Error {

--- a/apps/hub/src/lib/api.ts
+++ b/apps/hub/src/lib/api.ts
@@ -26,6 +26,10 @@ export type OrgMember = {
   user_id: string;
   role: string;
   created_at?: number;
+  /** GitHub profile display name (from login-time profile snapshot). */
+  display_name?: string;
+  avatar_url?: string;
+  github_id?: string;
 };
 
 export type ResultShare = {
@@ -262,17 +266,53 @@ export async function deviceCode(): Promise<{
   });
 }
 
+/** Hub browser OAuth (Authorization Code) — Harbor-style, no device user_code. */
+export async function startWebLogin(
+  redirectUri: string,
+): Promise<{ authorize_url: string; state: string }> {
+  return requestJson("/v1/auth/github/web/start", {
+    method: "POST",
+    body: { redirect_uri: redirectUri },
+  });
+}
+
+export async function completeWebLogin(opts: {
+  code: string;
+  state: string;
+  redirectUri: string;
+}): Promise<{
+  token: string;
+  github_user?: string;
+  github_name?: string;
+  github_id?: number;
+  avatar_url?: string;
+  scopes?: string[];
+}> {
+  return requestJson("/v1/auth/github/web/callback", {
+    method: "POST",
+    body: {
+      code: opts.code,
+      state: opts.state,
+      redirect_uri: opts.redirectUri,
+    },
+  });
+}
+
 /**
  * Device poll. Registry returns 202 while pending (not an error).
  * Success 200: ``{ token, github_user, scopes }`` (Registry API token, not GH).
  */
 export async function devicePoll(
   deviceCodeValue: string,
+  opts?: { signal?: AbortSignal },
 ): Promise<{
   status?: string;
   token?: string;
   access_token?: string;
   github_user?: string;
+  github_name?: string;
+  github_id?: number;
+  avatar_url?: string;
   message?: string;
   error?: string;
 }> {
@@ -284,6 +324,7 @@ export async function devicePoll(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({ device_code: deviceCodeValue }),
+    signal: opts?.signal,
   });
   const text = await res.text();
   let data: Record<string, unknown> = {};
@@ -314,6 +355,11 @@ export async function devicePoll(
       typeof data.access_token === "string" ? data.access_token : undefined,
     github_user:
       typeof data.github_user === "string" ? data.github_user : undefined,
+    github_name:
+      typeof data.github_name === "string" ? data.github_name : undefined,
+    github_id: typeof data.github_id === "number" ? data.github_id : undefined,
+    avatar_url:
+      typeof data.avatar_url === "string" ? data.avatar_url : undefined,
   };
 }
 

--- a/apps/hub/src/lib/api.ts
+++ b/apps/hub/src/lib/api.ts
@@ -12,6 +12,30 @@ export type PackageRelease = {
   org_id?: string;
 };
 
+export type OrgRow = {
+  org_id: string;
+  name: string;
+  display_name?: string;
+  is_claimable?: boolean;
+  created_at?: number;
+  role?: string;
+};
+
+export type OrgMember = {
+  org_id: string;
+  user_id: string;
+  role: string;
+  created_at?: number;
+};
+
+export type ResultShare = {
+  result_kind: string;
+  result_id: string;
+  target_type: string;
+  target_id: string;
+  created_at?: number;
+};
+
 export type FileItem = {
   path: string;
   type: "file" | "dir" | string;
@@ -176,12 +200,49 @@ export async function getPackageFile(
 }
 
 export async function listSuites(
-  databaseId: string,
+  databaseId: string | null,
   token: string | null,
 ): Promise<SuiteRow[]> {
-  const q = new URLSearchParams({ database_id: databaseId });
-  const data = await requestJson<{ items?: SuiteRow[] }>(
-    `/v1/results/suites?${q.toString()}`,
+  const q = new URLSearchParams();
+  if (databaseId) q.set("database_id", databaseId);
+  const path = q.toString()
+    ? `/v1/results/suites?${q.toString()}`
+    : "/v1/results/suites";
+  const data = await requestJson<{ items?: SuiteRow[] }>(path, { token });
+  return Array.isArray(data.items) ? data.items : [];
+}
+
+export async function listOrgs(token: string | null): Promise<OrgRow[]> {
+  const data = await requestJson<{ items?: OrgRow[] }>("/v1/orgs", { token });
+  return Array.isArray(data.items) ? data.items : [];
+}
+
+export async function getOrg(
+  orgId: string,
+  token: string | null,
+): Promise<OrgRow> {
+  return requestJson(`/v1/orgs/${encodeURIComponent(orgId)}`, { token });
+}
+
+export async function listOrgMembers(
+  orgId: string,
+  token: string | null,
+): Promise<OrgMember[]> {
+  const data = await requestJson<{ items?: OrgMember[] }>(
+    `/v1/orgs/${encodeURIComponent(orgId)}/members`,
+    { token },
+  );
+  return Array.isArray(data.items) ? data.items : [];
+}
+
+export async function listResultShares(
+  kind: "attempt" | "suite",
+  resultId: string,
+  token: string | null,
+): Promise<ResultShare[]> {
+  const kindPath = kind === "attempt" ? "attempts" : "suites";
+  const data = await requestJson<{ items?: ResultShare[] }>(
+    `/v1/results/${kindPath}/${encodeURIComponent(resultId)}/shares`,
     { token },
   );
   return Array.isArray(data.items) ? data.items : [];

--- a/apps/hub/src/lib/auth.ts
+++ b/apps/hub/src/lib/auth.ts
@@ -1,6 +1,7 @@
 /** Browser-local token storage for Hub login (never written to packages/evidence). */
 
 const TOKEN_KEY = "bora-hub-registry-token";
+const USER_KEY = "bora-hub-github-user";
 
 export function getToken(): string | null {
   try {
@@ -10,12 +11,24 @@ export function getToken(): string | null {
   }
 }
 
-export function setToken(token: string): void {
+export function setToken(token: string, githubUser?: string | null): void {
   localStorage.setItem(TOKEN_KEY, token);
+  if (githubUser) {
+    localStorage.setItem(USER_KEY, githubUser);
+  }
+}
+
+export function getGithubUser(): string | null {
+  try {
+    return localStorage.getItem(USER_KEY);
+  } catch {
+    return null;
+  }
 }
 
 export function clearToken(): void {
   localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(USER_KEY);
 }
 
 export function isLoggedIn(): boolean {

--- a/apps/hub/src/lib/auth.ts
+++ b/apps/hub/src/lib/auth.ts
@@ -2,6 +2,8 @@
 
 const TOKEN_KEY = "bora-hub-registry-token";
 const USER_KEY = "bora-hub-github-user";
+const NAME_KEY = "bora-hub-github-name";
+const AVATAR_KEY = "bora-hub-github-avatar";
 
 export function getToken(): string | null {
   try {
@@ -11,10 +13,31 @@ export function getToken(): string | null {
   }
 }
 
-export function setToken(token: string, githubUser?: string | null): void {
+export function setToken(
+  token: string,
+  githubUser?: string | null,
+  githubName?: string | null,
+  avatarUrl?: string | null,
+): void {
   localStorage.setItem(TOKEN_KEY, token);
   if (githubUser) {
     localStorage.setItem(USER_KEY, githubUser);
+  }
+  if (githubName) {
+    localStorage.setItem(NAME_KEY, githubName);
+  } else {
+    localStorage.removeItem(NAME_KEY);
+  }
+  if (avatarUrl) {
+    localStorage.setItem(AVATAR_KEY, avatarUrl);
+  } else if (githubUser) {
+    // Fallback: GitHub avatar by login (works without stored avatar_url).
+    localStorage.setItem(
+      AVATAR_KEY,
+      `https://github.com/${encodeURIComponent(githubUser)}.png?size=64`,
+    );
+  } else {
+    localStorage.removeItem(AVATAR_KEY);
   }
 }
 
@@ -26,9 +49,27 @@ export function getGithubUser(): string | null {
   }
 }
 
+export function getGithubName(): string | null {
+  try {
+    return localStorage.getItem(NAME_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function getGithubAvatar(): string | null {
+  try {
+    return localStorage.getItem(AVATAR_KEY);
+  } catch {
+    return null;
+  }
+}
+
 export function clearToken(): void {
   localStorage.removeItem(TOKEN_KEY);
   localStorage.removeItem(USER_KEY);
+  localStorage.removeItem(NAME_KEY);
+  localStorage.removeItem(AVATAR_KEY);
 }
 
 export function isLoggedIn(): boolean {

--- a/apps/hub/src/pages/DatasetDetailPage.tsx
+++ b/apps/hub/src/pages/DatasetDetailPage.tsx
@@ -136,7 +136,15 @@ export function DatasetDetailPage() {
         </h1>
         {release ? (
           <p className="text-sm text-mute mt-1">
-            v{release.version} · {release.visibility} ·{" "}
+            v{release.version} · {release.visibility}
+            {release.org_id ? (
+              <>
+                {" "}
+                · org{" "}
+                <span className="font-mono text-xs text-body">{release.org_id}</span>
+              </>
+            ) : null}{" "}
+            ·{" "}
             <span className="font-mono text-xs">
               {release.package_digest.slice(0, 19)}…
             </span>

--- a/apps/hub/src/pages/DatasetsPage.tsx
+++ b/apps/hub/src/pages/DatasetsPage.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
 import { BreadcrumbNav } from "@/components/breadcrumb";
 import { Shell } from "@/components/layout";
+import { Input } from "@/components/ui/input";
 import {
   Table,
   TableBody,
@@ -13,12 +14,13 @@ import {
 } from "@/components/ui/table";
 import {
   encodeDatasetId,
+  listOrgs,
   listPackages,
   type PackageRelease,
   RegistryHttpError,
 } from "@/lib/api";
 import { getToken } from "@/lib/auth";
-import { formatDate } from "@/lib/utils";
+import { cn, formatDate } from "@/lib/utils";
 
 /** Collapse multi-version list to latest per database_id (by created_at). */
 function latestByDatabase(items: PackageRelease[]): PackageRelease[] {
@@ -38,22 +40,35 @@ function latestByDatabase(items: PackageRelease[]): PackageRelease[] {
   );
 }
 
+type Scope = "orgs" | "explore";
+
 export function DatasetsPage() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const scope: Scope =
+    searchParams.get("scope") === "explore" ? "explore" : "orgs";
+
   const [items, setItems] = useState<PackageRelease[]>([]);
+  const [myOrgIds, setMyOrgIds] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState("");
   const token = getToken();
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    listPackages(token)
-      .then((rows) => {
-        if (!cancelled) {
-          setItems(rows);
-          setError(null);
-        }
+    const packagesP = listPackages(token);
+    const orgsP = token
+      ? listOrgs(token).catch(() => [] as Awaited<ReturnType<typeof listOrgs>>)
+      : Promise.resolve([]);
+
+    Promise.all([packagesP, orgsP])
+      .then(([rows, orgs]) => {
+        if (cancelled) return;
+        setItems(rows);
+        setMyOrgIds(new Set(orgs.map((o) => o.org_id)));
+        setError(null);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -72,7 +87,28 @@ export function DatasetsPage() {
     };
   }, [token]);
 
-  const datasets = useMemo(() => latestByDatabase(items), [items]);
+  const datasets = useMemo(() => {
+    const latest = latestByDatabase(items);
+    const scoped =
+      scope === "orgs"
+        ? latest.filter(
+            (r) => r.org_id && myOrgIds.has(r.org_id) && token,
+          )
+        : latest.filter((r) => r.visibility === "public");
+    const q = query.trim().toLowerCase();
+    if (!q) return scoped;
+    return scoped.filter(
+      (r) =>
+        r.database_id.toLowerCase().includes(q) ||
+        (r.org_id && r.org_id.toLowerCase().includes(q)),
+    );
+  }, [items, scope, myOrgIds, query, token]);
+
+  function setScope(next: Scope) {
+    setSearchParams(next === "explore" ? { scope: "explore" } : {}, {
+      replace: true,
+    });
+  }
 
   function openDataset(id: string) {
     navigate(`/datasets/${encodeDatasetId(id)}`);
@@ -81,90 +117,155 @@ export function DatasetsPage() {
   return (
     <Shell>
       <BreadcrumbNav items={[{ label: "Datasets" }]} className="mb-4" />
-      <div className="flex items-baseline justify-between gap-4 mb-4">
-        <div>
-          <h1 className="text-xl font-semibold tracking-tight text-ink">Datasets</h1>
-          <p className="text-sm text-body mt-1">
-            Public Registry packages
-            {token ? " (including private visible to your token)" : ""}.
-            Sign in to see authorized private Datasets.
-          </p>
-        </div>
+      <div className="mb-4">
+        <p className="text-xs uppercase tracking-wide text-mute font-medium">
+          BORA Registry
+        </p>
+        <h1 className="text-2xl font-semibold tracking-tight text-ink mt-1">
+          {scope === "orgs" ? "Your datasets" : "Explore datasets"}
+        </h1>
+        <p className="text-sm text-body mt-1">
+          {scope === "orgs"
+            ? "Packages published by organizations you belong to."
+            : "Public packages on this Registry."}
+        </p>
       </div>
 
-      {loading ? (
+      <div className="flex gap-1 border-b border-hairline mb-4">
+        {(
+          [
+            ["orgs", "Your organizations"],
+            ["explore", "Explore"],
+          ] as const
+        ).map(([id, label]) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => setScope(id)}
+            className={cn(
+              "px-3 py-2 text-sm transition-colors border-b-2 -mb-px",
+              scope === id
+                ? "border-ink text-ink font-medium"
+                : "border-transparent text-body hover:text-ink",
+            )}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {scope === "orgs" && !token ? (
+        <div className="rounded-[8px] border border-hairline bg-canvas-soft p-6 text-sm text-body">
+          <p className="font-medium text-ink">Sign in to see org packages</p>
+          <p className="mt-1 text-mute">
+            <Link to="/login" className="underline underline-offset-2">
+              Sign in
+            </Link>{" "}
+            to list datasets from your organizations. Public packages are under{" "}
+            <button
+              type="button"
+              className="underline underline-offset-2"
+              onClick={() => setScope("explore")}
+            >
+              Explore
+            </button>
+            .
+          </p>
+        </div>
+      ) : loading ? (
         <p className="text-sm text-mute">Loading…</p>
       ) : error ? (
         <div className="rounded-[8px] border border-hairline bg-canvas-soft p-4 text-sm text-body">
           <p className="text-error font-medium">Could not load packages</p>
           <p className="mt-1 font-mono text-xs">{error}</p>
-          <p className="mt-2 text-mute">
-            Ensure Registry is running and{" "}
-            <code className="font-mono">VITE_REGISTRY_PROXY_TARGET</code> points at it.
-          </p>
-        </div>
-      ) : datasets.length === 0 ? (
-        <div className="rounded-[8px] border border-hairline bg-canvas-soft p-6 text-sm text-body">
-          <p className="font-medium text-ink">No Datasets yet</p>
-          <p className="mt-1 text-mute">
-            Publish with <code className="font-mono">bora publish</code> (public) or sign in
-            for private.
-          </p>
         </div>
       ) : (
-        <div className="rounded-[8px] border border-hairline overflow-hidden">
-          <Table>
-            <TableHeader>
-              <TableRow className="hover:bg-transparent">
-                <TableHead>Dataset</TableHead>
-                <TableHead>Version</TableHead>
-                <TableHead>Visibility</TableHead>
-                <TableHead className="text-right tabular-nums">Size</TableHead>
-                <TableHead>Updated</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {datasets.map((row) => (
-                <TableRow
-                  key={`${row.database_id}@${row.version}`}
-                  className="cursor-pointer"
-                  onClick={() => openDataset(row.database_id)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      openDataset(row.database_id);
-                    }
-                  }}
-                  tabIndex={0}
-                  role="link"
-                >
-                  <TableCell className="font-medium font-mono text-sm">
-                    {row.database_id}
-                  </TableCell>
-                  <TableCell className="font-mono text-xs text-body">
-                    {row.version}
-                  </TableCell>
-                  <TableCell className="text-body">
-                    {row.visibility}
-                    {row.org_id ? (
-                      <span className="ml-2 font-mono text-xs text-mute">
-                        @{row.org_id}
-                      </span>
-                    ) : null}
-                  </TableCell>
-                  <TableCell className="text-right tabular-nums text-body">
-                    {row.size.toLocaleString()}
-                  </TableCell>
-                  <TableCell className="text-mute text-xs">
-                    {typeof row.created_at === "number"
-                      ? formatDate(new Date(row.created_at * 1000).toISOString())
-                      : "-"}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
+        <>
+          <div className="mb-3 max-w-md">
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search datasets…"
+              aria-label="Search datasets"
+            />
+          </div>
+          {datasets.length === 0 ? (
+            <div className="rounded-[8px] border border-dashed border-hairline bg-canvas-soft p-10 text-center text-sm text-body">
+              <p className="font-medium text-ink">No datasets found</p>
+              <p className="mt-1 text-mute">
+                {scope === "orgs"
+                  ? "No packages from your organizations yet. Publish with bora publish --org <id>."
+                  : "No public packages on this Registry yet."}
+              </p>
+            </div>
+          ) : (
+            <div className="rounded-[8px] border border-hairline overflow-hidden">
+              <Table>
+                <TableHeader>
+                  <TableRow className="hover:bg-transparent">
+                    <TableHead>Dataset</TableHead>
+                    <TableHead>Org</TableHead>
+                    <TableHead>Version</TableHead>
+                    <TableHead>Visibility</TableHead>
+                    <TableHead className="text-right tabular-nums">Size</TableHead>
+                    <TableHead>Updated</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {datasets.map((row) => (
+                    <TableRow
+                      key={`${row.database_id}@${row.version}`}
+                      className="cursor-pointer"
+                      onClick={() => openDataset(row.database_id)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          openDataset(row.database_id);
+                        }
+                      }}
+                      tabIndex={0}
+                      role="link"
+                    >
+                      <TableCell className="font-medium font-mono text-sm">
+                        {row.database_id}
+                      </TableCell>
+                      <TableCell className="font-mono text-xs text-mute">
+                        {row.org_id ? (
+                          <Link
+                            to={`/organizations/${encodeURIComponent(row.org_id)}`}
+                            className="hover:text-ink"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            @{row.org_id}
+                          </Link>
+                        ) : (
+                          "—"
+                        )}
+                      </TableCell>
+                      <TableCell className="font-mono text-xs text-body">
+                        {row.version}
+                      </TableCell>
+                      <TableCell className="text-body">{row.visibility}</TableCell>
+                      <TableCell className="text-right tabular-nums text-body">
+                        {row.size.toLocaleString()}
+                      </TableCell>
+                      <TableCell className="text-mute text-xs">
+                        {typeof row.created_at === "number"
+                          ? formatDate(
+                              new Date(row.created_at * 1000).toISOString(),
+                            )
+                          : "-"}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+          <p className="text-xs text-mute mt-3 tabular-nums">
+            {datasets.length} dataset{datasets.length === 1 ? "" : "s"}
+          </p>
+        </>
       )}
     </Shell>
   );

--- a/apps/hub/src/pages/DatasetsPage.tsx
+++ b/apps/hub/src/pages/DatasetsPage.tsx
@@ -144,7 +144,14 @@ export function DatasetsPage() {
                   <TableCell className="font-mono text-xs text-body">
                     {row.version}
                   </TableCell>
-                  <TableCell className="text-body">{row.visibility}</TableCell>
+                  <TableCell className="text-body">
+                    {row.visibility}
+                    {row.org_id ? (
+                      <span className="ml-2 font-mono text-xs text-mute">
+                        @{row.org_id}
+                      </span>
+                    ) : null}
+                  </TableCell>
                   <TableCell className="text-right tabular-nums text-body">
                     {row.size.toLocaleString()}
                   </TableCell>

--- a/apps/hub/src/pages/DatasetsPage.tsx
+++ b/apps/hub/src/pages/DatasetsPage.tsx
@@ -1,7 +1,7 @@
+import { Database } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
-import { BreadcrumbNav } from "@/components/breadcrumb";
 import { Shell } from "@/components/layout";
 import { Input } from "@/components/ui/input";
 import {
@@ -116,12 +116,8 @@ export function DatasetsPage() {
 
   return (
     <Shell>
-      <BreadcrumbNav items={[{ label: "Datasets" }]} className="mb-4" />
       <div className="mb-4">
-        <p className="text-xs uppercase tracking-wide text-mute font-medium">
-          BORA Registry
-        </p>
-        <h1 className="text-2xl font-semibold tracking-tight text-ink mt-1">
+        <h1 className="text-2xl font-semibold tracking-tight text-ink">
           {scope === "orgs" ? "Your datasets" : "Explore datasets"}
         </h1>
         <p className="text-sm text-body mt-1">
@@ -191,6 +187,11 @@ export function DatasetsPage() {
           </div>
           {datasets.length === 0 ? (
             <div className="rounded-[8px] border border-dashed border-hairline bg-canvas-soft p-10 text-center text-sm text-body">
+              <div className="flex justify-center mb-4">
+                <div className="flex h-16 w-16 items-center justify-center rounded-[12px] bg-canvas border border-hairline text-mute">
+                  <Database className="h-8 w-8" strokeWidth={1.5} aria-hidden />
+                </div>
+              </div>
               <p className="font-medium text-ink">No datasets found</p>
               <p className="mt-1 text-mute">
                 {scope === "orgs"

--- a/apps/hub/src/pages/LoginCallbackPage.tsx
+++ b/apps/hub/src/pages/LoginCallbackPage.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+
+import { Shell } from "@/components/layout";
+import { completeWebLogin, RegistryHttpError } from "@/lib/api";
+import { setToken } from "@/lib/auth";
+
+/** OAuth redirect target: ?code=&state= → Registry token → /datasets */
+export function LoginCallbackPage() {
+  const [params] = useSearchParams();
+  const [error, setError] = useState<string | null>(null);
+  // React StrictMode remounts effects in dev; exchange GitHub code exactly once.
+  const startedRef = useRef(false);
+
+  const code = params.get("code");
+  const oauthState = params.get("state");
+  const oauthError = params.get("error");
+  const desc = params.get("error_description");
+
+  useEffect(() => {
+    if (oauthError) {
+      setError(`${oauthError}: ${desc || "GitHub denied authorization"}`);
+      return;
+    }
+    if (!code || !oauthState) {
+      setError("Missing code/state in callback URL. Start sign-in again.");
+      return;
+    }
+    if (startedRef.current) return;
+    startedRef.current = true;
+
+    const redirectUri = `${window.location.origin}/login/callback`;
+    completeWebLogin({ code, state: oauthState, redirectUri })
+      .then((session) => {
+        setToken(
+          session.token,
+          session.github_user,
+          session.github_name,
+          session.avatar_url,
+        );
+        window.location.replace("/datasets");
+      })
+      .catch((err: unknown) => {
+        if (err instanceof RegistryHttpError) {
+          setError(
+            err.code === "login_not_allowed"
+              ? `${err.code}: ${err.message}\n→ 把你的 GitHub login 加入 BORA_GITHUB_LOGIN_ALLOWLIST 并重启 Registry。`
+              : err.code === "invalid_state"
+                ? `${err.code}: ${err.message}\n→ 开发模式勿重复打开 callback；请从 /login 重新 Sign in（不要刷新本页）。`
+                : `${err.code}: ${err.message}`,
+          );
+        } else {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      });
+  }, [code, oauthState, oauthError, desc]);
+
+  return (
+    <Shell>
+      <h1 className="text-xl font-semibold tracking-tight text-ink mb-2">
+        Completing sign-in…
+      </h1>
+      {error ? (
+        <div className="mt-4 rounded-[8px] border border-error/30 bg-canvas-soft p-3 max-w-lg">
+          <p className="text-sm text-error font-medium">Login failed</p>
+          <p className="mt-1 text-sm text-error font-mono whitespace-pre-wrap">
+            {error}
+          </p>
+          <p className="mt-3 text-sm">
+            <Link to="/login" className="text-link hover:text-link-deep">
+              ← Try again
+            </Link>
+          </p>
+        </div>
+      ) : (
+        <p className="text-sm text-mute">
+          Exchanging GitHub code for a Registry token…
+        </p>
+      )}
+    </Shell>
+  );
+}

--- a/apps/hub/src/pages/LoginPage.tsx
+++ b/apps/hub/src/pages/LoginPage.tsx
@@ -56,7 +56,7 @@ export function LoginPage() {
           }
           const token = poll.token || poll.access_token;
           if (token) {
-            setToken(token);
+            setToken(token, poll.github_user);
             stopPoll();
             setStatus("done");
             setPollHint(

--- a/apps/hub/src/pages/LoginPage.tsx
+++ b/apps/hub/src/pages/LoginPage.tsx
@@ -1,114 +1,41 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useCallback, useState } from "react";
+import { Link } from "react-router-dom";
 
 import { BreadcrumbNav } from "@/components/breadcrumb";
 import { Shell } from "@/components/layout";
 import { Button } from "@/components/ui/button";
-import { deviceCode, devicePoll, RegistryHttpError } from "@/lib/api";
-import { setToken } from "@/lib/auth";
+import { RegistryHttpError, startWebLogin } from "@/lib/api";
 
+/**
+ * Hub login uses browser OAuth (Authorization Code) — same family as Harbor.
+ * GitHub redirects back to /login/callback; no device user_code to type.
+ * CLI keeps Device Flow via ``bora login``.
+ */
 export function LoginPage() {
-  const navigate = useNavigate();
-  const [userCode, setUserCode] = useState<string | null>(null);
-  const [verifyUri, setVerifyUri] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [status, setStatus] = useState<string>("idle");
-  const [pollHint, setPollHint] = useState<string>("Waiting for authorization…");
-  const intervalRef = useRef<number | null>(null);
-  const inFlightRef = useRef(false);
-  const stoppedRef = useRef(false);
-
-  const stopPoll = useCallback(() => {
-    stoppedRef.current = true;
-    if (intervalRef.current != null) {
-      window.clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-  }, []);
+  const [busy, setBusy] = useState(false);
 
   const start = useCallback(async () => {
     setError(null);
-    setStatus("requesting");
-    setPollHint("Waiting for authorization…");
-    stopPoll();
-    stoppedRef.current = false;
+    setBusy(true);
     try {
-      const code = await deviceCode();
-      setUserCode(code.user_code);
-      setVerifyUri(
-        code.verification_uri_complete ||
-          code.verification_uri ||
-          "https://github.com/login/device",
-      );
-      setStatus("pending");
-
-      const intervalMs = Math.max(5, code.interval ?? 5) * 1000;
-
-      const tick = async () => {
-        if (stoppedRef.current || inFlightRef.current) return;
-        inFlightRef.current = true;
-        try {
-          const poll = await devicePoll(code.device_code);
-          if (stoppedRef.current) return;
-          if (poll.status === "authorization_pending") {
-            setPollHint("Waiting for authorization…");
-            return;
-          }
-          const token = poll.token || poll.access_token;
-          if (token) {
-            setToken(token, poll.github_user);
-            stopPoll();
-            setStatus("done");
-            setPollHint(
-              poll.github_user
-                ? `Signed in as ${poll.github_user}`
-                : "Signed in",
-            );
-            navigate("/datasets");
-            return;
-          }
-          // Unexpected 200 shape
-          setPollHint("Unexpected poll response (no token); retrying…");
-        } catch (err) {
-          if (stoppedRef.current) return;
-          // Terminal failures: stop and surface (allowlist, expired, denied).
-          if (err instanceof RegistryHttpError) {
-            if (err.status === 202) {
-              setPollHint("Waiting for authorization…");
-              return;
-            }
-            stopPoll();
-            setStatus("error");
-            setError(`${err.code}: ${err.message}`);
-            return;
-          }
-          // Network blip — keep polling, show soft hint
-          setPollHint(
-            err instanceof Error
-              ? `Poll error: ${err.message} (retrying…)`
-              : "Poll error (retrying…)",
-          );
-        } finally {
-          inFlightRef.current = false;
-        }
-      };
-
-      // Poll immediately, then on interval (do not wait first full interval).
-      void tick();
-      intervalRef.current = window.setInterval(() => {
-        void tick();
-      }, intervalMs);
+      const redirectUri = `${window.location.origin}/login/callback`;
+      const { authorize_url } = await startWebLogin(redirectUri);
+      // Full navigation — GitHub → back to /login/callback?code=&state=
+      window.location.assign(authorize_url);
     } catch (err) {
-      setStatus("error");
+      setBusy(false);
       if (err instanceof RegistryHttpError) {
-        setError(`${err.code}: ${err.message}`);
+        setError(
+          err.code === "oauth_not_configured"
+            ? `${err.code}: ${err.message}\n→ 配置 BORA_GITHUB_CLIENT_ID / SECRET，并在 GitHub OAuth App 里加 Callback URL：\n  ${window.location.origin}/login/callback`
+            : `${err.code}: ${err.message}`,
+        );
       } else {
         setError(err instanceof Error ? err.message : String(err));
       }
     }
-  }, [navigate, stopPoll]);
-
-  useEffect(() => () => stopPoll(), [stopPoll]);
+  }, []);
 
   return (
     <Shell>
@@ -122,53 +49,36 @@ export function LoginPage() {
       <h1 className="text-xl font-semibold tracking-tight text-ink mb-2">
         Sign in with GitHub
       </h1>
-      <p className="text-sm text-body mb-6 whitespace-nowrap">
-        Device login uses the same Registry OAuth flow as{" "}
-        <code className="font-mono">bora login</code>. The token stays in this
-        browser only (localStorage) — never in packages or evidence.
+      <p className="text-sm text-body mb-6 max-w-lg">
+        Browser OAuth: you will be sent to GitHub, click{" "}
+        <strong>Authorize</strong>, then return here automatically. No device
+        code to type (CLI still uses <code className="font-mono">bora login</code>{" "}
+        device flow).
       </p>
 
-      {status === "idle" || status === "error" ? (
-        <Button type="button" onClick={() => void start()}>
-          {status === "error" ? "Try again" : "Start device login"}
-        </Button>
-      ) : null}
+      <Button type="button" onClick={() => void start()} disabled={busy}>
+        {busy ? "Redirecting to GitHub…" : "Sign in with GitHub"}
+      </Button>
 
-      {status === "requesting" ? (
-        <p className="text-sm text-mute">Requesting device code…</p>
-      ) : null}
-
-      {status === "pending" && userCode ? (
-        <div className="rounded-[8px] border border-hairline bg-canvas-soft p-4 space-y-3 max-w-lg">
-          <p className="text-sm text-body">
-            Open the verification URL and enter this code:
+      {error ? (
+        <div className="mt-4 rounded-[8px] border border-error/30 bg-canvas-soft p-3 max-w-lg">
+          <p className="text-sm text-error font-medium">Login failed</p>
+          <p className="mt-1 text-sm text-error font-mono whitespace-pre-wrap">
+            {error}
           </p>
-          <p className="font-mono text-2xl tracking-widest text-ink">{userCode}</p>
-          {verifyUri ? (
-            <a
-              href={verifyUri}
-              target="_blank"
-              rel="noreferrer"
-              className="text-link hover:text-link-deep text-sm break-all"
-            >
-              {verifyUri}
-            </a>
-          ) : null}
-          <p className="text-xs text-mute">{pollHint}</p>
         </div>
       ) : null}
 
-      {status === "done" ? (
-        <p className="text-sm text-body">{pollHint}</p>
-      ) : null}
+      <p className="mt-8 text-sm text-mute max-w-lg">
+        GitHub OAuth App → Authorization callback URL must include:{" "}
+        <code className="font-mono text-xs">
+          {typeof window !== "undefined"
+            ? `${window.location.origin}/login/callback`
+            : "http://127.0.0.1:5174/login/callback"}
+        </code>
+      </p>
 
-      {error ? (
-        <p className="mt-4 text-sm text-error font-mono whitespace-pre-wrap">
-          {error}
-        </p>
-      ) : null}
-
-      <p className="mt-8 text-sm">
+      <p className="mt-4 text-sm">
         <Link to="/datasets" className="text-link hover:text-link-deep">
           ← Back to Datasets
         </Link>

--- a/apps/hub/src/pages/OrganizationDetailPage.tsx
+++ b/apps/hub/src/pages/OrganizationDetailPage.tsx
@@ -1,0 +1,376 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { BreadcrumbNav } from "@/components/breadcrumb";
+import { Shell } from "@/components/layout";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  encodeDatasetId,
+  getOrg,
+  listOrgMembers,
+  listPackages,
+  listResultShares,
+  listSuites,
+  type OrgMember,
+  type OrgRow,
+  type PackageRelease,
+  type SuiteRow,
+  RegistryHttpError,
+} from "@/lib/api";
+import { getToken } from "@/lib/auth";
+import { cn, formatDate } from "@/lib/utils";
+
+function latestByDatabase(items: PackageRelease[]): PackageRelease[] {
+  const map = new Map<string, PackageRelease>();
+  for (const row of items) {
+    const prev = map.get(row.database_id);
+    if (!prev || (row.created_at ?? 0) >= (prev.created_at ?? 0)) {
+      map.set(row.database_id, row);
+    }
+  }
+  return Array.from(map.values()).sort((a, b) =>
+    a.database_id.localeCompare(b.database_id),
+  );
+}
+
+type Tab = "overview" | "settings";
+
+export function OrganizationDetailPage() {
+  const { orgId: rawOrgId } = useParams();
+  const orgId = rawOrgId ? decodeURIComponent(rawOrgId) : "";
+  const token = getToken();
+  const [tab, setTab] = useState<Tab>("overview");
+  const [org, setOrg] = useState<OrgRow | null>(null);
+  const [members, setMembers] = useState<OrgMember[]>([]);
+  const [datasets, setDatasets] = useState<PackageRelease[]>([]);
+  const [sharedSuites, setSharedSuites] = useState<SuiteRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!orgId || !token) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+
+    (async () => {
+      try {
+        const [orgRow, memberRows, packages] = await Promise.all([
+          getOrg(orgId, token),
+          listOrgMembers(orgId, token),
+          listPackages(token),
+        ]);
+        if (cancelled) return;
+        setOrg(orgRow);
+        setMembers(memberRows);
+        setDatasets(
+          latestByDatabase(packages).filter((p) => p.org_id === orgId),
+        );
+        setError(null);
+
+        // Shared suite results: visible suites that list this org as a share target.
+        try {
+          const suites = await listSuites(null, token);
+          const candidates = suites.slice(0, 80);
+          const hits: SuiteRow[] = [];
+          await Promise.all(
+            candidates.map(async (s) => {
+              if (!s.suite_run_id) return;
+              try {
+                const shares = await listResultShares(
+                  "suite",
+                  s.suite_run_id,
+                  token,
+                );
+                const orgKey = orgId.toLowerCase();
+                if (
+                  shares.some(
+                    (sh) =>
+                      sh.target_type === "org" &&
+                      sh.target_id.toLowerCase() === orgKey,
+                  )
+                ) {
+                  hits.push(s);
+                }
+              } catch {
+                // ignore unreadable share lists
+              }
+            }),
+          );
+          if (!cancelled) setSharedSuites(hits);
+        } catch {
+          if (!cancelled) setSharedSuites([]);
+        }
+      } catch (err: unknown) {
+        if (cancelled) return;
+        if (err instanceof RegistryHttpError) {
+          setError(`${err.code}: ${err.message}`);
+        } else {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+        setOrg(null);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [orgId, token]);
+
+  const title = useMemo(
+    () => org?.display_name || org?.name || orgId,
+    [org, orgId],
+  );
+
+  if (!token) {
+    return (
+      <Shell>
+        <BreadcrumbNav
+          items={[
+            { label: "Organizations", href: "/organizations" },
+            { label: orgId || "…" },
+          ]}
+          className="mb-4"
+        />
+        <div className="rounded-[8px] border border-hairline bg-canvas-soft p-6 text-sm">
+          <p className="font-medium text-ink">Sign in required</p>
+          <p className="mt-1 text-mute">
+            <Link to="/login" className="underline underline-offset-2">
+              Sign in
+            </Link>{" "}
+            to view this organization.
+          </p>
+        </div>
+      </Shell>
+    );
+  }
+
+  return (
+    <Shell>
+      <BreadcrumbNav
+        items={[
+          { label: "Organizations", href: "/organizations" },
+          { label: title },
+        ]}
+        className="mb-4"
+      />
+
+      {loading ? (
+        <p className="text-sm text-mute">Loading…</p>
+      ) : error ? (
+        <div className="rounded-[8px] border border-hairline bg-canvas-soft p-4 text-sm">
+          <p className="text-error font-medium">Could not load organization</p>
+          <p className="mt-1 font-mono text-xs text-body">{error}</p>
+        </div>
+      ) : (
+        <>
+          <div className="mb-4">
+            <h1 className="text-2xl font-semibold tracking-tight text-ink">
+              {title}
+            </h1>
+            <p className="font-mono text-sm text-mute mt-1">@{orgId}</p>
+            {org?.role ? (
+              <p className="text-xs text-body mt-1 capitalize">
+                Your role: {org.role}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="flex gap-1 border-b border-hairline mb-6">
+            {(
+              [
+                ["overview", "Overview"],
+                ["settings", "Settings"],
+              ] as const
+            ).map(([id, label]) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setTab(id)}
+                className={cn(
+                  "px-3 py-2 text-sm transition-colors border-b-2 -mb-px",
+                  tab === id
+                    ? "border-ink text-ink font-medium"
+                    : "border-transparent text-body hover:text-ink",
+                )}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          {tab === "overview" ? (
+            <div className="space-y-8">
+              <section>
+                <h2 className="text-sm font-medium text-ink mb-2">Members</h2>
+                {members.length === 0 ? (
+                  <p className="text-sm text-mute">No members listed.</p>
+                ) : (
+                  <div className="rounded-[8px] border border-hairline overflow-hidden">
+                    <Table>
+                      <TableHeader>
+                        <TableRow className="hover:bg-transparent">
+                          <TableHead>Member</TableHead>
+                          <TableHead>Role</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {members.map((m) => (
+                          <TableRow key={m.user_id}>
+                            <TableCell className="font-mono text-sm">
+                              @{m.user_id}
+                            </TableCell>
+                            <TableCell className="text-sm capitalize text-body">
+                              {m.role}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                )}
+              </section>
+
+              <section>
+                <h2 className="text-sm font-medium text-ink mb-2">Datasets</h2>
+                {datasets.length === 0 ? (
+                  <div className="rounded-[8px] border border-dashed border-hairline p-6 text-sm text-mute">
+                    No packages published under this org yet.
+                  </div>
+                ) : (
+                  <div className="rounded-[8px] border border-hairline overflow-hidden">
+                    <Table>
+                      <TableHeader>
+                        <TableRow className="hover:bg-transparent">
+                          <TableHead>Dataset</TableHead>
+                          <TableHead>Version</TableHead>
+                          <TableHead>Visibility</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {datasets.map((d) => (
+                          <TableRow key={d.database_id}>
+                            <TableCell>
+                              <Link
+                                to={`/datasets/${encodeDatasetId(d.database_id)}`}
+                                className="font-mono text-sm hover:underline"
+                              >
+                                {d.database_id}
+                              </Link>
+                            </TableCell>
+                            <TableCell className="font-mono text-xs text-body">
+                              {d.version}
+                            </TableCell>
+                            <TableCell className="text-sm text-body">
+                              {d.visibility}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                )}
+              </section>
+
+              <section>
+                <h2 className="text-sm font-medium text-ink mb-2">
+                  Shared results
+                </h2>
+                <p className="text-xs text-mute mb-2">
+                  Suite results explicitly shared with this organization
+                  (visible to you).
+                </p>
+                {sharedSuites.length === 0 ? (
+                  <div className="rounded-[8px] border border-dashed border-hairline p-6 text-sm text-mute">
+                    No suite results have been shared with this organization
+                    yet.
+                  </div>
+                ) : (
+                  <div className="rounded-[8px] border border-hairline overflow-hidden">
+                    <Table>
+                      <TableHeader>
+                        <TableRow className="hover:bg-transparent">
+                          <TableHead>Suite</TableHead>
+                          <TableHead>Dataset</TableHead>
+                          <TableHead>By</TableHead>
+                          <TableHead>Updated</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {sharedSuites.map((s) => (
+                          <TableRow key={s.suite_run_id}>
+                            <TableCell className="font-mono text-xs">
+                              {s.suite_run_id}
+                            </TableCell>
+                            <TableCell className="font-mono text-xs text-body">
+                              {s.database_id ? (
+                                <Link
+                                  to={`/datasets/${encodeDatasetId(s.database_id)}`}
+                                  className="hover:underline"
+                                >
+                                  {s.database_id}
+                                </Link>
+                              ) : (
+                                "—"
+                              )}
+                            </TableCell>
+                            <TableCell className="font-mono text-xs text-mute">
+                              {s.uploaded_by ? `@${s.uploaded_by}` : "—"}
+                            </TableCell>
+                            <TableCell className="text-xs text-mute">
+                              {typeof s.created_at === "number"
+                                ? formatDate(
+                                    new Date(s.created_at * 1000).toISOString(),
+                                  )
+                                : typeof s.created_at === "string"
+                                  ? formatDate(s.created_at)
+                                  : "—"}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                )}
+              </section>
+            </div>
+          ) : (
+            <div className="space-y-8 max-w-2xl">
+              <section>
+                <h2 className="text-sm font-medium text-ink mb-1">
+                  Organization description
+                </h2>
+                <p className="text-sm text-mute">
+                  No description field on Registry yet. Display name:{" "}
+                  <span className="text-body">
+                    {org?.display_name || org?.name || "—"}
+                  </span>
+                  .
+                </p>
+              </section>
+              <section>
+                <h2 className="text-sm font-medium text-ink mb-1">Secrets</h2>
+                <div className="rounded-[8px] border border-dashed border-hairline p-6 text-sm text-mute">
+                  Organization-scoped secrets (API keys for hosted jobs) are not
+                  implemented in BORA Registry. Use host env / CLI credentials
+                  instead.
+                </div>
+              </section>
+            </div>
+          )}
+        </>
+      )}
+    </Shell>
+  );
+}

--- a/apps/hub/src/pages/OrganizationDetailPage.tsx
+++ b/apps/hub/src/pages/OrganizationDetailPage.tsx
@@ -226,16 +226,39 @@ export function OrganizationDetailPage() {
                         </TableRow>
                       </TableHeader>
                       <TableBody>
-                        {members.map((m) => (
-                          <TableRow key={m.user_id}>
-                            <TableCell className="font-mono text-sm">
-                              @{m.user_id}
-                            </TableCell>
-                            <TableCell className="text-sm capitalize text-body">
-                              {m.role}
-                            </TableCell>
-                          </TableRow>
-                        ))}
+                        {members.map((m) => {
+                          const avatar =
+                            m.avatar_url ||
+                            `https://github.com/${encodeURIComponent(m.user_id)}.png?size=64`;
+                          const title = m.display_name || m.user_id;
+                          return (
+                            <TableRow key={m.user_id}>
+                              <TableCell>
+                                <div className="flex items-center gap-3 min-w-0">
+                                  <img
+                                    src={avatar}
+                                    alt=""
+                                    width={36}
+                                    height={36}
+                                    className="h-9 w-9 rounded-full bg-canvas-soft border border-hairline shrink-0 object-cover"
+                                    loading="lazy"
+                                  />
+                                  <div className="min-w-0 leading-tight">
+                                    <div className="text-sm font-medium text-ink truncate">
+                                      {title}
+                                    </div>
+                                    <div className="text-xs font-mono text-mute truncate">
+                                      @{m.user_id}
+                                    </div>
+                                  </div>
+                                </div>
+                              </TableCell>
+                              <TableCell className="text-sm capitalize text-body">
+                                {m.role}
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })}
                       </TableBody>
                     </Table>
                   </div>

--- a/apps/hub/src/pages/OrganizationsPage.tsx
+++ b/apps/hub/src/pages/OrganizationsPage.tsx
@@ -1,7 +1,7 @@
+import { Building2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
-import { BreadcrumbNav } from "@/components/breadcrumb";
 import { Shell } from "@/components/layout";
 import { Input } from "@/components/ui/input";
 import {
@@ -95,7 +95,6 @@ export function OrganizationsPage() {
 
   return (
     <Shell>
-      <BreadcrumbNav items={[{ label: "Organizations" }]} className="mb-4" />
       <div className="mb-4">
         <h1 className="text-2xl font-semibold tracking-tight text-ink">
           Organizations
@@ -134,6 +133,11 @@ export function OrganizationsPage() {
           </div>
           {filtered.length === 0 ? (
             <div className="rounded-[8px] border border-dashed border-hairline bg-canvas-soft p-10 text-center text-sm">
+              <div className="flex justify-center mb-4">
+                <div className="flex h-16 w-16 items-center justify-center rounded-[12px] bg-canvas border border-hairline text-mute">
+                  <Building2 className="h-8 w-8" strokeWidth={1.5} aria-hidden />
+                </div>
+              </div>
               <p className="font-medium text-ink">No organizations</p>
               <p className="mt-1 text-mute">
                 Create one with{" "}

--- a/apps/hub/src/pages/OrganizationsPage.tsx
+++ b/apps/hub/src/pages/OrganizationsPage.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+import { BreadcrumbNav } from "@/components/breadcrumb";
+import { Shell } from "@/components/layout";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  listOrgs,
+  listPackages,
+  type OrgRow,
+  type PackageRelease,
+  RegistryHttpError,
+} from "@/lib/api";
+import { getToken } from "@/lib/auth";
+
+function latestByDatabase(items: PackageRelease[]): PackageRelease[] {
+  const map = new Map<string, PackageRelease>();
+  for (const row of items) {
+    const prev = map.get(row.database_id);
+    if (!prev || (row.created_at ?? 0) >= (prev.created_at ?? 0)) {
+      map.set(row.database_id, row);
+    }
+  }
+  return Array.from(map.values());
+}
+
+export function OrganizationsPage() {
+  const navigate = useNavigate();
+  const token = getToken();
+  const [orgs, setOrgs] = useState<OrgRow[]>([]);
+  const [packages, setPackages] = useState<PackageRelease[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    if (!token) {
+      setLoading(false);
+      setOrgs([]);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    Promise.all([listOrgs(token), listPackages(token)])
+      .then(([orgRows, pkgRows]) => {
+        if (cancelled) return;
+        setOrgs(orgRows);
+        setPackages(pkgRows);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof RegistryHttpError) {
+          setError(`${err.code}: ${err.message}`);
+        } else {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+        setOrgs([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const datasetCountByOrg = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const row of latestByDatabase(packages)) {
+      if (!row.org_id) continue;
+      counts.set(row.org_id, (counts.get(row.org_id) ?? 0) + 1);
+    }
+    return counts;
+  }, [packages]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return orgs;
+    return orgs.filter(
+      (o) =>
+        o.org_id.toLowerCase().includes(q) ||
+        (o.display_name || "").toLowerCase().includes(q) ||
+        (o.name || "").toLowerCase().includes(q),
+    );
+  }, [orgs, query]);
+
+  return (
+    <Shell>
+      <BreadcrumbNav items={[{ label: "Organizations" }]} className="mb-4" />
+      <div className="mb-4">
+        <h1 className="text-2xl font-semibold tracking-tight text-ink">
+          Organizations
+        </h1>
+        <p className="text-sm text-body mt-1">
+          Organizations you belong to. Packages are published under an org.
+        </p>
+      </div>
+
+      {!token ? (
+        <div className="rounded-[8px] border border-hairline bg-canvas-soft p-6 text-sm text-body">
+          <p className="font-medium text-ink">Sign in required</p>
+          <p className="mt-1 text-mute">
+            <Link to="/login" className="underline underline-offset-2">
+              Sign in
+            </Link>{" "}
+            to list your organizations.
+          </p>
+        </div>
+      ) : loading ? (
+        <p className="text-sm text-mute">Loading…</p>
+      ) : error ? (
+        <div className="rounded-[8px] border border-hairline bg-canvas-soft p-4 text-sm">
+          <p className="text-error font-medium">Could not load organizations</p>
+          <p className="mt-1 font-mono text-xs text-body">{error}</p>
+        </div>
+      ) : (
+        <>
+          <div className="mb-3 max-w-md">
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search your organizations…"
+              aria-label="Search organizations"
+            />
+          </div>
+          {filtered.length === 0 ? (
+            <div className="rounded-[8px] border border-dashed border-hairline bg-canvas-soft p-10 text-center text-sm">
+              <p className="font-medium text-ink">No organizations</p>
+              <p className="mt-1 text-mute">
+                Create one with{" "}
+                <code className="font-mono text-xs">
+                  bora registry org-create &lt;name&gt;
+                </code>
+                .
+              </p>
+            </div>
+          ) : (
+            <div className="rounded-[8px] border border-hairline overflow-hidden">
+              <Table>
+                <TableHeader>
+                  <TableRow className="hover:bg-transparent">
+                    <TableHead>Organization</TableHead>
+                    <TableHead>ID</TableHead>
+                    <TableHead>Role</TableHead>
+                    <TableHead className="text-right tabular-nums">
+                      Datasets
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filtered.map((org) => (
+                    <TableRow
+                      key={org.org_id}
+                      className="cursor-pointer"
+                      onClick={() =>
+                        navigate(
+                          `/organizations/${encodeURIComponent(org.org_id)}`,
+                        )
+                      }
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          navigate(
+                            `/organizations/${encodeURIComponent(org.org_id)}`,
+                          );
+                        }
+                      }}
+                      tabIndex={0}
+                      role="link"
+                    >
+                      <TableCell className="font-medium text-ink">
+                        {org.display_name || org.name || org.org_id}
+                      </TableCell>
+                      <TableCell className="font-mono text-xs text-mute">
+                        @{org.org_id}
+                      </TableCell>
+                      <TableCell className="text-body capitalize text-sm">
+                        {org.role || "—"}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums text-body">
+                        {datasetCountByOrg.get(org.org_id) ?? 0}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+          <p className="text-xs text-mute mt-3 tabular-nums">
+            {filtered.length} organization
+            {filtered.length === 1 ? "" : "s"}
+          </p>
+        </>
+      )}
+    </Shell>
+  );
+}

--- a/services/registry/.env.example
+++ b/services/registry/.env.example
@@ -16,3 +16,10 @@ BORA_REGISTRY_PORT=8700
 
 # Comma-separated GitHub logins allowed to bora login (required for OAuth)
 BORA_GITHUB_LOGIN_ALLOWLIST=
+
+# Hub browser OAuth callback allowlist (optional extras; localhost Hub is built-in)
+# BORA_GITHUB_WEB_REDIRECT_URIS=https://hub.example.com/login/callback
+#
+# GitHub OAuth App → Authorization callback URL must include e.g.:
+#   http://127.0.0.1:5174/login/callback
+#   http://localhost:5174/login/callback

--- a/services/registry/README.md
+++ b/services/registry/README.md
@@ -41,7 +41,11 @@ uv run bora login
 # CI / bootstrap
 export BORA_REGISTRY_TOKEN=<token>
 
-uv run bora publish tests/fixtures/databases/publish-min
+# Orgs (packages must belong to an org; results belong to the uploader)
+uv run bora registry org-create my-lab --display-name "My Lab"
+uv run bora registry org-list
+
+uv run bora publish tests/fixtures/databases/publish-min --org my-lab
 uv run bora registry list
 uv run bora registry show 'test/publish-min@0.1.0'
 uv run bora lock 'test/publish-min@0.1.0' --task hello
@@ -50,6 +54,8 @@ uv run bora lock 'test/publish-min@0.1.0' --task hello
 uv run bora results upload <database> --run <run_id>
 uv run bora results get <run_id> --out /tmp/restored
 uv run bora results list
+# Share a private result (owner only)
+uv run bora results share <run_id> --kind attempt --share-org my-lab
 
 # After a suite run produced .bora/suite-runs/<suite_run_id>/summary.json
 uv run bora results upload-suite <database> --suite-run <suite_run_id> [--public] [--agent x] [--model y]
@@ -111,12 +117,30 @@ Browse published package contents **without** downloading the whole tar to the b
 - Private unauthorized → **404** (not 403)
 - Server indexes tar on first access (process LRU by digest); does not change upload format
 
+### Organizations + ACL (design #52)
+
+| Surface | Ownership | Private read |
+| --- | --- | --- |
+| Package release | **org** (`org_id` required on publish) | org members (or `admin`) |
+| Attempt / suite result | **uploader** (`uploaded_by` server-set) | owner, share→org/user, or `admin` |
+
+Joining an org does **not** reveal private results until the owner shares them.
+
+| Method | Path |
+| --- | --- |
+| POST/GET | `/v1/orgs` |
+| GET | `/v1/orgs/{id}` |
+| POST | `/v1/orgs/{id}/claim` |
+| GET/POST | `/v1/orgs/{id}/members` |
+| DELETE | `/v1/orgs/{id}/members/{user}` |
+| GET/POST/DELETE | `/v1/results/attempts\|suites/{id}/shares` |
+
 ### Suite results API
 
 | Method | Path | Scope |
 | --- | --- | --- |
-| POST | `/v1/results/suites` | `results:upload` |
-| GET | `/v1/results/suites` | public items; private needs `results:read` / `admin` |
+| POST | `/v1/results/suites` | `results:upload` (+ user identity) |
+| GET | `/v1/results/suites` | public ∪ owner ∪ share hit ∪ `admin` |
 | GET | `/v1/results/suites/{suite_run_id}` | same visibility rules as attempts |
 | GET | `/v1/results/suites/{suite_run_id}/content` | same |
 

--- a/services/registry/README.md
+++ b/services/registry/README.md
@@ -168,14 +168,44 @@ browsable tree.
 `bora login` issues tokens with publish + read-private + results upload/read.
 Scopes are independent: upload-only tokens cannot list private results.
 Private unauthorized reads return **404** (not 403).
-Visibility is only **`public` | `private`** (no org in this MVP).
+Visibility is only **`public` | `private`**. Packages require **`org_id`**; private package
+read is **org member** (or `admin`). Result private read is owner / share / admin
+(see Organizations + ACL above).
 
-## GitHub OAuth (Device Flow)
+## GitHub OAuth
 
-1. Create a GitHub OAuth App; enable **Device Flow**.
-2. Put in `services/registry/.env` (gitignored):
-   - `BORA_GITHUB_CLIENT_ID` / `BORA_GITHUB_CLIENT_SECRET`
-   - `BORA_GITHUB_LOGIN_ALLOWLIST=yourlogin` (comma-separated; **required** — empty deny)
-3. `bora login` → open verification URI → enter user code → credentials written.
+Create a **GitHub OAuth App** (Settings → Developer settings → OAuth Apps).
+
+| Setting | Local Hub / CLI |
+| --- | --- |
+| Homepage URL | e.g. `http://127.0.0.1:8700/` (informational) |
+| Authorization callback URL | **`http://127.0.0.1:5174/login/callback`** (and `http://localhost:5174/login/callback` if you use that host) |
+| Enable Device Flow | **On** (required for CLI `bora login`) |
+
+Put in `services/registry/.env` (gitignored):
+
+- `BORA_GITHUB_CLIENT_ID` / `BORA_GITHUB_CLIENT_SECRET`
+- `BORA_GITHUB_LOGIN_ALLOWLIST=yourlogin` (comma-separated; **required** — empty deny)
+- optional `BORA_GITHUB_WEB_REDIRECT_URIS=…` for extra Hub callback origins
+
+### CLI — Device Flow
+
+```bash
+export BORA_REGISTRY_URL=http://127.0.0.1:8700
+uv run bora login
+# Open https://github.com/login/device and enter the printed user code
+```
+
+Writes `~/.bora/credentials` (0600). On success, Registry also stores a **user profile**
+snapshot (`login` / display name / avatar) for Hub members list.
+
+### Hub SPA — browser OAuth (Authorization Code)
+
+1. Registry: `POST /v1/auth/github/web/start` with Hub `redirect_uri`
+2. Browser opens GitHub authorize → user clicks **Authorize**
+3. GitHub redirects to Hub `/login/callback?code=&state=`
+4. Hub: `POST /v1/auth/github/web/callback` → Registry API token in `localStorage`
+
+No device user code on Hub. Restart Registry after changing OAuth env.
 
 CI continues to use `BORA_REGISTRY_TOKEN` (bootstrap/admin) without a browser.

--- a/services/registry/app.py
+++ b/services/registry/app.py
@@ -4,6 +4,8 @@ Endpoints:
   GET  /health
   POST /v1/auth/github/device/code
   POST /v1/auth/github/device/poll
+  POST /v1/orgs | GET /v1/orgs | GET /v1/orgs/{id}
+  POST /v1/orgs/{id}/claim | GET|POST /v1/orgs/{id}/members | DELETE .../members/{user}
   POST /v1/packages
   GET  /v1/packages
   GET  /v1/packages/{id}
@@ -16,14 +18,16 @@ Endpoints:
   GET  /v1/results/attempts
   GET  /v1/results/attempts/{run_id}
   GET  /v1/results/attempts/{run_id}/content
+  GET|POST|DELETE /v1/results/attempts/{run_id}/shares
   POST /v1/results/suites
   GET  /v1/results/suites
   GET  /v1/results/suites/{suite_run_id}
   GET  /v1/results/suites/{suite_run_id}/content
+  GET|POST|DELETE /v1/results/suites/{suite_run_id}/shares
 
-Scopes: registry:publish | read-private | results:upload | results:read | admin
-Visibility: public | private only. Private unauthorized → 404 (not 403).
-Suite results: observational aggregates only — no suite-level PASS authority.
+Scopes: registry:publish | results:upload | admin (read-private legacy ignored for ACL)
+Visibility: public | private. Package private → org member; result private → owner/share.
+Unauthorized private → 404 (not 403). Suite results: no suite-level PASS authority.
 """
 
 from __future__ import annotations
@@ -68,11 +72,18 @@ from services.registry.store import (  # noqa: E402
     S3BlobStore,
     SqliteTokenStore,
     SuiteResultRow,
+    TokenInfo,
+    _normalize_user_id,
     attempt_to_dict,
+    membership_to_dict,
     now,
+    org_to_dict,
     release_to_dict,
+    share_to_dict,
     suite_to_dict,
 )
+
+_ORG_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9_-]{0,62}[a-z0-9])?$")
 
 MAX_UPLOAD_BYTES = 64 * 1024 * 1024  # 64 MiB hard top for v1
 RESULT_MEDIA_TYPE = "application/vnd.bora.attempt-result.v1.tar+gzip"
@@ -110,7 +121,7 @@ def _cors_headers(handler: BaseHTTPRequestHandler) -> None:
     origin = (os.environ.get("BORA_REGISTRY_CORS_ORIGIN") or "*").strip() or "*"
     handler.send_header("Access-Control-Allow-Origin", origin)
     handler.send_header("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept")
-    handler.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+    handler.send_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
     if origin != "*":
         handler.send_header("Vary", "Origin")
 
@@ -168,14 +179,49 @@ def _parse_multipart(body: bytes, content_type: str) -> dict[str, bytes]:
     return out
 
 
-def _can_list_private_packages(scopes: frozenset[str]) -> bool:
-    # publish may verify private releases they just wrote; not a results scope.
-    return "read-private" in scopes or "admin" in scopes or "registry:publish" in scopes
+def _is_admin(scopes: frozenset[str]) -> bool:
+    return "admin" in scopes
 
 
-def _can_list_private_results(scopes: frozenset[str]) -> bool:
-    # results:upload does NOT imply private read (independent scope model).
-    return "results:read" in scopes or "admin" in scopes
+def _require_user(auth: TokenInfo) -> str | None:
+    """Return user_id or None if missing (caller maps to 401)."""
+    return auth.user_id
+
+
+def _visible_package_row(state: RegistryState, row: ReleaseRow, auth: TokenInfo) -> bool:
+    if row.visibility == "public":
+        return True
+    if _is_admin(auth.scopes):
+        return True
+    if not auth.user_id or not row.org_id:
+        return False
+    return state.meta.membership(row.org_id, auth.user_id) is not None
+
+
+def _visible_result_row(
+    state: RegistryState,
+    *,
+    result_kind: str,
+    result_id: str,
+    visibility: str,
+    uploaded_by: str,
+    auth: TokenInfo,
+) -> bool:
+    if visibility == "public":
+        return True
+    if _is_admin(auth.scopes):
+        return True
+    if not auth.user_id:
+        return False
+    if uploaded_by and uploaded_by == auth.user_id:
+        return True
+    orgs = state.meta.user_org_ids(auth.user_id) if auth.user_id else set()
+    return state.meta.result_shared_with_user(
+        result_kind=result_kind,
+        result_id=result_id,
+        user_id=auth.user_id,
+        user_orgs=orgs,
+    )
 
 
 def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
@@ -203,10 +249,23 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 return
 
             token = _bearer(self)
-            scopes = state.tokens.scopes_for(token)
+            auth = state.tokens.auth_for(token)
+            scopes = auth.scopes
+
+            if path == "/v1/orgs":
+                self._list_orgs(auth=auth)
+                return
+            m = re.fullmatch(r"/v1/orgs/([^/]+)/members", path)
+            if m:
+                self._list_org_members(org_id=m.group(1), auth=auth)
+                return
+            m = re.fullmatch(r"/v1/orgs/([^/]+)", path)
+            if m:
+                self._get_org(org_id=m.group(1), auth=auth)
+                return
 
             if path == "/v1/packages":
-                self._list_packages(scopes=scopes, qs=qs)
+                self._list_packages(auth=auth, qs=qs)
                 return
 
             m = re.fullmatch(r"/v1/packages/([^/]+(?:/[^/]+)*)", path)
@@ -216,7 +275,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 # Prefer more specific routes first below; this branch only if no subpath.
                 rest = path[len("/v1/packages/") :]
                 if "/versions/" not in rest and "/by-digest/" not in rest and rest:
-                    self._list_package_versions(database_id=rest, scopes=scopes)
+                    self._list_package_versions(database_id=rest, auth=auth)
                     return
 
             m = re.fullmatch(r"/v1/packages/(.+)/versions/([^/]+)", path)
@@ -225,7 +284,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                     database_id=m.group(1),
                     version=m.group(2),
                     package_digest=None,
-                    scopes=scopes,
+                    auth=auth,
                 )
                 return
             m = re.fullmatch(
@@ -236,7 +295,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 self._serve_content(
                     database_id=m.group(1),
                     package_digest=m.group(2),
-                    scopes=scopes,
+                    auth=auth,
                 )
                 return
             # Package files list (#38) — more specific than bare by-digest meta.
@@ -248,7 +307,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 self._serve_package_files_list(
                     database_id=m.group(1),
                     package_digest=m.group(2),
-                    scopes=scopes,
+                    auth=auth,
                 )
                 return
             m = re.fullmatch(
@@ -260,7 +319,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                     database_id=m.group(1),
                     package_digest=m.group(2),
                     file_path=m.group(3),
-                    scopes=scopes,
+                    auth=auth,
                 )
                 return
             # Version-aliased files (resolve → digest internally).
@@ -272,7 +331,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 self._serve_package_files_list(
                     database_id=m.group(1),
                     version=m.group(2),
-                    scopes=scopes,
+                    auth=auth,
                 )
                 return
             m = re.fullmatch(
@@ -284,7 +343,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                     database_id=m.group(1),
                     version=m.group(2),
                     file_path=m.group(3),
-                    scopes=scopes,
+                    auth=auth,
                 )
                 return
             m = re.fullmatch(
@@ -296,32 +355,40 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                     database_id=m.group(1),
                     version=None,
                     package_digest=m.group(2),
-                    scopes=scopes,
+                    auth=auth,
                 )
                 return
 
             if path == "/v1/results/attempts":
-                self._list_attempts(scopes=scopes, qs=qs)
+                self._list_attempts(auth=auth, qs=qs)
                 return
             m = re.fullmatch(r"/v1/results/attempts/([^/]+)/content", path)
             if m:
-                self._serve_attempt_content(run_id=m.group(1), scopes=scopes)
+                self._serve_attempt_content(run_id=m.group(1), auth=auth)
+                return
+            m = re.fullmatch(r"/v1/results/attempts/([^/]+)/shares", path)
+            if m:
+                self._list_result_shares(result_kind="attempt", result_id=m.group(1), auth=auth)
                 return
             m = re.fullmatch(r"/v1/results/attempts/([^/]+)", path)
             if m:
-                self._serve_attempt_meta(run_id=m.group(1), scopes=scopes)
+                self._serve_attempt_meta(run_id=m.group(1), auth=auth)
                 return
 
             if path == "/v1/results/suites":
-                self._list_suites(scopes=scopes, qs=qs)
+                self._list_suites(auth=auth, qs=qs)
                 return
             m = re.fullmatch(r"/v1/results/suites/([^/]+)/content", path)
             if m:
-                self._serve_suite_content(suite_run_id=m.group(1), scopes=scopes)
+                self._serve_suite_content(suite_run_id=m.group(1), auth=auth)
+                return
+            m = re.fullmatch(r"/v1/results/suites/([^/]+)/shares", path)
+            if m:
+                self._list_result_shares(result_kind="suite", result_id=m.group(1), auth=auth)
                 return
             m = re.fullmatch(r"/v1/results/suites/([^/]+)", path)
             if m:
-                self._serve_suite_meta(suite_run_id=m.group(1), scopes=scopes)
+                self._serve_suite_meta(suite_run_id=m.group(1), auth=auth)
                 return
 
             _json_response(self, 404, {"error": "not_found", "message": "unknown path"})
@@ -335,6 +402,17 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             if path == "/v1/auth/github/device/poll":
                 self._auth_device_poll()
                 return
+            if path == "/v1/orgs":
+                self._create_org()
+                return
+            m = re.fullmatch(r"/v1/orgs/([^/]+)/claim", path)
+            if m:
+                self._claim_org(org_id=m.group(1))
+                return
+            m = re.fullmatch(r"/v1/orgs/([^/]+)/members", path)
+            if m:
+                self._add_org_member(org_id=m.group(1))
+                return
             if path == "/v1/packages":
                 self._publish_package()
                 return
@@ -343,6 +421,30 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 return
             if path == "/v1/results/suites":
                 self._upload_suite()
+                return
+            m = re.fullmatch(r"/v1/results/attempts/([^/]+)/shares", path)
+            if m:
+                self._add_result_share(result_kind="attempt", result_id=m.group(1))
+                return
+            m = re.fullmatch(r"/v1/results/suites/([^/]+)/shares", path)
+            if m:
+                self._add_result_share(result_kind="suite", result_id=m.group(1))
+                return
+            _json_response(self, 404, {"error": "not_found", "message": "unknown path"})
+
+        def do_DELETE(self) -> None:  # noqa: N802
+            path = unquote(self.path.split("?", 1)[0])
+            m = re.fullmatch(r"/v1/orgs/([^/]+)/members/([^/]+)", path)
+            if m:
+                self._remove_org_member(org_id=m.group(1), user_id=m.group(2))
+                return
+            m = re.fullmatch(r"/v1/results/attempts/([^/]+)/shares", path)
+            if m:
+                self._remove_result_share(result_kind="attempt", result_id=m.group(1))
+                return
+            m = re.fullmatch(r"/v1/results/suites/([^/]+)/shares", path)
+            if m:
+                self._remove_result_share(result_kind="suite", result_id=m.group(1))
                 return
             _json_response(self, 404, {"error": "not_found", "message": "unknown path"})
 
@@ -468,12 +570,24 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
 
         def _publish_package(self) -> None:
             token = _bearer(self)
-            scopes = state.tokens.scopes_for(token)
+            auth = state.tokens.auth_for(token)
+            scopes = auth.scopes
             if "registry:publish" not in scopes and "admin" not in scopes:
                 _json_response(
                     self,
                     401,
                     {"error": "unauthorized", "message": "publish scope required"},
+                )
+                return
+            user_id = auth.user_id
+            if not user_id:
+                _json_response(
+                    self,
+                    401,
+                    {
+                        "error": "unauthorized",
+                        "message": "publish requires authenticated user identity",
+                    },
                 )
                 return
             length = int(self.headers.get("Content-Length") or "0")
@@ -504,9 +618,35 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             blob_digest = str(meta.get("blob_digest") or "")
             media_type = str(meta.get("media_type") or "")
             visibility = str(meta.get("visibility") or "private")
+            raw_org = str(meta.get("org_id") or meta.get("org") or "").strip()
+            org_id = raw_org.casefold() if raw_org else None
             size = int(meta.get("size") or len(archive))
             if visibility not in {"private", "public"}:
                 _json_response(self, 400, {"error": "invalid_request", "message": "bad visibility"})
+                return
+            if not org_id:
+                _json_response(
+                    self,
+                    400,
+                    {"error": "org_required", "message": "publish requires org_id"},
+                )
+                return
+            if state.meta.get_org(org_id) is None:
+                _json_response(
+                    self,
+                    400,
+                    {"error": "org_not_found", "message": f"org {org_id!r} not found"},
+                )
+                return
+            if not _is_admin(scopes) and state.meta.membership(org_id, user_id) is None:
+                _json_response(
+                    self,
+                    403,
+                    {
+                        "error": "forbidden",
+                        "message": "must be org member to publish under this org",
+                    },
+                )
                 return
             actual_blob = f"sha256:{hashlib.sha256(archive).hexdigest()}"
             if actual_blob != blob_digest or size != len(archive):
@@ -550,6 +690,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 size=size,
                 media_type=media_type,
                 created_at=now(),
+                org_id=org_id,
             )
             try:
                 state.blobs.put_if_absent(blob_digest, archive, prefix="packages")
@@ -563,42 +704,31 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 return
             _json_response(self, 201, release_to_dict(row))
 
-        def _list_packages(self, *, scopes: frozenset[str], qs: dict[str, list[str]]) -> None:
-            include_private = _can_list_private_packages(scopes)
+        def _list_packages(self, *, auth: TokenInfo, qs: dict[str, list[str]]) -> None:
             prefix = (qs.get("database_id_prefix") or [None])[0]
             visibility = (qs.get("visibility") or [None])[0]
             version = (qs.get("version") or [None])[0]
             if visibility is not None and visibility not in {"public", "private"}:
                 _json_response(self, 400, {"error": "invalid_request", "message": "bad visibility"})
                 return
+            # Fetch public + private candidates; filter by ACL (no private leakage).
             rows = state.meta.list_releases(
                 database_id_prefix=prefix or None,
                 visibility=visibility,
                 version=version or None,
-                include_private=include_private,
+                include_private=True,
             )
+            items = [release_to_dict(r) for r in rows if _visible_package_row(state, r, auth)]
+            _json_response(self, 200, {"items": items})
+
+        def _list_package_versions(self, *, database_id: str, auth: TokenInfo) -> None:
+            rows = state.meta.list_versions(database_id, include_private=True)
+            items = [release_to_dict(r) for r in rows if _visible_package_row(state, r, auth)]
             _json_response(
                 self,
                 200,
-                {"items": [release_to_dict(r) for r in rows]},
+                {"database_id": database_id, "items": items},
             )
-
-        def _list_package_versions(self, *, database_id: str, scopes: frozenset[str]) -> None:
-            include_private = _can_list_private_packages(scopes)
-            rows = state.meta.list_versions(database_id, include_private=include_private)
-            _json_response(
-                self,
-                200,
-                {
-                    "database_id": database_id,
-                    "items": [release_to_dict(r) for r in rows],
-                },
-            )
-
-        def _visible_package(self, row: ReleaseRow, scopes: frozenset[str]) -> bool:
-            if row.visibility == "public":
-                return True
-            return _can_list_private_packages(scopes)
 
         def _serve_meta(
             self,
@@ -606,14 +736,14 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             database_id: str,
             version: str | None,
             package_digest: str | None,
-            scopes: frozenset[str],
+            auth: TokenInfo,
         ) -> None:
             if package_digest:
                 row = state.meta.get_by_digest(database_id, package_digest)
             else:
                 assert version is not None
                 row = state.meta.get_by_version(database_id, version)
-            if row is None or not self._visible_package(row, scopes):
+            if row is None or not _visible_package_row(state, row, auth):
                 _json_response(self, 404, {"error": "not_found", "message": "release not found"})
                 return
             _json_response(self, 200, release_to_dict(row))
@@ -623,10 +753,10 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             *,
             database_id: str,
             package_digest: str,
-            scopes: frozenset[str],
+            auth: TokenInfo,
         ) -> None:
             row = state.meta.get_by_digest(database_id, package_digest)
-            if row is None or not self._visible_package(row, scopes):
+            if row is None or not _visible_package_row(state, row, auth):
                 _json_response(self, 404, {"error": "not_found", "message": "release not found"})
                 return
             data = state.blobs.get(row.blob_digest, prefix="packages")
@@ -644,7 +774,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             self,
             *,
             database_id: str,
-            scopes: frozenset[str],
+            auth: TokenInfo,
             package_digest: str | None = None,
             version: str | None = None,
         ) -> ReleaseRow | None:
@@ -654,7 +784,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 row = state.meta.get_by_version(database_id, version)
             else:
                 return None
-            if row is None or not self._visible_package(row, scopes):
+            if row is None or not _visible_package_row(state, row, auth):
                 return None
             return row
 
@@ -662,7 +792,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             self,
             *,
             database_id: str,
-            scopes: frozenset[str],
+            auth: TokenInfo,
             package_digest: str | None = None,
             version: str | None = None,
         ) -> None:
@@ -670,7 +800,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
 
             row = self._resolve_visible_release(
                 database_id=database_id,
-                scopes=scopes,
+                auth=auth,
                 package_digest=package_digest,
                 version=version,
             )
@@ -706,7 +836,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             *,
             database_id: str,
             file_path: str,
-            scopes: frozenset[str],
+            auth: TokenInfo,
             package_digest: str | None = None,
             version: str | None = None,
         ) -> None:
@@ -722,7 +852,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
 
             row = self._resolve_visible_release(
                 database_id=database_id,
-                scopes=scopes,
+                auth=auth,
                 package_digest=package_digest,
                 version=version,
             )
@@ -781,12 +911,23 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
 
         def _upload_attempt(self) -> None:
             token = _bearer(self)
-            scopes = state.tokens.scopes_for(token)
+            auth = state.tokens.auth_for(token)
+            scopes = auth.scopes
             if "results:upload" not in scopes and "admin" not in scopes:
                 _json_response(
                     self,
                     401,
                     {"error": "unauthorized", "message": "results:upload scope required"},
+                )
+                return
+            if not auth.user_id:
+                _json_response(
+                    self,
+                    401,
+                    {
+                        "error": "unauthorized",
+                        "message": "upload requires authenticated user identity",
+                    },
                 )
                 return
             length = int(self.headers.get("Content-Length") or "0")
@@ -837,7 +978,6 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                     {"error": "digest_mismatch", "message": "blob digest or size mismatch"},
                 )
                 return
-            # Lightweight secret scan on archive bytes (patterns only; no extraction log).
             if _archive_looks_like_secret_leak(archive):
                 _json_response(
                     self,
@@ -859,6 +999,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 blob_digest=blob_digest,
                 size=size,
                 created_at=now(),
+                uploaded_by=auth.user_id,
             )
             try:
                 state.blobs.put_if_absent(blob_digest, archive, prefix="results")
@@ -872,34 +1013,50 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 return
             _json_response(self, 201, attempt_to_dict(row))
 
-        def _visible_result(self, row: AttemptResultRow, scopes: frozenset[str]) -> bool:
-            if row.visibility == "public":
-                return True
-            return _can_list_private_results(scopes)
-
-        def _list_attempts(self, *, scopes: frozenset[str], qs: dict[str, list[str]]) -> None:
-            include_private = _can_list_private_results(scopes)
+        def _list_attempts(self, *, auth: TokenInfo, qs: dict[str, list[str]]) -> None:
             database_id = (qs.get("database_id") or [None])[0]
             rows = state.meta.list_attempts(
                 database_id=database_id or None,
-                include_private=include_private,
+                include_private=True,
             )
-            _json_response(
-                self,
-                200,
-                {"items": [attempt_to_dict(r) for r in rows]},
-            )
+            items = [
+                attempt_to_dict(r)
+                for r in rows
+                if _visible_result_row(
+                    state,
+                    result_kind="attempt",
+                    result_id=r.run_id,
+                    visibility=r.visibility,
+                    uploaded_by=r.uploaded_by,
+                    auth=auth,
+                )
+            ]
+            _json_response(self, 200, {"items": items})
 
-        def _serve_attempt_meta(self, *, run_id: str, scopes: frozenset[str]) -> None:
+        def _serve_attempt_meta(self, *, run_id: str, auth: TokenInfo) -> None:
             row = state.meta.get_attempt(run_id)
-            if row is None or not self._visible_result(row, scopes):
+            if row is None or not _visible_result_row(
+                state,
+                result_kind="attempt",
+                result_id=row.run_id,
+                visibility=row.visibility,
+                uploaded_by=row.uploaded_by,
+                auth=auth,
+            ):
                 _json_response(self, 404, {"error": "not_found", "message": "attempt not found"})
                 return
             _json_response(self, 200, attempt_to_dict(row))
 
-        def _serve_attempt_content(self, *, run_id: str, scopes: frozenset[str]) -> None:
+        def _serve_attempt_content(self, *, run_id: str, auth: TokenInfo) -> None:
             row = state.meta.get_attempt(run_id)
-            if row is None or not self._visible_result(row, scopes):
+            if row is None or not _visible_result_row(
+                state,
+                result_kind="attempt",
+                result_id=row.run_id,
+                visibility=row.visibility,
+                uploaded_by=row.uploaded_by,
+                auth=auth,
+            ):
                 _json_response(self, 404, {"error": "not_found", "message": "attempt not found"})
                 return
             data = state.blobs.get(row.blob_digest, prefix="results")
@@ -916,19 +1073,25 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
 
         # ---- suite results -----------------------------------------------
 
-        def _visible_suite(self, row: SuiteResultRow, scopes: frozenset[str]) -> bool:
-            if row.visibility == "public":
-                return True
-            return _can_list_private_results(scopes)
-
         def _upload_suite(self) -> None:
             token = _bearer(self)
-            scopes = state.tokens.scopes_for(token)
+            auth = state.tokens.auth_for(token)
+            scopes = auth.scopes
             if "results:upload" not in scopes and "admin" not in scopes:
                 _json_response(
                     self,
                     401,
                     {"error": "unauthorized", "message": "results:upload scope required"},
+                )
+                return
+            if not auth.user_id:
+                _json_response(
+                    self,
+                    401,
+                    {
+                        "error": "unauthorized",
+                        "message": "upload requires authenticated user identity",
+                    },
                 )
                 return
             length = int(self.headers.get("Content-Length") or "0")
@@ -972,7 +1135,6 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             if visibility not in {"private", "public"}:
                 _json_response(self, 400, {"error": "invalid_request", "message": "bad visibility"})
                 return
-            # Reject any client-supplied suite PASS authority field.
             if "pass" in meta or "verdict" in meta or meta.get("suite_pass") is not None:
                 _json_response(
                     self,
@@ -1019,7 +1181,6 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             except (TypeError, ValueError):
                 exit_code = 0
 
-            # #42 config fingerprint projection from suite summary (optional).
             config_payload: dict[str, Any] = {}
             if meta.get("config_fingerprint"):
                 config_payload["config_fingerprint"] = str(meta["config_fingerprint"])
@@ -1027,9 +1188,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 config_payload["config_homogeneous"] = bool(meta.get("config_homogeneous"))
             actors_raw = meta.get("actors_summary")
             if isinstance(actors_raw, list):
-                config_payload["actors_summary"] = [
-                    a for a in actors_raw if isinstance(a, dict)
-                ]
+                config_payload["actors_summary"] = [a for a in actors_raw if isinstance(a, dict)]
 
             row = SuiteResultRow(
                 suite_run_id=suite_run_id,
@@ -1047,6 +1206,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 exit_code=exit_code,
                 created_at=now(),
                 config_json=json.dumps(config_payload, sort_keys=True),
+                uploaded_by=auth.user_id,
             )
             try:
                 state.blobs.put_if_absent(blob_digest, archive, prefix="suite-results")
@@ -1060,29 +1220,50 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 return
             _json_response(self, 201, suite_to_dict(row))
 
-        def _list_suites(self, *, scopes: frozenset[str], qs: dict[str, list[str]]) -> None:
-            include_private = _can_list_private_results(scopes)
+        def _list_suites(self, *, auth: TokenInfo, qs: dict[str, list[str]]) -> None:
             database_id = (qs.get("database_id") or [None])[0]
             rows = state.meta.list_suites(
                 database_id=database_id or None,
-                include_private=include_private,
+                include_private=True,
             )
-            _json_response(
-                self,
-                200,
-                {"items": [suite_to_dict(r) for r in rows]},
-            )
+            items = [
+                suite_to_dict(r)
+                for r in rows
+                if _visible_result_row(
+                    state,
+                    result_kind="suite",
+                    result_id=r.suite_run_id,
+                    visibility=r.visibility,
+                    uploaded_by=r.uploaded_by,
+                    auth=auth,
+                )
+            ]
+            _json_response(self, 200, {"items": items})
 
-        def _serve_suite_meta(self, *, suite_run_id: str, scopes: frozenset[str]) -> None:
+        def _serve_suite_meta(self, *, suite_run_id: str, auth: TokenInfo) -> None:
             row = state.meta.get_suite(suite_run_id)
-            if row is None or not self._visible_suite(row, scopes):
+            if row is None or not _visible_result_row(
+                state,
+                result_kind="suite",
+                result_id=row.suite_run_id,
+                visibility=row.visibility,
+                uploaded_by=row.uploaded_by,
+                auth=auth,
+            ):
                 _json_response(self, 404, {"error": "not_found", "message": "suite not found"})
                 return
             _json_response(self, 200, suite_to_dict(row))
 
-        def _serve_suite_content(self, *, suite_run_id: str, scopes: frozenset[str]) -> None:
+        def _serve_suite_content(self, *, suite_run_id: str, auth: TokenInfo) -> None:
             row = state.meta.get_suite(suite_run_id)
-            if row is None or not self._visible_suite(row, scopes):
+            if row is None or not _visible_result_row(
+                state,
+                result_kind="suite",
+                result_id=row.suite_run_id,
+                visibility=row.visibility,
+                uploaded_by=row.uploaded_by,
+                auth=auth,
+            ):
                 _json_response(self, 404, {"error": "not_found", "message": "suite not found"})
                 return
             data = state.blobs.get(row.blob_digest, prefix="suite-results")
@@ -1096,6 +1277,309 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             self.send_header("X-Bora-Media-Type", SUITE_RESULT_MEDIA_TYPE)
             self.end_headers()
             self.wfile.write(data)
+
+        # ---- org ---------------------------------------------------------
+
+        def _create_org(self) -> None:
+            token = _bearer(self)
+            auth = state.tokens.auth_for(token)
+            if not auth.scopes:
+                _json_response(self, 401, {"error": "unauthorized", "message": "login required"})
+                return
+            if not auth.user_id:
+                _json_response(
+                    self,
+                    401,
+                    {"error": "unauthorized", "message": "user identity required"},
+                )
+                return
+            length = int(self.headers.get("Content-Length") or "0")
+            raw = self.rfile.read(length) if length > 0 else b"{}"
+            try:
+                body = json.loads(raw.decode("utf-8"))
+            except json.JSONDecodeError:
+                _json_response(self, 400, {"error": "invalid_request", "message": "bad JSON"})
+                return
+            name = str(body.get("name") or "").strip().casefold()
+            display_name = str(body.get("display_name") or name)
+            is_claimable = bool(body.get("is_claimable", False))
+            if not name or not _ORG_NAME_RE.match(name):
+                _json_response(
+                    self,
+                    400,
+                    {
+                        "error": "invalid_request",
+                        "message": "name must be lowercase slug [a-z0-9][a-z0-9_-]*",
+                    },
+                )
+                return
+            try:
+                org = state.meta.create_org(
+                    name=name,
+                    owner_user_id=auth.user_id,
+                    display_name=display_name,
+                    is_claimable=is_claimable,
+                )
+            except ValueError:
+                _json_response(self, 409, {"error": "conflict", "message": "org already exists"})
+                return
+            _json_response(self, 201, org_to_dict(org))
+
+        def _list_orgs(self, *, auth: TokenInfo) -> None:
+            if not auth.user_id:
+                _json_response(self, 401, {"error": "unauthorized", "message": "login required"})
+                return
+            items = []
+            for org, role in state.meta.list_orgs_for_user(auth.user_id):
+                d = org_to_dict(org)
+                d["role"] = role
+                items.append(d)
+            _json_response(self, 200, {"items": items})
+
+        def _get_org(self, *, org_id: str, auth: TokenInfo) -> None:
+            org = state.meta.get_org(org_id.casefold())
+            if org is None:
+                _json_response(self, 404, {"error": "not_found", "message": "org not found"})
+                return
+            # Public metadata of org is readable; membership list is restricted.
+            payload = org_to_dict(org)
+            if auth.user_id:
+                m = state.meta.membership(org.org_id, auth.user_id)
+                if m:
+                    payload["role"] = m.role
+            _json_response(self, 200, payload)
+
+        def _claim_org(self, *, org_id: str) -> None:
+            token = _bearer(self)
+            auth = state.tokens.auth_for(token)
+            if not auth.user_id:
+                _json_response(
+                    self,
+                    401,
+                    {"error": "unauthorized", "message": "user identity required"},
+                )
+                return
+            try:
+                org = state.meta.claim_org(org_id.casefold(), auth.user_id)
+            except LookupError:
+                _json_response(self, 404, {"error": "not_found", "message": "org not found"})
+                return
+            except PermissionError as exc:
+                _json_response(self, 403, {"error": "forbidden", "message": str(exc)})
+                return
+            _json_response(self, 200, org_to_dict(org))
+
+        def _list_org_members(self, *, org_id: str, auth: TokenInfo) -> None:
+            org_id = org_id.casefold()
+            org = state.meta.get_org(org_id)
+            if org is None:
+                _json_response(self, 404, {"error": "not_found", "message": "org not found"})
+                return
+            if not _is_admin(auth.scopes):
+                if not auth.user_id or state.meta.membership(org_id, auth.user_id) is None:
+                    _json_response(self, 404, {"error": "not_found", "message": "org not found"})
+                    return
+            members = [membership_to_dict(m) for m in state.meta.list_members(org_id)]
+            _json_response(self, 200, {"org_id": org_id, "items": members})
+
+        def _add_org_member(self, *, org_id: str) -> None:
+            token = _bearer(self)
+            auth = state.tokens.auth_for(token)
+            org_id = org_id.casefold()
+            if not auth.user_id and not _is_admin(auth.scopes):
+                _json_response(self, 401, {"error": "unauthorized", "message": "login required"})
+                return
+            mem = state.meta.membership(org_id, auth.user_id) if auth.user_id else None
+            if not _is_admin(auth.scopes) and (mem is None or mem.role != "owner"):
+                _json_response(
+                    self,
+                    403,
+                    {"error": "forbidden", "message": "owner required to add members"},
+                )
+                return
+            length = int(self.headers.get("Content-Length") or "0")
+            raw = self.rfile.read(length) if length > 0 else b"{}"
+            try:
+                body = json.loads(raw.decode("utf-8"))
+            except json.JSONDecodeError:
+                _json_response(self, 400, {"error": "invalid_request", "message": "bad JSON"})
+                return
+            user_id = _normalize_user_id(str(body.get("user_id") or ""))
+            role = str(body.get("role") or "member")
+            if not user_id:
+                _json_response(
+                    self,
+                    400,
+                    {"error": "invalid_request", "message": "user_id required"},
+                )
+                return
+            try:
+                m = state.meta.add_member(org_id, user_id, role=role)
+            except LookupError:
+                _json_response(self, 404, {"error": "not_found", "message": "org not found"})
+                return
+            except ValueError as exc:
+                code = "conflict" if "exists" in str(exc) else "invalid_request"
+                status = 409 if code == "conflict" else 400
+                _json_response(self, status, {"error": code, "message": str(exc)})
+                return
+            _json_response(self, 201, membership_to_dict(m))
+
+        def _remove_org_member(self, *, org_id: str, user_id: str) -> None:
+            token = _bearer(self)
+            auth = state.tokens.auth_for(token)
+            org_id = org_id.casefold()
+            target = _normalize_user_id(user_id) or user_id.casefold()
+            mem = state.meta.membership(org_id, auth.user_id) if auth.user_id else None
+            if not _is_admin(auth.scopes) and (mem is None or mem.role != "owner"):
+                _json_response(
+                    self,
+                    403,
+                    {"error": "forbidden", "message": "owner required to remove members"},
+                )
+                return
+            try:
+                state.meta.remove_member(org_id, target)
+            except LookupError:
+                _json_response(self, 404, {"error": "not_found", "message": "membership not found"})
+                return
+            _json_response(self, 200, {"ok": True, "org_id": org_id, "user_id": target})
+
+        # ---- result shares -----------------------------------------------
+
+        def _list_result_shares(self, *, result_kind: str, result_id: str, auth: TokenInfo) -> None:
+            if not self._can_manage_result(result_kind, result_id, auth, for_read=True):
+                _json_response(self, 404, {"error": "not_found", "message": "result not found"})
+                return
+            shares = state.meta.list_result_shares(result_kind=result_kind, result_id=result_id)
+            _json_response(
+                self,
+                200,
+                {
+                    "result_kind": result_kind,
+                    "result_id": result_id,
+                    "items": [share_to_dict(s) for s in shares],
+                },
+            )
+
+        def _add_result_share(self, *, result_kind: str, result_id: str) -> None:
+            token = _bearer(self)
+            auth = state.tokens.auth_for(token)
+            if not self._can_manage_result(result_kind, result_id, auth, for_read=False):
+                _json_response(self, 404, {"error": "not_found", "message": "result not found"})
+                return
+            length = int(self.headers.get("Content-Length") or "0")
+            raw = self.rfile.read(length) if length > 0 else b"{}"
+            try:
+                body = json.loads(raw.decode("utf-8"))
+            except json.JSONDecodeError:
+                _json_response(self, 400, {"error": "invalid_request", "message": "bad JSON"})
+                return
+            target_type = str(body.get("target_type") or "").strip()
+            target_id = str(body.get("target_id") or "").strip()
+            if target_type not in {"org", "user"} or not target_id:
+                _json_response(
+                    self,
+                    400,
+                    {
+                        "error": "invalid_request",
+                        "message": "target_type (org|user) and target_id required",
+                    },
+                )
+                return
+            if target_type == "user":
+                target_id = _normalize_user_id(target_id) or target_id.casefold()
+            else:
+                target_id = target_id.casefold()
+                if state.meta.get_org(target_id) is None:
+                    _json_response(
+                        self,
+                        400,
+                        {"error": "org_not_found", "message": f"org {target_id!r} not found"},
+                    )
+                    return
+            try:
+                share = state.meta.add_result_share(
+                    result_kind=result_kind,
+                    result_id=result_id,
+                    target_type=target_type,
+                    target_id=target_id,
+                )
+            except ValueError:
+                _json_response(self, 409, {"error": "conflict", "message": "share already exists"})
+                return
+            _json_response(self, 201, share_to_dict(share))
+
+        def _remove_result_share(self, *, result_kind: str, result_id: str) -> None:
+            token = _bearer(self)
+            auth = state.tokens.auth_for(token)
+            if not self._can_manage_result(result_kind, result_id, auth, for_read=False):
+                _json_response(self, 404, {"error": "not_found", "message": "result not found"})
+                return
+            length = int(self.headers.get("Content-Length") or "0")
+            raw = self.rfile.read(length) if length > 0 else b"{}"
+            try:
+                body = json.loads(raw.decode("utf-8"))
+            except json.JSONDecodeError:
+                _json_response(self, 400, {"error": "invalid_request", "message": "bad JSON"})
+                return
+            target_type = str(body.get("target_type") or "").strip()
+            target_id = str(body.get("target_id") or "").strip()
+            if target_type == "user":
+                target_id = _normalize_user_id(target_id) or target_id.casefold()
+            else:
+                target_id = target_id.casefold()
+            try:
+                state.meta.remove_result_share(
+                    result_kind=result_kind,
+                    result_id=result_id,
+                    target_type=target_type,
+                    target_id=target_id,
+                )
+            except LookupError:
+                _json_response(self, 404, {"error": "not_found", "message": "share not found"})
+                return
+            _json_response(self, 200, {"ok": True})
+
+        def _can_manage_result(
+            self,
+            result_kind: str,
+            result_id: str,
+            auth: TokenInfo,
+            *,
+            for_read: bool,
+        ) -> bool:
+            if result_kind == "attempt":
+                row = state.meta.get_attempt(result_id)
+                if row is None:
+                    return False
+                if for_read:
+                    return _visible_result_row(
+                        state,
+                        result_kind="attempt",
+                        result_id=row.run_id,
+                        visibility=row.visibility,
+                        uploaded_by=row.uploaded_by,
+                        auth=auth,
+                    )
+                return _is_admin(auth.scopes) or (
+                    bool(auth.user_id) and row.uploaded_by == auth.user_id
+                )
+            row_s = state.meta.get_suite(result_id)
+            if row_s is None:
+                return False
+            if for_read:
+                return _visible_result_row(
+                    state,
+                    result_kind="suite",
+                    result_id=row_s.suite_run_id,
+                    visibility=row_s.visibility,
+                    uploaded_by=row_s.uploaded_by,
+                    auth=auth,
+                )
+            return _is_admin(auth.scopes) or (
+                bool(auth.user_id) and row_s.uploaded_by == auth.user_id
+            )
 
     return Handler
 
@@ -1126,7 +1610,7 @@ def build_default_state(
     tokens: Any = SqliteTokenStore(db_path)
     blobs: Any = MemoryBlobStore() if memory_blob else FilesystemBlobStore(data_dir / "blobs")
     token = bootstrap_token or secrets.token_urlsafe(24)
-    tokens.add(token, ADMIN_SCOPES)
+    tokens.add(token, ADMIN_SCOPES, github_user="bootstrap")
     return (
         RegistryState(
             meta=meta,
@@ -1173,7 +1657,7 @@ def build_state_from_env(
         region=os.environ.get("BORA_REGISTRY_S3_REGION") or "us-east-1",
     )
     token = bootstrap_token or secrets.token_urlsafe(24)
-    tokens.add(token, ADMIN_SCOPES)
+    tokens.add(token, ADMIN_SCOPES, github_user="bootstrap")
     return (
         RegistryState(
             meta=meta,

--- a/services/registry/app.py
+++ b/services/registry/app.py
@@ -4,6 +4,8 @@ Endpoints:
   GET  /health
   POST /v1/auth/github/device/code
   POST /v1/auth/github/device/poll
+  POST /v1/auth/github/web/start
+  POST /v1/auth/github/web/callback
   POST /v1/orgs | GET /v1/orgs | GET /v1/orgs/{id}
   POST /v1/orgs/{id}/claim | GET|POST /v1/orgs/{id}/members | DELETE .../members/{user}
   POST /v1/packages
@@ -38,6 +40,7 @@ import json
 import os
 import re
 import secrets
+import time
 import sys
 import tempfile
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -55,6 +58,8 @@ if str(_REPO) not in sys.path:
 from services.registry.envload import load_env_file  # noqa: E402
 from services.registry.oauth_github import (  # noqa: E402
     GitHubOAuthError,
+    build_web_authorize_url,
+    exchange_web_code,
     fetch_user,
     poll_access_token,
     request_device_code,
@@ -110,6 +115,8 @@ class RegistryState:
         self.github_client_secret = github_client_secret
         # Empty allowlist = refuse OAuth token issue (fail closed). Bootstrap token still works.
         self.github_login_allowlist = github_login_allowlist or frozenset()
+        # Web OAuth (Hub): state -> {redirect_uri, created_at}
+        self.oauth_web_states: dict[str, dict[str, Any]] = {}
 
 
 def _cors_headers(handler: BaseHTTPRequestHandler) -> None:
@@ -402,6 +409,12 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             if path == "/v1/auth/github/device/poll":
                 self._auth_device_poll()
                 return
+            if path == "/v1/auth/github/web/start":
+                self._auth_web_start()
+                return
+            if path == "/v1/auth/github/web/callback":
+                self._auth_web_callback()
+                return
             if path == "/v1/orgs":
                 self._create_org()
                 return
@@ -450,6 +463,229 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
 
         # ---- OAuth -------------------------------------------------------
 
+        def _allowed_web_redirect(self, redirect_uri: str) -> bool:
+            """Local Hub defaults + optional BORA_GITHUB_WEB_REDIRECT_URIS allowlist."""
+            uri = (redirect_uri or "").strip()
+            if not uri:
+                return False
+            defaults = {
+                "http://127.0.0.1:5174/login/callback",
+                "http://localhost:5174/login/callback",
+            }
+            extra = os.environ.get("BORA_GITHUB_WEB_REDIRECT_URIS") or ""
+            for part in extra.split(","):
+                p = part.strip()
+                if p:
+                    defaults.add(p)
+            return uri in defaults
+
+        def _purge_stale_oauth_states(self) -> None:
+            now_ts = time.time()
+            dead = [
+                k
+                for k, v in state.oauth_web_states.items()
+                if now_ts - float(v.get("created_at") or 0) > 600
+            ]
+            for k in dead:
+                state.oauth_web_states.pop(k, None)
+
+        def _issue_registry_session(self, identity: Any) -> dict[str, Any] | None:
+            """Allowlist check + mint Registry API token. None if not allowed (response sent)."""
+            allow = state.github_login_allowlist
+            login = str(getattr(identity, "login", "") or "")
+            if not allow:
+                _json_response(
+                    self,
+                    403,
+                    {
+                        "error": "login_not_allowed",
+                        "message": (
+                            "BORA_GITHUB_LOGIN_ALLOWLIST is empty; "
+                            "set comma-separated GitHub logins before login"
+                        ),
+                    },
+                )
+                return None
+            if login.casefold() not in {u.casefold() for u in allow}:
+                _json_response(
+                    self,
+                    403,
+                    {
+                        "error": "login_not_allowed",
+                        "message": (
+                            f"GitHub user {login!r} is not on "
+                            "BORA_GITHUB_LOGIN_ALLOWLIST "
+                            f"(allowed: {', '.join(sorted(allow))})"
+                        ),
+                    },
+                )
+                return None
+            api_token = secrets.token_urlsafe(32)
+            state.tokens.add(
+                api_token,
+                DEFAULT_LOGIN_SCOPES,
+                github_user=login,
+            )
+            display_name = getattr(identity, "name", None) or ""
+            avatar_url = getattr(identity, "avatar_url", None) or ""
+            github_id = getattr(identity, "id", None)
+            try:
+                upsert = getattr(state.meta, "upsert_user_profile", None)
+                if callable(upsert):
+                    upsert(
+                        user_id=login,
+                        display_name=str(display_name or ""),
+                        avatar_url=str(avatar_url or ""),
+                        github_id="" if github_id is None else str(github_id),
+                    )
+            except Exception:  # noqa: BLE001
+                pass
+            payload: dict[str, Any] = {
+                "token": api_token,
+                "token_type": "bearer",
+                "scopes": sorted(DEFAULT_LOGIN_SCOPES),
+                "github_user": login,
+            }
+            if github_id is not None:
+                payload["github_id"] = github_id
+            if display_name:
+                payload["github_name"] = str(display_name)
+            if avatar_url:
+                payload["avatar_url"] = str(avatar_url)
+            return payload
+
+        def _auth_web_start(self) -> None:
+            """Hub SPA: start Authorization Code flow (Harbor-style browser login)."""
+            if not state.github_client_id:
+                _json_response(
+                    self,
+                    503,
+                    {
+                        "error": "oauth_not_configured",
+                        "message": "BORA_GITHUB_CLIENT_ID not set",
+                    },
+                )
+                return
+            length = int(self.headers.get("Content-Length") or "0")
+            raw = self.rfile.read(length) if length > 0 else b"{}"
+            try:
+                body = json.loads(raw.decode("utf-8"))
+            except json.JSONDecodeError:
+                _json_response(self, 400, {"error": "invalid_request", "message": "bad JSON"})
+                return
+            redirect_uri = str(body.get("redirect_uri") or "").strip()
+            if not self._allowed_web_redirect(redirect_uri):
+                _json_response(
+                    self,
+                    400,
+                    {
+                        "error": "invalid_redirect_uri",
+                        "message": (
+                            "redirect_uri not allowed "
+                            "(default: http://127.0.0.1:5174/login/callback; "
+                            "extend via BORA_GITHUB_WEB_REDIRECT_URIS)"
+                        ),
+                    },
+                )
+                return
+            self._purge_stale_oauth_states()
+            state_token = secrets.token_urlsafe(24)
+            state.oauth_web_states[state_token] = {
+                "redirect_uri": redirect_uri,
+                "created_at": time.time(),
+            }
+            sys.stderr.write(
+                f"oauth web start state={state_token[:8]}... "
+                f"redirect={redirect_uri!r} pending={len(state.oauth_web_states)}\n"
+            )
+            url = build_web_authorize_url(
+                client_id=state.github_client_id,
+                redirect_uri=redirect_uri,
+                state=state_token,
+            )
+            _json_response(
+                self,
+                200,
+                {"authorize_url": url, "state": state_token},
+            )
+
+        def _auth_web_callback(self) -> None:
+            """Hub SPA: exchange GitHub code for Registry API token."""
+            if not state.github_client_id or not state.github_client_secret:
+                _json_response(
+                    self,
+                    503,
+                    {
+                        "error": "oauth_not_configured",
+                        "message": "GitHub OAuth client not configured",
+                    },
+                )
+                return
+            length = int(self.headers.get("Content-Length") or "0")
+            raw = self.rfile.read(length) if length > 0 else b"{}"
+            try:
+                body = json.loads(raw.decode("utf-8"))
+            except json.JSONDecodeError:
+                _json_response(self, 400, {"error": "invalid_request", "message": "bad JSON"})
+                return
+            code = str(body.get("code") or "").strip()
+            state_token = str(body.get("state") or "").strip()
+            redirect_uri = str(body.get("redirect_uri") or "").strip()
+            if not code or not state_token:
+                _json_response(
+                    self,
+                    400,
+                    {"error": "invalid_request", "message": "code and state required"},
+                )
+                return
+            self._purge_stale_oauth_states()
+            # Peek first; pop only after GitHub exchange succeeds so a double
+            # client call (React StrictMode) is less likely to hit invalid_state
+            # before the first exchange finishes.
+            pending = state.oauth_web_states.get(state_token)
+            if pending is None:
+                _json_response(
+                    self,
+                    400,
+                    {
+                        "error": "invalid_state",
+                        "message": "unknown or expired OAuth state; start login again",
+                    },
+                )
+                return
+            expected_redirect = str(pending.get("redirect_uri") or "")
+            if redirect_uri and redirect_uri != expected_redirect:
+                _json_response(
+                    self,
+                    400,
+                    {"error": "invalid_redirect_uri", "message": "redirect_uri mismatch"},
+                )
+                return
+            redirect_uri = expected_redirect
+            try:
+                gh_token = exchange_web_code(
+                    client_id=state.github_client_id,
+                    client_secret=state.github_client_secret,
+                    code=code,
+                    redirect_uri=redirect_uri,
+                )
+                identity = fetch_user(gh_token)
+            except GitHubOAuthError as exc:
+                sys.stderr.write(
+                    f"oauth web callback failed code={exc.code} msg={exc.message!r}\n"
+                )
+                _json_response(self, 400, {"error": exc.code, "message": exc.message})
+                return
+            state.oauth_web_states.pop(state_token, None)
+            sys.stderr.write(
+                f"oauth web authorized github_user={identity.login!r} "
+                f"(issuing registry token)\n"
+            )
+            payload = self._issue_registry_session(identity)
+            if payload is None:
+                return
+            _json_response(self, 200, payload)
+
         def _auth_device_code(self) -> None:
             if not state.github_client_id:
                 _json_response(
@@ -466,15 +702,20 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             except GitHubOAuthError as exc:
                 _json_response(self, 502, {"error": exc.code, "message": exc.message})
                 return
+            from services.registry.oauth_github import _device_verify_url
+
             payload = {
                 "device_code": dc.device_code,
                 "user_code": dc.user_code,
                 "verification_uri": dc.verification_uri,
                 "expires_in": dc.expires_in,
                 "interval": dc.interval,
+                # One-click prefill; always re-normalize (user_code + skip picker).
+                "verification_uri_complete": _device_verify_url(
+                    dc.verification_uri_complete or dc.verification_uri,
+                    dc.user_code,
+                ),
             }
-            if dc.verification_uri_complete:
-                payload["verification_uri_complete"] = dc.verification_uri_complete
             _json_response(self, 200, payload)
 
         def _auth_device_poll(self) -> None:
@@ -510,6 +751,9 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                     device_code=device_code,
                 )
             except GitHubOAuthError as exc:
+                sys.stderr.write(
+                    f"oauth poll github_error code={exc.code} msg={exc.message!r}\n"
+                )
                 _json_response(self, 400, {"error": exc.code, "message": exc.message})
                 return
             if gh_token is None:
@@ -522,49 +766,19 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             try:
                 identity = fetch_user(gh_token)
             except GitHubOAuthError as exc:
+                sys.stderr.write(
+                    f"oauth fetch_user failed code={exc.code} msg={exc.message!r}\n"
+                )
                 _json_response(self, 502, {"error": exc.code, "message": exc.message})
                 return
-            allow = state.github_login_allowlist
-            if not allow:
-                _json_response(
-                    self,
-                    403,
-                    {
-                        "error": "login_not_allowed",
-                        "message": (
-                            "BORA_GITHUB_LOGIN_ALLOWLIST is empty; "
-                            "set comma-separated GitHub logins before bora login"
-                        ),
-                    },
-                )
-                return
-            if identity.login.casefold() not in {u.casefold() for u in allow}:
-                _json_response(
-                    self,
-                    403,
-                    {
-                        "error": "login_not_allowed",
-                        "message": f"GitHub user {identity.login!r} is not on the allowlist",
-                    },
-                )
-                return
-            # Issue Registry API token; do not store GitHub access token.
-            api_token = secrets.token_urlsafe(32)
-            state.tokens.add(
-                api_token,
-                DEFAULT_LOGIN_SCOPES,
-                github_user=identity.login,
+            sys.stderr.write(
+                f"oauth poll authorized github_user={identity.login!r} "
+                f"(issuing registry token)\n"
             )
-            _json_response(
-                self,
-                200,
-                {
-                    "token": api_token,
-                    "token_type": "bearer",
-                    "scopes": sorted(DEFAULT_LOGIN_SCOPES),
-                    "github_user": identity.login,
-                },
-            )
+            payload = self._issue_registry_session(identity)
+            if payload is None:
+                return
+            _json_response(self, 200, payload)
 
         # ---- packages ----------------------------------------------------
 
@@ -1379,7 +1593,12 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 if not auth.user_id or state.meta.membership(org_id, auth.user_id) is None:
                     _json_response(self, 404, {"error": "not_found", "message": "org not found"})
                     return
-            members = [membership_to_dict(m) for m in state.meta.list_members(org_id)]
+            member_rows = state.meta.list_members(org_id)
+            profiles = state.meta.get_user_profiles([m.user_id for m in member_rows])
+            members = [
+                membership_to_dict(m, profile=profiles.get(m.user_id))
+                for m in member_rows
+            ]
             _json_response(self, 200, {"org_id": org_id, "items": members})
 
         def _add_org_member(self, *, org_id: str) -> None:

--- a/services/registry/oauth_github.py
+++ b/services/registry/oauth_github.py
@@ -15,6 +15,7 @@ from typing import Any
 
 GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code"
 GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
 GITHUB_USER_URL = "https://api.github.com/user"
 
 
@@ -30,8 +31,13 @@ class DeviceCodeResponse:
 
 @dataclass(frozen=True, slots=True)
 class GitHubIdentity:
+    """GitHub user identity from ``GET /user`` (read:user scope)."""
+
     login: str
     id: int
+    # Profile display name (API field ``name``); may be empty.
+    name: str | None = None
+    avatar_url: str | None = None
 
 
 class GitHubOAuthError(Exception):
@@ -79,13 +85,55 @@ def request_device_code(*, client_id: str, scope: str = "read:user") -> DeviceCo
     )
     if "error" in data:
         raise GitHubOAuthError(str(data["error"]), str(data.get("error_description") or ""))
+    verification_uri = str(
+        data.get("verification_uri") or "https://github.com/login/device"
+    )
+    user_code = str(data["user_code"])
+    # Prefer GitHub's complete URI when present; always ensure user_code + skip
+    # account picker. Multi-account sessions hit /login/device/select_account and
+    # GitHub's default Continue drops bare ?user_code= — re-add both params.
+    complete = str(data.get("verification_uri_complete") or "").strip()
+    complete = _device_verify_url(complete or verification_uri, user_code)
     return DeviceCodeResponse(
         device_code=str(data["device_code"]),
-        user_code=str(data["user_code"]),
-        verification_uri=str(data.get("verification_uri") or "https://github.com/login/device"),
+        user_code=user_code,
+        verification_uri=verification_uri,
         expires_in=int(data.get("expires_in") or 900),
         interval=int(data.get("interval") or 5),
-        verification_uri_complete=str(data.get("verification_uri_complete") or ""),
+        verification_uri_complete=complete,
+    )
+
+
+def _device_verify_url(base: str, user_code: str) -> str:
+    """Build a device-activation URL that survives GitHub account picker redirects.
+
+    GitHub multi-session flow: /login/device?user_code=X → select_account →
+    /login/device?skip_account_picker=true (user_code stripped). Starting with
+    both ``user_code`` and ``skip_account_picker=true`` avoids the empty form.
+    """
+    if not user_code:
+        return base or "https://github.com/login/device"
+    # Normalize to the canonical path; drop other query noise.
+    parsed = urllib.parse.urlparse(base or "https://github.com/login/device")
+    path = parsed.path or "/login/device"
+    if path.rstrip("/").endswith("/select_account"):
+        path = "/login/device"
+    # Stable order for readability in CLI/logs.
+    query = urllib.parse.urlencode(
+        [
+            ("user_code", user_code),
+            ("skip_account_picker", "true"),
+        ]
+    )
+    return urllib.parse.urlunparse(
+        (
+            parsed.scheme or "https",
+            parsed.netloc or "github.com",
+            path,
+            "",
+            query,
+            "",
+        )
     )
 
 
@@ -116,6 +164,46 @@ def poll_access_token(
     raise GitHubOAuthError(err, str(data.get("error_description") or err))
 
 
+def build_web_authorize_url(
+    *,
+    client_id: str,
+    redirect_uri: str,
+    state: str,
+    scope: str = "read:user",
+) -> str:
+    """Browser OAuth authorize URL (Authorization Code flow; Hub SPA)."""
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "scope": scope,
+        "state": state,
+    }
+    return f"{GITHUB_AUTHORIZE_URL}?{urllib.parse.urlencode(params)}"
+
+
+def exchange_web_code(
+    *,
+    client_id: str,
+    client_secret: str,
+    code: str,
+    redirect_uri: str,
+) -> str:
+    """Exchange web OAuth *code* for a GitHub access token."""
+    data = _post_form(
+        GITHUB_ACCESS_TOKEN_URL,
+        {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "code": code,
+            "redirect_uri": redirect_uri,
+        },
+    )
+    if "access_token" in data:
+        return str(data["access_token"])
+    err = str(data.get("error") or "unknown")
+    raise GitHubOAuthError(err, str(data.get("error_description") or err))
+
+
 def fetch_user(access_token: str, *, timeout: float = 30.0) -> GitHubIdentity:
     req = urllib.request.Request(
         GITHUB_USER_URL,
@@ -134,4 +222,17 @@ def fetch_user(access_token: str, *, timeout: float = 30.0) -> GitHubIdentity:
     except urllib.error.URLError as exc:
         raise GitHubOAuthError("github_unavailable", str(exc.reason)) from exc
     data = json.loads(raw.decode("utf-8"))
-    return GitHubIdentity(login=str(data["login"]), id=int(data["id"]))
+    raw_name = data.get("name")
+    name = str(raw_name).strip() if raw_name else None
+    if name == "":
+        name = None
+    raw_avatar = data.get("avatar_url")
+    avatar_url = str(raw_avatar).strip() if raw_avatar else None
+    if avatar_url == "":
+        avatar_url = None
+    return GitHubIdentity(
+        login=str(data["login"]),
+        id=int(data["id"]),
+        name=name,
+        avatar_url=avatar_url,
+    )

--- a/services/registry/store.py
+++ b/services/registry/store.py
@@ -4,7 +4,10 @@ Unit tests: SQLite + Memory blob.
 Compose / production: Postgres + S3-compatible (RustFS).
 
 Raw API tokens are never persisted — only sha256 digests.
-Visibility is only ``public`` | ``private`` (no org in this MVP).
+Visibility is only ``public`` | ``private``.
+Packages require ``org_id`` on new publishes; results carry ``uploaded_by``
+and optional share targets (org / user). Private read is ownership/membership
+based (admin bypass); scopes alone no longer grant global private sight.
 """
 
 from __future__ import annotations
@@ -33,6 +36,7 @@ class ReleaseRow:
     size: int
     media_type: str
     created_at: float
+    org_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,6 +52,7 @@ class AttemptResultRow:
     blob_digest: str
     size: int
     created_at: float
+    uploaded_by: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -74,6 +79,41 @@ class SuiteResultRow:
     created_at: float
     # #42 config comparability (optional; empty/default on legacy rows)
     config_json: str = "{}"
+    uploaded_by: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class OrgRow:
+    org_id: str
+    name: str
+    display_name: str
+    is_claimable: bool
+    created_at: float
+
+
+@dataclass(frozen=True, slots=True)
+class MembershipRow:
+    org_id: str
+    user_id: str
+    role: str
+    created_at: float
+
+
+@dataclass(frozen=True, slots=True)
+class TokenInfo:
+    """Resolved bearer token: scopes + optional user identity (github login)."""
+
+    scopes: frozenset[str]
+    user_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ResultShareRow:
+    result_kind: str  # attempt | suite
+    result_id: str
+    target_type: str  # org | user
+    target_id: str
+    created_at: float
 
 
 # ---------------------------------------------------------------------------
@@ -214,12 +254,21 @@ ADMIN_SCOPES: frozenset[str] = frozenset(
 )
 
 
+def _normalize_user_id(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    u = str(raw).strip()
+    if not u:
+        return None
+    return u.casefold()
+
+
 class TokenStore:
     """In-memory tokens (tests). Prefer SqliteTokenStore / PostgresTokenStore."""
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._tokens: dict[str, frozenset[str]] = {}
+        self._tokens: dict[str, TokenInfo] = {}
 
     @staticmethod
     def hash_token(raw: str) -> str:
@@ -232,15 +281,20 @@ class TokenStore:
         *,
         github_user: str | None = None,
     ) -> None:
-        del github_user
         with self._lock:
-            self._tokens[self.hash_token(raw_token)] = frozenset(scopes)
+            self._tokens[self.hash_token(raw_token)] = TokenInfo(
+                scopes=frozenset(scopes),
+                user_id=_normalize_user_id(github_user),
+            )
+
+    def auth_for(self, raw_token: str | None) -> TokenInfo:
+        if not raw_token:
+            return TokenInfo(scopes=frozenset())
+        with self._lock:
+            return self._tokens.get(self.hash_token(raw_token), TokenInfo(scopes=frozenset()))
 
     def scopes_for(self, raw_token: str | None) -> frozenset[str]:
-        if not raw_token:
-            return frozenset()
-        with self._lock:
-            return self._tokens.get(self.hash_token(raw_token), frozenset())
+        return self.auth_for(raw_token).scopes
 
 
 class SqliteTokenStore:
@@ -294,22 +348,28 @@ class SqliteTokenStore:
             )
             conn.commit()
 
-    def scopes_for(self, raw_token: str | None) -> frozenset[str]:
+    def auth_for(self, raw_token: str | None) -> TokenInfo:
         if not raw_token:
-            return frozenset()
+            return TokenInfo(scopes=frozenset())
         with self._connect() as conn:
             cur = conn.execute(
-                "SELECT scopes, revoked_at FROM api_tokens WHERE token_hash=?",
+                "SELECT scopes, github_user, revoked_at FROM api_tokens WHERE token_hash=?",
                 (self.hash_token(raw_token),),
             )
             row = cur.fetchone()
             if row is None or row["revoked_at"] is not None:
-                return frozenset()
+                return TokenInfo(scopes=frozenset())
             try:
                 data = json.loads(row["scopes"])
             except json.JSONDecodeError:
-                return frozenset()
-            return frozenset(str(s) for s in data)
+                return TokenInfo(scopes=frozenset())
+            return TokenInfo(
+                scopes=frozenset(str(s) for s in data),
+                user_id=_normalize_user_id(row["github_user"]),
+            )
+
+    def scopes_for(self, raw_token: str | None) -> frozenset[str]:
+        return self.auth_for(raw_token).scopes
 
 
 class PostgresTokenStore:
@@ -369,30 +429,35 @@ class PostgresTokenStore:
             )
             conn.commit()
 
-    def scopes_for(self, raw_token: str | None) -> frozenset[str]:
+    def auth_for(self, raw_token: str | None) -> TokenInfo:
         if not raw_token:
-            return frozenset()
+            return TokenInfo(scopes=frozenset())
         with self._connect() as conn:
             cur = conn.execute(
                 """
-                SELECT scopes FROM api_tokens
+                SELECT scopes, github_user FROM api_tokens
                 WHERE token_hash = %s AND revoked_at IS NULL
                 """,
                 (self.hash_token(raw_token),),
             )
             row = cur.fetchone()
             if row is None:
-                return frozenset()
-            scopes = row[0]
-            if isinstance(scopes, list):
-                return frozenset(str(s) for s in scopes)
-            if isinstance(scopes, str):
-                return frozenset(str(s) for s in json.loads(scopes))
-            return frozenset()
+                return TokenInfo(scopes=frozenset())
+            scopes_raw = row[0]
+            if isinstance(scopes_raw, list):
+                scopes = frozenset(str(s) for s in scopes_raw)
+            elif isinstance(scopes_raw, str):
+                scopes = frozenset(str(s) for s in json.loads(scopes_raw))
+            else:
+                scopes = frozenset()
+            return TokenInfo(scopes=scopes, user_id=_normalize_user_id(row[1]))
+
+    def scopes_for(self, raw_token: str | None) -> frozenset[str]:
+        return self.auth_for(raw_token).scopes
 
 
 # ---------------------------------------------------------------------------
-# Metadata (packages + attempt results)
+# Metadata (packages + attempt results + orgs + shares)
 # ---------------------------------------------------------------------------
 
 
@@ -469,13 +534,62 @@ class MetadataStore:
                 """
             )
             # Migrate pre-#42 DBs: add config_json if missing.
-            cols = {
-                str(r[1])
-                for r in conn.execute("PRAGMA table_info(suite_results)").fetchall()
-            }
+            cols = {str(r[1]) for r in conn.execute("PRAGMA table_info(suite_results)").fetchall()}
             if "config_json" not in cols:
                 conn.execute(
                     "ALTER TABLE suite_results ADD COLUMN config_json TEXT NOT NULL DEFAULT '{}'"
+                )
+            # Org + ACL columns (#52 / #53 / #54)
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS organizations (
+                    org_id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    display_name TEXT NOT NULL DEFAULT '',
+                    is_claimable INTEGER NOT NULL DEFAULT 0,
+                    created_at REAL NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS org_memberships (
+                    org_id TEXT NOT NULL,
+                    user_id TEXT NOT NULL,
+                    role TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    PRIMARY KEY (org_id, user_id)
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS result_shares (
+                    result_kind TEXT NOT NULL,
+                    result_id TEXT NOT NULL,
+                    target_type TEXT NOT NULL,
+                    target_id TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    PRIMARY KEY (result_kind, result_id, target_type, target_id)
+                )
+                """
+            )
+            rel_cols = {str(r[1]) for r in conn.execute("PRAGMA table_info(releases)").fetchall()}
+            if "org_id" not in rel_cols:
+                conn.execute("ALTER TABLE releases ADD COLUMN org_id TEXT")
+            att_cols = {
+                str(r[1]) for r in conn.execute("PRAGMA table_info(attempt_results)").fetchall()
+            }
+            if "uploaded_by" not in att_cols:
+                conn.execute(
+                    "ALTER TABLE attempt_results ADD COLUMN uploaded_by TEXT NOT NULL DEFAULT ''"
+                )
+            suite_cols = {
+                str(r[1]) for r in conn.execute("PRAGMA table_info(suite_results)").fetchall()
+            }
+            if "uploaded_by" not in suite_cols:
+                conn.execute(
+                    "ALTER TABLE suite_results ADD COLUMN uploaded_by TEXT NOT NULL DEFAULT ''"
                 )
             conn.commit()
 
@@ -486,8 +600,8 @@ class MetadataStore:
                     """
                     INSERT INTO releases(
                         database_id, version, visibility, package_digest,
-                        blob_digest, size, media_type, created_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                        blob_digest, size, media_type, created_at, org_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         row.database_id,
@@ -498,6 +612,7 @@ class MetadataStore:
                         row.size,
                         row.media_type,
                         row.created_at,
+                        row.org_id,
                     ),
                 )
                 conn.commit()
@@ -569,8 +684,8 @@ class MetadataStore:
                     """
                     INSERT INTO attempt_results(
                         run_id, database_id, task_id, lock_digest, status,
-                        visibility, blob_digest, size, created_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        visibility, blob_digest, size, created_at, uploaded_by
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         row.run_id,
@@ -582,6 +697,7 @@ class MetadataStore:
                         row.blob_digest,
                         row.size,
                         row.created_at,
+                        row.uploaded_by or "",
                     ),
                 )
                 conn.commit()
@@ -627,8 +743,8 @@ class MetadataStore:
                         suite_run_id, database_id, database_version, visibility,
                         pass_rate, mean_score, metrics_json, tasks_json,
                         agent_label, model_label, blob_digest, size,
-                        exit_code, created_at, config_json
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        exit_code, created_at, config_json, uploaded_by
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         row.suite_run_id,
@@ -646,6 +762,7 @@ class MetadataStore:
                         row.exit_code,
                         row.created_at,
                         row.config_json or "{}",
+                        row.uploaded_by or "",
                     ),
                 )
                 conn.commit()
@@ -684,6 +801,8 @@ class MetadataStore:
 
     @staticmethod
     def _release_row(r: sqlite3.Row) -> ReleaseRow:
+        keys = r.keys()
+        org_id = r["org_id"] if "org_id" in keys else None
         return ReleaseRow(
             database_id=r["database_id"],
             version=r["version"],
@@ -693,10 +812,13 @@ class MetadataStore:
             size=int(r["size"]),
             media_type=r["media_type"],
             created_at=float(r["created_at"]),
+            org_id=str(org_id) if org_id else None,
         )
 
     @staticmethod
     def _attempt_row(r: sqlite3.Row) -> AttemptResultRow:
+        keys = r.keys()
+        uploaded_by = str(r["uploaded_by"]) if "uploaded_by" in keys and r["uploaded_by"] else ""
         return AttemptResultRow(
             run_id=r["run_id"],
             database_id=r["database_id"],
@@ -707,12 +829,14 @@ class MetadataStore:
             blob_digest=r["blob_digest"],
             size=int(r["size"]),
             created_at=float(r["created_at"]),
+            uploaded_by=uploaded_by,
         )
 
     @staticmethod
     def _suite_row(r: sqlite3.Row) -> SuiteResultRow:
         keys = r.keys()
         config_json = str(r["config_json"]) if "config_json" in keys and r["config_json"] else "{}"
+        uploaded_by = str(r["uploaded_by"]) if "uploaded_by" in keys and r["uploaded_by"] else ""
         return SuiteResultRow(
             suite_run_id=r["suite_run_id"],
             database_id=r["database_id"],
@@ -729,6 +853,307 @@ class MetadataStore:
             exit_code=int(r["exit_code"]),
             created_at=float(r["created_at"]),
             config_json=config_json,
+            uploaded_by=uploaded_by,
+        )
+
+    # ---- organizations ---------------------------------------------------
+
+    def create_org(
+        self,
+        *,
+        name: str,
+        owner_user_id: str,
+        display_name: str = "",
+        is_claimable: bool = False,
+    ) -> OrgRow:
+        org_id = name
+        row = OrgRow(
+            org_id=org_id,
+            name=name,
+            display_name=display_name or name,
+            is_claimable=is_claimable,
+            created_at=now(),
+        )
+        with self._connect() as conn:
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO organizations(
+                        org_id, name, display_name, is_claimable, created_at
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        row.org_id,
+                        row.name,
+                        row.display_name,
+                        1 if row.is_claimable else 0,
+                        row.created_at,
+                    ),
+                )
+                conn.execute(
+                    """
+                    INSERT INTO org_memberships(org_id, user_id, role, created_at)
+                    VALUES (?, ?, 'owner', ?)
+                    """,
+                    (row.org_id, owner_user_id, row.created_at),
+                )
+                conn.commit()
+            except sqlite3.IntegrityError as exc:
+                raise ValueError("org already exists") from exc
+        return row
+
+    def get_org(self, org_id: str) -> OrgRow | None:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT * FROM organizations WHERE org_id=?",
+                (org_id,),
+            )
+            r = cur.fetchone()
+            return self._org_row(r) if r else None
+
+    def list_orgs_for_user(self, user_id: str) -> list[tuple[OrgRow, str]]:
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                SELECT o.*, m.role AS membership_role
+                FROM organizations o
+                JOIN org_memberships m ON m.org_id = o.org_id
+                WHERE m.user_id = ?
+                ORDER BY o.name
+                """,
+                (user_id,),
+            )
+            out: list[tuple[OrgRow, str]] = []
+            for r in cur.fetchall():
+                out.append((self._org_row(r), str(r["membership_role"])))
+            return out
+
+    def claim_org(self, org_id: str, user_id: str) -> OrgRow:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT * FROM organizations WHERE org_id=?",
+                (org_id,),
+            )
+            r = cur.fetchone()
+            if r is None:
+                raise LookupError("org not found")
+            org = self._org_row(r)
+            if not org.is_claimable:
+                raise PermissionError("org not claimable")
+            owners = conn.execute(
+                "SELECT 1 FROM org_memberships WHERE org_id=? AND role='owner' LIMIT 1",
+                (org_id,),
+            ).fetchone()
+            if owners is not None:
+                raise PermissionError("org already claimed")
+            conn.execute(
+                """
+                INSERT INTO org_memberships(org_id, user_id, role, created_at)
+                VALUES (?, ?, 'owner', ?)
+                """,
+                (org_id, user_id, now()),
+            )
+            conn.execute(
+                "UPDATE organizations SET is_claimable=0 WHERE org_id=?",
+                (org_id,),
+            )
+            conn.commit()
+        got = self.get_org(org_id)
+        assert got is not None
+        return got
+
+    def add_member(self, org_id: str, user_id: str, *, role: str = "member") -> MembershipRow:
+        if role not in {"owner", "member"}:
+            raise ValueError("invalid role")
+        ts = now()
+        with self._connect() as conn:
+            if self.get_org(org_id) is None:
+                raise LookupError("org not found")
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO org_memberships(org_id, user_id, role, created_at)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (org_id, user_id, role, ts),
+                )
+                conn.commit()
+            except sqlite3.IntegrityError as exc:
+                raise ValueError("membership exists") from exc
+        return MembershipRow(org_id=org_id, user_id=user_id, role=role, created_at=ts)
+
+    def remove_member(self, org_id: str, user_id: str) -> None:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM org_memberships WHERE org_id=? AND user_id=?",
+                (org_id, user_id),
+            )
+            if cur.rowcount == 0:
+                raise LookupError("membership not found")
+            conn.commit()
+
+    def list_members(self, org_id: str) -> list[MembershipRow]:
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                SELECT org_id, user_id, role, created_at
+                FROM org_memberships WHERE org_id=? ORDER BY role, user_id
+                """,
+                (org_id,),
+            )
+            return [
+                MembershipRow(
+                    org_id=str(r["org_id"]),
+                    user_id=str(r["user_id"]),
+                    role=str(r["role"]),
+                    created_at=float(r["created_at"]),
+                )
+                for r in cur.fetchall()
+            ]
+
+    def membership(self, org_id: str, user_id: str) -> MembershipRow | None:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT org_id, user_id, role, created_at FROM org_memberships "
+                "WHERE org_id=? AND user_id=?",
+                (org_id, user_id),
+            )
+            r = cur.fetchone()
+            if r is None:
+                return None
+            return MembershipRow(
+                org_id=str(r["org_id"]),
+                user_id=str(r["user_id"]),
+                role=str(r["role"]),
+                created_at=float(r["created_at"]),
+            )
+
+    def user_org_ids(self, user_id: str) -> set[str]:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT org_id FROM org_memberships WHERE user_id=?",
+                (user_id,),
+            )
+            return {str(r["org_id"]) for r in cur.fetchall()}
+
+    # ---- result shares ---------------------------------------------------
+
+    def add_result_share(
+        self,
+        *,
+        result_kind: str,
+        result_id: str,
+        target_type: str,
+        target_id: str,
+    ) -> ResultShareRow:
+        if result_kind not in {"attempt", "suite"}:
+            raise ValueError("invalid result_kind")
+        if target_type not in {"org", "user"}:
+            raise ValueError("invalid target_type")
+        ts = now()
+        with self._connect() as conn:
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO result_shares(
+                        result_kind, result_id, target_type, target_id, created_at
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (result_kind, result_id, target_type, target_id, ts),
+                )
+                conn.commit()
+            except sqlite3.IntegrityError as exc:
+                raise ValueError("share already exists") from exc
+        return ResultShareRow(
+            result_kind=result_kind,
+            result_id=result_id,
+            target_type=target_type,
+            target_id=target_id,
+            created_at=ts,
+        )
+
+    def remove_result_share(
+        self,
+        *,
+        result_kind: str,
+        result_id: str,
+        target_type: str,
+        target_id: str,
+    ) -> None:
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                DELETE FROM result_shares
+                WHERE result_kind=? AND result_id=? AND target_type=? AND target_id=?
+                """,
+                (result_kind, result_id, target_type, target_id),
+            )
+            if cur.rowcount == 0:
+                raise LookupError("share not found")
+            conn.commit()
+
+    def list_result_shares(self, *, result_kind: str, result_id: str) -> list[ResultShareRow]:
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                SELECT * FROM result_shares
+                WHERE result_kind=? AND result_id=?
+                ORDER BY target_type, target_id
+                """,
+                (result_kind, result_id),
+            )
+            return [
+                ResultShareRow(
+                    result_kind=str(r["result_kind"]),
+                    result_id=str(r["result_id"]),
+                    target_type=str(r["target_type"]),
+                    target_id=str(r["target_id"]),
+                    created_at=float(r["created_at"]),
+                )
+                for r in cur.fetchall()
+            ]
+
+    def result_shared_with_user(
+        self,
+        *,
+        result_kind: str,
+        result_id: str,
+        user_id: str,
+        user_orgs: set[str],
+    ) -> bool:
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                SELECT 1 FROM result_shares
+                WHERE result_kind=? AND result_id=? AND target_type='user' AND target_id=?
+                LIMIT 1
+                """,
+                (result_kind, result_id, user_id),
+            )
+            if cur.fetchone() is not None:
+                return True
+            if not user_orgs:
+                return False
+            placeholders = ",".join("?" for _ in user_orgs)
+            cur = conn.execute(
+                f"""
+                SELECT 1 FROM result_shares
+                WHERE result_kind=? AND result_id=? AND target_type='org'
+                  AND target_id IN ({placeholders})
+                LIMIT 1
+                """,
+                (result_kind, result_id, *sorted(user_orgs)),
+            )
+            return cur.fetchone() is not None
+
+    @staticmethod
+    def _org_row(r: sqlite3.Row) -> OrgRow:
+        return OrgRow(
+            org_id=str(r["org_id"]),
+            name=str(r["name"]),
+            display_name=str(r["display_name"] or ""),
+            is_claimable=bool(int(r["is_claimable"])),
+            created_at=float(r["created_at"]),
         )
 
 
@@ -815,6 +1240,49 @@ class PostgresMetadataStore:
                 ADD COLUMN IF NOT EXISTS config_json TEXT NOT NULL DEFAULT '{}'
                 """
             )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS organizations (
+                    org_id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    display_name TEXT NOT NULL DEFAULT '',
+                    is_claimable BOOLEAN NOT NULL DEFAULT FALSE,
+                    created_at DOUBLE PRECISION NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS org_memberships (
+                    org_id TEXT NOT NULL,
+                    user_id TEXT NOT NULL,
+                    role TEXT NOT NULL,
+                    created_at DOUBLE PRECISION NOT NULL,
+                    PRIMARY KEY (org_id, user_id)
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS result_shares (
+                    result_kind TEXT NOT NULL,
+                    result_id TEXT NOT NULL,
+                    target_type TEXT NOT NULL,
+                    target_id TEXT NOT NULL,
+                    created_at DOUBLE PRECISION NOT NULL,
+                    PRIMARY KEY (result_kind, result_id, target_type, target_id)
+                )
+                """
+            )
+            conn.execute("ALTER TABLE releases ADD COLUMN IF NOT EXISTS org_id TEXT")
+            conn.execute(
+                "ALTER TABLE attempt_results "
+                "ADD COLUMN IF NOT EXISTS uploaded_by TEXT NOT NULL DEFAULT ''"
+            )
+            conn.execute(
+                "ALTER TABLE suite_results "
+                "ADD COLUMN IF NOT EXISTS uploaded_by TEXT NOT NULL DEFAULT ''"
+            )
             conn.commit()
 
     def insert(self, row: ReleaseRow) -> None:
@@ -824,8 +1292,8 @@ class PostgresMetadataStore:
                     """
                     INSERT INTO releases(
                         database_id, version, visibility, package_digest,
-                        blob_digest, size, media_type, created_at
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                        blob_digest, size, media_type, created_at, org_id
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                     """,
                     (
                         row.database_id,
@@ -836,6 +1304,7 @@ class PostgresMetadataStore:
                         row.size,
                         row.media_type,
                         row.created_at,
+                        row.org_id,
                     ),
                 )
                 conn.commit()
@@ -913,8 +1382,8 @@ class PostgresMetadataStore:
                     """
                     INSERT INTO attempt_results(
                         run_id, database_id, task_id, lock_digest, status,
-                        visibility, blob_digest, size, created_at
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        visibility, blob_digest, size, created_at, uploaded_by
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     """,
                     (
                         row.run_id,
@@ -926,6 +1395,7 @@ class PostgresMetadataStore:
                         row.blob_digest,
                         row.size,
                         row.created_at,
+                        row.uploaded_by or "",
                     ),
                 )
                 conn.commit()
@@ -978,8 +1448,8 @@ class PostgresMetadataStore:
                         suite_run_id, database_id, database_version, visibility,
                         pass_rate, mean_score, metrics_json, tasks_json,
                         agent_label, model_label, blob_digest, size,
-                        exit_code, created_at, config_json
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        exit_code, created_at, config_json, uploaded_by
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     """,
                     (
                         row.suite_run_id,
@@ -997,6 +1467,7 @@ class PostgresMetadataStore:
                         row.exit_code,
                         row.created_at,
                         row.config_json or "{}",
+                        row.uploaded_by or "",
                     ),
                 )
                 conn.commit()
@@ -1048,6 +1519,7 @@ class PostgresMetadataStore:
     @staticmethod
     def _release_from_cols(cols: list[str], r: Any) -> ReleaseRow:
         d = dict(zip(cols, r, strict=True))
+        org_raw = d.get("org_id")
         return ReleaseRow(
             database_id=str(d["database_id"]),
             version=str(d["version"]),
@@ -1057,6 +1529,7 @@ class PostgresMetadataStore:
             size=int(d["size"]),
             media_type=str(d["media_type"]),
             created_at=float(d["created_at"]),
+            org_id=str(org_raw) if org_raw else None,
         )
 
     @staticmethod
@@ -1072,6 +1545,7 @@ class PostgresMetadataStore:
             blob_digest=str(d["blob_digest"]),
             size=int(d["size"]),
             created_at=float(d["created_at"]),
+            uploaded_by=str(d.get("uploaded_by") or ""),
         )
 
     @staticmethod
@@ -1093,7 +1567,321 @@ class PostgresMetadataStore:
             exit_code=int(d["exit_code"]),
             created_at=float(d["created_at"]),
             config_json=str(d.get("config_json") or "{}"),
+            uploaded_by=str(d.get("uploaded_by") or ""),
         )
+
+    # Delegate org/share to same SQL shape as SQLite (psycopg %s).
+    def create_org(
+        self,
+        *,
+        name: str,
+        owner_user_id: str,
+        display_name: str = "",
+        is_claimable: bool = False,
+    ) -> OrgRow:
+        org_id = name
+        row = OrgRow(
+            org_id=org_id,
+            name=name,
+            display_name=display_name or name,
+            is_claimable=is_claimable,
+            created_at=now(),
+        )
+        with self._connect() as conn:
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO organizations(
+                        org_id, name, display_name, is_claimable, created_at
+                    ) VALUES (%s, %s, %s, %s, %s)
+                    """,
+                    (
+                        row.org_id,
+                        row.name,
+                        row.display_name,
+                        row.is_claimable,
+                        row.created_at,
+                    ),
+                )
+                conn.execute(
+                    """
+                    INSERT INTO org_memberships(org_id, user_id, role, created_at)
+                    VALUES (%s, %s, 'owner', %s)
+                    """,
+                    (row.org_id, owner_user_id, row.created_at),
+                )
+                conn.commit()
+            except Exception as exc:
+                if type(exc).__name__ == "UniqueViolation" or "unique" in str(exc).lower():
+                    raise ValueError("org already exists") from exc
+                raise
+        return row
+
+    def get_org(self, org_id: str) -> OrgRow | None:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT org_id, name, display_name, is_claimable, created_at "
+                "FROM organizations WHERE org_id=%s",
+                (org_id,),
+            )
+            r = cur.fetchone()
+            if r is None:
+                return None
+            return OrgRow(
+                org_id=str(r[0]),
+                name=str(r[1]),
+                display_name=str(r[2] or ""),
+                is_claimable=bool(r[3]),
+                created_at=float(r[4]),
+            )
+
+    def list_orgs_for_user(self, user_id: str) -> list[tuple[OrgRow, str]]:
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                SELECT o.org_id, o.name, o.display_name, o.is_claimable, o.created_at, m.role
+                FROM organizations o
+                JOIN org_memberships m ON m.org_id = o.org_id
+                WHERE m.user_id = %s
+                ORDER BY o.name
+                """,
+                (user_id,),
+            )
+            out: list[tuple[OrgRow, str]] = []
+            for r in cur.fetchall():
+                out.append(
+                    (
+                        OrgRow(
+                            org_id=str(r[0]),
+                            name=str(r[1]),
+                            display_name=str(r[2] or ""),
+                            is_claimable=bool(r[3]),
+                            created_at=float(r[4]),
+                        ),
+                        str(r[5]),
+                    )
+                )
+            return out
+
+    def claim_org(self, org_id: str, user_id: str) -> OrgRow:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT org_id, name, display_name, is_claimable, created_at "
+                "FROM organizations WHERE org_id=%s",
+                (org_id,),
+            )
+            r = cur.fetchone()
+            if r is None:
+                raise LookupError("org not found")
+            if not bool(r[3]):
+                raise PermissionError("org not claimable")
+            owners = conn.execute(
+                "SELECT 1 FROM org_memberships WHERE org_id=%s AND role='owner' LIMIT 1",
+                (org_id,),
+            ).fetchone()
+            if owners is not None:
+                raise PermissionError("org already claimed")
+            conn.execute(
+                """
+                INSERT INTO org_memberships(org_id, user_id, role, created_at)
+                VALUES (%s, %s, 'owner', %s)
+                """,
+                (org_id, user_id, now()),
+            )
+            conn.execute(
+                "UPDATE organizations SET is_claimable=FALSE WHERE org_id=%s",
+                (org_id,),
+            )
+            conn.commit()
+        got = self.get_org(org_id)
+        assert got is not None
+        return got
+
+    def add_member(self, org_id: str, user_id: str, *, role: str = "member") -> MembershipRow:
+        if role not in {"owner", "member"}:
+            raise ValueError("invalid role")
+        ts = now()
+        if self.get_org(org_id) is None:
+            raise LookupError("org not found")
+        with self._connect() as conn:
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO org_memberships(org_id, user_id, role, created_at)
+                    VALUES (%s, %s, %s, %s)
+                    """,
+                    (org_id, user_id, role, ts),
+                )
+                conn.commit()
+            except Exception as exc:
+                if type(exc).__name__ == "UniqueViolation" or "unique" in str(exc).lower():
+                    raise ValueError("membership exists") from exc
+                raise
+        return MembershipRow(org_id=org_id, user_id=user_id, role=role, created_at=ts)
+
+    def remove_member(self, org_id: str, user_id: str) -> None:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM org_memberships WHERE org_id=%s AND user_id=%s",
+                (org_id, user_id),
+            )
+            if cur.rowcount == 0:
+                raise LookupError("membership not found")
+            conn.commit()
+
+    def list_members(self, org_id: str) -> list[MembershipRow]:
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                SELECT org_id, user_id, role, created_at
+                FROM org_memberships WHERE org_id=%s ORDER BY role, user_id
+                """,
+                (org_id,),
+            )
+            return [
+                MembershipRow(
+                    org_id=str(r[0]),
+                    user_id=str(r[1]),
+                    role=str(r[2]),
+                    created_at=float(r[3]),
+                )
+                for r in cur.fetchall()
+            ]
+
+    def membership(self, org_id: str, user_id: str) -> MembershipRow | None:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT org_id, user_id, role, created_at FROM org_memberships "
+                "WHERE org_id=%s AND user_id=%s",
+                (org_id, user_id),
+            )
+            r = cur.fetchone()
+            if r is None:
+                return None
+            return MembershipRow(
+                org_id=str(r[0]),
+                user_id=str(r[1]),
+                role=str(r[2]),
+                created_at=float(r[3]),
+            )
+
+    def user_org_ids(self, user_id: str) -> set[str]:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT org_id FROM org_memberships WHERE user_id=%s",
+                (user_id,),
+            )
+            return {str(r[0]) for r in cur.fetchall()}
+
+    def add_result_share(
+        self,
+        *,
+        result_kind: str,
+        result_id: str,
+        target_type: str,
+        target_id: str,
+    ) -> ResultShareRow:
+        if result_kind not in {"attempt", "suite"}:
+            raise ValueError("invalid result_kind")
+        if target_type not in {"org", "user"}:
+            raise ValueError("invalid target_type")
+        ts = now()
+        with self._connect() as conn:
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO result_shares(
+                        result_kind, result_id, target_type, target_id, created_at
+                    ) VALUES (%s, %s, %s, %s, %s)
+                    """,
+                    (result_kind, result_id, target_type, target_id, ts),
+                )
+                conn.commit()
+            except Exception as exc:
+                if type(exc).__name__ == "UniqueViolation" or "unique" in str(exc).lower():
+                    raise ValueError("share already exists") from exc
+                raise
+        return ResultShareRow(
+            result_kind=result_kind,
+            result_id=result_id,
+            target_type=target_type,
+            target_id=target_id,
+            created_at=ts,
+        )
+
+    def remove_result_share(
+        self,
+        *,
+        result_kind: str,
+        result_id: str,
+        target_type: str,
+        target_id: str,
+    ) -> None:
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                DELETE FROM result_shares
+                WHERE result_kind=%s AND result_id=%s AND target_type=%s AND target_id=%s
+                """,
+                (result_kind, result_id, target_type, target_id),
+            )
+            if cur.rowcount == 0:
+                raise LookupError("share not found")
+            conn.commit()
+
+    def list_result_shares(self, *, result_kind: str, result_id: str) -> list[ResultShareRow]:
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                SELECT result_kind, result_id, target_type, target_id, created_at
+                FROM result_shares
+                WHERE result_kind=%s AND result_id=%s
+                ORDER BY target_type, target_id
+                """,
+                (result_kind, result_id),
+            )
+            return [
+                ResultShareRow(
+                    result_kind=str(r[0]),
+                    result_id=str(r[1]),
+                    target_type=str(r[2]),
+                    target_id=str(r[3]),
+                    created_at=float(r[4]),
+                )
+                for r in cur.fetchall()
+            ]
+
+    def result_shared_with_user(
+        self,
+        *,
+        result_kind: str,
+        result_id: str,
+        user_id: str,
+        user_orgs: set[str],
+    ) -> bool:
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                SELECT 1 FROM result_shares
+                WHERE result_kind=%s AND result_id=%s AND target_type='user' AND target_id=%s
+                LIMIT 1
+                """,
+                (result_kind, result_id, user_id),
+            )
+            if cur.fetchone() is not None:
+                return True
+            if not user_orgs:
+                return False
+            cur = conn.execute(
+                """
+                SELECT 1 FROM result_shares
+                WHERE result_kind=%s AND result_id=%s AND target_type='org'
+                  AND target_id = ANY(%s)
+                LIMIT 1
+                """,
+                (result_kind, result_id, list(user_orgs)),
+            )
+            return cur.fetchone() is not None
 
 
 # ---------------------------------------------------------------------------
@@ -1102,7 +1890,7 @@ class PostgresMetadataStore:
 
 
 def release_to_dict(row: ReleaseRow) -> dict[str, Any]:
-    return {
+    out: dict[str, Any] = {
         "database_id": row.database_id,
         "version": row.version,
         "visibility": row.visibility,
@@ -1112,10 +1900,13 @@ def release_to_dict(row: ReleaseRow) -> dict[str, Any]:
         "media_type": row.media_type,
         "created_at": row.created_at,
     }
+    if row.org_id:
+        out["org_id"] = row.org_id
+    return out
 
 
 def attempt_to_dict(row: AttemptResultRow) -> dict[str, Any]:
-    return {
+    out: dict[str, Any] = {
         "run_id": row.run_id,
         "database_id": row.database_id,
         "task_id": row.task_id,
@@ -1124,6 +1915,38 @@ def attempt_to_dict(row: AttemptResultRow) -> dict[str, Any]:
         "visibility": row.visibility,
         "blob_digest": row.blob_digest,
         "size": row.size,
+        "created_at": row.created_at,
+    }
+    if row.uploaded_by:
+        out["uploaded_by"] = row.uploaded_by
+    return out
+
+
+def org_to_dict(row: OrgRow) -> dict[str, Any]:
+    return {
+        "org_id": row.org_id,
+        "name": row.name,
+        "display_name": row.display_name,
+        "is_claimable": row.is_claimable,
+        "created_at": row.created_at,
+    }
+
+
+def membership_to_dict(row: MembershipRow) -> dict[str, Any]:
+    return {
+        "org_id": row.org_id,
+        "user_id": row.user_id,
+        "role": row.role,
+        "created_at": row.created_at,
+    }
+
+
+def share_to_dict(row: ResultShareRow) -> dict[str, Any]:
+    return {
+        "result_kind": row.result_kind,
+        "result_id": row.result_id,
+        "target_type": row.target_type,
+        "target_id": row.target_id,
         "created_at": row.created_at,
     }
 
@@ -1160,6 +1983,8 @@ def suite_to_dict(row: SuiteResultRow) -> dict[str, Any]:
         # Explicit: no suite PASS authority
         "note": "per-task evaluator verdicts only; no suite-level PASS",
     }
+    if row.uploaded_by:
+        out["uploaded_by"] = row.uploaded_by
     # #42 config fingerprint projection (absent on legacy rows)
     try:
         cfg = json.loads(row.config_json or "{}")

--- a/services/registry/store.py
+++ b/services/registry/store.py
@@ -100,6 +100,17 @@ class MembershipRow:
 
 
 @dataclass(frozen=True, slots=True)
+class UserProfileRow:
+    """GitHub profile snapshot written at Registry login (not a credential)."""
+
+    user_id: str
+    display_name: str
+    avatar_url: str
+    github_id: str
+    updated_at: float
+
+
+@dataclass(frozen=True, slots=True)
 class TokenInfo:
     """Resolved bearer token: scopes + optional user identity (github login)."""
 
@@ -571,6 +582,17 @@ class MetadataStore:
                     target_id TEXT NOT NULL,
                     created_at REAL NOT NULL,
                     PRIMARY KEY (result_kind, result_id, target_type, target_id)
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS user_profiles (
+                    user_id TEXT PRIMARY KEY,
+                    display_name TEXT NOT NULL DEFAULT '',
+                    avatar_url TEXT NOT NULL DEFAULT '',
+                    github_id TEXT NOT NULL DEFAULT '',
+                    updated_at REAL NOT NULL
                 )
                 """
             )
@@ -1156,6 +1178,85 @@ class MetadataStore:
             created_at=float(r["created_at"]),
         )
 
+    def upsert_user_profile(
+        self,
+        *,
+        user_id: str,
+        display_name: str = "",
+        avatar_url: str = "",
+        github_id: str = "",
+    ) -> UserProfileRow:
+        uid = _normalize_user_id(user_id) or user_id
+        row = UserProfileRow(
+            user_id=uid,
+            display_name=(display_name or "").strip(),
+            avatar_url=(avatar_url or "").strip(),
+            github_id=str(github_id or "").strip(),
+            updated_at=now(),
+        )
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO user_profiles(
+                    user_id, display_name, avatar_url, github_id, updated_at
+                ) VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(user_id) DO UPDATE SET
+                    display_name=excluded.display_name,
+                    avatar_url=excluded.avatar_url,
+                    github_id=excluded.github_id,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    row.user_id,
+                    row.display_name,
+                    row.avatar_url,
+                    row.github_id,
+                    row.updated_at,
+                ),
+            )
+            conn.commit()
+        return row
+
+    def get_user_profile(self, user_id: str) -> UserProfileRow | None:
+        uid = _normalize_user_id(user_id) or user_id
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT * FROM user_profiles WHERE user_id=?",
+                (uid,),
+            )
+            r = cur.fetchone()
+            if r is None:
+                return None
+            return UserProfileRow(
+                user_id=str(r["user_id"]),
+                display_name=str(r["display_name"] or ""),
+                avatar_url=str(r["avatar_url"] or ""),
+                github_id=str(r["github_id"] or ""),
+                updated_at=float(r["updated_at"]),
+            )
+
+    def get_user_profiles(self, user_ids: list[str] | set[str]) -> dict[str, UserProfileRow]:
+        ids = sorted({_normalize_user_id(u) or u for u in user_ids if u})
+        if not ids:
+            return {}
+        placeholders = ",".join("?" for _ in ids)
+        with self._connect() as conn:
+            cur = conn.execute(
+                f"SELECT * FROM user_profiles WHERE user_id IN ({placeholders})",
+                ids,
+            )
+            out: dict[str, UserProfileRow] = {}
+            for r in cur.fetchall():
+                p = UserProfileRow(
+                    user_id=str(r["user_id"]),
+                    display_name=str(r["display_name"] or ""),
+                    avatar_url=str(r["avatar_url"] or ""),
+                    github_id=str(r["github_id"] or ""),
+                    updated_at=float(r["updated_at"]),
+                )
+                out[p.user_id] = p
+            return out
+
 
 class PostgresMetadataStore:
     """Postgres release + attempt_results metadata."""
@@ -1271,6 +1372,17 @@ class PostgresMetadataStore:
                     target_id TEXT NOT NULL,
                     created_at DOUBLE PRECISION NOT NULL,
                     PRIMARY KEY (result_kind, result_id, target_type, target_id)
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS user_profiles (
+                    user_id TEXT PRIMARY KEY,
+                    display_name TEXT NOT NULL DEFAULT '',
+                    avatar_url TEXT NOT NULL DEFAULT '',
+                    github_id TEXT NOT NULL DEFAULT '',
+                    updated_at DOUBLE PRECISION NOT NULL
                 )
                 """
             )
@@ -1883,6 +1995,86 @@ class PostgresMetadataStore:
             )
             return cur.fetchone() is not None
 
+    def upsert_user_profile(
+        self,
+        *,
+        user_id: str,
+        display_name: str = "",
+        avatar_url: str = "",
+        github_id: str = "",
+    ) -> UserProfileRow:
+        uid = _normalize_user_id(user_id) or user_id
+        row = UserProfileRow(
+            user_id=uid,
+            display_name=(display_name or "").strip(),
+            avatar_url=(avatar_url or "").strip(),
+            github_id=str(github_id or "").strip(),
+            updated_at=now(),
+        )
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO user_profiles(
+                    user_id, display_name, avatar_url, github_id, updated_at
+                ) VALUES (%s, %s, %s, %s, %s)
+                ON CONFLICT (user_id) DO UPDATE SET
+                    display_name = EXCLUDED.display_name,
+                    avatar_url = EXCLUDED.avatar_url,
+                    github_id = EXCLUDED.github_id,
+                    updated_at = EXCLUDED.updated_at
+                """,
+                (
+                    row.user_id,
+                    row.display_name,
+                    row.avatar_url,
+                    row.github_id,
+                    row.updated_at,
+                ),
+            )
+            conn.commit()
+        return row
+
+    def get_user_profile(self, user_id: str) -> UserProfileRow | None:
+        uid = _normalize_user_id(user_id) or user_id
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT user_id, display_name, avatar_url, github_id, updated_at "
+                "FROM user_profiles WHERE user_id=%s",
+                (uid,),
+            )
+            r = cur.fetchone()
+            if r is None:
+                return None
+            return UserProfileRow(
+                user_id=str(r[0]),
+                display_name=str(r[1] or ""),
+                avatar_url=str(r[2] or ""),
+                github_id=str(r[3] or ""),
+                updated_at=float(r[4]),
+            )
+
+    def get_user_profiles(self, user_ids: list[str] | set[str]) -> dict[str, UserProfileRow]:
+        ids = sorted({_normalize_user_id(u) or u for u in user_ids if u})
+        if not ids:
+            return {}
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT user_id, display_name, avatar_url, github_id, updated_at "
+                "FROM user_profiles WHERE user_id = ANY(%s)",
+                (ids,),
+            )
+            out: dict[str, UserProfileRow] = {}
+            for r in cur.fetchall():
+                p = UserProfileRow(
+                    user_id=str(r[0]),
+                    display_name=str(r[1] or ""),
+                    avatar_url=str(r[2] or ""),
+                    github_id=str(r[3] or ""),
+                    updated_at=float(r[4]),
+                )
+                out[p.user_id] = p
+            return out
+
 
 # ---------------------------------------------------------------------------
 # Serialization
@@ -1932,13 +2124,25 @@ def org_to_dict(row: OrgRow) -> dict[str, Any]:
     }
 
 
-def membership_to_dict(row: MembershipRow) -> dict[str, Any]:
-    return {
+def membership_to_dict(
+    row: MembershipRow,
+    *,
+    profile: UserProfileRow | None = None,
+) -> dict[str, Any]:
+    out: dict[str, Any] = {
         "org_id": row.org_id,
         "user_id": row.user_id,
         "role": row.role,
         "created_at": row.created_at,
     }
+    if profile is not None:
+        if profile.display_name:
+            out["display_name"] = profile.display_name
+        if profile.avatar_url:
+            out["avatar_url"] = profile.avatar_url
+        if profile.github_id:
+            out["github_id"] = profile.github_id
+    return out
 
 
 def share_to_dict(row: ResultShareRow) -> dict[str, Any]:

--- a/src/bora/application/login_command.py
+++ b/src/bora/application/login_command.py
@@ -53,9 +53,7 @@ def login_registry(
 
     # GitHub does not auto-fill user_code from URL query params; print code clearly.
     err.write(
-        f"1) Open {verification_uri}\n"
-        f"2) Enter code:  {user_code}\n"
-        "Waiting for authorization…\n"
+        f"1) Open {verification_uri}\n2) Enter code:  {user_code}\nWaiting for authorization…\n"
     )
     err.flush()
 

--- a/src/bora/application/login_command.py
+++ b/src/bora/application/login_command.py
@@ -51,7 +51,12 @@ def login_registry(
             location="registry",
         )
 
-    err.write(f"Open {verification_uri} and enter code: {user_code}\nWaiting for authorization…\n")
+    # GitHub does not auto-fill user_code from URL query params; print code clearly.
+    err.write(
+        f"1) Open {verification_uri}\n"
+        f"2) Enter code:  {user_code}\n"
+        "Waiting for authorization…\n"
+    )
     err.flush()
 
     deadline = time.monotonic() + poll_timeout

--- a/src/bora/application/publish_command.py
+++ b/src/bora/application/publish_command.py
@@ -17,6 +17,7 @@ def publish_database(
     database_root: Path,
     *,
     public: bool = False,
+    org: str | None = None,
     registry_url: str | None = None,
     token: str | None = None,
 ) -> dict[str, Any]:
@@ -48,6 +49,13 @@ def publish_database(
 
     client = RegistryClient(url, token=tok)
     visibility = "public" if public else "private"
+    org_id = (org or "").strip()
+    if not org_id:
+        raise ConfigError(
+            "org_required",
+            "publish requires --org (package must belong to an organization)",
+            location="registry",
+        )
     try:
         info = client.publish(
             database_id=manifest.database_id,
@@ -58,6 +66,7 @@ def publish_database(
             media_type=MEDIA_TYPE,
             visibility=visibility,
             archive=archive,
+            org_id=org_id,
         )
     except RegistryError as exc:
         raise ConfigError(exc.code, exc.message, location="registry") from exc
@@ -73,4 +82,5 @@ def publish_database(
         "media_type": info.media_type,
         "ref": f"{info.database_id}@{info.version}",
         "digest_ref": f"{info.database_id}@{info.package_digest}",
+        "org_id": info.org_id or org_id,
     }

--- a/src/bora/application/registry_org_command.py
+++ b/src/bora/application/registry_org_command.py
@@ -1,0 +1,60 @@
+"""Application use cases for Registry organizations."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from bora.config.errors import ConfigError
+from bora.registry.client import RegistryClient, RegistryError
+from bora.registry.credentials import load_credentials
+
+
+def _client(*, registry_url: str | None = None) -> RegistryClient:
+    creds = load_credentials()
+    url = (registry_url or creds.url or os.environ.get("BORA_REGISTRY_URL") or "").rstrip("/")
+    if not url:
+        raise ConfigError(
+            "registry_unavailable",
+            "registry URL required (BORA_REGISTRY_URL or ~/.bora/credentials)",
+            location="registry",
+        )
+    token = creds.token or os.environ.get("BORA_REGISTRY_TOKEN")
+    if not token:
+        raise ConfigError(
+            "unauthorized",
+            "registry token required (bora login or BORA_REGISTRY_TOKEN)",
+            location="registry",
+        )
+    return RegistryClient(url, token=token)
+
+
+def create_org(
+    *,
+    name: str,
+    display_name: str | None = None,
+    is_claimable: bool = False,
+    registry_url: str | None = None,
+) -> dict[str, Any]:
+    client = _client(registry_url=registry_url)
+    try:
+        data = client.create_org(
+            name=name,
+            display_name=display_name,
+            is_claimable=is_claimable,
+        )
+    except RegistryError as exc:
+        raise ConfigError(exc.code, exc.message, location="registry") from exc
+    return {"ok": True, **data}
+
+
+def list_orgs(*, registry_url: str | None = None) -> dict[str, Any]:
+    client = _client(registry_url=registry_url)
+    try:
+        data = client.list_orgs()
+    except RegistryError as exc:
+        raise ConfigError(exc.code, exc.message, location="registry") from exc
+    items = data.get("items") if isinstance(data, dict) else None
+    if not isinstance(items, list):
+        items = []
+    return {"ok": True, "count": len(items), "items": items}

--- a/src/bora/application/results_command.py
+++ b/src/bora/application/results_command.py
@@ -419,3 +419,50 @@ def list_suite_results(
     except RegistryError as exc:
         raise ConfigError(exc.code, exc.message, location="registry") from exc
     return {"ok": True, "items": items, "count": len(items), "source": "registry"}
+
+
+def share_result(
+    *,
+    result_kind: str,
+    result_id: str,
+    share_orgs: list[str] | None = None,
+    share_users: list[str] | None = None,
+    registry_url: str | None = None,
+) -> dict[str, Any]:
+    """Share a private attempt/suite result with orgs and/or users (owner only)."""
+    if result_kind not in {"attempt", "suite"}:
+        raise ConfigError(
+            "invalid_request",
+            "result_kind must be attempt or suite",
+            location="registry",
+        )
+    client = _client(registry_url=registry_url)
+    created: list[dict[str, Any]] = []
+    try:
+        for org in share_orgs or []:
+            created.append(
+                client.share_result(
+                    result_kind=result_kind,
+                    result_id=result_id,
+                    target_type="org",
+                    target_id=org,
+                )
+            )
+        for user in share_users or []:
+            created.append(
+                client.share_result(
+                    result_kind=result_kind,
+                    result_id=result_id,
+                    target_type="user",
+                    target_id=user,
+                )
+            )
+    except RegistryError as exc:
+        raise ConfigError(exc.code, exc.message, location="registry") from exc
+    return {
+        "ok": True,
+        "result_kind": result_kind,
+        "result_id": result_id,
+        "shares": created,
+        "count": len(created),
+    }

--- a/src/bora/cli/README.md
+++ b/src/bora/cli/README.md
@@ -86,7 +86,7 @@ Credentials file `~/.bora/credentials` (mode `0600`):
 | `bora executors` | Host executor / ACP entry inventory |
 | `bora evidence` | Export sealed trajectory copy (does not change score) |
 | `bora submit` / `status` / `cancel` | Durable Run control (v0.12 sketch) |
-| `bora login` | GitHub Device Flow → write credentials |
+| `bora login` | GitHub **Device Flow** → write credentials (Hub uses browser OAuth instead) |
 | `bora publish` | Publish a Database package (**requires `--org`**) |
 | `bora registry list\|show` | Browse remote packages |
 | `bora registry org-create\|org-list` | Create / list organizations (packages belong to orgs) |

--- a/src/bora/cli/README.md
+++ b/src/bora/cli/README.md
@@ -87,11 +87,13 @@ Credentials file `~/.bora/credentials` (mode `0600`):
 | `bora evidence` | Export sealed trajectory copy (does not change score) |
 | `bora submit` / `status` / `cancel` | Durable Run control (v0.12 sketch) |
 | `bora login` | GitHub Device Flow → write credentials |
-| `bora publish` | Publish a whole Database package to the Registry |
+| `bora publish` | Publish a Database package (**requires `--org`**) |
 | `bora registry list\|show` | Browse remote packages |
+| `bora registry org-create\|org-list` | Create / list organizations (packages belong to orgs) |
 | `bora cache list\|path\|purge` | Local verified cache |
 | `bora results upload\|get\|list` | Attempt run evidence bundles |
 | `bora results upload-suite\|get-suite\|list-suites` | Suite/job aggregates + task refs (no suite PASS) |
+| `bora results share` | Share a private result with org(s) and/or user(s) |
 | `bora view` | Local read-only Database Web UI (no Registry) |
 
 Discover flags with `uv run bora <cmd> -h`.
@@ -173,7 +175,10 @@ uv run --extra registry python -m services.registry.app
 export BORA_REGISTRY_URL=http://127.0.0.1:8700
 ```
 
-### Login and publish
+### Login, org, and publish
+
+Packages **must** belong to an organization (`--org`). Results belong to the
+uploader and can later be shared to an org or user.
 
 ```bash
 # Interactive GitHub Device Flow (server needs BORA_GITHUB_* + LOGIN_ALLOWLIST)
@@ -182,9 +187,12 @@ uv run bora login
 # CI: no browser
 export BORA_REGISTRY_TOKEN=<bootstrap-or-ci-token>
 
-# Default visibility private; explicit public:
-uv run bora publish tests/fixtures/databases/publish-min
-uv run bora publish path/to/db --public
+uv run bora registry org-create my-lab --display-name "My Lab"
+uv run bora registry org-list
+
+# Default visibility private; explicit public. --org is required.
+uv run bora publish tests/fixtures/databases/publish-min --org my-lab
+uv run bora publish path/to/db --org my-lab --public
 ```
 
 ### Lock / run by ref
@@ -215,9 +223,14 @@ Upload sealed trees under `<database>/.bora/runs/<run_id>/` (not package release
 uv run bora results upload /path/to/database --run <run_id>
 uv run bora results list --database-id test/publish-min
 uv run bora results get <run_id> --out /tmp/restored-run
+# Share a private result (owner only):
+uv run bora results share <run_id> --kind attempt --share-org my-lab
 ```
 
-Visibility is **public** or **private** only (no org in this MVP). Default private; `--public` for public.
+Visibility is **public** or **private** only. Packages are owned by an **org**;
+results are owned by the **uploader** (`uploaded_by`). Private results stay
+invisible to org members until the owner shares them. Default private; `--public`
+for public.
 
 ### Suite / job results
 

--- a/src/bora/cli/cmd_executors_publish_login.py
+++ b/src/bora/cli/cmd_executors_publish_login.py
@@ -38,6 +38,13 @@ def register(app: typer.Typer) -> None:
             Path,
             typer.Argument(help="Local Database root to publish (bora.database/1)."),
         ],
+        org: Annotated[
+            str,
+            typer.Option(
+                "--org",
+                help="Organization id that owns this package (required).",
+            ),
+        ],
         public: Annotated[
             bool,
             typer.Option(
@@ -53,7 +60,7 @@ def register(app: typer.Typer) -> None:
             ),
         ] = None,
     ) -> None:
-        """Publish a local Database package to the configured Registry (Spec 21)."""
+        """Publish a local Database package to the configured Registry (must attach --org)."""
         from bora.application.publish_command import publish_database
         from bora.config.errors import ConfigError
 
@@ -61,6 +68,7 @@ def register(app: typer.Typer) -> None:
             summary = publish_database(
                 database,
                 public=public,
+                org=org,
                 registry_url=registry_url,
             )
         except ConfigError as exc:

--- a/src/bora/cli/cmd_registry.py
+++ b/src/bora/cli/cmd_registry.py
@@ -13,10 +13,60 @@ def register(app: typer.Typer) -> None:
 
     sub = typer.Typer(
         name="registry",
-        help="List/show Database packages on the configured Registry.",
+        help="List/show packages and orgs on the configured Registry.",
         no_args_is_help=True,
         add_completion=False,
     )
+
+    @sub.command("org-create")
+    def registry_org_create(
+        name: Annotated[str, typer.Argument(help="Org slug (lowercase).")],
+        display_name: Annotated[
+            str | None,
+            typer.Option("--display-name", help="Optional display name."),
+        ] = None,
+        claimable: Annotated[
+            bool,
+            typer.Option("--claimable", help="Allow later claim as owner."),
+        ] = False,
+        registry_url: Annotated[
+            str | None,
+            typer.Option("--registry-url", help="Override registry URL."),
+        ] = None,
+    ) -> None:
+        """Create an organization; caller becomes owner."""
+        from bora.application.registry_org_command import create_org
+        from bora.config.errors import ConfigError
+
+        try:
+            summary = create_org(
+                name=name,
+                display_name=display_name,
+                is_claimable=claimable,
+                registry_url=registry_url,
+            )
+        except ConfigError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=2) from exc
+        typer.echo(json.dumps(summary, ensure_ascii=False, separators=(",", ":"), sort_keys=True))
+
+    @sub.command("org-list")
+    def registry_org_list(
+        registry_url: Annotated[
+            str | None,
+            typer.Option("--registry-url", help="Override registry URL."),
+        ] = None,
+    ) -> None:
+        """List organizations the current user belongs to."""
+        from bora.application.registry_org_command import list_orgs
+        from bora.config.errors import ConfigError
+
+        try:
+            summary = list_orgs(registry_url=registry_url)
+        except ConfigError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=2) from exc
+        typer.echo(json.dumps(summary, ensure_ascii=False, separators=(",", ":"), sort_keys=True))
 
     @sub.command("list")
     def registry_list_command(

--- a/src/bora/cli/cmd_results.py
+++ b/src/bora/cli/cmd_results.py
@@ -227,4 +227,50 @@ def register(app: typer.Typer) -> None:
             raise typer.Exit(code=2) from exc
         typer.echo(json.dumps(summary, ensure_ascii=False, separators=(",", ":"), sort_keys=True))
 
+    @sub.command("share")
+    def results_share_command(
+        result_id: Annotated[
+            str,
+            typer.Argument(help="attempt run_id or suite_run_id."),
+        ],
+        kind: Annotated[
+            str,
+            typer.Option("--kind", help="attempt | suite"),
+        ] = "attempt",
+        share_org: Annotated[
+            list[str] | None,
+            typer.Option("--share-org", help="Share private result with org (repeatable)."),
+        ] = None,
+        share_user: Annotated[
+            list[str] | None,
+            typer.Option("--share-user", help="Share private result with user (repeatable)."),
+        ] = None,
+        registry_url: Annotated[
+            str | None,
+            typer.Option("--registry-url", help="Override registry / results URL."),
+        ] = None,
+    ) -> None:
+        """Share a private result with org(s) and/or user(s). Owner only."""
+        from bora.application.results_command import share_result
+        from bora.config.errors import ConfigError
+
+        if kind not in {"attempt", "suite"}:
+            typer.echo("kind must be attempt or suite", err=True)
+            raise typer.Exit(code=2)
+        if not share_org and not share_user:
+            typer.echo("provide --share-org and/or --share-user", err=True)
+            raise typer.Exit(code=2)
+        try:
+            summary = share_result(
+                result_kind=kind,
+                result_id=result_id,
+                share_orgs=share_org or [],
+                share_users=share_user or [],
+                registry_url=registry_url,
+            )
+        except ConfigError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=2) from exc
+        typer.echo(json.dumps(summary, ensure_ascii=False, separators=(",", ":"), sort_keys=True))
+
     app.add_typer(sub, name="results")

--- a/src/bora/registry/client.py
+++ b/src/bora/registry/client.py
@@ -29,6 +29,7 @@ class ReleaseInfo:
     blob_digest: str
     size: int
     media_type: str
+    org_id: str | None = None
 
 
 class RegistryClient:
@@ -101,6 +102,7 @@ class RegistryClient:
         media_type: str,
         visibility: str,
         archive: bytes,
+        org_id: str,
     ) -> ReleaseInfo:
         meta = {
             "database_id": database_id,
@@ -110,6 +112,7 @@ class RegistryClient:
             "size": size,
             "media_type": media_type,
             "visibility": visibility,
+            "org_id": org_id,
         }
         import secrets as _secrets
 
@@ -142,6 +145,7 @@ class RegistryClient:
             blob_digest=str(data["blob_digest"]),
             size=int(data["size"]),
             media_type=str(data["media_type"]),
+            org_id=str(data["org_id"]) if data.get("org_id") else None,
         )
 
     def get_metadata(
@@ -171,6 +175,7 @@ class RegistryClient:
             blob_digest=str(data["blob_digest"]),
             size=int(data["size"]),
             media_type=str(data["media_type"]),
+            org_id=str(data["org_id"]) if data.get("org_id") else None,
         )
 
     def fetch_content(self, *, database_id: str, package_digest: str) -> bytes:
@@ -490,4 +495,91 @@ class RegistryClient:
             blob_digest=str(data["blob_digest"]),
             size=int(data["size"]),
             media_type=str(data["media_type"]),
+            org_id=str(data["org_id"]) if data.get("org_id") else None,
         )
+
+    # ---- orgs / shares ---------------------------------------------------
+
+    def create_org(
+        self,
+        *,
+        name: str,
+        display_name: str | None = None,
+        is_claimable: bool = False,
+    ) -> dict[str, Any]:
+        body = {
+            "name": name,
+            "display_name": display_name or name,
+            "is_claimable": is_claimable,
+        }
+        status, raw, _ = self._request(
+            "POST",
+            "/v1/orgs",
+            body=json.dumps(body, sort_keys=True).encode("utf-8"),
+            headers=self._headers(content_type="application/json"),
+        )
+        if status not in {200, 201}:
+            raise RegistryError("org_create_failed", f"status {status}", status=status)
+        return json.loads(raw.decode("utf-8"))
+
+    def list_orgs(self) -> dict[str, Any]:
+        status, raw, _ = self._request("GET", "/v1/orgs")
+        if status != 200:
+            raise RegistryError("org_list_failed", f"status {status}", status=status)
+        return json.loads(raw.decode("utf-8"))
+
+    def add_org_member(self, *, org_id: str, user_id: str, role: str = "member") -> dict[str, Any]:
+        body = {"user_id": user_id, "role": role}
+        status, raw, _ = self._request(
+            "POST",
+            f"/v1/orgs/{quote(org_id, safe='')}/members",
+            body=json.dumps(body, sort_keys=True).encode("utf-8"),
+            headers=self._headers(content_type="application/json"),
+        )
+        if status not in {200, 201}:
+            raise RegistryError("org_member_failed", f"status {status}", status=status)
+        return json.loads(raw.decode("utf-8"))
+
+    def share_result(
+        self,
+        *,
+        result_kind: str,
+        result_id: str,
+        target_type: str,
+        target_id: str,
+    ) -> dict[str, Any]:
+        body = {"target_type": target_type, "target_id": target_id}
+        path = f"/v1/results/{result_kind}s/{quote(result_id, safe='')}/shares"
+        # result_kind is attempt|suite → attempts|suites
+        kind_path = "attempts" if result_kind == "attempt" else "suites"
+        path = f"/v1/results/{kind_path}/{quote(result_id, safe='')}/shares"
+        status, raw, _ = self._request(
+            "POST",
+            path,
+            body=json.dumps(body, sort_keys=True).encode("utf-8"),
+            headers=self._headers(content_type="application/json"),
+        )
+        if status not in {200, 201}:
+            raise RegistryError("share_failed", f"status {status}", status=status)
+        return json.loads(raw.decode("utf-8"))
+
+    def unshare_result(
+        self,
+        *,
+        result_kind: str,
+        result_id: str,
+        target_type: str,
+        target_id: str,
+    ) -> dict[str, Any]:
+        body = {"target_type": target_type, "target_id": target_id}
+        kind_path = "attempts" if result_kind == "attempt" else "suites"
+        path = f"/v1/results/{kind_path}/{quote(result_id, safe='')}/shares"
+        status, raw, _ = self._request(
+            "DELETE",
+            path,
+            body=json.dumps(body, sort_keys=True).encode("utf-8"),
+            headers=self._headers(content_type="application/json"),
+        )
+        if status != 200:
+            raise RegistryError("unshare_failed", f"status {status}", status=status)
+        return json.loads(raw.decode("utf-8"))

--- a/src/bora/registry/client.py
+++ b/src/bora/registry/client.py
@@ -549,7 +549,6 @@ class RegistryClient:
         target_id: str,
     ) -> dict[str, Any]:
         body = {"target_type": target_type, "target_id": target_id}
-        path = f"/v1/results/{result_kind}s/{quote(result_id, safe='')}/shares"
         # result_kind is attempt|suite → attempts|suites
         kind_path = "attempts" if result_kind == "attempt" else "suites"
         path = f"/v1/results/{kind_path}/{quote(result_id, safe='')}/shares"

--- a/tests/registry/test_registry_e2e.py
+++ b/tests/registry/test_registry_e2e.py
@@ -20,6 +20,25 @@ from bora.registry.digest import compute_package_digest
 REPO = Path(__file__).resolve().parents[2]
 FIXTURE = REPO / "tests" / "fixtures" / "databases" / "publish-min"
 
+TEST_ORG = "test"
+
+
+def _ensure_org() -> None:
+    """Create default test org owned by current token (idempotent)."""
+    import os
+
+    from bora.registry.client import RegistryClient, RegistryError
+
+    url = os.environ.get("BORA_REGISTRY_URL") or ""
+    token = os.environ.get("BORA_REGISTRY_TOKEN") or ""
+    if not url or not token:
+        return
+    client = RegistryClient(url, token=token)
+    try:
+        client.create_org(name=TEST_ORG, display_name="Test Org")
+    except RegistryError:
+        return
+
 
 @pytest.fixture()
 def registry_server(tmp_path: Path):
@@ -49,8 +68,9 @@ def test_publish_and_lock_by_ref(
     monkeypatch.setenv("BORA_REGISTRY_TOKEN", registry_server["token"])
     cache_root = tmp_path / "cache"
     monkeypatch.setenv("BORA_CACHE_ROOT", str(cache_root))
+    _ensure_org()
 
-    summary = publish_database(FIXTURE, public=False)
+    summary = publish_database(FIXTURE, public=False, org=TEST_ORG)
     assert summary["ok"] is True
     assert summary["database_id"] == "test/publish-min"
     assert summary["package_digest"] == compute_package_digest(FIXTURE)
@@ -83,7 +103,8 @@ def test_private_without_token_is_not_found(
 ) -> None:
     monkeypatch.setenv("BORA_REGISTRY_URL", registry_server["url"])
     monkeypatch.setenv("BORA_REGISTRY_TOKEN", registry_server["token"])
-    summary = publish_database(FIXTURE, public=False)
+    _ensure_org()
+    summary = publish_database(FIXTURE, public=False, org=TEST_ORG)
 
     # Client without token
     client = RegistryClient(registry_server["url"], token=None)
@@ -99,5 +120,5 @@ def test_publish_requires_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
     # Empty token via missing credentials
     monkeypatch.setenv("HOME", str(tmp_path))
     with pytest.raises(ConfigError) as ei:
-        publish_database(FIXTURE)
+        publish_database(FIXTURE, org=TEST_ORG)
     assert ei.value.error_code in {"unauthorized", "registry_unavailable"}

--- a/tests/registry/test_registry_operator.py
+++ b/tests/registry/test_registry_operator.py
@@ -30,6 +30,25 @@ from bora.registry.credentials import write_credentials
 REPO = Path(__file__).resolve().parents[2]
 FIXTURE = REPO / "tests" / "fixtures" / "databases" / "publish-min"
 
+TEST_ORG = "test"
+
+
+def _ensure_org() -> None:
+    """Create default test org owned by current token (idempotent)."""
+    import os
+
+    from bora.registry.client import RegistryClient, RegistryError
+
+    url = os.environ.get("BORA_REGISTRY_URL") or ""
+    token = os.environ.get("BORA_REGISTRY_TOKEN") or ""
+    if not url or not token:
+        return
+    client = RegistryClient(url, token=token)
+    try:
+        client.create_org(name=TEST_ORG, display_name="Test Org")
+    except RegistryError:
+        return
+
 
 @pytest.fixture()
 def registry_server(tmp_path: Path):
@@ -69,7 +88,8 @@ def test_list_private_packages_with_and_without_token(
     registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _auth_env(monkeypatch, registry_server, tmp_path)
-    publish_database(FIXTURE, public=False)
+    _ensure_org()
+    publish_database(FIXTURE, public=False, org=TEST_ORG)
     listed = list_packages()
     assert listed["count"] >= 1
     assert any(i["database_id"] == "test/publish-min" for i in listed["items"])
@@ -90,7 +110,8 @@ def test_show_matches_publish(
     registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _auth_env(monkeypatch, registry_server, tmp_path)
-    summary = publish_database(FIXTURE, public=False)
+    _ensure_org()
+    summary = publish_database(FIXTURE, public=False, org=TEST_ORG)
     shown = show_package(summary["ref"])
     assert shown["package_digest"] == summary["package_digest"]
     assert shown["blob_digest"] == summary["blob_digest"]
@@ -101,6 +122,7 @@ def test_results_upload_get_roundtrip(
     registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _auth_env(monkeypatch, registry_server, tmp_path)
+    _ensure_org()
     # Synthetic run dir under a copy of fixture
     db = tmp_path / "db"
     import shutil
@@ -135,6 +157,7 @@ def test_results_private_without_token_404(
     registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _auth_env(monkeypatch, registry_server, tmp_path)
+    _ensure_org()
     db = tmp_path / "db"
     import shutil
 
@@ -186,12 +209,13 @@ def test_oauth_device_flow_mocked(
         assert done["github_user"] == "testuser"
         assert set(done["scopes"]) == set(DEFAULT_LOGIN_SCOPES)
 
-    # Issued token can publish
+    # Issued token can create org + publish
     tok = done["token"]
     monkeypatch.setenv("BORA_REGISTRY_TOKEN", tok)
     write_credentials(url=registry_server["url"], token=tok, path=tmp_path / "c")
     monkeypatch.setenv("HOME", str(tmp_path))
-    summary = publish_database(FIXTURE, public=True)
+    _ensure_org()
+    summary = publish_database(FIXTURE, public=True, org=TEST_ORG)
     assert summary["ok"] is True
 
 
@@ -240,6 +264,7 @@ def test_results_upload_scope_cannot_read_private(
     state.tokens.add(upload_only, {"results:upload"})
 
     _auth_env(monkeypatch, registry_server, tmp_path)
+    _ensure_org()
     db = tmp_path / "db-upload-scope"
     import shutil
 
@@ -299,6 +324,7 @@ def test_suite_results_upload_get_list_roundtrip(
     registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _auth_env(monkeypatch, registry_server, tmp_path)
+    _ensure_org()
     import shutil
 
     db = tmp_path / "db-suite"
@@ -392,6 +418,7 @@ def test_suite_upload_scope_cannot_read_private(
     upload_only = "upload-only-suite-token"
     state.tokens.add(upload_only, {"results:upload"})
     _auth_env(monkeypatch, registry_server, tmp_path)
+    _ensure_org()
     import shutil
 
     db = tmp_path / "db-suite-scope"
@@ -416,6 +443,7 @@ def test_suite_upload_rejects_suite_pass_field(
 ) -> None:
     """Server must reject suite-level PASS authority fields."""
     _auth_env(monkeypatch, registry_server, tmp_path)
+    _ensure_org()
     client = RegistryClient(registry_server["url"], token=registry_server["token"])
     # Craft a minimal valid archive
     from bora.registry.results_archive import build_suite_archive

--- a/tests/registry/test_registry_org_share.py
+++ b/tests/registry/test_registry_org_share.py
@@ -1,0 +1,168 @@
+"""Org membership, package org binding, result uploaded_by + share (#52/#53/#54)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import threading
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+from services.registry.app import build_default_state, make_handler
+from services.registry.store import DEFAULT_LOGIN_SCOPES
+
+from bora.application.publish_command import publish_database
+from bora.application.results_command import list_attempt_results, upload_attempt_result
+from bora.registry.client import RegistryClient, RegistryError
+from bora.registry.credentials import write_credentials
+
+REPO = Path(__file__).resolve().parents[2]
+FIXTURE = REPO / "tests" / "fixtures" / "databases" / "publish-min"
+
+
+@pytest.fixture()
+def registry_server(tmp_path: Path):
+    data = tmp_path / "reg-data"
+    state, token = build_default_state(data, bootstrap_token="boot-token", memory_blob=True)
+    handler = make_handler(state)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_address[1]}"
+    yield {"url": url, "token": token, "state": state}
+    server.shutdown()
+
+
+def _user_token(state, *, user: str, scopes=DEFAULT_LOGIN_SCOPES) -> str:
+    raw = f"tok-{user}"
+    state.tokens.add(raw, scopes, github_user=user)
+    return raw
+
+
+def test_org_create_list_and_publish_requires_org(
+    registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    url = registry_server["url"]
+    boot = RegistryClient(url, token=registry_server["token"])
+    org = boot.create_org(name="acme", display_name="Acme Lab")
+    assert org["org_id"] == "acme"
+    listed = boot.list_orgs()
+    assert any(i["org_id"] == "acme" for i in listed["items"])
+
+    write_credentials(url=url, token=registry_server["token"], path=tmp_path / "c")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BORA_REGISTRY_URL", url)
+    monkeypatch.setenv("BORA_REGISTRY_TOKEN", registry_server["token"])
+
+    with pytest.raises(Exception) as ei:
+        publish_database(FIXTURE, public=False)
+    assert "org" in str(ei.value).lower()
+
+    summary = publish_database(FIXTURE, public=False, org="acme")
+    assert summary["ok"] is True
+    assert summary["org_id"] == "acme"
+
+    meta = boot.get_metadata(database_id=summary["database_id"], version=summary["version"])
+    assert meta.org_id == "acme"
+
+
+def test_private_package_visible_to_org_member_only(
+    registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = registry_server["state"]
+    url = registry_server["url"]
+    boot = RegistryClient(url, token=registry_server["token"])
+    boot.create_org(name="lab")
+
+    alice_tok = _user_token(state, user="alice")
+    bob_tok = _user_token(state, user="bob")
+    # bootstrap owner adds alice
+    boot.add_org_member(org_id="lab", user_id="alice", role="member")
+
+    write_credentials(url=url, token=alice_tok, path=tmp_path / "c")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BORA_REGISTRY_URL", url)
+    monkeypatch.setenv("BORA_REGISTRY_TOKEN", alice_tok)
+    summary = publish_database(FIXTURE, public=False, org="lab")
+
+    alice = RegistryClient(url, token=alice_tok)
+    alice.get_metadata(database_id=summary["database_id"], version=summary["version"])
+
+    bob = RegistryClient(url, token=bob_tok)
+    with pytest.raises(RegistryError) as ei:
+        bob.get_metadata(database_id=summary["database_id"], version=summary["version"])
+    assert ei.value.status == 404
+
+
+def test_result_uploaded_by_and_share_org(
+    registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = registry_server["state"]
+    url = registry_server["url"]
+    boot = RegistryClient(url, token=registry_server["token"])
+    boot.create_org(name="sharelab")
+
+    alice_tok = _user_token(state, user="alice")
+    bob_tok = _user_token(state, user="bob")
+    boot.add_org_member(org_id="sharelab", user_id="bob", role="member")
+
+    db = tmp_path / "db"
+    shutil.copytree(FIXTURE, db)
+    run_id = "sha256_share_run1"
+    run_dir = db / ".bora" / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "result.json").write_text(
+        json.dumps({"task_id": "hello", "status": "PASS"}),
+        encoding="utf-8",
+    )
+
+    write_credentials(url=url, token=alice_tok, path=tmp_path / "c")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BORA_REGISTRY_URL", url)
+    monkeypatch.setenv("BORA_REGISTRY_TOKEN", alice_tok)
+
+    up = upload_attempt_result(db, run_id=run_id, public=False)
+    assert up["ok"] is True
+    meta = RegistryClient(url, token=alice_tok).get_attempt(run_id)
+    assert meta.get("uploaded_by") == "alice"
+
+    # bob cannot see private unshared result
+    with pytest.raises(RegistryError) as ei:
+        RegistryClient(url, token=bob_tok).get_attempt(run_id)
+    assert ei.value.status == 404
+
+    # alice shares to org; bob is member → can read
+    RegistryClient(url, token=alice_tok).share_result(
+        result_kind="attempt",
+        result_id=run_id,
+        target_type="org",
+        target_id="sharelab",
+    )
+    bob_meta = RegistryClient(url, token=bob_tok).get_attempt(run_id)
+    assert bob_meta["run_id"] == run_id
+
+    # unshare → bob loses access
+    RegistryClient(url, token=alice_tok).unshare_result(
+        result_kind="attempt",
+        result_id=run_id,
+        target_type="org",
+        target_id="sharelab",
+    )
+    with pytest.raises(RegistryError) as ei2:
+        RegistryClient(url, token=bob_tok).get_attempt(run_id)
+    assert ei2.value.status == 404
+
+    # non-owner cannot share
+    with pytest.raises(RegistryError):
+        RegistryClient(url, token=bob_tok).share_result(
+            result_kind="attempt",
+            result_id=run_id,
+            target_type="user",
+            target_id="bob",
+        )
+
+    # list does not leak to bob
+    monkeypatch.setenv("BORA_REGISTRY_TOKEN", bob_tok)
+    listed = list_attempt_results(database_id="test/publish-min")
+    assert listed["count"] == 0

--- a/tests/registry/test_registry_package_files.py
+++ b/tests/registry/test_registry_package_files.py
@@ -26,6 +26,24 @@ from bora.registry.client import RegistryClient, RegistryError
 
 REPO = Path(__file__).resolve().parents[2]
 FIXTURE = REPO / "tests" / "fixtures" / "databases" / "publish-min"
+TEST_ORG = "test"
+
+
+def _ensure_org() -> None:
+    """Create default test org owned by current token (idempotent)."""
+    import os
+
+    from bora.registry.client import RegistryClient, RegistryError
+
+    url = os.environ.get("BORA_REGISTRY_URL") or ""
+    token = os.environ.get("BORA_REGISTRY_TOKEN") or ""
+    if not url or not token:
+        return
+    client = RegistryClient(url, token=token)
+    try:
+        client.create_org(name=TEST_ORG, display_name="Test Org")
+    except RegistryError:
+        return
 
 
 @pytest.fixture()
@@ -46,7 +64,8 @@ def registry_server(tmp_path: Path):
 def _publish_public(registry_server, monkeypatch: pytest.MonkeyPatch) -> dict:
     monkeypatch.setenv("BORA_REGISTRY_URL", registry_server["url"])
     monkeypatch.setenv("BORA_REGISTRY_TOKEN", registry_server["token"])
-    return publish_database(FIXTURE, public=True)
+    _ensure_org()
+    return publish_database(FIXTURE, public=True, org=TEST_ORG)
 
 
 def test_normalize_path_rejects_traversal() -> None:
@@ -93,7 +112,8 @@ def test_private_without_token_404(
 ) -> None:
     monkeypatch.setenv("BORA_REGISTRY_URL", registry_server["url"])
     monkeypatch.setenv("BORA_REGISTRY_TOKEN", registry_server["token"])
-    summary = publish_database(FIXTURE, public=False)
+    _ensure_org()
+    summary = publish_database(FIXTURE, public=False, org=TEST_ORG)
 
     anon = RegistryClient(registry_server["url"], token=None)
     with pytest.raises(RegistryError) as ei:


### PR DESCRIPTION
## Summary

This PR delivers the **Registry org + result share** slice of Epic **#51** (design **#52**), with Hub browse UI and dual login surfaces:

1. **#53** — Organizations, membership (`owner` | `member`), packages **require `org_id`** on publish  
2. **#54** — Results carry server-set **`uploaded_by`**; private read = owner ∪ share(org|user) ∪ `admin` (join org ≠ auto-see private results)  
3. **#55** — CLI `--org` / org create-list / result share; Hub thin labels + org browse SPA  
4. **Login** — CLI keeps **GitHub Device Flow** (`bora login`); Hub uses **browser Authorization Code** (`/login` → GitHub → `/login/callback`)  
5. **Profiles** — On successful login, snapshot GitHub login / display name / avatar for Hub members header  

- **No** suite-level PASS authority  
- **No** official score badges / crypto integrity  
- **No** org invite links or secrets UI (placeholders only)  
- **Does not** close #43 (Jobs deep-link / full attempt evidence packaging)

## Issues

| Issue | Role |
| --- | --- |
| #51 | Epic parent |
| #52 | Design (org vs result ownership) |
| #53 | Org + membership + package `org_id` |
| #54 | `uploaded_by` + share + list filter |
| #55 | CLI / Hub surface |

Related (not closed by this PR): **#41** (upload policy → implemented via #54), **#43** (attempt content deep-link).

## Features

### Data model & ACL (#52 / #53 / #54)

| Surface | Ownership | Private read |
| --- | --- | --- |
| Package release | **org** (`org_id` required on new publish) | org members (or `admin`) |
| Attempt / suite result | **uploader** (`uploaded_by`, server-set) | owner, share→org/user, or `admin` |

- Visibility remains **`public` | `private` only** (no `visibility=org`).  
- Tables: `organizations`, `org_memberships`, `result_shares`, `user_profiles` (login snapshot).  
- Legacy releases without `org_id` stay readable when public; private fail-closed for non-admin.

### CLI

```bash
export BORA_REGISTRY_URL=http://127.0.0.1:8700
uv run bora login                          # Device Flow
uv run bora registry org-create my-lab
uv run bora publish path/to/db --org my-lab
uv run bora results share <run_id> --kind attempt --share-org my-lab
```

### Hub SPA

| Path | Behavior |
| --- | --- |
| `/datasets` | **Your organizations** vs **Explore** (public) |
| `/organizations` | Orgs you belong to (+ dataset counts) |
| `/organizations/:id` | Members (avatar), datasets, shared suite results; Settings placeholder |
| `/login` | Browser OAuth start |
| `/login/callback` | Code exchange → Registry token in `localStorage` |

Header after login: **avatar + display name**.

### Auth surfaces

| Client | Flow | Notes |
| --- | --- | --- |
| Hub | Authorization Code | Callback URL must include `http://127.0.0.1:5174/login/callback` |
| CLI | Device Flow | Enable Device Flow on the OAuth App; `BORA_GITHUB_LOGIN_ALLOWLIST` required |

## Verification

Local (on this branch):

- [x] `uv run pytest tests/registry` — **30 passed**  
- [x] Hub `pnpm exec tsc -b` (typecheck)  
- [x] Manual Hub login (browser OAuth) + org create/publish path exercised during development  

Suggested after merge / for reviewers:

```bash
# Registry
set -a && source services/registry/.env && set +a
uv run --extra registry python -m services.registry.app --host 127.0.0.1 --port 8700

# Hub
cd apps/hub
VITE_REGISTRY_PROXY_TARGET=http://127.0.0.1:8700 pnpm dev --host 127.0.0.1 --port 5174
```

## Commits (this branch)

```text
feat(registry): add org, membership, share store models
feat(registry): enforce org package ACL and result share HTTP API
feat(cli): wire --org publish, org list/create, and result share
feat(hub): show package org_id and suite uploaded_by
test(registry): cover org membership, package binding, and result share
docs(cli): sync registry org publish and share surface
feat(hub): add Registry org and share API client helpers
feat(hub): Organizations nav and basic org/dataset views
feat(registry): store GitHub user profiles at login
feat(registry): browser OAuth for Hub and clearer device login
feat(hub): browser GitHub login and header avatar
docs(registry): document Hub web OAuth and CLI device login
```

## Non-goals / follow-up

| Item | Notes |
| --- | --- |
| Org invite links / member admin UI | Post-MVP |
| Org secrets / description edit | Placeholder only |
| Jobs deep-link to attempt evidence | #43 |
| Rebase onto latest `main` if needed | Branch was forked while `main` moved; resolve conflicts before merge |