### PR TITLE
feat: Always-k n_attempts, pass@k/pass^k, job progress and phase timing (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ uv run bora run examples/core --task builtin-executor-conformance \
 # Full Dataset suite (omit --task)
 uv run bora run examples/core --max-concurrent-tasks 2
 
+# Always-k: k independent Attempts per task (CLI/job only; feeds pass@k / pass^k)
+uv run bora run examples/core -k 5 --max-concurrent-tasks 2
+# uv run bora run examples/core --task sdk-agent-session -k 5
+# uv run bora run examples/core --resume-suite suite_<id> --task sdk-agent-session -k 5
+
+# Suite job control (optional --database for progress / cancel.requested)
+# uv run bora status suite_<id> --database examples/core
+# uv run bora cancel suite_<id> --database examples/core
+
 # Local results console (build SPA once: cd apps/viewer && pnpm build)
 uv run bora view examples/core --no-browser
 
@@ -150,13 +159,22 @@ tasks/<task_id>/.bora/runs/<run_id>/
 uv run bora evidence "$LOGS_PATH" --out /tmp/bora-export
 ```
 
-A **full suite** (omit `--task`) also writes observational aggregates at the Dataset root:
+A **full suite** (omit `--task`), or a single task with `-k` / `--n-attempts` > 1, also writes a suite job under the Dataset root:
 
 ```text
-.bora/suite-runs/<suite_run_id>/summary.json   # metrics.pass_rate / mean_score, task_refs
+.bora/suite-runs/<suite_run_id>/
+├── summary.json     # metrics.pass_rate / mean_score / pass_at_k / pass_power_k, task_refs
+├── progress.json    # multi-unit progress (when running / after)
+└── cancel.requested # present if suite cancel was requested
 ```
 
-PASS remains per-task only. Optional Registry archive: `bora results upload-suite` (see CLI README). Local UI: `bora view <dataset>`.
+| Metric | Role |
+| --- | --- |
+| `pass_rate` / `mean_score` | Observational skim |
+| `pass_at_k` / `pass_power_k` | Job stats after Always-k (mean over tasks); **not** package identity |
+| `n_attempts` | Job k budget |
+
+PASS remains **per-task** only. `n_attempts` is **CLI/job only** (never `task.yaml` / fingerprint). Attempt `result.json` may include `phase_timing`. Optional Registry archive: `bora results upload-suite` (see CLI README). Local UI: `bora view <dataset>` (Timing / Tokens on Attempt pages).
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,6 +58,15 @@ uv run bora run examples/core --task builtin-executor-conformance \
 # 整份 Dataset suite（省略 --task）
 uv run bora run examples/core --max-concurrent-tasks 2
 
+# Always-k：每题 k 次独立 Attempt（仅 CLI/job；用于 pass@k / pass^k）
+uv run bora run examples/core -k 5 --max-concurrent-tasks 2
+# uv run bora run examples/core --task sdk-agent-session -k 5
+# uv run bora run examples/core --resume-suite suite_<id> --task sdk-agent-session -k 5
+
+# suite job 控制（可选 --database 读进度 / 写 cancel）
+# uv run bora status suite_<id> --database examples/core
+# uv run bora cancel suite_<id> --database examples/core
+
 # 本机结果台（SPA 先构建一次：cd apps/viewer && pnpm build）
 uv run bora view examples/core --no-browser
 
@@ -150,13 +159,22 @@ tasks/<task_id>/.bora/runs/<run_id>/
 uv run bora evidence "$LOGS_PATH" --out /tmp/bora-export
 ```
 
-**整份 suite**（省略 `--task`）还会在 Dataset 根写入观测聚合：
+**整份 suite**（省略 `--task`），或单 task 且 `-k` / `--n-attempts` > 1，会在 Dataset 根写入 suite job：
 
 ```text
-.bora/suite-runs/<suite_run_id>/summary.json   # metrics.pass_rate / mean_score、task_refs
+.bora/suite-runs/<suite_run_id>/
+├── summary.json     # metrics.pass_rate / mean_score / pass_at_k / pass_power_k、task_refs
+├── progress.json    # 多 unit 进度
+└── cancel.requested # suite cancel 后出现
 ```
 
-PASS 仍仅 per-task。可选 Registry 归档：`bora results upload-suite`（见 CLI README）。本机 UI：`bora view <dataset>`。
+| 指标 | 作用 |
+| --- | --- |
+| `pass_rate` / `mean_score` | 观测扫一眼 |
+| `pass_at_k` / `pass_power_k` | Always-k 后的 job 统计（按 task 取 mean）；**不是** package 身份 |
+| `n_attempts` | 本次 job 的 k 预算 |
+
+PASS 仍仅 **per-task**。`n_attempts` **只走 CLI/job**（不进 `task.yaml` / fingerprint）。Attempt `result.json` 可含 `phase_timing`。可选 Registry 归档：`bora results upload-suite`（见 CLI README）。本机 UI：`bora view <dataset>`（Attempt 页 Timing / Tokens）。
 
 ---
 

--- a/apps/hub/README.md
+++ b/apps/hub/README.md
@@ -58,7 +58,7 @@ modal; the list only shows a prefix. Members join from **Organizations → Join*
 | `/datasets/:id/tasks/:task` | README · Files · Jobs (row opens detail when uploaded) |
 | `/organizations` | Your orgs · Join |
 | `/organizations/:orgId` | Overview · Settings |
-| `/jobs/...` | Remote Attempt detail (tabs + trajectory) |
+| `/jobs/...` | Remote Attempt detail (Timing / Tokens when present, tabs + trajectory) |
 | `/login` | Starts browser OAuth |
 | `/login/callback` | OAuth redirect target |
 

--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.24",
     "@radix-ui/react-select": "^2.3.7",
     "@radix-ui/react-slot": "^1.3.3",
+    "@radix-ui/react-tooltip": "^1.2.16",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.28.0",

--- a/apps/hub/pnpm-lock.yaml
+++ b/apps/hub/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.3.3
         version: 1.3.3(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.16
+        version: 1.2.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -451,6 +454,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.16':
+    resolution: {integrity: sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.4':
@@ -1847,6 +1863,27 @@ snapshots:
       react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.18
+
+  '@radix-ui/react-tooltip@1.2.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   '@radix-ui/react-use-callback-ref@1.1.4(@types/react@19.2.18)(react@19.2.8)':
     dependencies:

--- a/apps/hub/src/components/trial/outcome-strip.tsx
+++ b/apps/hub/src/components/trial/outcome-strip.tsx
@@ -9,7 +9,7 @@ export function OutcomeStrip({ trial }: { trial: Trial }) {
 
   return (
     <>
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 rounded-[8px] border border-hairline p-4">
+      <div className="grid grid-cols-2 gap-3 rounded-[8px] border border-hairline p-4 sm:grid-cols-4">
         <Outcome label="Status">
           <span className={bad ? "text-error font-medium" : "text-ink font-medium"}>
             {status || "-"}

--- a/apps/hub/src/components/trial/phase-timing-bar.tsx
+++ b/apps/hub/src/components/trial/phase-timing-bar.tsx
@@ -3,6 +3,13 @@
  * Data from Attempt result.phase_timing / token_timing (#47 D).
  */
 
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
 export type PhaseSeg = {
   id: string;
   label?: string;
@@ -79,49 +86,74 @@ function SegmentBar({
   const total = segments.reduce((acc, s) => acc + (Number(s[valueKey]) || 0), 0);
   if (total <= 0 && segments.length === 0) return null;
 
+  const visible = segments.filter((seg) => {
+    const v = Number(seg[valueKey]) || 0;
+    return !(v <= 0 && total > 0);
+  });
+
   return (
-    <div className="space-y-2">
-      <div className="flex items-baseline justify-between gap-3">
-        <h3 className="text-sm font-medium text-ink">{title}</h3>
-        <span className="text-xs tabular text-mute">{totalLabel}</span>
+    <TooltipProvider delayDuration={200}>
+      <div className="space-y-2">
+        {/* Title + total on the left (Status-label style + value). */}
+        <div className="flex items-baseline gap-2">
+          <div className="text-xs text-mute">{title}</div>
+          <span className="text-sm tabular text-ink">{totalLabel}</span>
+        </div>
+        <div
+          className="flex h-3 w-full overflow-hidden rounded-[4px] bg-canvas-soft border border-hairline"
+          role="img"
+          aria-label={`${title}: ${totalLabel}`}
+        >
+          {segments.map((seg) => {
+            const v = Number(seg[valueKey]) || 0;
+            const pct = total > 0 ? (v / total) * 100 : 0;
+            if (pct <= 0) return null;
+            const label = seg.label || seg.id;
+            return (
+              <Tooltip key={seg.id}>
+                <TooltipTrigger asChild>
+                  <div
+                    className={`${colorFor(seg.id, kind)} h-full min-w-[2px] cursor-default transition-opacity hover:opacity-90`}
+                    style={{ width: `${pct}%` }}
+                  />
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  {label}: {formatValue(v)}
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
+        </div>
+        {/* Legend: labels only; values via Tooltip. */}
+        <ul className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-mute">
+          {visible.map((seg) => {
+            const v = Number(seg[valueKey]) || 0;
+            const label = seg.label || seg.id;
+            return (
+              <li key={seg.id}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className="inline-flex cursor-default items-center gap-1.5 outline-none"
+                    >
+                      <span
+                        className={`inline-block h-2 w-2 shrink-0 rounded-[2px] ${colorFor(seg.id, kind)}`}
+                        aria-hidden
+                      />
+                      <span>{label}</span>
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {label}: {formatValue(v)}
+                  </TooltipContent>
+                </Tooltip>
+              </li>
+            );
+          })}
+        </ul>
       </div>
-      <div
-        className="flex h-3 w-full overflow-hidden rounded-[4px] bg-canvas-soft border border-hairline"
-        role="img"
-        aria-label={`${title}: ${totalLabel}`}
-      >
-        {segments.map((seg) => {
-          const v = Number(seg[valueKey]) || 0;
-          const pct = total > 0 ? (v / total) * 100 : 0;
-          if (pct <= 0) return null;
-          const label = seg.label || seg.id;
-          return (
-            <div
-              key={seg.id}
-              className={`${colorFor(seg.id, kind)} h-full min-w-[2px] transition-opacity hover:opacity-90`}
-              style={{ width: `${pct}%` }}
-              title={`${label}: ${formatValue(v)}`}
-            />
-          );
-        })}
-      </div>
-      <ul className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-mute">
-        {segments.map((seg) => {
-          const v = Number(seg[valueKey]) || 0;
-          if (v <= 0 && total > 0) return null;
-          return (
-            <li key={seg.id} className="inline-flex items-center gap-1.5">
-              <span
-                className={`inline-block h-2 w-2 rounded-[2px] ${colorFor(seg.id, kind)}`}
-                aria-hidden
-              />
-              <span>{seg.label || seg.id}</span>
-              <span className="tabular text-body">{formatValue(v)}</span>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
+    </TooltipProvider>
   );
 }
 
@@ -137,27 +169,39 @@ export function PhaseTimingBar({
 
   if (phases.length === 0 && tokens.length === 0) return null;
 
+  const both = tokens.length > 0 && phases.length > 0;
+
   return (
-    <div className="space-y-4 rounded-[8px] border border-hairline p-4">
+    <div
+      className={
+        both
+          ? "flex flex-col gap-6 rounded-[8px] border border-hairline p-4 sm:flex-row sm:items-stretch sm:gap-0"
+          : "rounded-[8px] border border-hairline p-4"
+      }
+    >
       {tokens.length > 0 ? (
-        <SegmentBar
-          title="Tokens"
-          segments={tokens}
-          totalLabel={`${formatTokens(tokenTiming?.total_tokens)} tokens`}
-          kind="token"
-          valueKey="tokens"
-          formatValue={formatTokens}
-        />
+        <div className={both ? "min-w-0 flex-1 sm:pr-6" : undefined}>
+          <SegmentBar
+            title="Tokens"
+            segments={tokens}
+            totalLabel={`${formatTokens(tokenTiming?.total_tokens)} tokens`}
+            kind="token"
+            valueKey="tokens"
+            formatValue={formatTokens}
+          />
+        </div>
       ) : null}
       {phases.length > 0 ? (
-        <SegmentBar
-          title="Timing"
-          segments={phases}
-          totalLabel={formatMs(phaseTiming?.total_ms)}
-          kind="phase"
-          valueKey="duration_ms"
-          formatValue={formatMs}
-        />
+        <div className={both ? "min-w-0 flex-1 sm:pl-6" : undefined}>
+          <SegmentBar
+            title="Timing"
+            segments={phases}
+            totalLabel={formatMs(phaseTiming?.total_ms)}
+            kind="phase"
+            valueKey="duration_ms"
+            formatValue={formatMs}
+          />
+        </div>
       ) : null}
     </div>
   );

--- a/apps/hub/src/components/trial/phase-timing-bar.tsx
+++ b/apps/hub/src/components/trial/phase-timing-bar.tsx
@@ -1,0 +1,164 @@
+/**
+ * Harbor-style horizontal phase / token bars with legend + hover labels.
+ * Data from Attempt result.phase_timing / token_timing (#47 D).
+ */
+
+export type PhaseSeg = {
+  id: string;
+  label?: string;
+  duration_ms?: number;
+  tokens?: number;
+};
+
+export type PhaseTiming = {
+  phases?: PhaseSeg[];
+  total_ms?: number;
+  started_at?: string | null;
+  finished_at?: string | null;
+};
+
+export type TokenTiming = {
+  segments?: PhaseSeg[];
+  total_tokens?: number;
+};
+
+const PHASE_COLORS: Record<string, string> = {
+  prepare: "bg-zinc-300 dark:bg-zinc-600",
+  run: "bg-zinc-500 dark:bg-zinc-400",
+  evaluate: "bg-zinc-400 dark:bg-zinc-500",
+  cleanup: "bg-zinc-200 dark:bg-zinc-700",
+  env_setup: "bg-zinc-300 dark:bg-zinc-600",
+  agent_setup: "bg-zinc-500 dark:bg-zinc-400",
+  agent_execution: "bg-zinc-500 dark:bg-zinc-400",
+  verifier: "bg-zinc-400 dark:bg-zinc-500",
+};
+
+const TOKEN_COLORS: Record<string, string> = {
+  cached_input: "bg-zinc-300 dark:bg-zinc-600",
+  uncached_input: "bg-zinc-500 dark:bg-zinc-400",
+  output: "bg-zinc-700 dark:bg-zinc-300",
+};
+
+function formatMs(ms: number | undefined | null): string {
+  if (ms == null || Number.isNaN(ms)) return "—";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const s = ms / 1000;
+  if (s < 60) return s < 10 ? `${s.toFixed(1)}s` : `${Math.round(s)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s - m * 60);
+  return rem ? `${m}m ${String(rem).padStart(2, "0")}s` : `${m}m`;
+}
+
+function formatTokens(n: number | undefined | null): string {
+  if (n == null || Number.isNaN(n)) return "—";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}K`;
+  return String(Math.round(n));
+}
+
+function colorFor(id: string, kind: "phase" | "token"): string {
+  const map = kind === "phase" ? PHASE_COLORS : TOKEN_COLORS;
+  return map[id] || "bg-zinc-400 dark:bg-zinc-500";
+}
+
+function SegmentBar({
+  title,
+  segments,
+  totalLabel,
+  kind,
+  valueKey,
+  formatValue,
+}: {
+  title: string;
+  segments: PhaseSeg[];
+  totalLabel: string;
+  kind: "phase" | "token";
+  valueKey: "duration_ms" | "tokens";
+  formatValue: (n: number | undefined) => string;
+}) {
+  const total = segments.reduce((acc, s) => acc + (Number(s[valueKey]) || 0), 0);
+  if (total <= 0 && segments.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between gap-3">
+        <h3 className="text-sm font-medium text-ink">{title}</h3>
+        <span className="text-xs tabular text-mute">{totalLabel}</span>
+      </div>
+      <div
+        className="flex h-3 w-full overflow-hidden rounded-[4px] bg-canvas-soft border border-hairline"
+        role="img"
+        aria-label={`${title}: ${totalLabel}`}
+      >
+        {segments.map((seg) => {
+          const v = Number(seg[valueKey]) || 0;
+          const pct = total > 0 ? (v / total) * 100 : 0;
+          if (pct <= 0) return null;
+          const label = seg.label || seg.id;
+          return (
+            <div
+              key={seg.id}
+              className={`${colorFor(seg.id, kind)} h-full min-w-[2px] transition-opacity hover:opacity-90`}
+              style={{ width: `${pct}%` }}
+              title={`${label}: ${formatValue(v)}`}
+            />
+          );
+        })}
+      </div>
+      <ul className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-mute">
+        {segments.map((seg) => {
+          const v = Number(seg[valueKey]) || 0;
+          if (v <= 0 && total > 0) return null;
+          return (
+            <li key={seg.id} className="inline-flex items-center gap-1.5">
+              <span
+                className={`inline-block h-2 w-2 rounded-[2px] ${colorFor(seg.id, kind)}`}
+                aria-hidden
+              />
+              <span>{seg.label || seg.id}</span>
+              <span className="tabular text-body">{formatValue(v)}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export function PhaseTimingBar({
+  phaseTiming,
+  tokenTiming,
+}: {
+  phaseTiming?: PhaseTiming | null;
+  tokenTiming?: TokenTiming | null;
+}) {
+  const phases = phaseTiming?.phases || [];
+  const tokens = (tokenTiming?.segments || []).filter((s) => (s.tokens ?? 0) > 0);
+
+  if (phases.length === 0 && tokens.length === 0) return null;
+
+  return (
+    <div className="space-y-4 rounded-[8px] border border-hairline p-4">
+      {tokens.length > 0 ? (
+        <SegmentBar
+          title="Tokens"
+          segments={tokens}
+          totalLabel={`${formatTokens(tokenTiming?.total_tokens)} tokens`}
+          kind="token"
+          valueKey="tokens"
+          formatValue={formatTokens}
+        />
+      ) : null}
+      {phases.length > 0 ? (
+        <SegmentBar
+          title="Timing"
+          segments={phases}
+          totalLabel={formatMs(phaseTiming?.total_ms)}
+          kind="phase"
+          valueKey="duration_ms"
+          formatValue={formatMs}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/hub/src/components/ui/tooltip.tsx
+++ b/apps/hub/src/components/ui/tooltip.tsx
@@ -1,0 +1,26 @@
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export const TooltipProvider = TooltipPrimitive.Provider;
+export const Tooltip = TooltipPrimitive.Root;
+export const TooltipTrigger = TooltipPrimitive.Trigger;
+
+export const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 max-w-xs rounded-[6px] border border-hairline bg-canvas px-2 py-1 text-xs text-ink shadow-[0_1px_1px_#00000008,0_8px_16px_-4px_#00000014]",
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;

--- a/apps/hub/src/lib/attempt-evidence.ts
+++ b/apps/hub/src/lib/attempt-evidence.ts
@@ -409,11 +409,80 @@ export function buildTrialMeta(opts: {
       ? (prov.upstream as Record<string, unknown>)
       : null;
 
-  const startedRaw = summary.started_at ?? summary.started ?? null;
+  const phaseTimingRaw =
+    (result.phase_timing && typeof result.phase_timing === "object"
+      ? result.phase_timing
+      : null) ||
+    (summary.phase_timing && typeof summary.phase_timing === "object"
+      ? summary.phase_timing
+      : null);
+  const phase_timing = phaseTimingRaw as Trial["phase_timing"];
+
+  const startedRaw =
+    summary.started_at ??
+    (phase_timing && typeof phase_timing.started_at === "string"
+      ? phase_timing.started_at
+      : null) ??
+    summary.started ??
+    null;
   let started: string | null = null;
   if (typeof startedRaw === "string") started = startedRaw;
   else if (typeof startedRaw === "number") {
     started = new Date(startedRaw * (startedRaw < 1e12 ? 1000 : 1)).toISOString();
+  }
+
+  let duration: string | null =
+    (typeof result.duration === "string" && result.duration) ||
+    (typeof summary.duration === "string" && summary.duration) ||
+    null;
+  if (!duration && phase_timing && typeof phase_timing.total_ms === "number") {
+    const ms = phase_timing.total_ms;
+    if (ms < 1000) duration = `${Math.round(ms)}ms`;
+    else if (ms < 60_000) duration = `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)}s`;
+    else {
+      const m = Math.floor(ms / 60_000);
+      const s = Math.round((ms % 60_000) / 1000);
+      duration = s ? `${m}m ${String(s).padStart(2, "0")}s` : `${m}m`;
+    }
+  }
+
+  // Token bar from actor usage when present (often null on Hub until usage wired).
+  let token_timing: Trial["token_timing"] = null;
+  {
+    let cached = 0;
+    let uncached = 0;
+    let output = 0;
+    let anyTok = false;
+    for (const a of actors) {
+      const u = a.usage;
+      if (!u) continue;
+      if (typeof u.output_tokens === "number") {
+        output += u.output_tokens;
+        anyTok = true;
+      }
+      if (typeof u.input_tokens === "number") {
+        anyTok = true;
+        const cr =
+          typeof u.cached_read_tokens === "number" ? u.cached_read_tokens : 0;
+        cached += cr;
+        uncached += Math.max(0, u.input_tokens - cr);
+      }
+    }
+    if (anyTok) {
+      token_timing = {
+        schema: "bora.token_timing/1",
+        segments: [
+          { id: "cached_input", label: "Cached Input", tokens: Math.round(cached) },
+          {
+            id: "uncached_input",
+            label: "Uncached Input",
+            tokens: Math.round(uncached),
+          },
+          { id: "output", label: "Output", tokens: Math.round(output) },
+        ],
+        total_tokens: Math.round(cached + uncached + output),
+      };
+    }
   }
 
   const invCount =
@@ -431,6 +500,9 @@ export function buildTrialMeta(opts: {
     reward: score,
     error,
     started,
+    duration,
+    phase_timing,
+    token_timing,
     has_evidence: true,
     available_tabs: tabs,
     agent_invocations: invCount,

--- a/apps/hub/src/lib/trial-types.ts
+++ b/apps/hub/src/lib/trial-types.ts
@@ -50,6 +50,19 @@ export type Trial = {
   upstream_name?: string | null;
   upstream_ref?: string | null;
   note?: string | null;
+  /** #47 D — wall-time phases (prepare/run/evaluate/cleanup) */
+  phase_timing?: {
+    schema?: string;
+    phases?: Array<{ id: string; label?: string; duration_ms?: number }>;
+    total_ms?: number;
+    started_at?: string | null;
+    finished_at?: string | null;
+  } | null;
+  token_timing?: {
+    schema?: string;
+    segments?: Array<{ id: string; label?: string; tokens?: number }>;
+    total_tokens?: number;
+  } | null;
 };
 
 export type TreeEntry = {

--- a/apps/hub/src/pages/AttemptEvidencePage.tsx
+++ b/apps/hub/src/pages/AttemptEvidencePage.tsx
@@ -6,6 +6,7 @@ import { Shell } from "@/components/layout";
 import { ActorsTable } from "@/components/trial/actors-table";
 import { EvidenceTabs } from "@/components/trial/evidence-tabs";
 import { OutcomeStrip } from "@/components/trial/outcome-strip";
+import { PhaseTimingBar } from "@/components/trial/phase-timing-bar";
 import { TrialHeader } from "@/components/trial/trial-header";
 import { useAttemptEvidence } from "@/hooks/use-attempt-evidence";
 import { decodeDatasetId } from "@/lib/api";
@@ -92,6 +93,11 @@ export function AttemptEvidencePage() {
         {!loading && !error && trial ? (
           <>
             <OutcomeStrip trial={trial} />
+
+            <PhaseTimingBar
+              phaseTiming={trial.phase_timing}
+              tokenTiming={trial.token_timing}
+            />
 
             {trial.actors && trial.actors.length > 0 ? (
               <ActorsTable actors={trial.actors} />

--- a/apps/viewer/README.md
+++ b/apps/viewer/README.md
@@ -8,7 +8,7 @@ Local results console for a Database package:
 
 | Layer | Content |
 | --- | --- |
-| **Jobs** | Local suite runs under `.bora/suite-runs/` |
+| **Jobs** | Local suite runs under `.bora/suite-runs/` (summary metrics, optional Always-k) |
 | **Tasks** | Per-task status / score / run refs from suite summary (+ local evidence when present) |
 | **Attempt** | One `run_id`: outcome strip, actors table, evidence tabs |
 

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.24",
     "@radix-ui/react-select": "^2.3.7",
     "@radix-ui/react-slot": "^1.3.3",
+    "@radix-ui/react-tooltip": "^1.2.16",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.28.0",

--- a/apps/viewer/pnpm-lock.yaml
+++ b/apps/viewer/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.3.3
         version: 1.3.3(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.16
+        version: 1.2.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -442,6 +445,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.16':
+    resolution: {integrity: sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.4':
@@ -1470,6 +1486,27 @@ snapshots:
       react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.18
+
+  '@radix-ui/react-tooltip@1.2.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   '@radix-ui/react-use-callback-ref@1.1.4(@types/react@19.2.18)(react@19.2.8)':
     dependencies:

--- a/apps/viewer/src/components/trial/outcome-strip.tsx
+++ b/apps/viewer/src/components/trial/outcome-strip.tsx
@@ -9,7 +9,7 @@ export function OutcomeStrip({ trial }: { trial: Trial }) {
 
   return (
     <>
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 rounded-[8px] border border-hairline p-4">
+      <div className="grid grid-cols-2 gap-3 rounded-[8px] border border-hairline p-4 sm:grid-cols-4">
         <Outcome label="Status">
           <span className={bad ? "text-error font-medium" : "text-ink font-medium"}>
             {status || "-"}

--- a/apps/viewer/src/components/trial/phase-timing-bar.tsx
+++ b/apps/viewer/src/components/trial/phase-timing-bar.tsx
@@ -3,6 +3,13 @@
  * Data from Attempt result.phase_timing / token_timing (#47 D).
  */
 
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
 export type PhaseSeg = {
   id: string;
   label?: string;
@@ -80,49 +87,74 @@ function SegmentBar({
   const total = segments.reduce((acc, s) => acc + (Number(s[valueKey]) || 0), 0);
   if (total <= 0 && segments.length === 0) return null;
 
+  const visible = segments.filter((seg) => {
+    const v = Number(seg[valueKey]) || 0;
+    return !(v <= 0 && total > 0);
+  });
+
   return (
-    <div className="space-y-2">
-      <div className="flex items-baseline justify-between gap-3">
-        <h3 className="text-sm font-medium text-ink">{title}</h3>
-        <span className="text-xs tabular text-mute">{totalLabel}</span>
+    <TooltipProvider delayDuration={200}>
+      <div className="space-y-2">
+        {/* Title + total on the left (Status-label style + value). */}
+        <div className="flex items-baseline gap-2">
+          <div className="text-xs text-mute">{title}</div>
+          <span className="text-sm tabular text-ink">{totalLabel}</span>
+        </div>
+        <div
+          className="flex h-3 w-full overflow-hidden rounded-[4px] bg-canvas-soft border border-hairline"
+          role="img"
+          aria-label={`${title}: ${totalLabel}`}
+        >
+          {segments.map((seg) => {
+            const v = Number(seg[valueKey]) || 0;
+            const pct = total > 0 ? (v / total) * 100 : 0;
+            if (pct <= 0) return null;
+            const label = seg.label || seg.id;
+            return (
+              <Tooltip key={seg.id}>
+                <TooltipTrigger asChild>
+                  <div
+                    className={`${colorFor(seg.id, kind)} h-full min-w-[2px] cursor-default transition-opacity hover:opacity-90`}
+                    style={{ width: `${pct}%` }}
+                  />
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  {label}: {formatValue(v)}
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
+        </div>
+        {/* Legend: labels only; values via Tooltip. */}
+        <ul className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-mute">
+          {visible.map((seg) => {
+            const v = Number(seg[valueKey]) || 0;
+            const label = seg.label || seg.id;
+            return (
+              <li key={seg.id}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className="inline-flex cursor-default items-center gap-1.5 outline-none"
+                    >
+                      <span
+                        className={`inline-block h-2 w-2 shrink-0 rounded-[2px] ${colorFor(seg.id, kind)}`}
+                        aria-hidden
+                      />
+                      <span>{label}</span>
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {label}: {formatValue(v)}
+                  </TooltipContent>
+                </Tooltip>
+              </li>
+            );
+          })}
+        </ul>
       </div>
-      <div
-        className="flex h-3 w-full overflow-hidden rounded-[4px] bg-canvas-soft border border-hairline"
-        role="img"
-        aria-label={`${title}: ${totalLabel}`}
-      >
-        {segments.map((seg) => {
-          const v = Number(seg[valueKey]) || 0;
-          const pct = total > 0 ? (v / total) * 100 : 0;
-          if (pct <= 0) return null;
-          const label = seg.label || seg.id;
-          return (
-            <div
-              key={seg.id}
-              className={`${colorFor(seg.id, kind)} h-full min-w-[2px] transition-opacity hover:opacity-90`}
-              style={{ width: `${pct}%` }}
-              title={`${label}: ${formatValue(v)}`}
-            />
-          );
-        })}
-      </div>
-      <ul className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-mute">
-        {segments.map((seg) => {
-          const v = Number(seg[valueKey]) || 0;
-          if (v <= 0 && total > 0) return null;
-          return (
-            <li key={seg.id} className="inline-flex items-center gap-1.5">
-              <span
-                className={`inline-block h-2 w-2 rounded-[2px] ${colorFor(seg.id, kind)}`}
-                aria-hidden
-              />
-              <span>{seg.label || seg.id}</span>
-              <span className="tabular text-body">{formatValue(v)}</span>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
+    </TooltipProvider>
   );
 }
 
@@ -140,27 +172,39 @@ export function PhaseTimingBar({
 
   if (phases.length === 0 && tokens.length === 0) return null;
 
+  const both = tokens.length > 0 && phases.length > 0;
+
   return (
-    <div className="space-y-4 rounded-[8px] border border-hairline p-4">
+    <div
+      className={
+        both
+          ? "flex flex-col gap-6 rounded-[8px] border border-hairline p-4 sm:flex-row sm:items-stretch sm:gap-0"
+          : "rounded-[8px] border border-hairline p-4"
+      }
+    >
       {tokens.length > 0 ? (
-        <SegmentBar
-          title="Tokens"
-          segments={tokens}
-          totalLabel={`${formatTokens(tokenTiming?.total_tokens)} tokens`}
-          kind="token"
-          valueKey="tokens"
-          formatValue={formatTokens}
-        />
+        <div className={both ? "min-w-0 flex-1 sm:pr-6" : undefined}>
+          <SegmentBar
+            title="Tokens"
+            segments={tokens}
+            totalLabel={`${formatTokens(tokenTiming?.total_tokens)} tokens`}
+            kind="token"
+            valueKey="tokens"
+            formatValue={formatTokens}
+          />
+        </div>
       ) : null}
       {phases.length > 0 ? (
-        <SegmentBar
-          title="Timing"
-          segments={phases}
-          totalLabel={formatMs(phaseTiming?.total_ms)}
-          kind="phase"
-          valueKey="duration_ms"
-          formatValue={formatMs}
-        />
+        <div className={both ? "min-w-0 flex-1 sm:pl-6" : undefined}>
+          <SegmentBar
+            title="Timing"
+            segments={phases}
+            totalLabel={formatMs(phaseTiming?.total_ms)}
+            kind="phase"
+            valueKey="duration_ms"
+            formatValue={formatMs}
+          />
+        </div>
       ) : null}
     </div>
   );

--- a/apps/viewer/src/components/trial/phase-timing-bar.tsx
+++ b/apps/viewer/src/components/trial/phase-timing-bar.tsx
@@ -1,0 +1,167 @@
+/**
+ * Harbor-style horizontal phase / token bars with legend + hover labels.
+ * Data from Attempt result.phase_timing / token_timing (#47 D).
+ */
+
+export type PhaseSeg = {
+  id: string;
+  label?: string;
+  duration_ms?: number;
+  tokens?: number;
+};
+
+export type PhaseTiming = {
+  phases?: PhaseSeg[];
+  total_ms?: number;
+  started_at?: string | null;
+  finished_at?: string | null;
+};
+
+export type TokenTiming = {
+  segments?: PhaseSeg[];
+  total_tokens?: number;
+};
+
+const PHASE_COLORS: Record<string, string> = {
+  prepare: "bg-zinc-300 dark:bg-zinc-600",
+  run: "bg-zinc-500 dark:bg-zinc-400",
+  evaluate: "bg-zinc-400 dark:bg-zinc-500",
+  cleanup: "bg-zinc-200 dark:bg-zinc-700",
+  // Harbor aliases
+  env_setup: "bg-zinc-300 dark:bg-zinc-600",
+  agent_setup: "bg-zinc-500 dark:bg-zinc-400",
+  agent_execution: "bg-zinc-500 dark:bg-zinc-400",
+  verifier: "bg-zinc-400 dark:bg-zinc-500",
+};
+
+const TOKEN_COLORS: Record<string, string> = {
+  cached_input: "bg-zinc-300 dark:bg-zinc-600",
+  uncached_input: "bg-zinc-500 dark:bg-zinc-400",
+  output: "bg-zinc-700 dark:bg-zinc-300",
+};
+
+function formatMs(ms: number | undefined | null): string {
+  if (ms == null || Number.isNaN(ms)) return "—";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const s = ms / 1000;
+  if (s < 60) return s < 10 ? `${s.toFixed(1)}s` : `${Math.round(s)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s - m * 60);
+  return rem ? `${m}m ${String(rem).padStart(2, "0")}s` : `${m}m`;
+}
+
+function formatTokens(n: number | undefined | null): string {
+  if (n == null || Number.isNaN(n)) return "—";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}K`;
+  return String(Math.round(n));
+}
+
+function colorFor(id: string, kind: "phase" | "token"): string {
+  const map = kind === "phase" ? PHASE_COLORS : TOKEN_COLORS;
+  return map[id] || "bg-zinc-400 dark:bg-zinc-500";
+}
+
+function SegmentBar({
+  title,
+  segments,
+  totalLabel,
+  kind,
+  valueKey,
+  formatValue,
+}: {
+  title: string;
+  segments: PhaseSeg[];
+  totalLabel: string;
+  kind: "phase" | "token";
+  valueKey: "duration_ms" | "tokens";
+  formatValue: (n: number | undefined) => string;
+}) {
+  const total = segments.reduce((acc, s) => acc + (Number(s[valueKey]) || 0), 0);
+  if (total <= 0 && segments.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between gap-3">
+        <h3 className="text-sm font-medium text-ink">{title}</h3>
+        <span className="text-xs tabular text-mute">{totalLabel}</span>
+      </div>
+      <div
+        className="flex h-3 w-full overflow-hidden rounded-[4px] bg-canvas-soft border border-hairline"
+        role="img"
+        aria-label={`${title}: ${totalLabel}`}
+      >
+        {segments.map((seg) => {
+          const v = Number(seg[valueKey]) || 0;
+          const pct = total > 0 ? (v / total) * 100 : 0;
+          if (pct <= 0) return null;
+          const label = seg.label || seg.id;
+          return (
+            <div
+              key={seg.id}
+              className={`${colorFor(seg.id, kind)} h-full min-w-[2px] transition-opacity hover:opacity-90`}
+              style={{ width: `${pct}%` }}
+              title={`${label}: ${formatValue(v)}`}
+            />
+          );
+        })}
+      </div>
+      <ul className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-mute">
+        {segments.map((seg) => {
+          const v = Number(seg[valueKey]) || 0;
+          if (v <= 0 && total > 0) return null;
+          return (
+            <li key={seg.id} className="inline-flex items-center gap-1.5">
+              <span
+                className={`inline-block h-2 w-2 rounded-[2px] ${colorFor(seg.id, kind)}`}
+                aria-hidden
+              />
+              <span>{seg.label || seg.id}</span>
+              <span className="tabular text-body">{formatValue(v)}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export function PhaseTimingBar({
+  phaseTiming,
+  tokenTiming,
+}: {
+  phaseTiming?: PhaseTiming | null;
+  tokenTiming?: TokenTiming | null;
+}) {
+  const phases = (phaseTiming?.phases || []).filter(
+    (p) => (p.duration_ms ?? 0) > 0 || (phaseTiming?.phases?.length ?? 0) <= 4,
+  );
+  const tokens = (tokenTiming?.segments || []).filter((s) => (s.tokens ?? 0) > 0);
+
+  if (phases.length === 0 && tokens.length === 0) return null;
+
+  return (
+    <div className="space-y-4 rounded-[8px] border border-hairline p-4">
+      {tokens.length > 0 ? (
+        <SegmentBar
+          title="Tokens"
+          segments={tokens}
+          totalLabel={`${formatTokens(tokenTiming?.total_tokens)} tokens`}
+          kind="token"
+          valueKey="tokens"
+          formatValue={formatTokens}
+        />
+      ) : null}
+      {phases.length > 0 ? (
+        <SegmentBar
+          title="Timing"
+          segments={phases}
+          totalLabel={formatMs(phaseTiming?.total_ms)}
+          kind="phase"
+          valueKey="duration_ms"
+          formatValue={formatMs}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/ui/tooltip.tsx
+++ b/apps/viewer/src/components/ui/tooltip.tsx
@@ -1,0 +1,26 @@
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export const TooltipProvider = TooltipPrimitive.Provider;
+export const Tooltip = TooltipPrimitive.Root;
+export const TooltipTrigger = TooltipPrimitive.Trigger;
+
+export const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 max-w-xs rounded-[6px] border border-hairline bg-canvas px-2 py-1 text-xs text-ink shadow-[0_1px_1px_#00000008,0_8px_16px_-4px_#00000014]",
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;

--- a/apps/viewer/src/lib/api.ts
+++ b/apps/viewer/src/lib/api.ts
@@ -89,6 +89,20 @@ export type Trial = {
   upstream_name?: string | null;
   upstream_ref?: string | null;
   note?: string | null;
+  /** #47 D — wall-time phases (prepare/run/evaluate/cleanup) */
+  phase_timing?: {
+    schema?: string;
+    phases?: Array<{ id: string; label?: string; duration_ms?: number }>;
+    total_ms?: number;
+    started_at?: string | null;
+    finished_at?: string | null;
+  } | null;
+  /** Aggregated token segments for Harbor-style bar (when usage present) */
+  token_timing?: {
+    schema?: string;
+    segments?: Array<{ id: string; label?: string; tokens?: number }>;
+    total_tokens?: number;
+  } | null;
 };
 
 export type TreeEntry = {

--- a/apps/viewer/src/pages/TrialDetailPage.tsx
+++ b/apps/viewer/src/pages/TrialDetailPage.tsx
@@ -6,6 +6,7 @@ import { Shell } from "@/components/layout";
 import { ActorsTable } from "@/components/trial/actors-table";
 import { EvidenceTabs } from "@/components/trial/evidence-tabs";
 import { OutcomeStrip } from "@/components/trial/outcome-strip";
+import { PhaseTimingBar } from "@/components/trial/phase-timing-bar";
 import { TrialHeader } from "@/components/trial/trial-header";
 import { useTrialDetail } from "@/hooks/use-trial-detail";
 
@@ -77,6 +78,11 @@ export function TrialDetailPage() {
         {!loading && !error && trial && (
           <>
             <OutcomeStrip trial={trial} />
+
+            <PhaseTimingBar
+              phaseTiming={trial.phase_timing}
+              tokenTiming={trial.token_timing}
+            />
 
             {trial.actors && trial.actors.length > 0 ? (
               <ActorsTable actors={trial.actors} />

--- a/docs/design/02-task-package-and-config.md
+++ b/docs/design/02-task-package-and-config.md
@@ -188,7 +188,7 @@ Package 里的自然语言按读者与用途分层，**不**强制存在根级 `
 | harness / evaluator / gold / intent `limits` / 角色槽拓扑 | **Task / package 身份** | 改了 ≈ 新 task 或新 version |
 | agent entry + model（`profiles.yaml` / CLI overlay） | **Job binding** | 新 `config_fingerprint` |
 | host secrets（`.env` 值） | 本机 only | 不进 fingerprint / lock / upload |
-| suite concurrency / pre–pass@k `n_attempts` | CLI / job 调度 | **不是**排行榜维度 |
+| suite concurrency / Always-k `n_attempts`（及 pass@k job 指标） | CLI / job 调度；**禁止**写进 `task.yaml` | **不是**排行榜身份键（metrics 另列；Hub 呈现见 #60） |
 
 **Merge 顺序（Config Core 唯一读者）：**
 
@@ -608,27 +608,31 @@ bora lock|run <path|ref> --task <id>      # ref 经 verified cache 后走 Databa
 
 ## Suite 执行 vs Campaign
 
-| | Suite run | Campaign |
-| --- | --- | --- |
-| 轴 | 同一 Database 的 **task_id** | 同一 task 的 **parameter matrix** |
-| CLI | `bora run <database> [--task] [--max-concurrent-tasks N]` | `bora campaign … --matrix` |
-| PASS | **仅** per-task evaluator；无 suite PASS | 每 variant 独立 Trial PASS |
-| 失败 | 默认不取消其余 task | 既有 campaign 策略 |
+| | Suite run | Campaign | Always-k |
+| --- | --- | --- | --- |
+| 轴 | 同一 Database 的 **task_id** | 同一 task 的 **parameter matrix** | 每 task **k 次独立 Attempt** |
+| CLI | `bora run <database> [--task] [--max-concurrent-tasks N] [-k N] [--resume-suite id]` | `bora campaign … --matrix` | 同上 `-k` / `--n-attempts`（**非** matrix） |
+| PASS | **仅** per-task evaluator；无 suite PASS | 每 variant 独立 Trial PASS | 仍仅 per-Attempt evaluator；job 再算 pass@k |
+| 失败 | 默认可 `bora cancel suite_…` 停新 unit | 既有 campaign 策略 | 补跑只追加 Attempt |
 
-Summary 写在 Database 根：`.bora/suite-runs/<suite_run_id>/summary.json`。
+Summary 写在 Database 根：`.bora/suite-runs/<suite_run_id>/summary.json`（另有 `progress.json`；cancel 可写 `cancel.requested`）。
 
 ### Suite metrics（观测聚合，非 PASS 权威）
 
 Suite summary 含 `metrics` 对象（`bora.suite.summary/1` 附加字段），供 job/dataset 级展示与 Registry suite-result 上传：
 
-| 字段 | 公式 |
+| 字段 | 公式 / 语义 |
 | --- | --- |
-| `pass_rate` | `count(status==PASS) / n_tasks` |
+| `pass_rate` | `count(status==PASS) / n_tasks`（一 task 多 Attempt 时，按实现的 task 行聚合规则） |
 | `mean_score` | 各 task `score` 的算术平均；**缺 score / 非数值 / status=ERROR → 0.0**（Harbor 缺 reward 当 0） |
 | `n_tasks` / `n_pass` / `n_fail` / `n_error` | 计数；未知 status 计入 `n_error` |
 | `missing_score_as` | 固定 `0.0`（文档化默认） |
+| `n_attempts` | 本次 job 的 Always-k 预算（CLI/job；**不进** fingerprint） |
+| `pass_at_k` | **pass@k**：无偏估计 \(1 - C(n-c,k)/C(n,k)\)（Harbor / Chen）；suite 分 = **对 task 取 mean**；`n < k` 的 task 不进该 k 分母 |
+| `pass_power_k` | **pass^k**：\((c/n)^k\)（k 次都成功）；同样对 task 取 mean |
 
-**禁止** suite-level PASS 字段作为最终权威；PASS 仅 per-task evaluator。`exit_code` 与 `counts` 仍是操作者退出/计数语义，不是榜单 PASS。
+**禁止** suite-level PASS 字段作为最终权威；PASS 仅 per-task evaluator。`exit_code` 与 `counts` 仍是操作者退出/计数语义，不是榜单 PASS。  
+pass@k / pass^k **不是** package 身份键；Hub Leaderboard 列呈现为 follow-up（#60）。
 
 ### Suite/job 结果上传（Registry）
 

--- a/docs/design/05-runtime/campaign-suite.md
+++ b/docs/design/05-runtime/campaign-suite.md
@@ -48,7 +48,7 @@ Variant 是 Config Core 的显式输入。它不会成为 Task Package 内第二
 
 - **Always-k**：范围内每 task 固定产出 k 个独立 Attempt（并列或链均可；**不许**改旧 Attempt）。
 - **pass@k**：无偏估计（Harbor）；**pass^k**：\((c/n)^k\)；suite / dataset 分 = 各 task 指标的 **mean**（样本不够的 task 不进该 k 分母）。
-- **补跑**：`--resume-suite` 跳过已完成 `(task_id, attempt_index)`，**追加** Attempt 后重算 metrics。
+- **补跑**：`--resume-suite` 跳过**真实跑完**的 `(task_id, attempt_index)`，**追加** Attempt 后重算 metrics；suite **cancel 占位**（未真正执行）在 resume 时会**重跑**（避免永久压低 pass@k / pass^k），并清除 `cancel.requested`。
 - **进度 / 取消**：suite `progress.json`；`bora status|cancel suite_…`（可选 `--database`）。
 - **阶段耗时**：Attempt `phase_timing`（prepare / run / evaluate / cleanup），服务进度与 Viewer/Hub Timing 条；不替代 PASS。
 

--- a/docs/design/05-runtime/campaign-suite.md
+++ b/docs/design/05-runtime/campaign-suite.md
@@ -28,23 +28,34 @@ variants:
 
 Variant 是 Config Core 的显式输入。它不会成为 Task Package 内第二份被 Harness 直接读取的配置。
 
-## Campaign vs Suite
+## Campaign vs Suite vs Always-k
 
 | 轴 | 含义 | 典型入口 |
 | --- | --- | --- |
-| **Suite / Database 成员轴** | 同一 Database 下按 **task_id** 调度多个成员 | `bora` suite / 批量 task 选择（以 CLI 为准） |
-| **Campaign / matrix 轴** | 同一 task 的 **parameter / profile matrix** | `bora campaign` |
+| **Suite / Database 成员轴** | 同一 Database 下按 **task_id** 调度多个成员 | `bora run`（省略 `--task`） |
+| **Campaign / matrix 轴** | 同一 task 的 **parameter / profile / binding matrix** | `bora campaign` |
+| **Always-k / k-attempt 轴** | 范围内每个 task **固定 k 次独立 Attempt**，为 pass@k / pass^k 攒样本 | `bora run … -k` / `--n-attempts`；可选 `--resume-suite` |
 
-二者**设计正交**：
+三者**设计正交**：
 
 - Suite 不负责改写 profile 的 experiment matrix；
 - Campaign 不合并进 Attempt 内 Harness workflow scheduler；
-- 两者都消费 Config Core 的 `load_and_lock`，不维护第二份真配置。
+- Always-k **不是** campaign matrix 字段，也**禁止**写进 `task.yaml` / `config_fingerprint`；
+- 并行（`max_concurrent_tasks`）只压缩**总耗时**，不改变 k，也不改变 PASS 判定；
+- 三者都消费 Config Core 的 `load_and_lock`，不维护第二份真配置。
+
+### Always-k 与 job 指标（#47）
+
+- **Always-k**：范围内每 task 固定产出 k 个独立 Attempt（并列或链均可；**不许**改旧 Attempt）。
+- **pass@k**：无偏估计（Harbor）；**pass^k**：\((c/n)^k\)；suite / dataset 分 = 各 task 指标的 **mean**（样本不够的 task 不进该 k 分母）。
+- **补跑**：`--resume-suite` 跳过已完成 `(task_id, attempt_index)`，**追加** Attempt 后重算 metrics。
+- **进度 / 取消**：suite `progress.json`；`bora status|cancel suite_…`（可选 `--database`）。
+- **阶段耗时**：Attempt `phase_timing`（prepare / run / evaluate / cleanup），服务进度与 Viewer/Hub Timing 条；不替代 PASS。
 
 Summary / suite-run 布局见 [02-task-package-and-config.md](../02-task-package-and-config.md)（Database Registry 与 Suite 轴）。
 
 ## 多 Attempt / 重试（设计契约）
 
-- 重试、矩阵单元、取消后的再跑 → **新 Attempt identity**；
+- 重试、矩阵单元、Always-k 样本、取消后的再跑 → **新 Attempt identity**；
 - 不静默改写旧 Attempt 的 score 或 identity；
-- multi-attempt 编排细节（并行度、配额）属 Application / Campaign 实现面；稳定不变量见 [lifecycle.md](lifecycle.md)。
+- multi-attempt 编排细节（并行度、k、resume）属 Application / CLI job 参数面；稳定不变量见 [lifecycle.md](lifecycle.md)。

--- a/docs/design/05-runtime/lifecycle.md
+++ b/docs/design/05-runtime/lifecycle.md
@@ -74,6 +74,20 @@ created
   → terminal       # succeeded | failed | cancelled | …
 ```
 
+## 阶段耗时（观测，#47 D）
+
+Runtime 在 Attempt 边界记录标准阶段墙钟，写入 `result.json` 的 `phase_timing`（schema `bora.phase_timing/1`）：
+
+| 阶段 id | 含义（展示标签可映射） |
+| --- | --- |
+| `prepare` | lock / Provider / Environment 准备 |
+| `run` | Harness / Agent 执行 |
+| `evaluate` | barrier 后独立评测 |
+| `cleanup` | teardown / 收尾 |
+
+- 服务 suite 进度、Viewer/Hub Timing 条与 job 复盘；**不**参与 PASS 判定。  
+- L0 与 L1 SDK 路径均应落盘；缺字段时 UI 可不渲染 Timing，禁止用假数据回填。
+
 ## 不变量
 
 1. `LockedTaskConfig` 在 Attempt 前形成，运行中不热更新；

--- a/skills/bora-cli/SKILL.md
+++ b/skills/bora-cli/SKILL.md
@@ -34,12 +34,14 @@ uv run bora --help
 | `bora lock ... --set /parameters/seed=7`                   | Allowlisted override                                                 |
 | `bora lock/run ... --profiles path/to/profiles.yaml`       | Alternate job binding file (replaces Database `profiles.yaml`)       |
 | `bora run <package> --task <id>`                           | One foreground Attempt                                               |
+| `bora run <package> [-k N] [--max-concurrent-tasks N]`     | Suite / Always-k job (`-k` = `--n-attempts`; CLI only)               |
+| `bora run … --resume-suite suite_<id> [--task id] -k N`  | Append Attempts into existing suite job; recompute pass@k / pass^k   |
 | `bora run ... --set '/bindings/solver/options/entry="pi"'` | Job binding override (entry/model; #59)                              |
-| `bora campaign <package> --task <id> --matrix ...`         | Serial matrix (`/parameters/*` or `/bindings/<role>/…`)               |
+| `bora campaign <package> --task <id> --matrix ...`         | Serial matrix (`/parameters/*` or `/bindings/<role>/…`); ≠ Always-k  |
 | `bora evidence <logs-path> --out <dir>`                    | Sealed trajectory export (no score change)                           |
 | `bora results upload-suite …`                              | Suite aggregates → Registry (includes job_overlay when present)      |
 | `bora results export-profiles <suite_run_id> --out …`      | Rehydrate job binding as profiles.yaml (#59; locators only)          |
-| `bora submit` / `bora status` / `bora cancel`              | Durable control sketch (v0.12)                                       |
+| `bora submit` / `bora status` / `bora cancel`              | Durable Run **or suite job** (`suite_…`; status/cancel may take `--database`) |
 
 Discover flags with `uv run bora <cmd> --help`. Source of truth: `src/bora/cli/main.py`.
 
@@ -96,11 +98,23 @@ Value after `=` is JSON (strings need quotes):
 
 ## Interpret `bora run` JSON
 
-Typical stdout fields: `status`, `score`, `assurance`, `agent_invocations`, `evidence_path`, **`logs`** (Attempt evidence root).
+**Single Attempt** (`--task` and default `-k 1`, no resume): typical fields `status`, `score`, `assurance`, `agent_invocations`, `evidence_path`, **`logs`** (Attempt evidence root).
 
 - Inspect trajectory: open `$logs/agent/invocations/<nnnn>-*/trajectory.jsonl` (**turn-level** training rows) and `events.jsonl` (optional stream/debug)
 - Export: `uv run bora evidence "$logs" --out /tmp/bora-export`
 - Trajectory presence **never** upgrades score
+
+**Suite / Always-k** (omit `--task`, or `-k` > 1, or `--resume-suite`): job under `.bora/suite-runs/<suite_run_id>/`.
+
+| Path | Content |
+| --- | --- |
+| `summary.json` → `metrics` | `pass_rate`, `mean_score`, `pass_at_k`, `pass_power_k`, `n_attempts` |
+| `progress.json` | Multi-unit progress |
+| Attempt `result.json` | May include `phase_timing` (prepare/run/evaluate/cleanup) |
+
+- pass@k / pass^k are **job** metrics (mean over tasks); **not** package identity / fingerprint  
+- `n_attempts` is **CLI/job only** — never invent a `task.yaml` field  
+- Concurrency (`--max-concurrent-tasks`) only speeds scheduling
 
 ## Offline / fail-closed
 

--- a/skills/bora-cli/references/commands.md
+++ b/skills/bora-cli/references/commands.md
@@ -33,14 +33,21 @@ Stdout JSON (high level):
 
 ## `bora run`
 
-- One foreground Attempt via production composition root.
-- Creates evidence under package `.bora/runs/...` unless overridden internally.
-- `logs` is absolute path to Attempt evidence root when available.
+- One foreground Attempt via production composition root **when** `--task` is set, `-k` defaults to 1, and no `--resume-suite`.
+- Creates evidence under package `tasks/<id>/.bora/runs/...` unless overridden internally.
+- `logs` is absolute path to Attempt evidence root when available (single-Attempt path).
+- **Always-k** (`--n-attempts` / `-k`, integer ≥1): fixed k independent Attempts per task in scope.
+  CLI/job only — not `task.yaml`, not `config_fingerprint`. Feeds `metrics.pass_at_k` / `pass_power_k`.
+- **Suite**: omit `--task` → all members; also used as the job container when `k>1` or resume.
+- **`--max-concurrent-tasks`**: speeds wall time only; does not change k or PASS.
+- **`--resume-suite <suite_run_id>`**: skip finished `(task_id, attempt_index)`, append Attempts, recompute metrics.
+- Suite artifacts: `.bora/suite-runs/<id>/summary.json`, `progress.json`.
 - Per invocation (ACP path): `agent/invocations/<nnnn>-*/trajectory.jsonl` is **turn-level**
   (user + merged assistant/thought + terminal). Stream chunks are not the training default;
   see `docs/design/05-runtime/evidence.md`.
 - Docker packages use L1 path when `provider.kind: docker` (ACP via parent client +
   `docker exec` placement for coding entries).
+- Attempt `result.json` may include `phase_timing` (`prepare` / `run` / `evaluate` / `cleanup`).
 
 ## `bora evidence`
 
@@ -56,4 +63,13 @@ Stdout JSON (high level):
 
 ## Control surface
 
-- `submit` / `status` / `cancel` operate on ControlStore records (sketch maturity).
+- `submit` / `status` / `cancel` operate on ControlStore records.
+- **Suite jobs** (`suite_…`): `status` / `cancel` accept optional `--database` to read
+  `progress.json` or write `cancel.requested` when ControlStore has no row.
+- Suite cancel: stop scheduling new units; SIGTERM stored pid when present.
+
+## Always-k vs campaign
+
+- **Always-k** (`bora run -k`): repeat independent Attempts for pass@k samples.
+- **Campaign** (`bora campaign --matrix`): sweep allowlisted parameters / bindings on one task.
+- Do not treat matrix axes as `n_attempts`.

--- a/skills/bora-config-package/SKILL.md
+++ b/skills/bora-config-package/SKILL.md
@@ -46,9 +46,10 @@ database_id: org/my-suite
 version: "0.1.0"
 tasks:
   root: tasks
-# optional defaults (suite scheduling only):
+# optional defaults (suite scheduling only — not Always-k):
 # defaults:
 #   max_concurrent_tasks: 1
+# n_attempts / -k is CLI/job only — never a package field
 ```
 
 ## Minimal member `task.yaml` skeleton (role slots only)
@@ -145,7 +146,7 @@ bindings:
 
 ### Suite summary 自检字段
 
-`bora suite` / suite run 结束写入 `.bora/suite-runs/<id>/summary.json`：
+`bora run` suite / Always-k 结束写入 `.bora/suite-runs/<id>/summary.json`：
 
 | 字段 | 含义 |
 | --- | --- |
@@ -153,8 +154,13 @@ bindings:
 | `config_homogeneous` | suite 级 job 轴（`profiles.yaml` / `job_overlay`）一致 → `true`；角色槽拓扑不同**不**算不一致 |
 | `actors_summary` | `[{profile_id, entry, model}, …]` |
 | `agent_label` / `model_label` | 同构时从 actors 派生；异构时留空 |
+| `metrics.pass_rate` / `mean_score` | 观测聚合（非 suite PASS） |
+| `metrics.pass_at_k` / `pass_power_k` | Always-k job 指标（按 task mean）；**不进** fingerprint |
+| `metrics.n_attempts` | job k 预算（CLI only） |
 
-Upload（`bora results upload-suite`）**投影**这些字段到 Registry；Hub **不**在 upload 时解 tar 硬提配置。
+**禁止**在 `task.yaml` / `bora.yaml` 增加 `n_attempts`。Always-k 只走 `bora run -k` / job 参数。
+
+Upload（`bora results upload-suite`）**投影**这些字段到 Registry；Hub **不**在 upload 时解 tar 硬提配置。Hub 榜 pass@k 列见 #60。
 
 **Hub Leaderboard 消费（#40）：**
 

--- a/src/bora/application/phase_timing.py
+++ b/src/bora/application/phase_timing.py
@@ -155,7 +155,9 @@ def phase_facts_to_timing(phase_facts: Sequence[Any]) -> dict[str, Any]:
     rows: list[dict[str, Any]] = []
     for fact in phase_facts:
         phase = getattr(fact, "phase", None)
-        pid = phase.value if hasattr(phase, "value") else str(phase or "")
+        # Enum PhaseFact.phase → .value; avoid optional member access for pyright.
+        raw_id = getattr(phase, "value", None) if phase is not None else None
+        pid = str(raw_id if raw_id is not None else (phase or ""))
         ms = getattr(fact, "duration_ms", None)
         if ms is None:
             detail = getattr(fact, "detail", None) or {}

--- a/src/bora/application/phase_timing.py
+++ b/src/bora/application/phase_timing.py
@@ -1,0 +1,188 @@
+"""Attempt / job phase wall-time recording (#47 D).
+
+Standard display phases (Harbor-like labels; BORA keys underneath):
+
+- ``prepare``  — Env / lock / provider / agent service setup
+- ``run``      — Harness (agent execution)
+- ``evaluate`` — Seal inputs + independent evaluator (+ bind)
+- ``cleanup``  — Teardown
+
+Metrics are observational only — never PASS authority, never fingerprint.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any
+
+# Canonical order for bars / summary.
+STANDARD_PHASES: tuple[str, ...] = ("prepare", "run", "evaluate", "cleanup")
+
+# Harbor-ish labels for UI (keys stay stable for APIs).
+PHASE_LABELS: dict[str, str] = {
+    "prepare": "Env Setup",
+    "run": "Agent Execution",
+    "evaluate": "Verifier",
+    "cleanup": "Cleanup",
+    # Lifecycle-internal names (coordinator) map into the four buckets.
+    "seal": "Verifier",
+    "bind": "Verifier",
+}
+
+# Map fine-grained lifecycle phases → display buckets.
+_BUCKET: dict[str, str] = {
+    "prepare": "prepare",
+    "run": "run",
+    "seal": "evaluate",
+    "evaluate": "evaluate",
+    "bind": "evaluate",
+    "cleanup": "cleanup",
+}
+
+
+@dataclass
+class PhaseTimer:
+    """Accumulate wall durations for named phases (monotonic clock)."""
+
+    _clock: Any = field(default=time.monotonic, repr=False)
+    _segments: dict[str, float] = field(default_factory=dict)
+    _started_at_wall: float | None = None
+    _finished_at_wall: float | None = None
+
+    def __post_init__(self) -> None:
+        self._started_at_wall = time.time()
+
+    @contextmanager
+    def phase(self, name: str) -> Iterator[None]:
+        """Time a phase; nested/re-entry adds to the same key."""
+        key = str(name or "").strip() or "unknown"
+        t0 = self._clock()
+        try:
+            yield
+        finally:
+            dt_ms = max(0.0, (self._clock() - t0) * 1000.0)
+            self._segments[key] = self._segments.get(key, 0.0) + dt_ms
+
+    def add_ms(self, name: str, duration_ms: float) -> None:
+        key = str(name or "").strip() or "unknown"
+        if duration_ms < 0:
+            duration_ms = 0.0
+        self._segments[key] = self._segments.get(key, 0.0) + float(duration_ms)
+
+    def finish(self) -> None:
+        self._finished_at_wall = time.time()
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serializable ``phase_timing`` block for result / summary / suite."""
+        self.finish()
+        phases = [
+            {
+                "id": name,
+                "label": PHASE_LABELS.get(name, name),
+                "duration_ms": round(self._segments.get(name, 0.0), 3),
+            }
+            for name in STANDARD_PHASES
+            if name in self._segments
+        ]
+        # Include any non-standard keys (e.g. environment-only) after standard.
+        for name, ms in self._segments.items():
+            if name in STANDARD_PHASES:
+                continue
+            phases.append(
+                {
+                    "id": name,
+                    "label": PHASE_LABELS.get(name, name),
+                    "duration_ms": round(ms, 3),
+                }
+            )
+        total = sum(float(p["duration_ms"]) for p in phases)
+        return {
+            "schema": "bora.phase_timing/1",
+            "phases": phases,
+            "total_ms": round(total, 3),
+            "started_at": (
+                time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(self._started_at_wall))
+                if self._started_at_wall is not None
+                else None
+            ),
+            "finished_at": (
+                time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(self._finished_at_wall))
+                if self._finished_at_wall is not None
+                else None
+            ),
+        }
+
+
+def bucket_phase_timing(raw_phases: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Collapse fine-grained phase rows into the four display buckets."""
+    buckets: dict[str, float] = {k: 0.0 for k in STANDARD_PHASES}
+    for row in raw_phases:
+        if not isinstance(row, Mapping):
+            continue
+        pid = str(row.get("id") or row.get("phase") or "").strip()
+        ms = row.get("duration_ms")
+        if not isinstance(ms, int | float) or isinstance(ms, bool):
+            continue
+        bucket = _BUCKET.get(pid, pid if pid in STANDARD_PHASES else None)
+        if bucket is None:
+            continue
+        buckets[bucket] = buckets.get(bucket, 0.0) + float(ms)
+    phases = [
+        {
+            "id": name,
+            "label": PHASE_LABELS.get(name, name),
+            "duration_ms": round(buckets[name], 3),
+        }
+        for name in STANDARD_PHASES
+        if buckets.get(name, 0.0) > 0 or name in buckets
+    ]
+    # Drop zero-only trailing noise: keep zeros only if something else exists.
+    if any(p["duration_ms"] > 0 for p in phases):
+        phases = [p for p in phases if p["duration_ms"] > 0 or p["id"] in ("prepare", "run")]
+    total = sum(float(p["duration_ms"]) for p in phases)
+    return {
+        "schema": "bora.phase_timing/1",
+        "phases": phases,
+        "total_ms": round(total, 3),
+    }
+
+
+def phase_facts_to_timing(phase_facts: Sequence[Any]) -> dict[str, Any]:
+    """Build phase_timing from coordinator ``PhaseFact`` rows (duration_ms field)."""
+    rows: list[dict[str, Any]] = []
+    for fact in phase_facts:
+        phase = getattr(fact, "phase", None)
+        pid = phase.value if hasattr(phase, "value") else str(phase or "")
+        ms = getattr(fact, "duration_ms", None)
+        if ms is None:
+            detail = getattr(fact, "detail", None) or {}
+            if isinstance(detail, Mapping):
+                ms = detail.get("duration_ms")
+        if not isinstance(ms, int | float) or isinstance(ms, bool):
+            continue
+        rows.append({"id": pid, "duration_ms": float(ms)})
+    return bucket_phase_timing(rows)
+
+
+def format_duration_ms(ms: float | None) -> str | None:
+    """Human label like Harbor (``1m 12s``, ``4m 27s``, ``830ms``)."""
+    if ms is None or not isinstance(ms, int | float) or isinstance(ms, bool):
+        return None
+    if ms < 0:
+        ms = 0.0
+    if ms < 1000:
+        return f"{int(round(ms))}ms"
+    total_s = ms / 1000.0
+    if total_s < 60:
+        if total_s < 10:
+            return f"{total_s:.1f}s"
+        return f"{int(round(total_s))}s"
+    minutes = int(total_s // 60)
+    seconds = int(round(total_s - minutes * 60))
+    if seconds == 60:
+        minutes += 1
+        seconds = 0
+    return f"{minutes}m {seconds:02d}s" if seconds else f"{minutes}m"

--- a/src/bora/application/run_command.py
+++ b/src/bora/application/run_command.py
@@ -209,8 +209,8 @@ async def run_task(
         # Full L1 orchestration for all docker packages (Spec 07) — no preflight-only PASS.
         from bora.application.run_l1 import run_l1_attempt
 
-        timer.add_ms("prepare", (_mono() - prepare_t0) * 1000.0)
-        l1_t0 = _mono()
+        # L1 owns full prepare/run/evaluate/cleanup timing; do not invent a
+        # coarse parent fallback (that hid missing L1 phase_timing).
         code, result_doc, details = run_l1_attempt(
             package_root=package_root,
             lock=lock,
@@ -218,18 +218,6 @@ async def run_task(
             agent_meta=agent_meta,
             allow_offline_agent=allow_offline_agent,
         )
-        # L1 owns internal phases; if it already wrote phase_timing, keep it.
-        if not isinstance(result_doc.get("phase_timing"), dict):
-            timer.add_ms("run", (_mono() - l1_t0) * 1000.0)
-            result_doc = dict(result_doc)
-            result_doc["phase_timing"] = timer.as_dict()
-            result_path = run_dir / "result.json"
-            if result_path.is_file():
-                with contextlib.suppress(OSError, TypeError, ValueError):
-                    result_path.write_text(
-                        json.dumps(result_doc, sort_keys=True, indent=2) + "\n",
-                        encoding="utf-8",
-                    )
         score_raw = result_doc.get("score")
         score_f = float(score_raw) if isinstance(score_raw, int | float) else None
         metrics_raw = (

--- a/src/bora/application/run_command.py
+++ b/src/bora/application/run_command.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from bora.adapters.package_fs import LocalPackageReader
+from bora.application.phase_timing import PhaseTimer, format_duration_ms
 from bora.application.run_command_environment import prepare_postgresql_environment
 from bora.application.run_command_evaluator import run_evaluator_worker
 from bora.application.run_harness import run_harness_package
@@ -85,6 +86,7 @@ async def run_task(
     assurance = "l0"
     l1_meta: dict[str, Any] = {}
     evidence_store: AttemptEvidenceStore | None = None
+    timer = PhaseTimer()
 
     # Never trust residual agent materialization from a previous run/package tree.
     agent_file = package_root / ".bora_agent_result.json"
@@ -92,6 +94,10 @@ async def run_task(
         agent_file.unlink()
 
     # Parent Agent Service: non-empty agent_profiles ⇒ harness session/invoke (L0 only).
+    import time as _time_mod
+
+    _mono = _time_mod.monotonic
+    prepare_t0 = _mono()
     profiles = thaw(lock.agent_profiles)
     params = thaw(lock.parameters)
     evaluation = thaw(lock.evaluation)
@@ -173,13 +179,11 @@ async def run_task(
                 lock_doc["job_overlay"] = thaw(lock.job_overlay)
             evidence_store.write_lock_summary(lock_doc)
         # Wall hard ceiling from locked limits (design §13.1): pre-effect deadline.
-        import time as _time
-
         try:
             wall_s = float(thaw(lock.limits).get("wall_time_seconds") or 0)  # type: ignore[union-attr]
         except Exception:
             wall_s = 0.0
-        deadline = (_time.monotonic() + wall_s) if wall_s > 0 else None
+        deadline = (_mono() + wall_s) if wall_s > 0 else None
         agent_service = ParentAgentService(
             profiles=[p for p in profiles if isinstance(p, dict)],
             agent_invocation_limit=inv_limit,
@@ -205,6 +209,8 @@ async def run_task(
         # Full L1 orchestration for all docker packages (Spec 07) — no preflight-only PASS.
         from bora.application.run_l1 import run_l1_attempt
 
+        timer.add_ms("prepare", (_mono() - prepare_t0) * 1000.0)
+        l1_t0 = _mono()
         code, result_doc, details = run_l1_attempt(
             package_root=package_root,
             lock=lock,
@@ -212,6 +218,18 @@ async def run_task(
             agent_meta=agent_meta,
             allow_offline_agent=allow_offline_agent,
         )
+        # L1 owns internal phases; if it already wrote phase_timing, keep it.
+        if not isinstance(result_doc.get("phase_timing"), dict):
+            timer.add_ms("run", (_mono() - l1_t0) * 1000.0)
+            result_doc = dict(result_doc)
+            result_doc["phase_timing"] = timer.as_dict()
+            result_path = run_dir / "result.json"
+            if result_path.is_file():
+                with contextlib.suppress(OSError, TypeError, ValueError):
+                    result_path.write_text(
+                        json.dumps(result_doc, sort_keys=True, indent=2) + "\n",
+                        encoding="utf-8",
+                    )
         score_raw = result_doc.get("score")
         score_f = float(score_raw) if isinstance(score_raw, int | float) else None
         metrics_raw = (
@@ -231,7 +249,11 @@ async def run_task(
             assurance=str(result_doc.get("assurance") or "l0"),
             logs=str(result_doc.get("logs") or run_dir),
         )
-        details = {**details, "logs": flat.logs}
+        details = {
+            **details,
+            "logs": flat.logs,
+            "phase_timing": result_doc.get("phase_timing"),
+        }
         return code, flat, details
 
     # Environment Manager (Spec 09) — resource-type named only (postgresql).
@@ -248,12 +270,15 @@ async def run_task(
             evidence_store=evidence_store,
         )
         if early is not None:
+            timer.add_ms("prepare", (_mono() - prepare_t0) * 1000.0)
             return early
         agent_meta["environment"] = env_meta
         (run_dir / "env_manager.json").write_text(
             json.dumps({"resource_id": env_meta.get("resource_id")}, sort_keys=True) + "\n",
             encoding="utf-8",
         )
+
+    timer.add_ms("prepare", (_mono() - prepare_t0) * 1000.0)
 
     try:
         harness_timeout = (
@@ -268,6 +293,7 @@ async def run_task(
             wall_cap = 0.0
         if wall_cap > 0:
             harness_timeout = min(harness_timeout, wall_cap)
+        run_t0 = _mono()
         harness_out = await run_harness_package(
             lock,
             package_root,
@@ -276,6 +302,7 @@ async def run_task(
             # Reuse ParentAgentService identity so AgentSession + harness share one Attempt.
             attempt=shared_attempt,
         )
+        timer.add_ms("run", (_mono() - run_t0) * 1000.0)
     finally:
         if agent_server is not None:
             agent_server.stop()
@@ -314,6 +341,7 @@ async def run_task(
         harness_kind = str(envelope.get("terminal", {}).get("kind", "unknown"))
 
     # Writer barrier: require published artifacts before evaluator.
+    eval_t0 = _mono()
     published = dict(envelope.get("published") or {})
     eval_inputs = list(evaluation.get("inputs") or [])
     staging = run_dir / "eval_staging"
@@ -347,8 +375,10 @@ async def run_task(
     evaluator_raw: dict[str, Any] | None = None
     if error_phase is None:
         evaluator_raw = run_evaluator_worker(package_root, lock, artifacts_map)
+    timer.add_ms("evaluate", (_mono() - eval_t0) * 1000.0)
 
     # Cleanup agent materialization
+    cleanup_t0 = _mono()
     agent_file = package_root / ".bora_agent_result.json"
     if agent_file.exists():
         agent_file.unlink()
@@ -384,6 +414,7 @@ async def run_task(
                 }
             )
         evidence_locator = evidence_store.locator
+    timer.add_ms("cleanup", (_mono() - cleanup_t0) * 1000.0)
 
     flat = bind_result(
         evaluator_raw=evaluator_raw,
@@ -400,6 +431,9 @@ async def run_task(
     result_doc["assurance"] = assurance
     if l1_meta:
         result_doc["l1"] = l1_meta
+    phase_timing = timer.as_dict()
+    result_doc["phase_timing"] = phase_timing
+    result_doc["duration"] = format_duration_ms(phase_timing.get("total_ms"))
     (run_dir / "result.json").write_text(
         json.dumps(result_doc, sort_keys=True, indent=2) + "\n",
         encoding="utf-8",
@@ -422,6 +456,9 @@ async def run_task(
                     "harness_kind": harness_kind,
                     "logs": evidence_locator,
                     "result": result_doc,
+                    "phase_timing": phase_timing,
+                    "started_at": phase_timing.get("started_at"),
+                    "finished_at": phase_timing.get("finished_at"),
                 }
             )
 
@@ -438,6 +475,8 @@ async def run_task(
         "assurance": assurance,
         "digest": lock.digest,
         "logs": evidence_locator,
+        "phase_timing": phase_timing,
+        "metrics": flat.metrics,
     }
     if l1_meta:
         details["l1"] = l1_meta

--- a/src/bora/application/run_l1.py
+++ b/src/bora/application/run_l1.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from bora.adapters.credential_projection import project_executor_credentials
+from bora.application.phase_timing import PhaseTimer, format_duration_ms
 from bora.application.run_l1_evaluator import run_clean_evaluator_container
 from bora.application.run_l1_evidence import l1_error_result, write_l1_evidence
 from bora.application.run_l1_prepare import (
@@ -26,6 +27,20 @@ from bora.application.run_l1_prepare import (
     prepare_l1_runtime,
     seed_l1_workspace,
 )
+
+
+def _attach_timing(
+    doc: dict[str, Any],
+    details: dict[str, Any],
+    timer: PhaseTimer,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Stamp phase_timing onto result doc + details (and duration label)."""
+    timing = timer.as_dict()
+    doc = dict(doc)
+    doc["phase_timing"] = timing
+    doc["duration"] = format_duration_ms(timing.get("total_ms"))  # type: ignore[arg-type]
+    details = {**details, "phase_timing": timing}
+    return doc, details
 
 
 def run_l1_attempt(
@@ -93,6 +108,7 @@ def run_l1_sdk_session_attempt(
     from bora.runtime.parent_agent_service import ParentAgentService
 
     package_root = package_root.resolve()
+    timer = PhaseTimer()
     params = thaw(lock.parameters)
     profiles = [p for p in thaw(lock.agent_profiles) if isinstance(p, dict)]
     provider_cfg = thaw(lock.provider) if hasattr(lock, "provider") else {}
@@ -109,7 +125,7 @@ def run_l1_sdk_session_attempt(
             implicit_profiles=[str(p.get("id")) for p in profiles if p.get("id")],
         )
     except Exception as exc:  # ConfigError or validation
-        return l1_error_result(
+        code, doc, details = l1_error_result(
             run_dir,
             "config",
             {"error": str(exc), "kind": "agent_isolation_invalid"},
@@ -117,8 +133,11 @@ def run_l1_sdk_session_attempt(
             0,
             kind="agent_isolation_invalid",
         )
+        doc, details = _attach_timing(doc, details, timer)
+        write_l1_evidence(run_dir, doc, agent_meta, doc.get("l1") or {})
+        return code, doc, details
     if topology is None:
-        return l1_error_result(
+        code, doc, details = l1_error_result(
             run_dir,
             "config",
             {"error": "missing agent topology"},
@@ -126,179 +145,187 @@ def run_l1_sdk_session_attempt(
             0,
             kind="agent_isolation_invalid",
         )
+        doc, details = _attach_timing(doc, details, timer)
+        write_l1_evidence(run_dir, doc, agent_meta, doc.get("l1") or {})
+        return code, doc, details
 
-    docker, runtime, l1_meta = prepare_l1_runtime(
-        package_root, lock, run_dir, network_mode=network_mode
-    )
-    assert runtime.workdir_host is not None
-    assert runtime.attempt is not None
+    with timer.phase("prepare"):
+        docker, runtime, l1_meta = prepare_l1_runtime(
+            package_root, lock, run_dir, network_mode=network_mode
+        )
+        assert runtime.workdir_host is not None
+        assert runtime.attempt is not None
 
-    workspace_host = runtime.workdir_host / "workspace"
-    seed_l1_workspace(
-        package_root=package_root,
-        workspace_host=workspace_host,
-        allow_offline_agent=allow_offline_agent,
-        l1_meta=l1_meta,
-    )
+        workspace_host = runtime.workdir_host / "workspace"
+        seed_l1_workspace(
+            package_root=package_root,
+            workspace_host=workspace_host,
+            allow_offline_agent=allow_offline_agent,
+            l1_meta=l1_meta,
+        )
 
-    # Reuse prepare attempt identity for ParentAgentService + harness.
-    attempt_ident = runtime.attempt
-    run_ident = attempt_ident.trial.run
-    trial_ident = attempt_ident.trial
+        # Reuse prepare attempt identity for ParentAgentService + harness.
+        attempt_ident = runtime.attempt
+        run_ident = attempt_ident.trial.run
+        trial_ident = attempt_ident.trial
 
-    evidence_store = AttemptEvidenceStore(
-        root=run_dir,
-        attempt_id=attempt_ident.value,
-        run_id=run_ident.value,
-    )
-    with contextlib.suppress(Exception):
-        from bora.config.model import thaw as _thaw_lock
+        evidence_store = AttemptEvidenceStore(
+            root=run_dir,
+            attempt_id=attempt_ident.value,
+            run_id=run_ident.value,
+        )
+        with contextlib.suppress(Exception):
+            from bora.config.model import thaw as _thaw_lock
 
-        lock_doc: dict[str, Any] = {
-            "digest": lock.digest,
-            "task_id": lock.task_id,
-            "topology": topology.public_summary(),
-            "profiles": [
-                {
-                    "id": p.get("id"),
-                    "executor": p.get("executor"),
-                    "model": p.get("model"),
-                    **(
-                        {"options": {"entry": (p.get("options") or {}).get("entry")}}
-                        if isinstance(p.get("options"), dict)
-                        and (p.get("options") or {}).get("entry") is not None
-                        else {}
-                    ),
-                }
-                for p in profiles
-            ],
+            lock_doc: dict[str, Any] = {
+                "digest": lock.digest,
+                "task_id": lock.task_id,
+                "topology": topology.public_summary(),
+                "profiles": [
+                    {
+                        "id": p.get("id"),
+                        "executor": p.get("executor"),
+                        "model": p.get("model"),
+                        **(
+                            {"options": {"entry": (p.get("options") or {}).get("entry")}}
+                            if isinstance(p.get("options"), dict)
+                            and (p.get("options") or {}).get("entry") is not None
+                            else {}
+                        ),
+                    }
+                    for p in profiles
+                ],
+            }
+            if lock.provenance is not None:
+                lock_doc["provenance"] = _thaw_lock(lock.provenance)
+            if lock.job_overlay is not None:
+                lock_doc["job_overlay"] = _thaw_lock(lock.job_overlay)
+            evidence_store.write_lock_summary(lock_doc)
+
+        cred = project_executor_credentials(work_root=runtime.workdir_host)
+        l1_meta["credential_projection"] = {
+            "keys": list(cred.locator_keys),
+            "has_material": cred.has_material,
         }
-        if lock.provenance is not None:
-            lock_doc["provenance"] = _thaw_lock(lock.provenance)
-        if lock.job_overlay is not None:
-            lock_doc["job_overlay"] = _thaw_lock(lock.job_overlay)
-        evidence_store.write_lock_summary(lock_doc)
+        l1_meta["isolation"] = topology.public_summary()
+        l1_meta["scheduling"] = "sdk_session"
+        l1_meta["residual_one_shot"] = False
 
-    cred = project_executor_credentials(work_root=runtime.workdir_host)
-    l1_meta["credential_projection"] = {
-        "keys": list(cred.locator_keys),
-        "has_material": cred.has_material,
-    }
-    l1_meta["isolation"] = topology.public_summary()
-    l1_meta["scheduling"] = "sdk_session"
-    l1_meta["residual_one_shot"] = False
-
-    try:
-        ledger = docker.prepare_agent_targets(
-            runtime,
-            topology,
-            cred_root=cred.root,
-            network_mode=network_mode,
-        )
-    except Exception as exc:  # noqa: BLE001
-        docker.cleanup(runtime)
-        cred.cleanup()
-        return l1_error_result(
-            run_dir,
-            "provider",
-            {**l1_meta, "prepare_error": type(exc).__name__, "message": str(exc)[:500]},
-            agent_meta,
-            0,
-            kind="target_prepare_failed",
-        )
-
-    l1_meta["targets"] = [t.public_view() for t in ledger.targets.values()]
-    l1_meta["actors"] = [a.public_view() for a in ledger.actors.values()]
-
-    def validate_actor_profile(actor_id: str, profile_id: str) -> dict[str, Any]:
-        if not topology.allowed_profile(actor_id, profile_id):
-            if topology.actor(actor_id) is None:
-                return {"ok": False, "error": "unknown_actor"}
-            return {"ok": False, "error": "profile_not_allowed"}
-        binding = ledger.actors.get(actor_id)
-        if binding is None:
-            return {"ok": False, "error": "unknown_actor"}
-        target = ledger.targets.get(binding.target_id)
-        if target is None or target.state != "ready":
-            return {"ok": False, "error": "target_dead"}
-        return {
-            "ok": True,
-            "target_id": binding.target_id,
-            "generation": binding.generation,
-        }
-
-    make_target_executor = make_l1_target_executor_factory(ledger=ledger, profiles=profiles)
-
-    limits: dict[str, Any] = {}
-    try:
-        raw_limits = thaw(lock.limits) if hasattr(lock, "limits") else {}
-        if isinstance(raw_limits, dict):
-            limits = raw_limits
-    except Exception:
-        limits = {}
-    try:
-        inv_limit = int(limits.get("agent_invocations") or 1)
-    except Exception:
-        inv_limit = 1
-    try:
-        wall_s = float(limits.get("wall_time_seconds") or 0)
-    except Exception:
-        wall_s = 0.0
-    deadline = (time.monotonic() + wall_s) if wall_s > 0 else None
-
-    def _host_resolve(*_a: Any, **_k: Any) -> Any:
-        # L1 path must never call host CLI — mark counter and fail.
-        ledger.host_fallback_count += 1
-        raise RuntimeError("host_fallback_forbidden")
-
-    agent_service = ParentAgentService(
-        profiles=profiles,
-        agent_invocation_limit=inv_limit,
-        resolve_executor=_host_resolve,
-        attempt_id=attempt_ident.value,
-        evidence_store=evidence_store,
-        deadline_monotonic=deadline,
-        require_actor_id=True,
-        validate_actor_profile=validate_actor_profile,
-        make_target_executor=make_target_executor,
-        l1_container_only=True,
-    )
-    short = Path(tempfile.gettempdir()) / f"bora-ags-{run_ident.value[:12]}.sock"
-    agent_server = AgentServiceServer(agent_service, short)
-    agent_server.start()
-
-    agent_meta = {
-        **agent_meta,
-        "mode": "parent_agent_service_l1",
-        "attempt_id": attempt_ident.value,
-        "trial_id": trial_ident.value,
-        "run_id": run_ident.value,
-        "executor_containment": "attempt-container",
-        "scheduling": "sdk_session",
-    }
-
-    try:
-        harness_timeout = float(params.get("harness_timeout_seconds") or 360.0)
-        if wall_s > 0:
-            harness_timeout = min(harness_timeout, wall_s)
-        harness_coro = run_harness_package(
-            lock,
-            package_root,
-            timeout_seconds=harness_timeout,
-            agent_service_sock=str(short),
-            attempt=attempt_ident,
-            workspace_root=workspace_host,
-        )
-        # run_task is already async; nest safely without asyncio.run in-loop.
         try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            harness_out = asyncio.run(harness_coro)
-        else:
-            import concurrent.futures
+            ledger = docker.prepare_agent_targets(
+                runtime,
+                topology,
+                cred_root=cred.root,
+                network_mode=network_mode,
+            )
+        except Exception as exc:  # noqa: BLE001
+            docker.cleanup(runtime)
+            cred.cleanup()
+            code, doc, details = l1_error_result(
+                run_dir,
+                "provider",
+                {**l1_meta, "prepare_error": type(exc).__name__, "message": str(exc)[:500]},
+                agent_meta,
+                0,
+                kind="target_prepare_failed",
+            )
+            doc, details = _attach_timing(doc, details, timer)
+            write_l1_evidence(run_dir, doc, agent_meta, doc.get("l1") or {})
+            return code, doc, details
 
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                harness_out = pool.submit(asyncio.run, harness_coro).result()
+        l1_meta["targets"] = [t.public_view() for t in ledger.targets.values()]
+        l1_meta["actors"] = [a.public_view() for a in ledger.actors.values()]
+
+        def validate_actor_profile(actor_id: str, profile_id: str) -> dict[str, Any]:
+            if not topology.allowed_profile(actor_id, profile_id):
+                if topology.actor(actor_id) is None:
+                    return {"ok": False, "error": "unknown_actor"}
+                return {"ok": False, "error": "profile_not_allowed"}
+            binding = ledger.actors.get(actor_id)
+            if binding is None:
+                return {"ok": False, "error": "unknown_actor"}
+            target = ledger.targets.get(binding.target_id)
+            if target is None or target.state != "ready":
+                return {"ok": False, "error": "target_dead"}
+            return {
+                "ok": True,
+                "target_id": binding.target_id,
+                "generation": binding.generation,
+            }
+
+        make_target_executor = make_l1_target_executor_factory(ledger=ledger, profiles=profiles)
+
+        limits: dict[str, Any] = {}
+        try:
+            raw_limits = thaw(lock.limits) if hasattr(lock, "limits") else {}
+            if isinstance(raw_limits, dict):
+                limits = raw_limits
+        except Exception:
+            limits = {}
+        try:
+            inv_limit = int(limits.get("agent_invocations") or 1)
+        except Exception:
+            inv_limit = 1
+        try:
+            wall_s = float(limits.get("wall_time_seconds") or 0)
+        except Exception:
+            wall_s = 0.0
+        deadline = (time.monotonic() + wall_s) if wall_s > 0 else None
+
+        def _host_resolve(*_a: Any, **_k: Any) -> Any:
+            # L1 path must never call host CLI — mark counter and fail.
+            ledger.host_fallback_count += 1
+            raise RuntimeError("host_fallback_forbidden")
+
+        agent_service = ParentAgentService(
+            profiles=profiles,
+            agent_invocation_limit=inv_limit,
+            resolve_executor=_host_resolve,
+            attempt_id=attempt_ident.value,
+            evidence_store=evidence_store,
+            deadline_monotonic=deadline,
+            require_actor_id=True,
+            validate_actor_profile=validate_actor_profile,
+            make_target_executor=make_target_executor,
+            l1_container_only=True,
+        )
+        short = Path(tempfile.gettempdir()) / f"bora-ags-{run_ident.value[:12]}.sock"
+        agent_server = AgentServiceServer(agent_service, short)
+        agent_server.start()
+
+        agent_meta = {
+            **agent_meta,
+            "mode": "parent_agent_service_l1",
+            "attempt_id": attempt_ident.value,
+            "trial_id": trial_ident.value,
+            "run_id": run_ident.value,
+            "executor_containment": "attempt-container",
+            "scheduling": "sdk_session",
+        }
+
+    try:
+        with timer.phase("run"):
+            harness_timeout = float(params.get("harness_timeout_seconds") or 360.0)
+            if wall_s > 0:
+                harness_timeout = min(harness_timeout, wall_s)
+            harness_coro = run_harness_package(
+                lock,
+                package_root,
+                timeout_seconds=harness_timeout,
+                agent_service_sock=str(short),
+                attempt=attempt_ident,
+                workspace_root=workspace_host,
+            )
+            # run_task is already async; nest safely without asyncio.run in-loop.
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                harness_out = asyncio.run(harness_coro)
+            else:
+                import concurrent.futures
+
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                    harness_out = pool.submit(asyncio.run, harness_coro).result()
     finally:
         agent_server.stop()
         inv_count = agent_service.invocations_completed
@@ -314,95 +341,106 @@ def run_l1_sdk_session_attempt(
         harness_kind = str(envelope["terminal"].get("kind") or harness_kind)
 
     # Materialize published artifacts for clean evaluator.
-    published = envelope.get("published") or {}
-    hold = harness_out.get("artifact_hold")
-    staging = run_dir / "eval_staging"
-    if staging.exists():
-        shutil.rmtree(staging)
-    staging.mkdir(parents=True)
+    with timer.phase("evaluate"):
+        published = envelope.get("published") or {}
+        hold = harness_out.get("artifact_hold")
+        staging = run_dir / "eval_staging"
+        if staging.exists():
+            shutil.rmtree(staging)
+        staging.mkdir(parents=True)
 
-    eval_inputs = thaw(lock.evaluation).get("inputs") or []
-    artifact_filename = "session-output.json"
-    artifact_key = "session-output"
-    if isinstance(eval_inputs, list) and eval_inputs:
-        first = eval_inputs[0]
-        if isinstance(first, dict):
-            artifact_key = str(first.get("artifact") or artifact_key)
-            target = str(first.get("target") or f"artifacts/{artifact_key}.json")
-            artifact_filename = Path(target).name
+        eval_inputs = thaw(lock.evaluation).get("inputs") or []
+        artifact_filename = "session-output.json"
+        artifact_key = "session-output"
+        if isinstance(eval_inputs, list) and eval_inputs:
+            first = eval_inputs[0]
+            if isinstance(first, dict):
+                artifact_key = str(first.get("artifact") or artifact_key)
+                target = str(first.get("target") or f"artifacts/{artifact_key}.json")
+                artifact_filename = Path(target).name
 
-    # Copy from durable hold (run_harness rewrites published to hold paths).
-    src_art: Path | None = None
-    if isinstance(published, dict) and artifact_key in published:
-        cand = Path(str(published[artifact_key]))
-        if cand.is_file():
-            src_art = cand
-    if src_art is None and hold:
-        hold_path = Path(str(hold))
-        for p in hold_path.glob(f"{artifact_key}*"):
-            if p.is_file():
-                src_art = p
-                break
-    if src_art is None or not src_art.is_file():
+        # Copy from durable hold (run_harness rewrites published to hold paths).
+        src_art: Path | None = None
+        if isinstance(published, dict) and artifact_key in published:
+            cand = Path(str(published[artifact_key]))
+            if cand.is_file():
+                src_art = cand
+        if src_art is None and hold:
+            hold_path = Path(str(hold))
+            for p in hold_path.glob(f"{artifact_key}*"):
+                if p.is_file():
+                    src_art = p
+                    break
+        if src_art is None or not src_art.is_file():
+            with timer.phase("cleanup"):
+                docker.cleanup(runtime)
+                cred.cleanup()
+            code, doc, details = l1_error_result(
+                run_dir,
+                "harness" if not envelope.get("ok") else "evaluation_input",
+                {
+                    **l1_meta,
+                    "harness": envelope,
+                    "host_fallback_count": agent_meta.get("host_fallback_count", 0),
+                },
+                agent_meta,
+                inv_count,
+            )
+            doc, details = _attach_timing(doc, details, timer)
+            write_l1_evidence(run_dir, doc, agent_meta, doc.get("l1") or {})
+            return code, doc, details
+
+        (staging / artifact_filename).write_bytes(src_art.read_bytes())
+        eval_py = package_root / "evaluator.py"
+        if eval_py.is_file():
+            (staging / "evaluator.py").write_bytes(eval_py.read_bytes())
+        # Gold materialize for terminal-class packages (never mounted during harness).
+        expected_filename: str | None = None
+        expected_host = package_root / "evaluation" / "expected.json"
+        if expected_host.is_file():
+            (staging / "expected.json").write_bytes(expected_host.read_bytes())
+            expected_filename = "expected.json"
+
+        # Wait for writer stop before evaluator.
+        if not runtime.writer_stop_confirmed:
+            with timer.phase("cleanup"):
+                docker.cleanup(runtime)
+                cred.cleanup()
+            code, doc, details = l1_error_result(
+                run_dir,
+                "evaluation_input",
+                {
+                    **l1_meta,
+                    "error_kind": "residual_writer",
+                    "writer_stop_confirmed": False,
+                },
+                agent_meta,
+                inv_count,
+                kind="residual_writer",
+            )
+            doc, details = _attach_timing(doc, details, timer)
+            write_l1_evidence(run_dir, doc, agent_meta, doc.get("l1") or {})
+            return code, doc, details
+
+        eval_raw, eval_meta = run_clean_evaluator_container(
+            image_tag=runtime.image_lock.image_tag if runtime.image_lock else "bora-attempt:l1",
+            staging=staging,
+            artifact_filename=artifact_filename,
+            artifact_key=artifact_key,
+            expected_filename=expected_filename,
+        )
+        l1_meta["evaluator"] = eval_meta
+        l1_meta["writer_inventory"] = list(runtime.writer_inventory)
+        l1_meta["writer_stop_confirmed"] = runtime.writer_stop_confirmed and bool(
+            eval_meta.get("writer_stop_confirmed")
+        )
+        l1_meta["host_fallback_count"] = int(agent_meta.get("host_fallback_count") or 0)
+        l1_meta["executor_containment"] = "attempt-container"
+        l1_meta["execution_location"] = "attempt-container"
+
+    with timer.phase("cleanup"):
         docker.cleanup(runtime)
         cred.cleanup()
-        return l1_error_result(
-            run_dir,
-            "harness" if not envelope.get("ok") else "evaluation_input",
-            {
-                **l1_meta,
-                "harness": envelope,
-                "host_fallback_count": agent_meta.get("host_fallback_count", 0),
-            },
-            agent_meta,
-            inv_count,
-        )
-
-    (staging / artifact_filename).write_bytes(src_art.read_bytes())
-    eval_py = package_root / "evaluator.py"
-    if eval_py.is_file():
-        (staging / "evaluator.py").write_bytes(eval_py.read_bytes())
-    # Gold materialize for terminal-class packages (never mounted during harness).
-    expected_filename: str | None = None
-    expected_host = package_root / "evaluation" / "expected.json"
-    if expected_host.is_file():
-        (staging / "expected.json").write_bytes(expected_host.read_bytes())
-        expected_filename = "expected.json"
-
-    # Wait for writer stop before evaluator.
-    if not runtime.writer_stop_confirmed:
-        docker.cleanup(runtime)
-        cred.cleanup()
-        return l1_error_result(
-            run_dir,
-            "evaluation_input",
-            {
-                **l1_meta,
-                "error_kind": "residual_writer",
-                "writer_stop_confirmed": False,
-            },
-            agent_meta,
-            inv_count,
-            kind="residual_writer",
-        )
-
-    eval_raw, eval_meta = run_clean_evaluator_container(
-        image_tag=runtime.image_lock.image_tag if runtime.image_lock else "bora-attempt:l1",
-        staging=staging,
-        artifact_filename=artifact_filename,
-        artifact_key=artifact_key,
-        expected_filename=expected_filename,
-    )
-    l1_meta["evaluator"] = eval_meta
-    l1_meta["writer_inventory"] = list(runtime.writer_inventory)
-    l1_meta["writer_stop_confirmed"] = runtime.writer_stop_confirmed and bool(
-        eval_meta.get("writer_stop_confirmed")
-    )
-    l1_meta["host_fallback_count"] = int(agent_meta.get("host_fallback_count") or 0)
-    l1_meta["executor_containment"] = "attempt-container"
-    l1_meta["execution_location"] = "attempt-container"
-    docker.cleanup(runtime)
-    cred.cleanup()
 
     full_l1 = bool(
         harness_kind == "completed"
@@ -424,21 +462,34 @@ def run_l1_sdk_session_attempt(
     doc = flat.as_dict()
     doc["assurance"] = "l1" if full_l1 else "l0"
     doc["l1"] = {**l1_meta, "full_l1": full_l1}
+    details = {
+        "agent": agent_meta,
+        "harness": envelope,
+        "l1": doc["l1"],
+        "assurance": doc["assurance"],
+        "run_dir": str(run_dir),
+        "digest": lock.digest,
+        "host_fallback_count": l1_meta["host_fallback_count"],
+    }
+    doc, details = _attach_timing(doc, details, timer)
+    # summary.json should also carry timing for viewer projection
     write_l1_evidence(run_dir, doc, agent_meta, doc["l1"])
+    # Rewrite summary with phase_timing (write_l1_evidence doesn't know about it)
+    summary_path = run_dir / "summary.json"
+    if summary_path.is_file():
+        with contextlib.suppress(OSError, ValueError, TypeError):
+            import json as _json
+
+            summary = _json.loads(summary_path.read_text(encoding="utf-8"))
+            if isinstance(summary, dict):
+                summary["phase_timing"] = doc.get("phase_timing")
+                summary["started_at"] = (doc.get("phase_timing") or {}).get("started_at")
+                summary["finished_at"] = (doc.get("phase_timing") or {}).get("finished_at")
+                summary_path.write_text(
+                    _json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+                )
     code = 0 if flat.status == "PASS" else (1 if flat.status == "FAIL" else 2)
     # Offline path: expected failure for real-agent smoke when offline.
     if allow_offline_agent and inv_count == 0 and not envelope.get("ok"):
         code = 2
-    return (
-        code,
-        doc,
-        {
-            "agent": agent_meta,
-            "harness": envelope,
-            "l1": doc["l1"],
-            "assurance": doc["assurance"],
-            "run_dir": str(run_dir),
-            "digest": lock.digest,
-            "host_fallback_count": l1_meta["host_fallback_count"],
-        },
-    )
+    return code, doc, details

--- a/src/bora/application/run_l1.py
+++ b/src/bora/application/run_l1.py
@@ -125,29 +125,25 @@ def run_l1_sdk_session_attempt(
             implicit_profiles=[str(p.get("id")) for p in profiles if p.get("id")],
         )
     except Exception as exc:  # ConfigError or validation
-        code, doc, details = l1_error_result(
+        return l1_error_result(
             run_dir,
             "config",
             {"error": str(exc), "kind": "agent_isolation_invalid"},
             agent_meta,
             0,
             kind="agent_isolation_invalid",
+            phase_timing=timer.as_dict(),
         )
-        doc, details = _attach_timing(doc, details, timer)
-        write_l1_evidence(run_dir, doc, agent_meta, doc.get("l1") or {})
-        return code, doc, details
     if topology is None:
-        code, doc, details = l1_error_result(
+        return l1_error_result(
             run_dir,
             "config",
             {"error": "missing agent topology"},
             agent_meta,
             0,
             kind="agent_isolation_invalid",
+            phase_timing=timer.as_dict(),
         )
-        doc, details = _attach_timing(doc, details, timer)
-        write_l1_evidence(run_dir, doc, agent_meta, doc.get("l1") or {})
-        return code, doc, details
 
     with timer.phase("prepare"):
         docker, runtime, l1_meta = prepare_l1_runtime(
@@ -221,17 +217,15 @@ def run_l1_sdk_session_attempt(
         except Exception as exc:  # noqa: BLE001
             docker.cleanup(runtime)
             cred.cleanup()
-            code, doc, details = l1_error_result(
+            return l1_error_result(
                 run_dir,
                 "provider",
                 {**l1_meta, "prepare_error": type(exc).__name__, "message": str(exc)[:500]},
                 agent_meta,
                 0,
                 kind="target_prepare_failed",
+                phase_timing=timer.as_dict(),
             )
-            doc, details = _attach_timing(doc, details, timer)
-            write_l1_evidence(run_dir, doc, agent_meta, doc.get("l1") or {})
-            return code, doc, details
 
         l1_meta["targets"] = [t.public_view() for t in ledger.targets.values()]
         l1_meta["actors"] = [a.public_view() for a in ledger.actors.values()]
@@ -375,7 +369,7 @@ def run_l1_sdk_session_attempt(
             with timer.phase("cleanup"):
                 docker.cleanup(runtime)
                 cred.cleanup()
-            code, doc, details = l1_error_result(
+            return l1_error_result(
                 run_dir,
                 "harness" if not envelope.get("ok") else "evaluation_input",
                 {
@@ -385,10 +379,8 @@ def run_l1_sdk_session_attempt(
                 },
                 agent_meta,
                 inv_count,
+                phase_timing=timer.as_dict(),
             )
-            doc, details = _attach_timing(doc, details, timer)
-            write_l1_evidence(run_dir, doc, agent_meta, doc.get("l1") or {})
-            return code, doc, details
 
         (staging / artifact_filename).write_bytes(src_art.read_bytes())
         eval_py = package_root / "evaluator.py"
@@ -406,7 +398,7 @@ def run_l1_sdk_session_attempt(
             with timer.phase("cleanup"):
                 docker.cleanup(runtime)
                 cred.cleanup()
-            code, doc, details = l1_error_result(
+            return l1_error_result(
                 run_dir,
                 "evaluation_input",
                 {
@@ -417,10 +409,8 @@ def run_l1_sdk_session_attempt(
                 agent_meta,
                 inv_count,
                 kind="residual_writer",
+                phase_timing=timer.as_dict(),
             )
-            doc, details = _attach_timing(doc, details, timer)
-            write_l1_evidence(run_dir, doc, agent_meta, doc.get("l1") or {})
-            return code, doc, details
 
         eval_raw, eval_meta = run_clean_evaluator_container(
             image_tag=runtime.image_lock.image_tag if runtime.image_lock else "bora-attempt:l1",
@@ -472,22 +462,8 @@ def run_l1_sdk_session_attempt(
         "host_fallback_count": l1_meta["host_fallback_count"],
     }
     doc, details = _attach_timing(doc, details, timer)
-    # summary.json should also carry timing for viewer projection
+    # Single write: write_l1_evidence copies phase_timing into summary.json.
     write_l1_evidence(run_dir, doc, agent_meta, doc["l1"])
-    # Rewrite summary with phase_timing (write_l1_evidence doesn't know about it)
-    summary_path = run_dir / "summary.json"
-    if summary_path.is_file():
-        with contextlib.suppress(OSError, ValueError, TypeError):
-            import json as _json
-
-            summary = _json.loads(summary_path.read_text(encoding="utf-8"))
-            if isinstance(summary, dict):
-                summary["phase_timing"] = doc.get("phase_timing")
-                summary["started_at"] = (doc.get("phase_timing") or {}).get("started_at")
-                summary["finished_at"] = (doc.get("phase_timing") or {}).get("finished_at")
-                summary_path.write_text(
-                    _json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-                )
     code = 0 if flat.status == "PASS" else (1 if flat.status == "FAIL" else 2)
     # Offline path: expected failure for real-agent smoke when offline.
     if allow_offline_agent and inv_count == 0 and not envelope.get("ok"):

--- a/src/bora/application/run_l1_evidence.py
+++ b/src/bora/application/run_l1_evidence.py
@@ -15,6 +15,7 @@ def l1_error_result(
     inv: int,
     *,
     kind: str | None = None,
+    phase_timing: dict[str, Any] | None = None,
 ) -> tuple[int, dict[str, Any], dict[str, Any]]:
     from bora.evaluation.result_binding import bind_result
 
@@ -32,8 +33,18 @@ def l1_error_result(
     if kind:
         doc["error"] = {"phase": phase, "kind": kind}
     doc["l1"] = l1_meta
+    if isinstance(phase_timing, dict):
+        doc["phase_timing"] = phase_timing
+        total_ms = phase_timing.get("total_ms")
+        if isinstance(total_ms, int | float) and not isinstance(total_ms, bool):
+            from bora.application.phase_timing import format_duration_ms
+
+            doc["duration"] = format_duration_ms(float(total_ms))
     write_l1_evidence(run_dir, doc, agent_meta, l1_meta)
-    return 2, doc, {"agent": agent_meta, "l1": l1_meta, "assurance": "l0"}
+    details: dict[str, Any] = {"agent": agent_meta, "l1": l1_meta, "assurance": "l0"}
+    if isinstance(phase_timing, dict):
+        details["phase_timing"] = phase_timing
+    return 2, doc, details
 
 
 def write_l1_evidence(

--- a/src/bora/application/run_l1_evidence.py
+++ b/src/bora/application/run_l1_evidence.py
@@ -87,6 +87,15 @@ def write_l1_evidence(
         "execution_location": exec_loc,
         "l1": safe,
     }
+    if isinstance(result_doc.get("phase_timing"), dict):
+        summary["phase_timing"] = result_doc["phase_timing"]
+        pt = result_doc["phase_timing"]
+        if pt.get("started_at"):
+            summary["started_at"] = pt.get("started_at")
+        if pt.get("finished_at"):
+            summary["finished_at"] = pt.get("finished_at")
+    if result_doc.get("duration") is not None:
+        summary["duration"] = result_doc.get("duration")
     (run_dir / "summary.json").write_text(
         json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )

--- a/src/bora/application/suite_metrics.py
+++ b/src/bora/application/suite_metrics.py
@@ -1,19 +1,27 @@
-"""Suite-level metric aggregation from per-task evaluator Results.
+"""Suite-level metric aggregation from per-task / per-attempt evaluator Results.
 
 Rules (MVP, fixed — not package-configurable):
 
-- ``pass_rate`` = count(status == PASS) / n_tasks
+- ``pass_rate`` = count(status == PASS) / n_tasks  (legacy, one row per task)
 - ``mean_score`` = mean of per-task scores; missing / non-numeric / ERROR
   treated as **0.0** (Harbor-like default for absent reward)
 - FAIL with numeric score keeps that score (typically 0.0)
 - **No suite-level PASS** — PASS remains per-task evaluator authority only
 
-These fields are observational aggregates for leaderboard / ops summary.
+Multi-attempt (#47):
+
+- Always-k produces *n* independent Attempt samples per task.
+- **pass@k** = unbiased estimator ``1 - C(n-c, k) / C(n, k)`` (Chen / Harbor).
+- **pass^k** = ``(c/n)^k`` (all-k succeed; BORA addition, not Harbor).
+- Suite / dataset score for a metric = **mean over tasks** that have enough
+  samples for that k (tasks with ``n < k`` are omitted from that k's mean).
+- These metrics are job summary only — **not** package identity / fingerprint.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from math import comb
 from typing import Any
 
 # Documented default for absent scores (Harbor reward-missing → 0).
@@ -98,12 +106,277 @@ def task_refs_for_summary(task_rows: Sequence[Mapping[str, Any]]) -> list[dict[s
     """Minimal per-task references for suite/job result rows (leaderboard)."""
     refs: list[dict[str, Any]] = []
     for row in task_rows:
-        refs.append(
+        ref: dict[str, Any] = {
+            "task_id": row.get("task_id"),
+            "status": _normalize_status(row.get("status")) or None,
+            "score": _numeric_score_or_none(row.get("score")),
+            "run_id": row.get("run_id"),
+        }
+        if row.get("n") is not None:
+            ref["n"] = row.get("n")
+        if row.get("c") is not None:
+            ref["c"] = row.get("c")
+        refs.append(ref)
+    return refs
+
+
+# ---------------------------------------------------------------------------
+# Multi-attempt: pass@k / pass^k (#47)
+# ---------------------------------------------------------------------------
+
+
+def pass_at_k(*, n: int, c: int, k: int) -> float | None:
+    """Unbiased pass@k estimator (Chen et al.; Harbor).
+
+    ``1 - C(n-c, k) / C(n, k)`` when ``n >= k``; else ``None`` (incomplete).
+    """
+    if not isinstance(n, int) or isinstance(n, bool) or n < 0:
+        return None
+    if not isinstance(c, int) or isinstance(c, bool) or c < 0 or c > n:
+        return None
+    if not isinstance(k, int) or isinstance(k, bool) or k < 1:
+        return None
+    if n < k:
+        return None
+    if n - c < k:
+        return 1.0
+    return 1.0 - (comb(n - c, k) / comb(n, k))
+
+
+def pass_power_k(*, n: int, c: int, k: int) -> float | None:
+    """pass^k estimator: probability all *k* independent attempts succeed.
+
+    Uses ``(c/n)^k``. Returns ``None`` when ``n < 1`` or *k* invalid.
+    Does not require ``n >= k`` (with Always-k, n is usually the sample budget).
+    """
+    if not isinstance(n, int) or isinstance(n, bool) or n < 1:
+        return None
+    if not isinstance(c, int) or isinstance(c, bool) or c < 0 or c > n:
+        return None
+    if not isinstance(k, int) or isinstance(k, bool) or k < 1:
+        return None
+    return (c / n) ** k
+
+
+def default_k_values(n_samples: int) -> list[int]:
+    """Harbor-like k set: 1, powers of 2, steps of 5, and *n_samples* itself."""
+    if not isinstance(n_samples, int) or isinstance(n_samples, bool) or n_samples < 1:
+        return []
+    ks: set[int] = {1, n_samples}
+    p = 2
+    while p <= n_samples:
+        ks.add(p)
+        p *= 2
+    for m in range(5, n_samples + 1, 5):
+        ks.add(m)
+    return sorted(ks)
+
+
+def count_passes(attempt_rows: Sequence[Mapping[str, Any]]) -> tuple[int, int]:
+    """Return ``(n, c)`` where *c* counts attempts with status PASS."""
+    n = len(attempt_rows)
+    c = sum(1 for row in attempt_rows if _normalize_status(row.get("status")) == "PASS")
+    return n, c
+
+
+def group_attempts_by_task(
+    attempt_rows: Sequence[Mapping[str, Any]],
+) -> dict[str, list[Mapping[str, Any]]]:
+    """Group attempt rows by ``task_id`` (stable insertion order of first seen)."""
+    groups: dict[str, list[Mapping[str, Any]]] = {}
+    for row in attempt_rows:
+        tid = str(row.get("task_id") or "")
+        if tid not in groups:
+            groups[tid] = []
+        groups[tid].append(row)
+    return groups
+
+
+def _metrics_map_for_nc(
+    n: int,
+    c: int,
+    k_values: Sequence[int],
+) -> tuple[dict[str, float | None], dict[str, float | None]]:
+    pass_at: dict[str, float | None] = {}
+    pass_pow: dict[str, float | None] = {}
+    for k in k_values:
+        key = str(k)
+        pass_at[key] = pass_at_k(n=n, c=c, k=k)
+        pass_pow[key] = pass_power_k(n=n, c=c, k=k)
+    return pass_at, pass_pow
+
+
+def rollup_task_from_attempts(
+    task_id: str,
+    attempt_rows: Sequence[Mapping[str, Any]],
+    *,
+    k_values: Sequence[int] | None = None,
+) -> dict[str, Any]:
+    """Collapse attempt samples for one task into a summary row + k-metrics."""
+    ordered = sorted(
+        attempt_rows,
+        key=lambda r: (
+            int(r["attempt_index"])
+            if isinstance(r.get("attempt_index"), int)
+            and not isinstance(r.get("attempt_index"), bool)
+            else 10**9,
+            str(r.get("run_id") or ""),
+        ),
+    )
+    n, c = count_passes(ordered)
+    ks = list(k_values) if k_values is not None else default_k_values(n if n else 1)
+    pass_at, pass_pow = _metrics_map_for_nc(n, c, ks)
+
+    # Rolled status: any PASS → PASS; else any FAIL → FAIL; else ERROR.
+    statuses = [_normalize_status(r.get("status")) for r in ordered]
+    if any(s == "PASS" for s in statuses):
+        status = "PASS"
+    elif any(s == "FAIL" for s in statuses):
+        status = "FAIL"
+    elif any(s == "ERROR" for s in statuses) or not statuses:
+        status = "ERROR"
+    else:
+        status = statuses[-1]
+
+    # Representative score: mean of attempt scores (ERROR→0), Harbor-like.
+    scores = [_score_value(r) for r in ordered]
+    mean_score = (sum(scores) / len(scores)) if scores else MISSING_SCORE_AS
+    # Prefer a PASS attempt's run_id for task_refs; else first.
+    run_id = None
+    for r in ordered:
+        if _normalize_status(r.get("status")) == "PASS" and r.get("run_id"):
+            run_id = r.get("run_id")
+            break
+    if run_id is None and ordered:
+        run_id = ordered[0].get("run_id")
+
+    return {
+        "task_id": task_id,
+        "status": status,
+        "score": mean_score,
+        "n": n,
+        "c": c,
+        "run_id": run_id,
+        "attempt_indices": [
+            r.get("attempt_index") for r in ordered if r.get("attempt_index") is not None
+        ],
+        "pass_at_k": pass_at,
+        "pass_power_k": pass_pow,
+        "attempts": list(ordered),
+    }
+
+
+def aggregate_k_metrics(
+    attempt_rows: Sequence[Mapping[str, Any]],
+    *,
+    task_ids: Sequence[str] | None = None,
+    n_attempts: int | None = None,
+    k_values: Sequence[int] | None = None,
+) -> dict[str, Any]:
+    """Compute per-task and suite-mean pass@k / pass^k from attempt samples.
+
+    Tasks with ``n < k`` are **omitted** from that *k*'s suite mean (incomplete).
+    Metrics never enter ``config_fingerprint`` — caller places them under
+    ``metrics`` / job summary only.
+    """
+    groups = group_attempts_by_task(attempt_rows)
+    ordered_ids: list[str]
+    if task_ids is not None:
+        ordered_ids = [str(t) for t in task_ids]
+        for tid in groups:
+            if tid not in ordered_ids:
+                ordered_ids.append(tid)
+    else:
+        ordered_ids = list(groups.keys())
+
+    sample_budget = n_attempts
+    if sample_budget is None:
+        sample_budget = max((len(groups[t]) for t in ordered_ids if t in groups), default=1)
+    if sample_budget < 1:
+        sample_budget = 1
+
+    ks = list(k_values) if k_values is not None else default_k_values(sample_budget)
+
+    task_rows: list[dict[str, Any]] = []
+    for tid in ordered_ids:
+        rows = groups.get(tid, [])
+        task_rows.append(rollup_task_from_attempts(tid, rows, k_values=ks))
+
+    # Suite mean per k: mean over tasks where the value is not None.
+    suite_pass_at: dict[str, Any] = {}
+    suite_pass_pow: dict[str, Any] = {}
+    for k in ks:
+        key = str(k)
+        at_vals = [
+            float(t["pass_at_k"][key])
+            for t in task_rows
+            if t.get("pass_at_k", {}).get(key) is not None
+        ]
+        pow_vals = [
+            float(t["pass_power_k"][key])
+            for t in task_rows
+            if t.get("pass_power_k", {}).get(key) is not None
+        ]
+        suite_pass_at[key] = {
+            "value": (sum(at_vals) / len(at_vals)) if at_vals else None,
+            "n_tasks": len(at_vals),
+            "incomplete_tasks": len(task_rows) - len(at_vals),
+        }
+        suite_pass_pow[key] = {
+            "value": (sum(pow_vals) / len(pow_vals)) if pow_vals else None,
+            "n_tasks": len(pow_vals),
+            "incomplete_tasks": len(task_rows) - len(pow_vals),
+        }
+
+    legacy = aggregate_task_metrics(task_rows)
+    return {
+        **legacy,
+        "n_attempts": sample_budget,
+        "k_values": list(ks),
+        "pass_at_k": suite_pass_at,
+        "pass_power_k": suite_pass_pow,
+        "per_task": [
+            {
+                "task_id": t["task_id"],
+                "n": t["n"],
+                "c": t["c"],
+                "status": t["status"],
+                "pass_at_k": t["pass_at_k"],
+                "pass_power_k": t["pass_power_k"],
+            }
+            for t in task_rows
+        ],
+        "task_rows": task_rows,
+    }
+
+
+def flatten_legacy_tasks_as_attempts(
+    task_rows: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Convert pre-#47 summary ``tasks[]`` (one row per task) into attempt rows."""
+    out: list[dict[str, Any]] = []
+    for row in task_rows:
+        # Already multi-attempt nested?
+        nested = row.get("attempts")
+        if isinstance(nested, list) and nested:
+            for a in nested:
+                if isinstance(a, Mapping):
+                    out.append(dict(a))
+            continue
+        attempt_index = row.get("attempt_index")
+        if not isinstance(attempt_index, int) or isinstance(attempt_index, bool):
+            attempt_index = 0
+        out.append(
             {
                 "task_id": row.get("task_id"),
-                "status": _normalize_status(row.get("status")) or None,
-                "score": _numeric_score_or_none(row.get("score")),
+                "attempt_index": attempt_index,
+                "exit_code": row.get("exit_code"),
+                "status": row.get("status"),
+                "score": row.get("score"),
+                "metrics": row.get("metrics") if isinstance(row.get("metrics"), dict) else {},
                 "run_id": row.get("run_id"),
+                "digest": row.get("digest"),
+                "error": row.get("error"),
             }
         )
-    return refs
+    return out

--- a/src/bora/application/suite_run.py
+++ b/src/bora/application/suite_run.py
@@ -252,6 +252,14 @@ async def _run_one(
             if not isinstance(raw_metrics, dict):
                 detail_metrics = details.get("metrics")
                 raw_metrics = detail_metrics if isinstance(detail_metrics, dict) else {}
+            phase_timing = details.get("phase_timing")
+            if not isinstance(phase_timing, dict):
+                phase_timing = None
+            duration = None
+            if phase_timing is not None:
+                from bora.application.phase_timing import format_duration_ms
+
+                duration = format_duration_ms(phase_timing.get("total_ms"))  # type: ignore[arg-type]
             return {
                 "task_id": task_id,
                 "attempt_index": attempt_index,
@@ -262,6 +270,9 @@ async def _run_one(
                 "run_id": run_id,
                 "digest": details.get("digest"),
                 "error": None if code != 2 else (details.get("error") or status),
+                "phase_timing": phase_timing,
+                "duration": duration,
+                "phase": "terminal",
             }
         except ConfigError as exc:
             return {
@@ -274,6 +285,9 @@ async def _run_one(
                 "run_id": None,
                 "digest": None,
                 "error": str(exc),
+                "phase_timing": None,
+                "duration": None,
+                "phase": "error",
             }
         except Exception as exc:  # noqa: BLE001
             return {
@@ -286,10 +300,41 @@ async def _run_one(
                 "run_id": None,
                 "digest": None,
                 "error": f"{type(exc).__name__}: {exc}",
+                "phase_timing": None,
+                "duration": None,
+                "phase": "error",
             }
         finally:
             async with _inflight_lock:
                 _inflight_current -= 1
+
+
+def _write_suite_progress(
+    plan: SuitePlan,
+    *,
+    done: int,
+    total: int,
+    running: list[dict[str, Any]],
+    status: str = "running",
+) -> None:
+    """Job progress snapshot for viewer / status (D2)."""
+    suite_dir = plan.database_root / ".bora" / "suite-runs" / plan.suite_run_id
+    suite_dir.mkdir(parents=True, exist_ok=True)
+    doc = {
+        "schema": "bora.suite.progress/1",
+        "suite_run_id": plan.suite_run_id,
+        "status": status,
+        "done": done,
+        "total": total,
+        "n_attempts": plan.n_attempts,
+        "max_concurrent_tasks": plan.max_concurrent_tasks,
+        "running": running,
+        "updated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+    }
+    out = suite_dir / "progress.json"
+    tmp = out.with_suffix(".tmp")
+    tmp.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(out)
 
 
 def _build_summary(
@@ -325,6 +370,8 @@ def _build_summary(
                 "digest": base.get("digest"),
                 "error": base.get("error"),
                 "attempt_index": 0,
+                "phase_timing": base.get("phase_timing"),
+                "duration": base.get("duration"),
             }
             # Surface k stats only when n_attempts was requested >1 historically;
             # for k==1 omit pass_at_k maps from task row to keep legacy tests green.
@@ -339,6 +386,13 @@ def _build_summary(
     else:
         tasks_out = []
         for t in task_rows:
+            # Prefer first attempt's phase_timing for job-level display (observational).
+            nested = t.get("attempts") or []
+            first_pt = None
+            first_dur = None
+            if nested and isinstance(nested[0], Mapping):
+                first_pt = nested[0].get("phase_timing")
+                first_dur = nested[0].get("duration")
             tasks_out.append(
                 {
                     "task_id": t["task_id"],
@@ -350,6 +404,8 @@ def _build_summary(
                     "pass_at_k": t["pass_at_k"],
                     "pass_power_k": t["pass_power_k"],
                     "attempt_indices": t.get("attempt_indices"),
+                    "phase_timing": first_pt,
+                    "duration": first_dur,
                 }
             )
         metrics = {
@@ -494,10 +550,35 @@ async def execute_suite_run(
     done_keys = _existing_attempt_keys(existing)
     units = planned_units(plan)
     todo = [(tid, idx) for tid, idx in units if (tid, idx) not in done_keys]
+    total_units = len(units) if not resume else max(len(units), len(done_keys | set(todo)))
+    # Progress: completed existing + in-flight bookkeeping.
+    completed_count = len(done_keys & set(units)) if resume else 0
+    _write_suite_progress(
+        plan,
+        done=completed_count,
+        total=max(total_units, len(todo) + completed_count),
+        running=[],
+        status="running" if todo else "complete",
+    )
 
     semaphore = asyncio.Semaphore(plan.max_concurrent_tasks)
-    coros = [
-        _run_one(
+    progress_lock = asyncio.Lock()
+    inflight_labels: dict[tuple[str, int], str] = {}
+
+    async def _tracked(tid: str, idx: int) -> dict[str, Any]:
+        nonlocal completed_count
+        async with progress_lock:
+            inflight_labels[(tid, idx)] = "running"
+            _write_suite_progress(
+                plan,
+                done=completed_count,
+                total=max(total_units, completed_count + len(todo)),
+                running=[
+                    {"task_id": t, "attempt_index": i, "phase": ph}
+                    for (t, i), ph in inflight_labels.items()
+                ],
+            )
+        row = await _run_one(
             plan,
             tid,
             idx,
@@ -506,8 +587,22 @@ async def execute_suite_run(
             run_fn=runner,
             profiles_path=profiles_path,
         )
-        for tid, idx in todo
-    ]
+        async with progress_lock:
+            inflight_labels.pop((tid, idx), None)
+            completed_count += 1
+            _write_suite_progress(
+                plan,
+                done=completed_count,
+                total=max(total_units, completed_count + len(inflight_labels)),
+                running=[
+                    {"task_id": t, "attempt_index": i, "phase": ph}
+                    for (t, i), ph in inflight_labels.items()
+                ],
+                status="running" if inflight_labels else "complete",
+            )
+        return row
+
+    coros = [_tracked(tid, idx) for tid, idx in todo]
     new_results: list[dict[str, Any]] = list(await asyncio.gather(*coros)) if coros else []
 
     # Append-only merge: existing first (stable), then new; never mutate old rows.

--- a/src/bora/application/suite_run.py
+++ b/src/bora/application/suite_run.py
@@ -1,7 +1,10 @@
-"""Database suite run: task_id-axis scheduling (Spec 22).
+"""Database suite run: task_id-axis scheduling (+ multi-attempt Always-k, #47).
 
 Orthogonal to Campaign (parameter matrix on one task). Application-layer only;
 does not invent suite-level PASS.
+
+``n_attempts`` / k-attempt and resume are **CLI / job** parameters only — never
+package identity or ``config_fingerprint`` inputs.
 """
 
 from __future__ import annotations
@@ -9,7 +12,7 @@ from __future__ import annotations
 import asyncio
 import json
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -17,7 +20,12 @@ from typing import Any
 
 from bora.application.run_command import run_task
 from bora.application.suite_config_fingerprint import collect_suite_config
-from bora.application.suite_metrics import aggregate_task_metrics, task_refs_for_summary
+from bora.application.suite_metrics import (
+    aggregate_k_metrics,
+    aggregate_task_metrics,
+    flatten_legacy_tasks_as_attempts,
+    task_refs_for_summary,
+)
 from bora.config.database import list_tasks, load_database_manifest
 from bora.config.errors import ConfigError
 from bora.registry.resolve import resolve_database_root
@@ -45,6 +53,7 @@ class SuitePlan:
     database_root: Path
     task_ids: list[str]
     max_concurrent_tasks: int
+    n_attempts: int = 1
     suite_run_id: str = field(default_factory=lambda: f"suite_{uuid.uuid4().hex[:16]}")
 
 
@@ -53,8 +62,19 @@ def plan_suite_run(
     *,
     task_id: str | None = None,
     max_concurrent_tasks: int | None = None,
+    n_attempts: int | None = None,
+    suite_run_id: str | None = None,
 ) -> SuitePlan:
-    """Build a suite plan from Database root/ref and optional single-task filter."""
+    """Build a suite plan from Database root/ref and optional single-task filter.
+
+    Parameters
+    ----------
+    n_attempts:
+        Always-k sample budget per task (CLI / job only). Default 1.
+        Does **not** change package identity or fingerprint.
+    suite_run_id:
+        When resuming, reuse an existing suite run id.
+    """
     root = resolve_database_root(database_ref)
     man = load_database_manifest(root)
     if task_id:
@@ -65,6 +85,14 @@ def plan_suite_run(
         ids = [task_id]
     else:
         ids = list_tasks(root, manifest=man)
+
+    k = 1 if n_attempts is None else n_attempts
+    if not isinstance(k, int) or isinstance(k, bool) or k < 1:
+        raise ConfigError(
+            "invalid_override",
+            "n_attempts must be an integer ≥ 1",
+            location="--n-attempts",
+        )
 
     n = max_concurrent_tasks
     if n is None:
@@ -78,17 +106,58 @@ def plan_suite_run(
             "max_concurrent_tasks must be an integer ≥ 1",
             location="--max-concurrent-tasks",
         )
-    # Single-task mode: N is ignored (still ≥1 for pool size = 1 effectively).
-    if len(ids) == 1:
+    # Single unit (one task × one attempt): concurrency is irrelevant → force 1.
+    # Multi-attempt or multi-task: keep pool size so parallel only speeds wall time.
+    if len(ids) == 1 and k == 1:
         n = 1
 
-    return SuitePlan(
+    plan = SuitePlan(
         database_id=man.database_id,
         database_version=man.version,
         database_root=root,
         task_ids=ids,
         max_concurrent_tasks=n,
+        n_attempts=k,
     )
+    if suite_run_id is not None and str(suite_run_id).strip():
+        plan.suite_run_id = str(suite_run_id).strip()
+    return plan
+
+
+def suite_summary_path(database_root: Path, suite_run_id: str) -> Path:
+    return (
+        database_root.expanduser().resolve(strict=False)
+        / ".bora"
+        / "suite-runs"
+        / suite_run_id
+        / "summary.json"
+    )
+
+
+def load_suite_summary(database_root: Path, suite_run_id: str) -> dict[str, Any]:
+    """Load an existing suite ``summary.json`` or raise ConfigError."""
+    path = suite_summary_path(database_root, suite_run_id)
+    if not path.is_file():
+        raise ConfigError(
+            "suite_not_found",
+            f"suite summary not found: {suite_run_id}",
+            location=str(path),
+        )
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfigError(
+            "suite_summary_invalid",
+            f"cannot read suite summary: {exc}",
+            location=str(path),
+        ) from exc
+    if not isinstance(data, dict):
+        raise ConfigError(
+            "suite_summary_invalid",
+            "suite summary must be a JSON object",
+            location=str(path),
+        )
+    return data
 
 
 def extract_run_id(database_root: Path, *candidates: object) -> str | None:
@@ -131,9 +200,28 @@ def extract_run_id(database_root: Path, *candidates: object) -> str | None:
     return None
 
 
+def planned_units(plan: SuitePlan) -> list[tuple[str, int]]:
+    """Expand Always-k units: ``(task_id, attempt_index)`` for index in ``0..k-1``."""
+    return [(tid, i) for tid in plan.task_ids for i in range(plan.n_attempts)]
+
+
+def _existing_attempt_keys(attempts: list[dict[str, Any]]) -> set[tuple[str, int]]:
+    keys: set[tuple[str, int]] = set()
+    for row in attempts:
+        tid = str(row.get("task_id") or "")
+        idx = row.get("attempt_index")
+        if not tid:
+            continue
+        if not isinstance(idx, int) or isinstance(idx, bool):
+            idx = 0
+        keys.add((tid, idx))
+    return keys
+
+
 async def _run_one(
     plan: SuitePlan,
     task_id: str,
+    attempt_index: int,
     *,
     semaphore: asyncio.Semaphore,
     overrides: dict[str, Any] | None,
@@ -166,6 +254,7 @@ async def _run_one(
                 raw_metrics = detail_metrics if isinstance(detail_metrics, dict) else {}
             return {
                 "task_id": task_id,
+                "attempt_index": attempt_index,
                 "exit_code": code,
                 "status": status,
                 "score": getattr(result, "score", None),
@@ -177,6 +266,7 @@ async def _run_one(
         except ConfigError as exc:
             return {
                 "task_id": task_id,
+                "attempt_index": attempt_index,
                 "exit_code": 2,
                 "status": "ERROR",
                 "score": None,
@@ -188,6 +278,7 @@ async def _run_one(
         except Exception as exc:  # noqa: BLE001
             return {
                 "task_id": task_id,
+                "attempt_index": attempt_index,
                 "exit_code": 2,
                 "status": "ERROR",
                 "score": None,
@@ -201,32 +292,83 @@ async def _run_one(
                 _inflight_current -= 1
 
 
-async def execute_suite_run(
+def _build_summary(
     plan: SuitePlan,
+    attempts: list[dict[str, Any]],
     *,
-    overrides: dict[str, Any] | None = None,
-    run_fn: Callable[..., Awaitable[tuple[int, Any, dict[str, Any]]]] | None = None,
-    profiles_path: Path | str | None = None,
+    overrides: dict[str, Any] | None,
+    profiles_path: Path | str | None,
 ) -> dict[str, Any]:
-    """Execute all planned tasks with a concurrency pool; write suite summary."""
-    reset_inflight_metrics()
-    runner = run_fn or run_task
-    semaphore = asyncio.Semaphore(plan.max_concurrent_tasks)
-    tasks = [
-        _run_one(
-            plan,
-            tid,
-            semaphore=semaphore,
-            overrides=overrides,
-            run_fn=runner,
-            profiles_path=profiles_path,
-        )
-        for tid in plan.task_ids
-    ]
-    results = await asyncio.gather(*tasks)
+    """Roll attempts → tasks + metrics; write identity fields (no k in fingerprint)."""
+    k_agg = aggregate_k_metrics(
+        attempts,
+        task_ids=plan.task_ids,
+        n_attempts=plan.n_attempts,
+    )
+    task_rows: list[dict[str, Any]] = list(k_agg.pop("task_rows"))
+
+    # Strip nested attempts from tasks[] for a flatter summary when k==1
+    # (backward-compatible shape); keep attempts[] always for resume.
+    tasks_out: list[dict[str, Any]]
+    if plan.n_attempts == 1 and all(len(t.get("attempts") or []) <= 1 for t in task_rows):
+        tasks_out = []
+        for t in task_rows:
+            nested = t.get("attempts") or []
+            base = nested[0] if nested else {}
+            row = {
+                "task_id": t["task_id"],
+                "exit_code": base.get("exit_code"),
+                "status": t["status"],
+                "score": base.get("score", t.get("score")),
+                "metrics": base.get("metrics") if isinstance(base.get("metrics"), dict) else {},
+                "run_id": t.get("run_id"),
+                "digest": base.get("digest"),
+                "error": base.get("error"),
+                "attempt_index": 0,
+            }
+            # Surface k stats only when n_attempts was requested >1 historically;
+            # for k==1 omit pass_at_k maps from task row to keep legacy tests green.
+            tasks_out.append(row)
+        metrics = aggregate_task_metrics(tasks_out)
+        # Still attach pass@k maps under metrics when useful (k=1 → pass@1 = pass_rate).
+        metrics["n_attempts"] = plan.n_attempts
+        metrics["k_values"] = k_agg.get("k_values", [1])
+        metrics["pass_at_k"] = k_agg.get("pass_at_k", {})
+        metrics["pass_power_k"] = k_agg.get("pass_power_k", {})
+        metrics["per_task"] = k_agg.get("per_task", [])
+    else:
+        tasks_out = []
+        for t in task_rows:
+            tasks_out.append(
+                {
+                    "task_id": t["task_id"],
+                    "status": t["status"],
+                    "score": t["score"],
+                    "n": t["n"],
+                    "c": t["c"],
+                    "run_id": t.get("run_id"),
+                    "pass_at_k": t["pass_at_k"],
+                    "pass_power_k": t["pass_power_k"],
+                    "attempt_indices": t.get("attempt_indices"),
+                }
+            )
+        metrics = {
+            "pass_rate": k_agg["pass_rate"],
+            "mean_score": k_agg["mean_score"],
+            "n_tasks": k_agg["n_tasks"],
+            "n_pass": k_agg["n_pass"],
+            "n_fail": k_agg["n_fail"],
+            "n_error": k_agg["n_error"],
+            "missing_score_as": k_agg["missing_score_as"],
+            "n_attempts": plan.n_attempts,
+            "k_values": k_agg["k_values"],
+            "pass_at_k": k_agg["pass_at_k"],
+            "pass_power_k": k_agg["pass_power_k"],
+            "per_task": k_agg["per_task"],
+        }
 
     counts = {"pass": 0, "fail": 0, "error": 0, "skipped": 0}
-    for row in results:
+    for row in tasks_out:
         st = str(row.get("status") or "").upper()
         if st == "PASS":
             counts["pass"] += 1
@@ -235,7 +377,6 @@ async def execute_suite_run(
         else:
             counts["error"] += 1
 
-    # Exit code matrix aligned with single-task bora run.
     if counts["error"] > 0:
         exit_code = 2
     elif counts["fail"] > 0:
@@ -243,50 +384,188 @@ async def execute_suite_run(
     else:
         exit_code = 0
 
-    metrics = aggregate_task_metrics(results)
-    # Config fingerprint for Leaderboard comparability (#42): written at
-    # summary time from per-task profiles — not at upload unpack.
+    # Fingerprint from one row per task (first attempt's run_id if needed).
+    fp_rows: list[dict[str, Any]] = []
+    by_task_attempt: dict[str, list[dict[str, Any]]] = {}
+    for a in attempts:
+        tid = str(a.get("task_id") or "")
+        by_task_attempt.setdefault(tid, []).append(a)
+    for tid in plan.task_ids:
+        rows = by_task_attempt.get(tid, [])
+        pick = None
+        for r in rows:
+            if str(r.get("status") or "").upper() == "PASS" and r.get("run_id"):
+                pick = r
+                break
+        if pick is None and rows:
+            pick = rows[0]
+        if pick is not None:
+            fp_rows.append({"task_id": tid, "run_id": pick.get("run_id")})
+        else:
+            fp_rows.append({"task_id": tid, "run_id": None})
+
     config_fields = collect_suite_config(
         plan.database_root,
-        results,
+        fp_rows,
         overrides=overrides,
         task_ids=plan.task_ids,
         profiles_path=profiles_path,
     )
+
     summary: dict[str, Any] = {
         "schema": "bora.suite.summary/1",
         "suite_run_id": plan.suite_run_id,
         "database_id": plan.database_id,
         "database_version": plan.database_version,
         "max_concurrent_tasks": plan.max_concurrent_tasks,
+        "n_attempts": plan.n_attempts,
         "task_ids": list(plan.task_ids),
-        "tasks": list(results),
-        "task_refs": task_refs_for_summary(results),
+        "attempts": list(attempts),
+        "tasks": tasks_out,
+        "task_refs": task_refs_for_summary(tasks_out),
         "counts": counts,
-        # Observational aggregates (leaderboard); never suite PASS authority.
+        # Observational aggregates (leaderboard / job stats); never suite PASS.
         "metrics": metrics,
         "exit_code": exit_code,
-        # UTC ISO-8601 (not unix epoch float).
         "created_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         "inflight_peak": get_inflight_peak(),
-        # Config comparability (Hub Leaderboard); not PASS authority.
         "config_fingerprint": config_fields["config_fingerprint"],
         "config_homogeneous": config_fields["config_homogeneous"],
         "actors_summary": config_fields["actors_summary"],
         "agent_label": config_fields.get("agent_label") or "",
         "model_label": config_fields.get("model_label") or "",
-        # Explicitly NOT a suite PASS authority:
         "note": "per-task evaluator verdicts only; no suite-level PASS",
     }
-    # #59 secret-free job binding for upload / Hub rehydrate (when homogeneous).
     if config_fields.get("job_overlay") is not None:
         summary["job_overlay"] = config_fields["job_overlay"]
+    return summary
 
+
+def _write_summary(plan: SuitePlan, summary: dict[str, Any]) -> dict[str, Any]:
     suite_dir = plan.database_root / ".bora" / "suite-runs" / plan.suite_run_id
     suite_dir.mkdir(parents=True, exist_ok=True)
     out = suite_dir / "summary.json"
     tmp = out.with_suffix(".tmp")
-    tmp.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    # summary_path is host-local; keep off the durable document? Historical
+    # code put it only on the returned dict, not always on disk — write clean.
+    disk = {k: v for k, v in summary.items() if k != "summary_path"}
+    tmp.write_text(json.dumps(disk, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     tmp.replace(out)
     summary["summary_path"] = str(out)
     return summary
+
+
+async def execute_suite_run(
+    plan: SuitePlan,
+    *,
+    overrides: dict[str, Any] | None = None,
+    run_fn: Callable[..., Awaitable[tuple[int, Any, dict[str, Any]]]] | None = None,
+    profiles_path: Path | str | None = None,
+    resume: bool = False,
+) -> dict[str, Any]:
+    """Execute planned task×attempt units with a concurrency pool; write summary.
+
+    When ``resume=True``, load existing attempts for ``plan.suite_run_id``, skip
+    units that already finished, **append** new attempts, and recompute metrics.
+    Existing attempt rows are never rewritten.
+    """
+    reset_inflight_metrics()
+    runner = run_fn or run_task
+
+    existing: list[dict[str, Any]] = []
+    if resume:
+        old = load_suite_summary(plan.database_root, plan.suite_run_id)
+        raw_attempts = old.get("attempts")
+        if isinstance(raw_attempts, list) and raw_attempts:
+            existing = [dict(a) for a in raw_attempts if isinstance(a, Mapping)]
+        else:
+            legacy_tasks = old.get("tasks")
+            if isinstance(legacy_tasks, list):
+                existing = flatten_legacy_tasks_as_attempts(
+                    [t for t in legacy_tasks if isinstance(t, Mapping)]
+                )
+        # Prefer higher n_attempts if resume raises budget.
+        old_k = old.get("n_attempts")
+        if isinstance(old_k, int) and not isinstance(old_k, bool) and old_k > plan.n_attempts:
+            # Keep caller's plan.n_attempts as target; old higher budget means
+            # more existing keys — fine.
+            pass
+
+    done_keys = _existing_attempt_keys(existing)
+    units = planned_units(plan)
+    todo = [(tid, idx) for tid, idx in units if (tid, idx) not in done_keys]
+
+    semaphore = asyncio.Semaphore(plan.max_concurrent_tasks)
+    coros = [
+        _run_one(
+            plan,
+            tid,
+            idx,
+            semaphore=semaphore,
+            overrides=overrides,
+            run_fn=runner,
+            profiles_path=profiles_path,
+        )
+        for tid, idx in todo
+    ]
+    new_results: list[dict[str, Any]] = list(await asyncio.gather(*coros)) if coros else []
+
+    # Append-only merge: existing first (stable), then new; never mutate old rows.
+    attempts = list(existing) + new_results
+    # Drop attempts outside planned task set only when filtering? Keep all that
+    # belong to plan.task_ids; preserve other tasks already in the job for resume
+    # of a subset (Harbor: re-run one task without wiping the rest).
+    if resume and plan.task_ids:
+        planned_set = set(plan.task_ids)
+        # Keep attempts for tasks not in this plan's filter (other suite members).
+        kept_other = [a for a in existing if str(a.get("task_id") or "") not in planned_set]
+        # For planned tasks: existing matching keys + new
+        planned_existing = [a for a in existing if str(a.get("task_id") or "") in planned_set]
+        attempts = kept_other + planned_existing + new_results
+
+    # Union task_ids for summary when resume brings siblings.
+    if resume:
+        all_ids: list[str] = []
+        seen: set[str] = set()
+        for tid in plan.task_ids:
+            if tid not in seen:
+                all_ids.append(tid)
+                seen.add(tid)
+        for a in attempts:
+            tid = str(a.get("task_id") or "")
+            if tid and tid not in seen:
+                all_ids.append(tid)
+                seen.add(tid)
+        # Mutate a shallow copy of plan fields for summary only.
+        summary_plan = SuitePlan(
+            database_id=plan.database_id,
+            database_version=plan.database_version,
+            database_root=plan.database_root,
+            task_ids=all_ids,
+            max_concurrent_tasks=plan.max_concurrent_tasks,
+            n_attempts=plan.n_attempts,
+            suite_run_id=plan.suite_run_id,
+        )
+        # If other tasks had more samples, take max n_attempts for display budget.
+        max_n = plan.n_attempts
+        by_t: dict[str, int] = {}
+        for a in attempts:
+            tid = str(a.get("task_id") or "")
+            by_t[tid] = by_t.get(tid, 0) + 1
+        if by_t:
+            max_n = max(max_n, max(by_t.values()))
+        summary_plan.n_attempts = max_n
+    else:
+        summary_plan = plan
+
+    summary = _build_summary(
+        summary_plan,
+        attempts,
+        overrides=overrides,
+        profiles_path=profiles_path,
+    )
+    if resume:
+        summary["resumed"] = True
+        summary["new_attempts"] = len(new_results)
+        summary["skipped_attempts"] = len(done_keys & set(units))
+    return _write_summary(plan, summary)

--- a/src/bora/application/suite_run.py
+++ b/src/bora/application/suite_run.py
@@ -205,9 +205,24 @@ def planned_units(plan: SuitePlan) -> list[tuple[str, int]]:
     return [(tid, i) for tid in plan.task_ids for i in range(plan.n_attempts)]
 
 
+def _is_cancelled_placeholder(row: Mapping[str, Any]) -> bool:
+    """Synthetic suite-cancel rows (never ran) — retriable on resume."""
+    if str(row.get("phase") or "") == "cancelled":
+        return True
+    return str(row.get("error") or "") == "suite_cancelled"
+
+
 def _existing_attempt_keys(attempts: list[dict[str, Any]]) -> set[tuple[str, int]]:
+    """Keys of finished attempts that resume must **not** re-run.
+
+    Suite-cancel placeholders (``phase: cancelled`` / ``error: suite_cancelled``)
+    are **excluded** so ``--resume-suite`` can top up Always-k samples; otherwise
+    pass@k / pass^k stay permanently deflated.
+    """
     keys: set[tuple[str, int]] = set()
     for row in attempts:
+        if _is_cancelled_placeholder(row):
+            continue
         tid = str(row.get("task_id") or "")
         idx = row.get("attempt_index")
         if not tid:
@@ -343,6 +358,15 @@ def request_suite_cancel(database_root: Path, suite_run_id: str) -> Path:
         encoding="utf-8",
     )
     return path
+
+
+def clear_suite_cancel(database_root: Path, suite_run_id: str) -> bool:
+    """Remove cancel.requested (e.g. before resume so the job can schedule again)."""
+    path = cancel_request_path(database_root, suite_run_id)
+    if not path.is_file():
+        return False
+    path.unlink(missing_ok=True)
+    return True
 
 
 def _write_suite_progress(
@@ -534,11 +558,14 @@ async def execute_suite_run(
     """Execute planned task×attempt units with a concurrency pool; write summary.
 
     When ``resume=True``, load existing attempts for ``plan.suite_run_id``, skip
-    units that already finished, **append** new attempts, and recompute metrics.
-    Existing attempt rows are never rewritten.
+    units that already finished a real run, **append** new attempts (including
+    re-runs of suite-cancel placeholders), and recompute metrics.
+    Real finished attempt rows are never rewritten; cancel placeholders are
+    dropped when their slot is re-executed.
 
     Cancel (#47 D4): if ``suite-runs/<id>/cancel.requested`` appears, no new units
     start; in-flight units finish; remaining planned units get cancelled rows.
+    Resume clears a prior cancel request so scheduling can proceed.
     """
     reset_inflight_metrics()
     runner = run_fn or run_task
@@ -546,6 +573,8 @@ async def execute_suite_run(
 
     existing: list[dict[str, Any]] = []
     if resume:
+        # Allow re-scheduling after a previous cancel.
+        clear_suite_cancel(plan.database_root, plan.suite_run_id)
         old = load_suite_summary(plan.database_root, plan.suite_run_id)
         raw_attempts = old.get("attempts")
         if isinstance(raw_attempts, list) and raw_attempts:
@@ -713,18 +742,40 @@ async def execute_suite_run(
     if skipped_cancelled:
         new_results.extend(skipped_cancelled)
 
-    # Append-only merge: existing first (stable), then new; never mutate old rows.
+    # Merge: keep real finished rows; drop cancel placeholders for slots we
+    # re-ran (or re-cancelled). Never mutate real finished attempt payloads.
+    new_keys: set[tuple[str, int]] = set()
+    for r in new_results:
+        tid = str(r.get("task_id") or "")
+        idx = r.get("attempt_index")
+        if not tid:
+            continue
+        if not isinstance(idx, int) or isinstance(idx, bool):
+            idx = 0
+        new_keys.add((tid, idx))
+
+    def _keep_existing_row(row: Mapping[str, Any]) -> bool:
+        tid = str(row.get("task_id") or "")
+        idx = row.get("attempt_index")
+        if not isinstance(idx, int) or isinstance(idx, bool):
+            idx = 0
+        key = (tid, idx)
+        # Slot re-executed this session → drop old placeholder / stale row.
+        return key not in new_keys
+
     attempts = list(existing) + new_results
-    # Drop attempts outside planned task set only when filtering? Keep all that
-    # belong to plan.task_ids; preserve other tasks already in the job for resume
-    # of a subset (Harbor: re-run one task without wiping the rest).
     if resume and plan.task_ids:
         planned_set = set(plan.task_ids)
-        # Keep attempts for tasks not in this plan's filter (other suite members).
+        # Sibling tasks outside this resume filter stay as-is.
         kept_other = [a for a in existing if str(a.get("task_id") or "") not in planned_set]
-        # For planned tasks: existing matching keys + new
-        planned_existing = [a for a in existing if str(a.get("task_id") or "") in planned_set]
+        planned_existing = [
+            a
+            for a in existing
+            if str(a.get("task_id") or "") in planned_set and _keep_existing_row(a)
+        ]
         attempts = kept_other + planned_existing + new_results
+    elif new_keys:
+        attempts = [a for a in existing if _keep_existing_row(a)] + new_results
 
     # Union task_ids for summary when resume brings siblings.
     if resume:

--- a/src/bora/application/suite_run.py
+++ b/src/bora/application/suite_run.py
@@ -10,6 +10,7 @@ package identity or ``config_fingerprint`` inputs.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import uuid
 from collections.abc import Awaitable, Callable, Mapping
@@ -309,6 +310,43 @@ async def _run_one(
                 _inflight_current -= 1
 
 
+def suite_dir_for(plan: SuitePlan) -> Path:
+    return plan.database_root / ".bora" / "suite-runs" / plan.suite_run_id
+
+
+def cancel_request_path(database_root: Path, suite_run_id: str) -> Path:
+    return (
+        database_root.expanduser().resolve(strict=False)
+        / ".bora"
+        / "suite-runs"
+        / suite_run_id
+        / "cancel.requested"
+    )
+
+
+def is_suite_cancel_requested(database_root: Path, suite_run_id: str) -> bool:
+    return cancel_request_path(database_root, suite_run_id).is_file()
+
+
+def request_suite_cancel(database_root: Path, suite_run_id: str) -> Path:
+    """Create cancel.requested so the suite loop stops starting new units."""
+    path = cancel_request_path(database_root, suite_run_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "bora.suite.cancel/1",
+                "suite_run_id": suite_run_id,
+                "requested_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
 def _write_suite_progress(
     plan: SuitePlan,
     *,
@@ -318,7 +356,7 @@ def _write_suite_progress(
     status: str = "running",
 ) -> None:
     """Job progress snapshot for viewer / status (D2)."""
-    suite_dir = plan.database_root / ".bora" / "suite-runs" / plan.suite_run_id
+    suite_dir = suite_dir_for(plan)
     suite_dir.mkdir(parents=True, exist_ok=True)
     doc = {
         "schema": "bora.suite.progress/1",
@@ -330,11 +368,15 @@ def _write_suite_progress(
         "max_concurrent_tasks": plan.max_concurrent_tasks,
         "running": running,
         "updated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "cancel_requested": is_suite_cancel_requested(plan.database_root, plan.suite_run_id),
     }
     out = suite_dir / "progress.json"
     tmp = out.with_suffix(".tmp")
     tmp.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     tmp.replace(out)
+
+
+ProgressCallback = Callable[[dict[str, Any]], None]
 
 
 def _build_summary(
@@ -518,15 +560,20 @@ async def execute_suite_run(
     run_fn: Callable[..., Awaitable[tuple[int, Any, dict[str, Any]]]] | None = None,
     profiles_path: Path | str | None = None,
     resume: bool = False,
+    on_progress: ProgressCallback | None = None,
 ) -> dict[str, Any]:
     """Execute planned task×attempt units with a concurrency pool; write summary.
 
     When ``resume=True``, load existing attempts for ``plan.suite_run_id``, skip
     units that already finished, **append** new attempts, and recompute metrics.
     Existing attempt rows are never rewritten.
+
+    Cancel (#47 D4): if ``suite-runs/<id>/cancel.requested`` appears, no new units
+    start; in-flight units finish; remaining planned units get cancelled rows.
     """
     reset_inflight_metrics()
     runner = run_fn or run_task
+    suite_dir_for(plan).mkdir(parents=True, exist_ok=True)
 
     existing: list[dict[str, Any]] = []
     if resume:
@@ -550,60 +597,159 @@ async def execute_suite_run(
     done_keys = _existing_attempt_keys(existing)
     units = planned_units(plan)
     todo = [(tid, idx) for tid, idx in units if (tid, idx) not in done_keys]
-    total_units = len(units) if not resume else max(len(units), len(done_keys | set(todo)))
+    total_units = max(len(units), len(todo) + len(done_keys & set(units)))
     # Progress: completed existing + in-flight bookkeeping.
     completed_count = len(done_keys & set(units)) if resume else 0
+    cancelled = False
+    new_results: list[dict[str, Any]] = []
+    skipped_cancelled: list[dict[str, Any]] = []
+
+    def _emit(event: dict[str, Any]) -> None:
+        if on_progress is not None:
+            with contextlib.suppress(Exception):
+                on_progress(event)
+
     _write_suite_progress(
         plan,
         done=completed_count,
-        total=max(total_units, len(todo) + completed_count),
+        total=total_units,
         running=[],
         status="running" if todo else "complete",
     )
+    _emit(
+        {
+            "type": "suite_start",
+            "suite_run_id": plan.suite_run_id,
+            "done": completed_count,
+            "total": total_units,
+            "todo": len(todo),
+        }
+    )
 
-    semaphore = asyncio.Semaphore(plan.max_concurrent_tasks)
+    # Worker pool: claim units by index so cancel can stop scheduling new work.
+    todo_list = list(todo)
+    claim_index = 0
+    claim_lock = asyncio.Lock()
+    worker_n = min(plan.max_concurrent_tasks, max(1, len(todo_list))) if todo_list else 0
+
     progress_lock = asyncio.Lock()
     inflight_labels: dict[tuple[str, int], str] = {}
+    semaphore = asyncio.Semaphore(plan.max_concurrent_tasks)
 
-    async def _tracked(tid: str, idx: int) -> dict[str, Any]:
-        nonlocal completed_count
-        async with progress_lock:
-            inflight_labels[(tid, idx)] = "running"
-            _write_suite_progress(
+    def _cancelled_row(tid: str, idx: int) -> dict[str, Any]:
+        return {
+            "task_id": tid,
+            "attempt_index": idx,
+            "exit_code": 2,
+            "status": "ERROR",
+            "score": None,
+            "metrics": {},
+            "run_id": None,
+            "digest": None,
+            "error": "suite_cancelled",
+            "phase_timing": None,
+            "duration": None,
+            "phase": "cancelled",
+        }
+
+    async def _worker() -> None:
+        nonlocal completed_count, cancelled, claim_index
+        while True:
+            if is_suite_cancel_requested(plan.database_root, plan.suite_run_id):
+                cancelled = True
+                return
+            async with claim_lock:
+                if claim_index >= len(todo_list):
+                    return
+                tid, idx = todo_list[claim_index]
+                claim_index += 1
+            if is_suite_cancel_requested(plan.database_root, plan.suite_run_id):
+                cancelled = True
+                async with progress_lock:
+                    skipped_cancelled.append(_cancelled_row(tid, idx))
+                    completed_count += 1
+                return
+
+            async with progress_lock:
+                inflight_labels[(tid, idx)] = "running"
+                _write_suite_progress(
+                    plan,
+                    done=completed_count,
+                    total=total_units,
+                    running=[
+                        {"task_id": t, "attempt_index": i, "phase": ph}
+                        for (t, i), ph in inflight_labels.items()
+                    ],
+                )
+                _emit(
+                    {
+                        "type": "unit_start",
+                        "task_id": tid,
+                        "attempt_index": idx,
+                        "done": completed_count,
+                        "total": total_units,
+                        "running": list(inflight_labels.keys()),
+                    }
+                )
+
+            row = await _run_one(
                 plan,
-                done=completed_count,
-                total=max(total_units, completed_count + len(todo)),
-                running=[
-                    {"task_id": t, "attempt_index": i, "phase": ph}
-                    for (t, i), ph in inflight_labels.items()
-                ],
+                tid,
+                idx,
+                semaphore=semaphore,
+                overrides=overrides,
+                run_fn=runner,
+                profiles_path=profiles_path,
             )
-        row = await _run_one(
-            plan,
-            tid,
-            idx,
-            semaphore=semaphore,
-            overrides=overrides,
-            run_fn=runner,
-            profiles_path=profiles_path,
-        )
-        async with progress_lock:
-            inflight_labels.pop((tid, idx), None)
+            async with progress_lock:
+                new_results.append(row)
+                inflight_labels.pop((tid, idx), None)
+                completed_count += 1
+                cancel_now = is_suite_cancel_requested(plan.database_root, plan.suite_run_id)
+                if cancel_now:
+                    cancelled = True
+                if cancel_now:
+                    st = "cancelling"
+                elif claim_index < len(todo_list) or inflight_labels:
+                    st = "running"
+                else:
+                    st = "complete"
+
+                _write_suite_progress(
+                    plan,
+                    done=completed_count,
+                    total=total_units,
+                    running=[
+                        {"task_id": t, "attempt_index": i, "phase": ph}
+                        for (t, i), ph in inflight_labels.items()
+                    ],
+                    status=st,
+                )
+                _emit(
+                    {
+                        "type": "unit_done",
+                        "task_id": tid,
+                        "attempt_index": idx,
+                        "status": row.get("status"),
+                        "done": completed_count,
+                        "total": total_units,
+                        "duration": row.get("duration"),
+                    }
+                )
+
+    if worker_n:
+        await asyncio.gather(*[asyncio.create_task(_worker()) for _ in range(worker_n)])
+
+    # Units never claimed because of cancel → synthetic cancelled rows.
+    async with claim_lock:
+        remaining = todo_list[claim_index:]
+    if remaining:
+        cancelled = True
+        for tid, idx in remaining:
+            skipped_cancelled.append(_cancelled_row(tid, idx))
             completed_count += 1
-            _write_suite_progress(
-                plan,
-                done=completed_count,
-                total=max(total_units, completed_count + len(inflight_labels)),
-                running=[
-                    {"task_id": t, "attempt_index": i, "phase": ph}
-                    for (t, i), ph in inflight_labels.items()
-                ],
-                status="running" if inflight_labels else "complete",
-            )
-        return row
-
-    coros = [_tracked(tid, idx) for tid, idx in todo]
-    new_results: list[dict[str, Any]] = list(await asyncio.gather(*coros)) if coros else []
+    if skipped_cancelled:
+        new_results.extend(skipped_cancelled)
 
     # Append-only merge: existing first (stable), then new; never mutate old rows.
     attempts = list(existing) + new_results
@@ -661,6 +807,45 @@ async def execute_suite_run(
     )
     if resume:
         summary["resumed"] = True
-        summary["new_attempts"] = len(new_results)
+        summary["new_attempts"] = len([r for r in new_results if r.get("phase") != "cancelled"])
         summary["skipped_attempts"] = len(done_keys & set(units))
+    if cancelled or is_suite_cancel_requested(plan.database_root, plan.suite_run_id):
+        summary["cancelled"] = True
+        summary["status"] = "cancelled"
+        # Prefer non-zero exit when cancelled with incomplete work.
+        if summary.get("exit_code") == 0 and skipped_cancelled:
+            summary["exit_code"] = 2
+        _write_suite_progress(
+            plan,
+            done=completed_count,
+            total=total_units,
+            running=[],
+            status="cancelled",
+        )
+        _emit(
+            {
+                "type": "suite_cancelled",
+                "suite_run_id": plan.suite_run_id,
+                "done": completed_count,
+                "total": total_units,
+                "cancelled_units": len(skipped_cancelled),
+            }
+        )
+    else:
+        _write_suite_progress(
+            plan,
+            done=completed_count,
+            total=total_units,
+            running=[],
+            status="complete",
+        )
+        _emit(
+            {
+                "type": "suite_complete",
+                "suite_run_id": plan.suite_run_id,
+                "done": completed_count,
+                "total": total_units,
+                "exit_code": summary.get("exit_code"),
+            }
+        )
     return _write_summary(plan, summary)

--- a/src/bora/application/suite_run.py
+++ b/src/bora/application/suite_run.py
@@ -23,7 +23,6 @@ from bora.application.run_command import run_task
 from bora.application.suite_config_fingerprint import collect_suite_config
 from bora.application.suite_metrics import (
     aggregate_k_metrics,
-    aggregate_task_metrics,
     flatten_legacy_tasks_as_attempts,
     task_refs_for_summary,
 )
@@ -224,90 +223,89 @@ async def _run_one(
     task_id: str,
     attempt_index: int,
     *,
-    semaphore: asyncio.Semaphore,
     overrides: dict[str, Any] | None,
     run_fn: Callable[..., Awaitable[tuple[int, Any, dict[str, Any]]]],
     profiles_path: Path | str | None = None,
 ) -> dict[str, Any]:
+    """Run one (task_id, attempt_index) unit. Concurrency is owned by the claim pool."""
     global _inflight_current, _inflight_peak
-    async with semaphore:
-        async with _inflight_lock:
-            _inflight_current += 1
-            _inflight_peak = max(_inflight_peak, _inflight_current)
-        try:
-            code, result, details = await run_fn(
-                plan.database_root,
-                task_id,
-                overrides=overrides,
-                profiles_path=profiles_path,
-            )
-            status = getattr(result, "status", None) or details.get("status") or "ERROR"
-            run_id = extract_run_id(
-                plan.database_root,
-                getattr(result, "evidence_path", None),
-                details.get("run_dir"),
-                details.get("logs"),
-                getattr(result, "logs", None),
-            )
-            raw_metrics = getattr(result, "metrics", None)
-            if not isinstance(raw_metrics, dict):
-                detail_metrics = details.get("metrics")
-                raw_metrics = detail_metrics if isinstance(detail_metrics, dict) else {}
-            phase_timing = details.get("phase_timing")
-            if not isinstance(phase_timing, dict):
-                phase_timing = None
-            duration = None
-            if phase_timing is not None:
-                from bora.application.phase_timing import format_duration_ms
+    async with _inflight_lock:
+        _inflight_current += 1
+        _inflight_peak = max(_inflight_peak, _inflight_current)
+    try:
+        code, result, details = await run_fn(
+            plan.database_root,
+            task_id,
+            overrides=overrides,
+            profiles_path=profiles_path,
+        )
+        status = getattr(result, "status", None) or details.get("status") or "ERROR"
+        run_id = extract_run_id(
+            plan.database_root,
+            getattr(result, "evidence_path", None),
+            details.get("run_dir"),
+            details.get("logs"),
+            getattr(result, "logs", None),
+        )
+        raw_metrics = getattr(result, "metrics", None)
+        if not isinstance(raw_metrics, dict):
+            detail_metrics = details.get("metrics")
+            raw_metrics = detail_metrics if isinstance(detail_metrics, dict) else {}
+        phase_timing = details.get("phase_timing")
+        if not isinstance(phase_timing, dict):
+            phase_timing = None
+        duration = None
+        if phase_timing is not None:
+            from bora.application.phase_timing import format_duration_ms
 
-                duration = format_duration_ms(phase_timing.get("total_ms"))  # type: ignore[arg-type]
-            return {
-                "task_id": task_id,
-                "attempt_index": attempt_index,
-                "exit_code": code,
-                "status": status,
-                "score": getattr(result, "score", None),
-                "metrics": dict(raw_metrics) if raw_metrics else {},
-                "run_id": run_id,
-                "digest": details.get("digest"),
-                "error": None if code != 2 else (details.get("error") or status),
-                "phase_timing": phase_timing,
-                "duration": duration,
-                "phase": "terminal",
-            }
-        except ConfigError as exc:
-            return {
-                "task_id": task_id,
-                "attempt_index": attempt_index,
-                "exit_code": 2,
-                "status": "ERROR",
-                "score": None,
-                "metrics": {},
-                "run_id": None,
-                "digest": None,
-                "error": str(exc),
-                "phase_timing": None,
-                "duration": None,
-                "phase": "error",
-            }
-        except Exception as exc:  # noqa: BLE001
-            return {
-                "task_id": task_id,
-                "attempt_index": attempt_index,
-                "exit_code": 2,
-                "status": "ERROR",
-                "score": None,
-                "metrics": {},
-                "run_id": None,
-                "digest": None,
-                "error": f"{type(exc).__name__}: {exc}",
-                "phase_timing": None,
-                "duration": None,
-                "phase": "error",
-            }
-        finally:
-            async with _inflight_lock:
-                _inflight_current -= 1
+            duration = format_duration_ms(phase_timing.get("total_ms"))  # type: ignore[arg-type]
+        return {
+            "task_id": task_id,
+            "attempt_index": attempt_index,
+            "exit_code": code,
+            "status": status,
+            "score": getattr(result, "score", None),
+            "metrics": dict(raw_metrics) if raw_metrics else {},
+            "run_id": run_id,
+            "digest": details.get("digest"),
+            "error": None if code != 2 else (details.get("error") or status),
+            "phase_timing": phase_timing,
+            "duration": duration,
+            "phase": "terminal",
+        }
+    except ConfigError as exc:
+        return {
+            "task_id": task_id,
+            "attempt_index": attempt_index,
+            "exit_code": 2,
+            "status": "ERROR",
+            "score": None,
+            "metrics": {},
+            "run_id": None,
+            "digest": None,
+            "error": str(exc),
+            "phase_timing": None,
+            "duration": None,
+            "phase": "error",
+        }
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "task_id": task_id,
+            "attempt_index": attempt_index,
+            "exit_code": 2,
+            "status": "ERROR",
+            "score": None,
+            "metrics": {},
+            "run_id": None,
+            "digest": None,
+            "error": f"{type(exc).__name__}: {exc}",
+            "phase_timing": None,
+            "duration": None,
+            "phase": "error",
+        }
+    finally:
+        async with _inflight_lock:
+            _inflight_current -= 1
 
 
 def suite_dir_for(plan: SuitePlan) -> Path:
@@ -379,6 +377,32 @@ def _write_suite_progress(
 ProgressCallback = Callable[[dict[str, Any]], None]
 
 
+def _task_row_from_rollup(t: Mapping[str, Any]) -> dict[str, Any]:
+    """One stable ``tasks[]`` row for any k (roll-up + primary attempt surface)."""
+    nested = t.get("attempts") or []
+    first: Mapping[str, Any] = nested[0] if nested and isinstance(nested[0], Mapping) else {}
+    first_metrics = first.get("metrics") if isinstance(first.get("metrics"), dict) else {}
+    return {
+        "task_id": t.get("task_id"),
+        "status": t.get("status"),
+        "score": t.get("score"),
+        "n": t.get("n"),
+        "c": t.get("c"),
+        "run_id": t.get("run_id"),
+        "pass_at_k": t.get("pass_at_k") or {},
+        "pass_power_k": t.get("pass_power_k") or {},
+        "attempt_indices": t.get("attempt_indices"),
+        # Primary attempt surface (k==1 ≡ the only sample; k>1 = first by index).
+        "exit_code": first.get("exit_code"),
+        "metrics": dict(first_metrics) if first_metrics else {},
+        "digest": first.get("digest"),
+        "error": first.get("error"),
+        "attempt_index": first.get("attempt_index", 0),
+        "phase_timing": first.get("phase_timing"),
+        "duration": first.get("duration"),
+    }
+
+
 def _build_summary(
     plan: SuitePlan,
     attempts: list[dict[str, Any]],
@@ -393,77 +417,22 @@ def _build_summary(
         n_attempts=plan.n_attempts,
     )
     task_rows: list[dict[str, Any]] = list(k_agg.pop("task_rows"))
-
-    # Strip nested attempts from tasks[] for a flatter summary when k==1
-    # (backward-compatible shape); keep attempts[] always for resume.
-    tasks_out: list[dict[str, Any]]
-    if plan.n_attempts == 1 and all(len(t.get("attempts") or []) <= 1 for t in task_rows):
-        tasks_out = []
-        for t in task_rows:
-            nested = t.get("attempts") or []
-            base = nested[0] if nested else {}
-            row = {
-                "task_id": t["task_id"],
-                "exit_code": base.get("exit_code"),
-                "status": t["status"],
-                "score": base.get("score", t.get("score")),
-                "metrics": base.get("metrics") if isinstance(base.get("metrics"), dict) else {},
-                "run_id": t.get("run_id"),
-                "digest": base.get("digest"),
-                "error": base.get("error"),
-                "attempt_index": 0,
-                "phase_timing": base.get("phase_timing"),
-                "duration": base.get("duration"),
-            }
-            # Surface k stats only when n_attempts was requested >1 historically;
-            # for k==1 omit pass_at_k maps from task row to keep legacy tests green.
-            tasks_out.append(row)
-        metrics = aggregate_task_metrics(tasks_out)
-        # Still attach pass@k maps under metrics when useful (k=1 → pass@1 = pass_rate).
-        metrics["n_attempts"] = plan.n_attempts
-        metrics["k_values"] = k_agg.get("k_values", [1])
-        metrics["pass_at_k"] = k_agg.get("pass_at_k", {})
-        metrics["pass_power_k"] = k_agg.get("pass_power_k", {})
-        metrics["per_task"] = k_agg.get("per_task", [])
-    else:
-        tasks_out = []
-        for t in task_rows:
-            # Prefer first attempt's phase_timing for job-level display (observational).
-            nested = t.get("attempts") or []
-            first_pt = None
-            first_dur = None
-            if nested and isinstance(nested[0], Mapping):
-                first_pt = nested[0].get("phase_timing")
-                first_dur = nested[0].get("duration")
-            tasks_out.append(
-                {
-                    "task_id": t["task_id"],
-                    "status": t["status"],
-                    "score": t["score"],
-                    "n": t["n"],
-                    "c": t["c"],
-                    "run_id": t.get("run_id"),
-                    "pass_at_k": t["pass_at_k"],
-                    "pass_power_k": t["pass_power_k"],
-                    "attempt_indices": t.get("attempt_indices"),
-                    "phase_timing": first_pt,
-                    "duration": first_dur,
-                }
-            )
-        metrics = {
-            "pass_rate": k_agg["pass_rate"],
-            "mean_score": k_agg["mean_score"],
-            "n_tasks": k_agg["n_tasks"],
-            "n_pass": k_agg["n_pass"],
-            "n_fail": k_agg["n_fail"],
-            "n_error": k_agg["n_error"],
-            "missing_score_as": k_agg["missing_score_as"],
-            "n_attempts": plan.n_attempts,
-            "k_values": k_agg["k_values"],
-            "pass_at_k": k_agg["pass_at_k"],
-            "pass_power_k": k_agg["pass_power_k"],
-            "per_task": k_agg["per_task"],
-        }
+    # Single shape for k==1 and k>1. Full samples live under ``attempts[]``.
+    tasks_out = [_task_row_from_rollup(t) for t in task_rows]
+    metrics = {
+        "pass_rate": k_agg["pass_rate"],
+        "mean_score": k_agg["mean_score"],
+        "n_tasks": k_agg["n_tasks"],
+        "n_pass": k_agg["n_pass"],
+        "n_fail": k_agg["n_fail"],
+        "n_error": k_agg["n_error"],
+        "missing_score_as": k_agg["missing_score_as"],
+        "n_attempts": plan.n_attempts,
+        "k_values": k_agg["k_values"],
+        "pass_at_k": k_agg["pass_at_k"],
+        "pass_power_k": k_agg["pass_power_k"],
+        "per_task": k_agg["per_task"],
+    }
 
     counts = {"pass": 0, "fail": 0, "error": 0, "skipped": 0}
     for row in tasks_out:
@@ -482,7 +451,7 @@ def _build_summary(
     else:
         exit_code = 0
 
-    # Fingerprint from one row per task (first attempt's run_id if needed).
+    # Fingerprint from one row per task (prefer a PASS attempt's run_id).
     fp_rows: list[dict[str, Any]] = []
     by_task_attempt: dict[str, list[dict[str, Any]]] = {}
     for a in attempts:
@@ -587,12 +556,6 @@ async def execute_suite_run(
                 existing = flatten_legacy_tasks_as_attempts(
                     [t for t in legacy_tasks if isinstance(t, Mapping)]
                 )
-        # Prefer higher n_attempts if resume raises budget.
-        old_k = old.get("n_attempts")
-        if isinstance(old_k, int) and not isinstance(old_k, bool) and old_k > plan.n_attempts:
-            # Keep caller's plan.n_attempts as target; old higher budget means
-            # more existing keys — fine.
-            pass
 
     done_keys = _existing_attempt_keys(existing)
     units = planned_units(plan)
@@ -627,6 +590,7 @@ async def execute_suite_run(
     )
 
     # Worker pool: claim units by index so cancel can stop scheduling new work.
+    # Pool size alone caps concurrency (no nested semaphore).
     todo_list = list(todo)
     claim_index = 0
     claim_lock = asyncio.Lock()
@@ -634,7 +598,6 @@ async def execute_suite_run(
 
     progress_lock = asyncio.Lock()
     inflight_labels: dict[tuple[str, int], str] = {}
-    semaphore = asyncio.Semaphore(plan.max_concurrent_tasks)
 
     def _cancelled_row(tid: str, idx: int) -> dict[str, Any]:
         return {
@@ -652,6 +615,12 @@ async def execute_suite_run(
             "phase": "cancelled",
         }
 
+    def _running_snapshot() -> list[dict[str, Any]]:
+        return [
+            {"task_id": t, "attempt_index": i, "phase": ph}
+            for (t, i), ph in inflight_labels.items()
+        ]
+
     async def _worker() -> None:
         nonlocal completed_count, cancelled, claim_index
         while True:
@@ -663,12 +632,13 @@ async def execute_suite_run(
                     return
                 tid, idx = todo_list[claim_index]
                 claim_index += 1
+            # Re-check after claim: do not start new work once cancel is requested.
             if is_suite_cancel_requested(plan.database_root, plan.suite_run_id):
                 cancelled = True
                 async with progress_lock:
                     skipped_cancelled.append(_cancelled_row(tid, idx))
                     completed_count += 1
-                return
+                continue
 
             async with progress_lock:
                 inflight_labels[(tid, idx)] = "running"
@@ -676,10 +646,7 @@ async def execute_suite_run(
                     plan,
                     done=completed_count,
                     total=total_units,
-                    running=[
-                        {"task_id": t, "attempt_index": i, "phase": ph}
-                        for (t, i), ph in inflight_labels.items()
-                    ],
+                    running=_running_snapshot(),
                 )
                 _emit(
                     {
@@ -696,7 +663,6 @@ async def execute_suite_run(
                 plan,
                 tid,
                 idx,
-                semaphore=semaphore,
                 overrides=overrides,
                 run_fn=runner,
                 profiles_path=profiles_path,
@@ -708,7 +674,6 @@ async def execute_suite_run(
                 cancel_now = is_suite_cancel_requested(plan.database_root, plan.suite_run_id)
                 if cancel_now:
                     cancelled = True
-                if cancel_now:
                     st = "cancelling"
                 elif claim_index < len(todo_list) or inflight_labels:
                     st = "running"
@@ -719,10 +684,7 @@ async def execute_suite_run(
                     plan,
                     done=completed_count,
                     total=total_units,
-                    running=[
-                        {"task_id": t, "attempt_index": i, "phase": ph}
-                        for (t, i), ph in inflight_labels.items()
-                    ],
+                    running=_running_snapshot(),
                     status=st,
                 )
                 _emit(

--- a/src/bora/cli/README.md
+++ b/src/bora/cli/README.md
@@ -81,11 +81,11 @@ Credentials file `~/.bora/credentials` (mode `0600`):
 | --- | --- |
 | `bora tasks` | List member task ids in a Database |
 | `bora lock` | Lock config (no Agent) |
-| `bora run` | Run one member or a full suite |
-| `bora campaign` | Serial parameter-matrix campaign |
+| `bora run` | Run one member or a full suite (Always-k via `-k` / `--n-attempts`) |
+| `bora campaign` | Serial parameter-matrix campaign (matrix axis ≠ k-attempt) |
 | `bora executors` | Host executor / ACP entry inventory |
 | `bora evidence` | Export sealed trajectory copy (does not change score) |
-| `bora submit` / `status` / `cancel` | Durable Run control (v0.12 sketch) |
+| `bora submit` / `status` / `cancel` | Durable Run / suite job control (`suite_…` + optional `--database`) |
 | `bora login` | GitHub **Device Flow** → write credentials (Hub uses browser OAuth instead) |
 | `bora publish` | Publish a Database package (**requires `--org`**) |
 | `bora registry list\|show` | Browse remote packages |
@@ -116,6 +116,12 @@ uv run bora run examples/core --task sdk-agent-session
 
 # Full suite (omit --task)
 uv run bora run examples/core
+
+# Always-k (#47): k independent Attempts per task — CLI/job only (not task.yaml)
+uv run bora run examples/core -k 5 --max-concurrent-tasks 2
+uv run bora run examples/core --task sdk-agent-session -k 5
+# Resume / top-up one task into an existing suite job, recompute pass@k / pass^k
+# uv run bora run examples/core --resume-suite suite_<id> --task sdk-agent-session -k 5
 
 # Allowlisted --set (JSON Pointer = JSON value)
 uv run bora lock examples/core --task config-minimal --set /parameters/seed=7
@@ -155,6 +161,19 @@ uv run bora evidence "$LOGS_PATH" --out /tmp/bora-export
 
 Trajectory presence **≠** PASS. PASS comes only from an independent evaluator.
 
+### Always-k metrics (suite job)
+
+After `-k` / full suite, read:
+
+```text
+.bora/suite-runs/<suite_run_id>/summary.json   # metrics.pass_at_k / pass_power_k / pass_rate …
+.bora/suite-runs/<suite_run_id>/progress.json
+```
+
+- **pass@k** / **pass^k** are **job** aggregates (mean over tasks); not package identity  
+- `--max-concurrent-tasks` only speeds scheduling; does not change k or PASS  
+- Single-task `k=1` without `--resume-suite` keeps the historical single Attempt JSON on stdout  
+
 ### Campaign / control plane (brief)
 
 ```bash
@@ -164,6 +183,10 @@ uv run bora campaign examples/core --task config-minimal \
 uv run bora submit examples/core --task config-minimal
 uv run bora status <run_id>
 uv run bora cancel <run_id>
+
+# Suite job (#47 D)
+uv run bora status suite_<id> --database examples/core
+uv run bora cancel suite_<id> --database examples/core
 ```
 
 ### Executors
@@ -244,9 +267,9 @@ for public.
 
 ### Suite / job results
 
-After `bora run <database>` (full suite), summary lives at
+After `bora run <database>` (full suite or Always-k), summary lives at
 `<database>/.bora/suite-runs/<suite_run_id>/summary.json` with observational
-`metrics.pass_rate` / `metrics.mean_score` (not suite PASS).
+`metrics.pass_rate` / `mean_score` / `pass_at_k` / `pass_power_k` (not suite PASS).
 
 ```bash
 uv run bora results upload-suite /path/to/database --suite-run <suite_run_id> \

--- a/src/bora/cli/README.md
+++ b/src/bora/cli/README.md
@@ -120,7 +120,7 @@ uv run bora run examples/core
 # Always-k (#47): k independent Attempts per task — CLI/job only (not task.yaml)
 uv run bora run examples/core -k 5 --max-concurrent-tasks 2
 uv run bora run examples/core --task sdk-agent-session -k 5
-# Resume / top-up one task into an existing suite job, recompute pass@k / pass^k
+# Resume / top-up: skip real finished units; re-run suite-cancel placeholders; recompute pass@k
 # uv run bora run examples/core --resume-suite suite_<id> --task sdk-agent-session -k 5
 
 # Allowlisted --set (JSON Pointer = JSON value)

--- a/src/bora/cli/cmd_campaign_run.py
+++ b/src/bora/cli/cmd_campaign_run.py
@@ -89,8 +89,32 @@ def register(app: typer.Typer) -> None:
             typer.Option(
                 "--max-concurrent-tasks",
                 help=(
-                    "Max concurrent suite tasks (integer ≥1). Default 1 or Database "
-                    "defaults.max_concurrent_tasks. Ignored when only one task runs."
+                    "Max concurrent suite work units (integer ≥1). Default 1 or Database "
+                    "defaults.max_concurrent_tasks. Speeds wall time only; does not change "
+                    "n_attempts or pass/fail. Forced to 1 when a single task runs once."
+                ),
+            ),
+        ] = None,
+        n_attempts: Annotated[
+            int | None,
+            typer.Option(
+                "--n-attempts",
+                "-k",
+                help=(
+                    "Always-k: independent Attempts per task (integer ≥1, default 1). "
+                    "CLI/job only — not a task.yaml field, not part of config_fingerprint. "
+                    "Feeds pass@k / pass^k job metrics."
+                ),
+            ),
+        ] = None,
+        resume_suite: Annotated[
+            str | None,
+            typer.Option(
+                "--resume-suite",
+                help=(
+                    "Resume an existing suite_run_id under .bora/suite-runs/. "
+                    "Skips finished (task_id, attempt_index) units, appends new Attempts, "
+                    "recomputes pass@k / pass^k. Combine with --task to top up one task."
                 ),
             ),
         ] = None,
@@ -127,14 +151,25 @@ def register(app: typer.Typer) -> None:
                 pointer, value = parse_set_override(raw)
                 overrides[pointer] = value
 
+            k = n_attempts if n_attempts is not None else 1
+            resume_id = resume_suite.strip() if resume_suite and str(resume_suite).strip() else None
+
             # Full suite when --task omitted; single task when provided.
             plan = plan_suite_run(
                 package,
                 task_id=task.strip() if task and str(task).strip() else None,
                 max_concurrent_tasks=max_concurrent_tasks,
+                n_attempts=k,
+                suite_run_id=resume_id,
             )
-            if len(plan.task_ids) == 1 and task and str(task).strip():
-                # Preserve historical single-task JSON stdout shape.
+            # Historical single-task JSON only when k==1 and not resuming.
+            if (
+                len(plan.task_ids) == 1
+                and task
+                and str(task).strip()
+                and plan.n_attempts == 1
+                and resume_id is None
+            ):
                 run_task = build_run_task()
                 code, result, _details = asyncio.run(
                     run_task(
@@ -170,6 +205,7 @@ def register(app: typer.Typer) -> None:
                     plan,
                     overrides=overrides or None,
                     profiles_path=profiles,
+                    resume=resume_id is not None,
                 )
             )
         except ConfigError as exc:

--- a/src/bora/cli/cmd_campaign_run.py
+++ b/src/bora/cli/cmd_campaign_run.py
@@ -249,13 +249,11 @@ def register(app: typer.Typer) -> None:
                     )
                 elif kind == "suite_complete":
                     sys.stderr.write(
-                        f"suite complete exit={ev.get('exit_code')} "
-                        f"done={done}/{total}\n"
+                        f"suite complete exit={ev.get('exit_code')} done={done}/{total}\n"
                     )
                 elif kind == "suite_cancelled":
                     sys.stderr.write(
-                        f"suite cancelled done={done}/{total} "
-                        f"skipped={ev.get('cancelled_units')}\n"
+                        f"suite cancelled done={done}/{total} skipped={ev.get('cancelled_units')}\n"
                     )
                 sys.stderr.flush()
 

--- a/src/bora/cli/cmd_campaign_run.py
+++ b/src/bora/cli/cmd_campaign_run.py
@@ -200,13 +200,92 @@ def register(app: typer.Typer) -> None:
                 )
                 raise typer.Exit(code=code)
 
+            import os
+            import sys
+
+            from bora.control.store import ControlStore
+
+            # Register suite job for bora status / bora cancel (D4).
+            control_path = Path.cwd() / ".bora" / "control.db"
+            cs = ControlStore(control_path)
+            cs.put(
+                plan.suite_run_id,
+                status="running",
+                owner="cli-run",
+                payload={
+                    "kind": "suite",
+                    "suite_run_id": plan.suite_run_id,
+                    "database_root": str(plan.database_root),
+                    "pid": os.getpid(),
+                    "n_attempts": plan.n_attempts,
+                    "task_ids": list(plan.task_ids),
+                    "max_concurrent_tasks": plan.max_concurrent_tasks,
+                },
+            )
+
+            def _progress(ev: dict) -> None:
+                # Terminal progress on stderr; final JSON stays on stdout.
+                kind = str(ev.get("type") or "")
+                done = ev.get("done")
+                total = ev.get("total")
+                if kind == "suite_start":
+                    sys.stderr.write(
+                        f"suite {plan.suite_run_id}: start "
+                        f"todo={ev.get('todo')} total={total} "
+                        f"(cancel: bora cancel {plan.suite_run_id})\n"
+                    )
+                elif kind == "unit_start":
+                    sys.stderr.write(
+                        f"[{done}/{total}] start {ev.get('task_id')} "
+                        f"attempt={ev.get('attempt_index')}\n"
+                    )
+                elif kind == "unit_done":
+                    sys.stderr.write(
+                        f"[{done}/{total}] done  {ev.get('task_id')} "
+                        f"attempt={ev.get('attempt_index')} "
+                        f"{ev.get('status')}"
+                        + (f" {ev.get('duration')}" if ev.get("duration") else "")
+                        + "\n"
+                    )
+                elif kind == "suite_complete":
+                    sys.stderr.write(
+                        f"suite complete exit={ev.get('exit_code')} "
+                        f"done={done}/{total}\n"
+                    )
+                elif kind == "suite_cancelled":
+                    sys.stderr.write(
+                        f"suite cancelled done={done}/{total} "
+                        f"skipped={ev.get('cancelled_units')}\n"
+                    )
+                sys.stderr.flush()
+
             suite_summary = asyncio.run(
                 execute_suite_run(
                     plan,
                     overrides=overrides or None,
                     profiles_path=profiles,
                     resume=resume_id is not None,
+                    on_progress=_progress,
                 )
+            )
+            final_status = (
+                "cancelled"
+                if suite_summary.get("cancelled")
+                else ("completed" if int(suite_summary.get("exit_code", 2)) == 0 else "failed")
+            )
+            cs.put(
+                plan.suite_run_id,
+                status=final_status,
+                owner="cli-run",
+                payload={
+                    "kind": "suite",
+                    "suite_run_id": plan.suite_run_id,
+                    "database_root": str(plan.database_root),
+                    "exit_code": suite_summary.get("exit_code"),
+                    "summary_path": suite_summary.get("summary_path"),
+                    "n_attempts": plan.n_attempts,
+                    "cancelled": bool(suite_summary.get("cancelled")),
+                },
             )
         except ConfigError as exc:
             typer.echo(str(exc), err=True)

--- a/src/bora/cli/cmd_cancel_submit.py
+++ b/src/bora/cli/cmd_cancel_submit.py
@@ -15,25 +15,71 @@ def register(app: typer.Typer) -> None:
 
     @app.command("cancel")
     def cancel_command(
-        run_id: Annotated[str, typer.Argument(help="Run id to cancel.")],
+        run_id: Annotated[
+            str,
+            typer.Argument(
+                help="Run id or suite_run_id (suite_…) from ControlStore / bora run suite.",
+            ),
+        ],
         store: Annotated[
             Path | None,
             typer.Option("--store", help="ControlStore sqlite path (default .bora/control.db)."),
         ] = None,
+        database: Annotated[
+            Path | None,
+            typer.Option(
+                "--database",
+                help=(
+                    "Database root for suite cancel when ControlStore has no record "
+                    "(writes suite-runs/<id>/cancel.requested)."
+                ),
+            ),
+        ] = None,
     ) -> None:
-        """Mark a durable Run as cancelled and SIGTERM stored pid when present (v0.12)."""
+        """Cancel a durable Run or suite job (#47 D4).
+
+        Suite: writes ``cancel.requested`` so no new units start; SIGTERM stored
+        pid when present. Single Run: same as v0.12 ControlStore cancel.
+        """
         import os
         import signal
 
+        from bora.application.suite_run import request_suite_cancel
         from bora.control.store import ControlStore
 
         path = store or (Path.cwd() / ".bora" / "control.db")
         cs = ControlStore(path)
         rec = cs.get(run_id)
-        if rec is None:
+        payload: dict = dict((rec or {}).get("payload") or {})
+        kind = str(payload.get("kind") or "")
+        is_suite = kind == "suite" or run_id.startswith("suite_")
+
+        cancel_file = None
+        if is_suite:
+            db_root = database
+            if db_root is None and payload.get("database_root"):
+                db_root = Path(str(payload["database_root"]))
+            if db_root is not None:
+                cancel_file = str(request_suite_cancel(db_root, run_id))
+
+        if rec is None and not is_suite:
             typer.echo(json.dumps({"ok": False, "error": "unknown_run", "run_id": run_id}))
             raise typer.Exit(code=2)
-        payload = dict(rec.get("payload") or {})
+        if rec is None and is_suite and cancel_file is None:
+            typer.echo(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "error": "unknown_suite",
+                        "run_id": run_id,
+                        "hint": "pass --database <root> or cancel while suite is registered",
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            )
+            raise typer.Exit(code=2)
+
         killed = False
         pid = payload.get("pid")
         if isinstance(pid, int) and pid > 0:
@@ -42,20 +88,30 @@ def register(app: typer.Typer) -> None:
                 killed = True
             except OSError:
                 killed = False
-        version = cs.put(
-            run_id,
-            status="cancelled",
-            owner=str(rec.get("owner") or "cli"),
-            payload={**payload, "cancel_requested": True, "sigterm_sent": killed},
-        )
+        version = None
+        if rec is not None or is_suite:
+            version = cs.put(
+                run_id,
+                status="cancelled",
+                owner=str((rec or {}).get("owner") or "cli"),
+                payload={
+                    **payload,
+                    "kind": "suite" if is_suite else payload.get("kind") or "run",
+                    "cancel_requested": True,
+                    "sigterm_sent": killed,
+                    "cancel_file": cancel_file,
+                },
+            )
         typer.echo(
             json.dumps(
                 {
                     "ok": True,
                     "run_id": run_id,
                     "status": "cancelled",
+                    "kind": "suite" if is_suite else "run",
                     "version": version,
                     "sigterm_sent": killed,
+                    "cancel_file": cancel_file,
                 },
                 sort_keys=True,
                 separators=(",", ":"),

--- a/src/bora/cli/cmd_evidence_status.py
+++ b/src/bora/cli/cmd_evidence_status.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 from pathlib import Path
 from typing import Annotated
@@ -44,18 +45,58 @@ def register(app: typer.Typer) -> None:
 
     @app.command("status")
     def status_command(
-        run_id: Annotated[str, typer.Argument(help="Run id from ControlStore.")],
+        run_id: Annotated[
+            str,
+            typer.Argument(help="Run id or suite_run_id from ControlStore / bora run."),
+        ],
         store: Annotated[
             Path | None,
             typer.Option("--store", help="ControlStore sqlite path (default .bora/control.db)."),
         ] = None,
+        database: Annotated[
+            Path | None,
+            typer.Option(
+                "--database",
+                help="Database root to also load suite progress.json when kind=suite.",
+            ),
+        ] = None,
     ) -> None:
-        """Query durable Run control record (v0.12)."""
+        """Query durable Run/suite control record (+ suite progress when available)."""
+        import json as _json
+
         from bora.control.store import ControlStore
 
         path = store or (Path.cwd() / ".bora" / "control.db")
         rec = ControlStore(path).get(run_id)
-        if rec is None:
+        if rec is None and not run_id.startswith("suite_"):
             typer.echo(json.dumps({"ok": False, "error": "unknown_run", "run_id": run_id}))
             raise typer.Exit(code=2)
-        typer.echo(json.dumps({"ok": True, **rec}, sort_keys=True, separators=(",", ":")))
+
+        out: dict = {"ok": True, "run_id": run_id}
+        if rec is not None:
+            out.update(rec)
+        payload = dict((rec or {}).get("payload") or {})
+        db_root = database
+        if db_root is None and payload.get("database_root"):
+            db_root = Path(str(payload["database_root"]))
+        if db_root is not None and (
+            str(payload.get("kind") or "") == "suite" or run_id.startswith("suite_")
+        ):
+            prog = (
+                Path(db_root).expanduser().resolve(strict=False)
+                / ".bora"
+                / "suite-runs"
+                / run_id
+                / "progress.json"
+            )
+            if prog.is_file():
+                with contextlib.suppress(OSError, ValueError, TypeError):
+                    data = _json.loads(prog.read_text(encoding="utf-8"))
+                    if isinstance(data, dict):
+                        out["progress"] = data
+            cancel_p = prog.parent / "cancel.requested"
+            out["cancel_requested"] = cancel_p.is_file()
+        if rec is None and "progress" not in out:
+            typer.echo(json.dumps({"ok": False, "error": "unknown_run", "run_id": run_id}))
+            raise typer.Exit(code=2)
+        typer.echo(json.dumps(out, sort_keys=True, separators=(",", ":")))

--- a/src/bora/runtime/coordinator.py
+++ b/src/bora/runtime/coordinator.py
@@ -125,6 +125,7 @@ class LifecycleCoordinator:
                     transition(LifecycleState.CLEANING_UP, "failure")
 
             cleanup_calls += 1
+            t0 = self.clock()
             try:
                 fact = await asyncio.wait_for(
                     self.stages.cleanup(attempt),
@@ -135,6 +136,16 @@ class LifecycleCoordinator:
                     raise LifecycleError(
                         ERROR_ILLEGAL_TRANSITION,
                         f"cleanup returned wrong phase: {fact.phase.value}",
+                    )
+                duration_ms = max(0.0, (self.clock() - t0) * 1000.0)
+                if fact.duration_ms is None:
+                    fact = PhaseFact(
+                        attempt=fact.attempt,
+                        phase=fact.phase,
+                        status=fact.status,
+                        message=fact.message,
+                        detail=dict(fact.detail),
+                        duration_ms=duration_ms,
                     )
                 facts.append(fact)
                 if fact.status != PhaseStatus.SUCCEEDED:
@@ -147,6 +158,7 @@ class LifecycleCoordinator:
                         phase=LifecyclePhase.CLEANUP,
                         status=PhaseStatus.TIMED_OUT,
                         message=cleanup_warning,
+                        duration_ms=max(0.0, (self.clock() - t0) * 1000.0),
                     )
                 )
             except Exception as exc:  # noqa: BLE001 — capture as warning, keep primary
@@ -157,6 +169,7 @@ class LifecycleCoordinator:
                         phase=LifecyclePhase.CLEANUP,
                         status=PhaseStatus.FAILED,
                         message=cleanup_warning,
+                        duration_ms=max(0.0, (self.clock() - t0) * 1000.0),
                     )
                 )
 
@@ -209,6 +222,7 @@ class LifecycleCoordinator:
                     f"duplicate stage: {phase.value}",
                 )
 
+            t0 = self.clock()
             try:
                 fact = await fn(attempt)
             except Exception as exc:  # noqa: BLE001 — stage failure → cleanup
@@ -218,6 +232,7 @@ class LifecycleCoordinator:
                         phase=phase,
                         status=PhaseStatus.FAILED,
                         message=f"{type(exc).__name__}: {exc}",
+                        duration_ms=max(0.0, (self.clock() - t0) * 1000.0),
                     )
                 )
                 await do_cleanup(RuntimeTerminalKind.FAILED)
@@ -229,6 +244,16 @@ class LifecycleCoordinator:
                 raise LifecycleError(
                     ERROR_ILLEGAL_TRANSITION,
                     f"stage returned wrong phase: {fact.phase.value} != {phase.value}",
+                )
+            duration_ms = max(0.0, (self.clock() - t0) * 1000.0)
+            if fact.duration_ms is None:
+                fact = PhaseFact(
+                    attempt=fact.attempt,
+                    phase=fact.phase,
+                    status=fact.status,
+                    message=fact.message,
+                    detail=dict(fact.detail),
+                    duration_ms=duration_ms,
                 )
             facts.append(fact)
             completed_phases.add(phase)

--- a/src/bora/runtime/outcomes.py
+++ b/src/bora/runtime/outcomes.py
@@ -39,6 +39,8 @@ class PhaseFact:
     status: PhaseStatus
     message: str = ""
     detail: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+    # Wall time for this stage in milliseconds (#47 D); observational only.
+    duration_ms: float | None = None
 
     def __post_init__(self) -> None:
         # Freeze nested detail mapping.

--- a/src/bora/viewer/jobs.py
+++ b/src/bora/viewer/jobs.py
@@ -130,6 +130,7 @@ def _job_row(summary: dict[str, Any], *, suite_dir: Path, database_root: Path) -
         "metrics": metrics,
         "started": summary.get("created_at"),
         "duration": summary.get("duration"),
+        "n_attempts": summary.get("n_attempts"),
         "trials_done": trials_done,
         "trials_total": n_tasks or len(refs),
         "exit_code": summary.get("exit_code"),
@@ -137,6 +138,17 @@ def _job_row(summary: dict[str, Any], *, suite_dir: Path, database_root: Path) -
         "summary_path": str(suite_dir / "summary.json"),
         "note": summary.get("note") or "per-task evaluator verdicts only; no suite-level PASS",
     }
+
+
+def _load_progress(suite_dir: Path) -> dict[str, Any] | None:
+    path = suite_dir / "progress.json"
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
 
 
 def list_jobs(database_root: Path) -> dict[str, Any]:
@@ -198,6 +210,9 @@ def get_job(database_root: Path, job_id: str) -> dict[str, Any]:
         )
     summary = _load_summary(summary_path)
     job = _job_row(summary, suite_dir=suite_dir, database_root=root)
+    progress = _load_progress(suite_dir)
+    if progress is not None:
+        job["progress"] = progress
     refs = _ensure_task_refs(summary)
     # Prefer full task rows when present (score/status/error)
     by_id: dict[str, dict[str, Any]] = {}
@@ -224,6 +239,9 @@ def get_job(database_root: Path, job_id: str) -> dict[str, Any]:
                 "provider_label": job.get("provider_label") or "",
                 "dataset": job.get("source") or job.get("database_id"),
                 "duration": full.get("duration"),
+                "phase_timing": full.get("phase_timing"),
+                "n": full.get("n"),
+                "c": full.get("c"),
             }
         )
 
@@ -232,6 +250,7 @@ def get_job(database_root: Path, job_id: str) -> dict[str, Any]:
         "job": job,
         "tasks": task_rows,
         "task_count": len(task_rows),
+        "progress": progress,
         "commands": commands_for(root),
         "note": job.get("note"),
     }

--- a/src/bora/viewer/trials/surface.py
+++ b/src/bora/viewer/trials/surface.py
@@ -311,6 +311,28 @@ def _trial_meta_from_evidence(
     locked_task = lock.get("task_id") if isinstance(lock.get("task_id"), str) else None
     surface = _agent_surface(evidence, lock=lock, result=result, summary=summary)
 
+    # Phase timing (#47 D): prefer result, then summary, then suite attempt row.
+    phase_timing = None
+    for src in (result, summary, suite_row):
+        if isinstance(src, dict) and isinstance(src.get("phase_timing"), dict):
+            phase_timing = src["phase_timing"]
+            break
+    duration = suite_row.get("duration") or result.get("duration") or summary.get("duration")
+    if duration is None and isinstance(phase_timing, dict):
+        total_ms = phase_timing.get("total_ms")
+        if isinstance(total_ms, (int, float)) and not isinstance(total_ms, bool):
+            from bora.application.phase_timing import format_duration_ms
+
+            duration = format_duration_ms(float(total_ms))
+    started = (
+        summary.get("started_at")
+        or (phase_timing or {}).get("started_at")
+        or suite_row.get("started")
+    )
+
+    # Token breakdown from actors (observational; Harbor-style bar when present).
+    token_timing = _token_bar_from_actors(surface.get("actors") or [])
+
     return {
         "trial_id": run_id,
         "run_id": run_id,
@@ -320,8 +342,10 @@ def _trial_meta_from_evidence(
         "reward": score,
         "error": error,
         "exit_code": suite_row.get("exit_code") or result.get("exit_code"),
-        "duration": suite_row.get("duration"),
-        "started": summary.get("started_at") or suite_row.get("started"),
+        "duration": duration,
+        "started": started,
+        "phase_timing": phase_timing,
+        "token_timing": token_timing,
         "evidence_relpath": None,  # filled by caller
         "has_evidence": True,
         "available_tabs": _available_tabs(evidence),
@@ -340,3 +364,44 @@ def _trial_meta_from_evidence(
         "upstream_ref": surface.get("upstream_ref"),
         "note": None,
     }
+
+
+def _token_bar_from_actors(actors: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Aggregate last-invoke token fields across actors for a Harbor-like token bar."""
+    cached = 0.0
+    uncached = 0.0
+    output = 0.0
+    any_tok = False
+    for a in actors:
+        if not isinstance(a, dict):
+            continue
+        usage = a.get("usage")
+        if not isinstance(usage, dict):
+            continue
+        inp = usage.get("input_tokens")
+        out = usage.get("output_tokens")
+        cached_read = usage.get("cached_read_tokens")
+        if isinstance(out, (int, float)) and not isinstance(out, bool):
+            output += float(out)
+            any_tok = True
+        if isinstance(inp, (int, float)) and not isinstance(inp, bool):
+            any_tok = True
+            cr = (
+                float(cached_read)
+                if isinstance(cached_read, (int, float)) and not isinstance(cached_read, bool)
+                else 0.0
+            )
+            cached += cr
+            uncached += max(0.0, float(inp) - cr)
+        elif isinstance(cached_read, (int, float)) and not isinstance(cached_read, bool):
+            cached += float(cached_read)
+            any_tok = True
+    if not any_tok:
+        return None
+    segments = [
+        {"id": "cached_input", "label": "Cached Input", "tokens": int(round(cached))},
+        {"id": "uncached_input", "label": "Uncached Input", "tokens": int(round(uncached))},
+        {"id": "output", "label": "Output", "tokens": int(round(output))},
+    ]
+    total = sum(s["tokens"] for s in segments)
+    return {"schema": "bora.token_timing/1", "segments": segments, "total_tokens": total}

--- a/tests/application/test_pass_at_k.py
+++ b/tests/application/test_pass_at_k.py
@@ -1,0 +1,74 @@
+"""pass@k / pass^k unit tests (#47)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bora.application.suite_metrics import (
+    aggregate_k_metrics,
+    default_k_values,
+    pass_at_k,
+    pass_power_k,
+)
+
+
+def test_pass_at_k_basic() -> None:
+    # n=k=1, c=1 → 1.0; c=0 → 0.0
+    assert pass_at_k(n=1, c=1, k=1) == pytest.approx(1.0)
+    assert pass_at_k(n=1, c=0, k=1) == pytest.approx(0.0)
+    # pass@1 = c/n
+    assert pass_at_k(n=10, c=3, k=1) == pytest.approx(0.3)
+    # incomplete
+    assert pass_at_k(n=3, c=2, k=5) is None
+    # n=10, c=3, k=5: classic sample 1 - C(7,5)/C(10,5)
+    expected = 1.0 - (21 / 252)
+    assert pass_at_k(n=10, c=3, k=5) == pytest.approx(expected)
+
+
+def test_pass_at_k_all_correct() -> None:
+    assert pass_at_k(n=5, c=5, k=5) == pytest.approx(1.0)
+    assert pass_at_k(n=5, c=5, k=3) == pytest.approx(1.0)
+
+
+def test_pass_power_k() -> None:
+    assert pass_power_k(n=4, c=2, k=2) == pytest.approx(0.25)
+    assert pass_power_k(n=4, c=4, k=3) == pytest.approx(1.0)
+    assert pass_power_k(n=4, c=0, k=2) == pytest.approx(0.0)
+    assert pass_power_k(n=0, c=0, k=1) is None
+
+
+def test_default_k_values() -> None:
+    assert default_k_values(1) == [1]
+    assert default_k_values(8) == [1, 2, 4, 5, 8]
+    assert default_k_values(10) == [1, 2, 4, 5, 8, 10]
+    assert default_k_values(0) == []
+
+
+def test_aggregate_k_mean_over_tasks() -> None:
+    # task a: 2/2 pass; task b: 0/2 pass → pass@1 mean = (1 + 0) / 2 = 0.5
+    attempts = [
+        {"task_id": "a", "attempt_index": 0, "status": "PASS"},
+        {"task_id": "a", "attempt_index": 1, "status": "PASS"},
+        {"task_id": "b", "attempt_index": 0, "status": "FAIL"},
+        {"task_id": "b", "attempt_index": 1, "status": "FAIL"},
+    ]
+    m = aggregate_k_metrics(attempts, task_ids=["a", "b"], n_attempts=2)
+    assert m["pass_at_k"]["1"]["value"] == pytest.approx(0.5)
+    assert m["pass_at_k"]["2"]["value"] == pytest.approx(0.5)  # a→1, b→0
+    assert m["pass_power_k"]["2"]["value"] == pytest.approx(0.5)  # a:(1)^2=1, b:0 → mean 0.5
+    assert m["n_pass"] == 1  # rolled task status: a PASS, b FAIL
+    assert m["n_fail"] == 1
+
+
+def test_incomplete_task_excluded_from_mean() -> None:
+    attempts = [
+        {"task_id": "a", "attempt_index": 0, "status": "PASS"},
+        {"task_id": "a", "attempt_index": 1, "status": "PASS"},
+        # b only 1 sample — incomplete for k=2
+        {"task_id": "b", "attempt_index": 0, "status": "PASS"},
+    ]
+    m = aggregate_k_metrics(attempts, task_ids=["a", "b"], n_attempts=2, k_values=[1, 2])
+    assert m["pass_at_k"]["2"]["n_tasks"] == 1
+    assert m["pass_at_k"]["2"]["incomplete_tasks"] == 1
+    assert m["pass_at_k"]["2"]["value"] == pytest.approx(1.0)
+    assert m["pass_at_k"]["1"]["n_tasks"] == 2

--- a/tests/application/test_phase_timing.py
+++ b/tests/application/test_phase_timing.py
@@ -1,0 +1,69 @@
+"""Phase timing helpers + coordinator duration_ms (#47 D)."""
+
+from __future__ import annotations
+
+import pytest
+from tests.doubles.lifecycle_stages import ScriptedLifecycleStages
+
+from bora.application.phase_timing import (
+    PhaseTimer,
+    bucket_phase_timing,
+    format_duration_ms,
+    phase_facts_to_timing,
+)
+from bora.runtime.coordinator import LifecycleCoordinator
+from bora.runtime.identity import IdentityFactory
+from bora.runtime.outcomes import RuntimeTerminalKind
+
+
+def test_phase_timer_as_dict() -> None:
+    t = PhaseTimer()
+    with t.phase("prepare"):
+        pass
+    t.add_ms("run", 1500.0)
+    t.add_ms("evaluate", 250.0)
+    doc = t.as_dict()
+    assert doc["schema"] == "bora.phase_timing/1"
+    ids = [p["id"] for p in doc["phases"]]
+    assert "prepare" in ids
+    assert "run" in ids
+    assert doc["total_ms"] >= 1500.0
+    assert any(p["label"] == "Agent Execution" for p in doc["phases"] if p["id"] == "run")
+
+
+def test_format_duration() -> None:
+    assert format_duration_ms(500) == "500ms"
+    assert format_duration_ms(12_000) == "12s"
+    assert format_duration_ms(72_000) == "1m 12s"
+
+
+def test_bucket_merges_seal_bind_into_evaluate() -> None:
+    doc = bucket_phase_timing(
+        [
+            {"id": "prepare", "duration_ms": 100},
+            {"id": "run", "duration_ms": 1000},
+            {"id": "seal", "duration_ms": 50},
+            {"id": "evaluate", "duration_ms": 200},
+            {"id": "bind", "duration_ms": 30},
+            {"id": "cleanup", "duration_ms": 40},
+        ]
+    )
+    by_id = {p["id"]: p["duration_ms"] for p in doc["phases"]}
+    assert by_id["evaluate"] == pytest.approx(280.0)
+    assert "seal" not in by_id
+
+
+@pytest.mark.asyncio
+async def test_coordinator_records_duration_ms() -> None:
+    stages = ScriptedLifecycleStages()
+    f = IdentityFactory()
+    run = f.new_run()
+    trial = f.new_trial(run, "sha256:" + "a" * 64)
+    attempt = f.new_attempt(trial)
+    record = await LifecycleCoordinator(stages=stages).run(attempt)
+    assert record.terminal == RuntimeTerminalKind.SUCCEEDED
+    assert record.phase_facts
+    assert all(f.duration_ms is not None and f.duration_ms >= 0 for f in record.phase_facts)
+    timing = phase_facts_to_timing(record.phase_facts)
+    assert timing["total_ms"] >= 0
+    assert any(p["id"] == "run" for p in timing["phases"])

--- a/tests/application/test_suite_cancel_progress.py
+++ b/tests/application/test_suite_cancel_progress.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 from bora.application.suite_run import (
+    _existing_attempt_keys,
     execute_suite_run,
     is_suite_cancel_requested,
     plan_suite_run,
@@ -44,6 +45,101 @@ async def test_cancel_stops_new_units() -> None:
     cancelled_rows = [a for a in summary["attempts"] if a.get("phase") == "cancelled"]
     assert cancelled_rows
     assert all(r.get("error") == "suite_cancelled" for r in cancelled_rows)
+
+
+def test_existing_keys_skip_cancelled_placeholders() -> None:
+    rows = [
+        {"task_id": "alpha", "attempt_index": 0, "status": "PASS", "run_id": "r0"},
+        {
+            "task_id": "alpha",
+            "attempt_index": 1,
+            "status": "ERROR",
+            "phase": "cancelled",
+            "error": "suite_cancelled",
+            "run_id": None,
+        },
+        {
+            "task_id": "beta",
+            "attempt_index": 0,
+            "status": "ERROR",
+            "error": "suite_cancelled",
+            "run_id": None,
+        },
+    ]
+    assert _existing_attempt_keys(rows) == {("alpha", 0)}
+
+
+@pytest.mark.asyncio
+async def test_resume_retries_cancelled_placeholders() -> None:
+    """Cancel mid-suite → resume must re-run cancelled slots (not deflate pass@k)."""
+    plan = plan_suite_run(SUITE, n_attempts=1, max_concurrent_tasks=1)
+    plan.task_ids = ["alpha", "beta", "gamma"]
+    first_calls: list[str] = []
+
+    async def runner1(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+        first_calls.append(task_id)
+        if task_id == "alpha":
+            request_suite_cancel(plan.database_root, plan.suite_run_id)
+            await asyncio.sleep(0.05)
+        await asyncio.sleep(0.02)
+        run_id = f"sha256_dead_run_{task_id}_1"
+        abs_run = Path(root) / ".bora" / "runs" / run_id
+        abs_run.mkdir(parents=True, exist_ok=True)
+        result = SimpleNamespace(
+            status="PASS",
+            score=1.0,
+            evidence_path=str(abs_run),
+            logs=str(abs_run),
+        )
+        return 0, result, {"digest": f"sha256:{task_id}", "run_dir": str(abs_run)}
+
+    first = await execute_suite_run(plan, run_fn=runner1)
+    assert first.get("cancelled") is True
+    suite_id = first["suite_run_id"]
+    cancelled = [a for a in first["attempts"] if a.get("phase") == "cancelled"]
+    assert cancelled
+    assert is_suite_cancel_requested(plan.database_root, suite_id)
+
+    plan2 = plan_suite_run(
+        SUITE,
+        n_attempts=1,
+        max_concurrent_tasks=1,
+        suite_run_id=suite_id,
+    )
+    plan2.task_ids = ["alpha", "beta", "gamma"]
+    second_calls: list[str] = []
+
+    async def runner2(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+        second_calls.append(task_id)
+        run_id = f"sha256_dead_run_{task_id}_2"
+        abs_run = Path(root) / ".bora" / "runs" / run_id
+        abs_run.mkdir(parents=True, exist_ok=True)
+        result = SimpleNamespace(
+            status="PASS",
+            score=1.0,
+            evidence_path=str(abs_run),
+            logs=str(abs_run),
+        )
+        return 0, result, {"digest": f"sha256:{task_id}2", "run_dir": str(abs_run)}
+
+    second = await execute_suite_run(plan2, run_fn=runner2, resume=True)
+    assert second.get("resumed") is True
+    # Cancel file cleared so scheduling works again.
+    assert not is_suite_cancel_requested(plan.database_root, suite_id)
+    # Cancelled slots re-ran; finished alpha not re-run.
+    assert "alpha" not in second_calls
+    assert (
+        set(second_calls) >= {c for c in ["beta", "gamma"] if c not in first_calls} or second_calls
+    )
+    # Prefer: every cancelled task_id appears in second_calls
+    cancelled_tids = {a["task_id"] for a in cancelled}
+    assert cancelled_tids <= set(second_calls)
+    # No leftover cancelled placeholders for completed k=1 suite
+    leftover = [a for a in second["attempts"] if a.get("phase") == "cancelled"]
+    assert leftover == []
+    assert len(second["attempts"]) == 3
+    assert all(a.get("status") == "PASS" for a in second["attempts"])
+    assert second["metrics"]["pass_rate"] == pytest.approx(1.0)
 
 
 @pytest.mark.asyncio

--- a/tests/application/test_suite_cancel_progress.py
+++ b/tests/application/test_suite_cancel_progress.py
@@ -1,0 +1,68 @@
+"""Suite cancel + progress callback (#47 D3/D4)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from bora.application.suite_run import (
+    execute_suite_run,
+    is_suite_cancel_requested,
+    plan_suite_run,
+    request_suite_cancel,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+SUITE = REPO / "tests" / "fixtures" / "databases" / "suite-min"
+
+
+@pytest.mark.asyncio
+async def test_cancel_stops_new_units() -> None:
+    plan = plan_suite_run(SUITE, n_attempts=1, max_concurrent_tasks=1)
+    plan.task_ids = ["alpha", "beta", "gamma"]
+    calls: list[str] = []
+
+    async def runner(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+        calls.append(task_id)
+        if task_id == "alpha":
+            # After first unit starts, request cancel so remaining are not run.
+            request_suite_cancel(plan.database_root, plan.suite_run_id)
+            await asyncio.sleep(0.05)
+        await asyncio.sleep(0.02)
+        result = SimpleNamespace(status="PASS", score=1.0, evidence_path=None, logs=None)
+        return 0, result, {"digest": f"sha256:{task_id}"}
+
+    summary = await execute_suite_run(plan, run_fn=runner)
+    assert summary.get("cancelled") is True
+    assert is_suite_cancel_requested(plan.database_root, plan.suite_run_id)
+    # At most alpha fully ran; beta/gamma cancelled (or not started as real runs).
+    assert "alpha" in calls
+    assert len(calls) < 3
+    cancelled_rows = [a for a in summary["attempts"] if a.get("phase") == "cancelled"]
+    assert cancelled_rows
+    assert all(r.get("error") == "suite_cancelled" for r in cancelled_rows)
+
+
+@pytest.mark.asyncio
+async def test_progress_callback_events() -> None:
+    plan = plan_suite_run(SUITE, task_id="alpha", n_attempts=2, max_concurrent_tasks=1)
+    events: list[str] = []
+
+    async def runner(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+        result = SimpleNamespace(status="PASS", score=1.0, evidence_path=None, logs=None)
+        return 0, result, {"digest": "sha256:x"}
+
+    def on_progress(ev: dict) -> None:
+        events.append(str(ev.get("type")))
+
+    summary = await execute_suite_run(plan, run_fn=runner, on_progress=on_progress)
+    assert summary["n_attempts"] == 2
+    assert "suite_start" in events
+    assert events.count("unit_start") == 2
+    assert events.count("unit_done") == 2
+    assert "suite_complete" in events
+    prog = Path(summary["summary_path"]).parent / "progress.json"
+    assert prog.is_file()

--- a/tests/application/test_suite_n_attempts.py
+++ b/tests/application/test_suite_n_attempts.py
@@ -1,0 +1,202 @@
+"""Always-k suite orchestration + resume (#47 A/C)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from bora.application.suite_run import (
+    execute_suite_run,
+    get_inflight_peak,
+    plan_suite_run,
+    planned_units,
+    reset_inflight_metrics,
+)
+from bora.config.errors import ConfigError
+
+REPO = Path(__file__).resolve().parents[2]
+SUITE = REPO / "tests" / "fixtures" / "databases" / "suite-min"
+
+
+def test_plan_n_attempts_default_and_reject() -> None:
+    plan = plan_suite_run(SUITE, task_id="alpha")
+    assert plan.n_attempts == 1
+    assert planned_units(plan) == [("alpha", 0)]
+
+    plan3 = plan_suite_run(SUITE, task_id="alpha", n_attempts=3, max_concurrent_tasks=2)
+    assert plan3.n_attempts == 3
+    assert plan3.max_concurrent_tasks == 2  # multi-attempt may parallelize
+    assert planned_units(plan3) == [("alpha", 0), ("alpha", 1), ("alpha", 2)]
+
+    with pytest.raises(ConfigError):
+        plan_suite_run(SUITE, n_attempts=0)
+
+
+def test_plan_single_task_k1_forces_concurrency_1() -> None:
+    plan = plan_suite_run(SUITE, task_id="alpha", max_concurrent_tasks=8, n_attempts=1)
+    assert plan.max_concurrent_tasks == 1
+
+
+@pytest.mark.asyncio
+async def test_always_k_produces_k_attempts() -> None:
+    plan = plan_suite_run(SUITE, task_id="alpha", n_attempts=3, max_concurrent_tasks=1)
+    calls: list[str] = []
+
+    async def runner(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+        calls.append(task_id)
+        run_id = f"sha256_dead_run_{task_id}_{len(calls)}"
+        abs_run = Path(root) / ".bora" / "runs" / run_id
+        abs_run.mkdir(parents=True, exist_ok=True)
+        # 2 pass, 1 fail across 3 calls
+        status = "PASS" if len(calls) <= 2 else "FAIL"
+        result = SimpleNamespace(
+            status=status,
+            score=1.0 if status == "PASS" else 0.0,
+            evidence_path=str(abs_run),
+            logs=str(abs_run),
+        )
+        code = 0 if status == "PASS" else 1
+        return code, result, {"digest": "sha256:x", "run_dir": str(abs_run)}
+
+    summary = await execute_suite_run(plan, run_fn=runner)
+    assert len(calls) == 3
+    assert summary["n_attempts"] == 3
+    assert len(summary["attempts"]) == 3
+    assert {a["attempt_index"] for a in summary["attempts"]} == {0, 1, 2}
+    assert summary["tasks"][0]["n"] == 3
+    assert summary["tasks"][0]["c"] == 2
+    # pass@1 ≈ 2/3; pass@3 = 1 (at least one pass when n=k and c>0 → wait
+    # unbiased with n=3,c=2,k=3: n-c=1 < 3 → 1.0
+    assert summary["metrics"]["pass_at_k"]["3"]["value"] == pytest.approx(1.0)
+    assert summary["metrics"]["pass_at_k"]["1"]["value"] == pytest.approx(2 / 3)
+    # pass^k: (2/3)^3
+    assert summary["metrics"]["pass_power_k"]["3"]["value"] == pytest.approx((2 / 3) ** 3)
+    # k-metrics must not appear as fingerprint inputs
+    assert "n_attempts" not in str(summary["config_fingerprint"])
+    path = Path(summary["summary_path"])
+    disk = json.loads(path.read_text(encoding="utf-8"))
+    assert disk["n_attempts"] == 3
+    assert len(disk["attempts"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_parallel_does_not_change_k() -> None:
+    plan = plan_suite_run(
+        SUITE,
+        task_id="alpha",
+        n_attempts=4,
+        max_concurrent_tasks=2,
+    )
+    reset_inflight_metrics()
+
+    async def slow(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+        await asyncio.sleep(0.08)
+        result = SimpleNamespace(status="PASS", score=1.0, evidence_path=None, logs=None)
+        return 0, result, {"digest": "sha256:x"}
+
+    summary = await execute_suite_run(plan, run_fn=slow)
+    assert len(summary["attempts"]) == 4
+    assert summary["n_attempts"] == 4
+    assert get_inflight_peak() <= 2
+    assert get_inflight_peak() >= 2  # actually exercised concurrency
+
+
+@pytest.mark.asyncio
+async def test_resume_skips_completed_and_appends() -> None:
+    plan = plan_suite_run(SUITE, task_id="alpha", n_attempts=2, max_concurrent_tasks=1)
+    call_n = {"n": 0}
+
+    async def runner(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+        call_n["n"] += 1
+        i = call_n["n"]
+        run_id = f"sha256_dead_run_alpha_{i}"
+        abs_run = Path(root) / ".bora" / "runs" / run_id
+        abs_run.mkdir(parents=True, exist_ok=True)
+        result = SimpleNamespace(
+            status="PASS",
+            score=1.0,
+            evidence_path=str(abs_run),
+            logs=str(abs_run),
+        )
+        return 0, result, {"digest": f"sha256:{i}", "run_dir": str(abs_run)}
+
+    first = await execute_suite_run(plan, run_fn=runner)
+    assert len(first["attempts"]) == 2
+    assert call_n["n"] == 2
+    suite_id = first["suite_run_id"]
+    first_run_ids = {a["run_id"] for a in first["attempts"]}
+
+    # Resume with higher k → only new indices run
+    plan2 = plan_suite_run(
+        SUITE,
+        task_id="alpha",
+        n_attempts=4,
+        max_concurrent_tasks=1,
+        suite_run_id=suite_id,
+    )
+    second = await execute_suite_run(plan2, run_fn=runner, resume=True)
+    assert second["resumed"] is True
+    assert second["new_attempts"] == 2
+    assert second["skipped_attempts"] == 2
+    assert len(second["attempts"]) == 4
+    assert call_n["n"] == 4
+    # Existing rows preserved
+    kept = {a["run_id"] for a in second["attempts"] if a["attempt_index"] < 2}
+    assert kept == first_run_ids
+    assert second["metrics"]["pass_at_k"]["4"]["value"] == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_resume_other_tasks_preserved() -> None:
+    """Topping up one task must not drop sibling task attempts."""
+    plan = plan_suite_run(SUITE, n_attempts=1, max_concurrent_tasks=2)
+    plan.task_ids = ["alpha", "beta"]
+
+    async def runner(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+        run_id = f"sha256_dead_run_{task_id}"
+        abs_run = Path(root) / ".bora" / "runs" / run_id
+        abs_run.mkdir(parents=True, exist_ok=True)
+        result = SimpleNamespace(
+            status="PASS",
+            score=1.0,
+            evidence_path=str(abs_run),
+            logs=str(abs_run),
+        )
+        return 0, result, {"digest": f"sha256:{task_id}", "run_dir": str(abs_run)}
+
+    first = await execute_suite_run(plan, run_fn=runner)
+    suite_id = first["suite_run_id"]
+
+    plan_alpha = plan_suite_run(
+        SUITE,
+        task_id="alpha",
+        n_attempts=2,
+        suite_run_id=suite_id,
+    )
+    call_tasks: list[str] = []
+
+    async def runner2(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+        call_tasks.append(task_id)
+        run_id = f"sha256_dead_run_{task_id}_extra"
+        abs_run = Path(root) / ".bora" / "runs" / run_id
+        abs_run.mkdir(parents=True, exist_ok=True)
+        result = SimpleNamespace(
+            status="PASS",
+            score=1.0,
+            evidence_path=str(abs_run),
+            logs=str(abs_run),
+        )
+        return 0, result, {"digest": "sha256:extra", "run_dir": str(abs_run)}
+
+    second = await execute_suite_run(plan_alpha, run_fn=runner2, resume=True)
+    task_ids_present = {a["task_id"] for a in second["attempts"]}
+    assert "beta" in task_ids_present
+    assert "alpha" in task_ids_present
+    # only alpha attempt_index=1 is new (index 0 already done)
+    assert call_tasks == ["alpha"]
+    alpha_attempts = [a for a in second["attempts"] if a["task_id"] == "alpha"]
+    assert len(alpha_attempts) == 2

--- a/website/content/docs/reference/cli.en.mdx
+++ b/website/content/docs/reference/cli.en.mdx
@@ -1,6 +1,6 @@
 ---
 title: CLI reference
-description: Commands, --task, --set allowlist.
+description: Commands, --task, Always-k, --set allowlist.
 ---
 
 Trust `uv run bora --help`.
@@ -11,7 +11,11 @@ uv run bora lock <dataset> --task <id>
 uv run bora run <dataset> --task <id>
 uv run bora run <dataset>
 uv run bora run <dataset> --max-concurrent-tasks 2
+uv run bora run <dataset> -k 5
+uv run bora run <dataset> --resume-suite suite_<id> --task <id> -k 5
 uv run bora campaign <dataset> --task <id> ...
+uv run bora status suite_<id> --database <dataset>
+uv run bora cancel suite_<id> --database <dataset>
 uv run bora executors -v
 uv run bora evidence --help
 uv run bora view <dataset>
@@ -19,15 +23,30 @@ uv run bora view <dataset>
 
 Path = Dataset root.
 
+## Common `bora run` flags
+
+| Flag | Meaning |
+| --- | --- |
+| `--task <id>` | One member; omit = full suite |
+| `--max-concurrent-tasks N` | Max concurrent units; **speeds wall time only** |
+| `--n-attempts` / `-k N` | Always-k: N independent Attempts per task (default 1); **CLI/job only** |
+| `--resume-suite <suite_run_id>` | Resume job: skip finished units, append Attempts, recompute pass@k / pass^k |
+| `--set` / `--profiles` | Overrides / alternate job binding |
+
+## `status` / `cancel`
+
+| Command | Meaning |
+| --- | --- |
+| `bora status <run_id\|suite_…>` | ControlStore; add `--database` for suite `progress.json` |
+| `bora cancel <run_id\|suite_…>` | One Run or suite job; suite may use `--database` → `cancel.requested` |
+
 ## `--set`
 
 | Pointer | Meaning |
 | --- | --- |
 | `/parameters/seed` | Seed etc. |
 | `/parameters/active_profile` | Profile id |
-| `/limits/wall_time_seconds` | Wall clock |
-| `/limits/agent_invocations` | Agent invoke ceiling |
-| `/limits/environment_actions` | Env action ceiling |
-| `/limits/memory_mb` | Memory ceiling |
+| `/bindings/<role>/options/entry` … | Job binding override (#59) |
+| Intent `limits.*` | **Not** overridable via `--set` |
 
-Anything else fails at lock.
+Anything else fails at lock. Details: `src/bora/cli/README.md` · skill `bora-cli`.

--- a/website/content/docs/reference/cli.mdx
+++ b/website/content/docs/reference/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: CLI 参考
-description: 命令、--task、--set 白名单。
+description: 命令、--task、Always-k、--set 白名单。
 ---
 
 以本机 `uv run bora --help` 为准。
@@ -11,13 +11,34 @@ uv run bora lock <dataset> --task <id>
 uv run bora run <dataset> --task <id>
 uv run bora run <dataset>                         # suite
 uv run bora run <dataset> --max-concurrent-tasks 2
+uv run bora run <dataset> -k 5                    # Always-k（每题 k 次）
+uv run bora run <dataset> --resume-suite suite_<id> --task <id> -k 5
 uv run bora campaign <dataset> --task <id> ...
+uv run bora status suite_<id> --database <dataset>
+uv run bora cancel suite_<id> --database <dataset>
 uv run bora executors -v
 uv run bora evidence --help
 uv run bora view <dataset>
 ```
 
 路径 = Dataset 根（含 `bora.yaml`）。
+
+## `bora run` 常用选项
+
+| 选项 | 含义 |
+| --- | --- |
+| `--task <id>` | 只跑该成员；省略 = 整包 suite |
+| `--max-concurrent-tasks N` | 并行 unit 上限；**只加速**，不改 k / PASS |
+| `--n-attempts` / `-k N` | Always-k：每题 N 次独立 Attempt（默认 1）；**CLI/job only** |
+| `--resume-suite <suite_run_id>` | 并进已有 job：跳过已完成 unit，追加 Attempt，重算 pass@k / pass^k |
+| `--set` / `--profiles` | 见下；与 job binding 相关 |
+
+## `status` / `cancel`
+
+| 命令 | 含义 |
+| --- | --- |
+| `bora status <run_id\|suite_…>` | ControlStore；suite 可加 `--database` 读 `progress.json` |
+| `bora cancel <run_id\|suite_…>` | 单 Run 或 suite job；suite 可加 `--database` 写 `cancel.requested` |
 
 ## `--set`
 
@@ -27,9 +48,9 @@ uv run bora view <dataset>
 | --- | --- |
 | `/parameters/seed` | 业务 seed 等 |
 | `/parameters/active_profile` | 切换 profile |
-| `/limits/wall_time_seconds` | 墙钟 |
-| `/limits/agent_invocations` | agent 调用次数顶 |
-| `/limits/environment_actions` | 环境动作顶 |
-| `/limits/memory_mb` | 内存顶 |
+| `/bindings/<role>/options/entry` 等 | job binding 覆盖（#59） |
+| `/limits/wall_time_seconds` | 墙钟（intent；**不可**覆盖 — 见下） |
 
-其它指针在 lock 阶段失败。
+Intent `limits.*` **不能**经 `--set` 覆盖。其它指针在 lock 阶段失败。
+
+细节：`src/bora/cli/README.md` · skill `bora-cli`。

--- a/website/content/docs/reference/config-fields.en.mdx
+++ b/website/content/docs/reference/config-fields.en.mdx
@@ -16,6 +16,8 @@ Tutorial path: [Author a task](/docs/author/tutorial). This page is for lookup.
 | `defaults` | Only `max_concurrent_tasks` (≥1) |
 | Forbidden | harness / provider / limits / evaluation / profiles |
 
+**Not** in yaml: `n_attempts` / Always-k (CLI/job only — see [Suite](/docs/run/suite)).
+
 Empty suite fails lock.
 
 ## Member `task.yaml`

--- a/website/content/docs/reference/config-fields.mdx
+++ b/website/content/docs/reference/config-fields.mdx
@@ -16,6 +16,8 @@ description: bora.yaml / task.yaml 字段与校验要点速查。
 | `defaults` | 仅 `max_concurrent_tasks`（≥1） |
 | 禁止 | harness / provider / limits / evaluation / agent_profiles |
 
+**不在** yaml 里：`n_attempts` / Always-k（只走 CLI/job，见 [Suite](/docs/run/suite)）。
+
 空 suite → lock 失败。
 
 ## 成员 `task.yaml`

--- a/website/content/docs/reference/results-and-pass.en.mdx
+++ b/website/content/docs/reference/results-and-pass.en.mdx
@@ -1,6 +1,6 @@
 ---
 title: Results and PASS
-description: How to read Result; what counts as pass.
+description: How to read Result; pass@k is a job metric, not suite PASS.
 ---
 
 ## Hard boundaries
@@ -8,16 +8,31 @@ description: How to read Result; what counts as pass.
 1. Harness completed **≠** PASS  
 2. Trajectory / tokens / agent self-report **≠** score  
 3. PASS / FAIL from the **independent evaluator** only  
+4. Suite / job aggregates (including pass@k) **≠** suite-level PASS authority  
 
 ## On the terminal
 
-- **Result** — status and evaluation for this run  
-- **`logs`** — Attempt evidence locator  
-- Suite aggregates — observational, not suite-level PASS  
+- **Result** — status and evaluation for this Attempt  
+- **`logs`** — Attempt evidence locator (typical when `k=1`)  
+- Suite `pass_rate` / `mean_score` — observational  
+
+## Always-k and pass@k / pass^k
+
+After Always-k (`-k` / `--n-attempts`), suite `summary.json` → `metrics` includes:
+
+| Key | Meaning |
+| --- | --- |
+| `pass_at_k` | pass@k (unbiased “≥1 success”; Harbor-style) |
+| `pass_power_k` | pass^k (all-k success estimate) |
+| Suite score | **Mean over tasks** for that metric (omit tasks with too few samples) |
+
+These are **job summary metrics**, not package identity / `config_fingerprint`.  
+Hub Leaderboard columns for pass@k are a follow-up — do not infer “on the board” from local summary alone.
 
 ## Browse
 
-[Viewer](/docs/run/local-viewer).
+[Viewer](/docs/run/local-viewer).  
+Attempt pages may show **Timing** (and **Tokens** when present). Time / tokens are **hints**, not PASS.
 
 ## Failure kinds
 

--- a/website/content/docs/reference/results-and-pass.mdx
+++ b/website/content/docs/reference/results-and-pass.mdx
@@ -1,6 +1,6 @@
 ---
 title: 结果与 PASS
-description: Result 怎么读；什么算过、什么不算。
+description: Result 怎么读；pass@k 是 job 指标，不是整包 PASS。
 ---
 
 ## 几条硬边界
@@ -8,16 +8,31 @@ description: Result 怎么读；什么算过、什么不算。
 1. Harness 跑完 **≠** PASS  
 2. 轨迹 / token / agent 自述 **≠** 分数  
 3. PASS / FAIL 来自**独立 evaluator**  
+4. suite / job 汇总（含 pass@k）**≠** 整包 PASS 权威  
 
 ## 终端上
 
-- **Result**：绑定到本次 run 的状态与评测结论  
-- **`logs`**：Attempt 证据目录 locator  
-- suite 的 `pass_rate` 等：观测用，不是「整包 PASS」  
+- **Result**：绑定到本次 Attempt 的状态与评测结论  
+- **`logs`**：Attempt 证据目录 locator（单次 `k=1` 常见）  
+- suite 的 `pass_rate` / `mean_score`：观测用  
+
+## Always-k 与 pass@k / pass^k
+
+用 `-k` / `--n-attempts` 跑满 k 次后，suite `summary.json` → `metrics` 会写：
+
+| 键 | 含义 |
+| --- | --- |
+| `pass_at_k` | pass@k（至少一次成功的无偏估计；Harbor 同构） |
+| `pass_power_k` | pass^k（k 次都成功的估计） |
+| suite 总分 | 各 **task** 上该指标的 **mean**（样本不够的 task 不进分母） |
+
+这些是 **job 汇总指标**，不进 package 身份 / `config_fingerprint`。  
+Hub Leaderboard 是否展示 pass@k 列见 follow-up issue，**不能**从本机 summary 存在推导榜上已有。
 
 ## 本机翻看
 
-[Viewer](/docs/run/local-viewer)：Jobs → Tasks → Attempt。
+[Viewer](/docs/run/local-viewer)：Jobs → Tasks → Attempt。  
+Attempt 页可有 **Timing**（及有数据时的 **Tokens**）条；耗时 / token **只是参考**，不是 PASS。
 
 ## 失败怎么分
 

--- a/website/content/docs/run/campaign.en.mdx
+++ b/website/content/docs/run/campaign.en.mdx
@@ -11,9 +11,12 @@ uv run bora campaign <dataset> --task <id> ...
 
 See `bora campaign --help` for matrix flags.
 
-| | Suite | Campaign |
-| --- | --- | --- |
-| Axis | Many tasks | Parameter combos on one task |
-| Typical use | Full-suite regression | Compare seed / profile |
+| | Suite | Campaign | Always-k (`-k`) |
+| --- | --- | --- | --- |
+| Axis | Many tasks | Parameter combos on one task | Repeated independent Attempts |
+| Typical use | Full-suite regression | Compare seed / profile / binding | Samples for pass@k / pass^k |
+| Entry | `bora run` (optional `--task`) | `bora campaign` | `bora run … -k N` |
+
+**Matrix axis ≠ k-attempt axis.** Always-k is not a campaign matrix field and is not in `task.yaml`. See [Suite](/docs/run/suite).
 
 Overrides still follow the `--set` allowlist.

--- a/website/content/docs/run/campaign.mdx
+++ b/website/content/docs/run/campaign.mdx
@@ -11,9 +11,12 @@ uv run bora campaign <dataset> --task <id> ...
 
 具体矩阵参数以 `bora campaign --help` 为准。
 
-| | Suite | Campaign |
-| --- | --- | --- |
-| 轴 | 多个 task | 同一 task 的参数组合 |
-| 典型用途 | 整包回归 | 对比 seed / profile |
+| | Suite | Campaign | Always-k (`-k`) |
+| --- | --- | --- | --- |
+| 轴 | 多个 task | 同一 task 的参数组合 | 同一 task **重复独立 Attempt** |
+| 典型用途 | 整包回归 | 对比 seed / profile / binding | 攒 pass@k / pass^k 样本 |
+| 入口 | `bora run`（可省略 `--task`） | `bora campaign` | `bora run … -k N` |
+
+**矩阵轴 ≠ k-attempt 轴。** Always-k 不写进 campaign matrix，也不写进 `task.yaml`。见 [Suite](/docs/run/suite)。
 
 覆盖仍受 `--set` 白名单约束，不能随意改任意字段。

--- a/website/content/docs/run/local-viewer.en.mdx
+++ b/website/content/docs/run/local-viewer.en.mdx
@@ -24,8 +24,9 @@ Serves `apps/viewer/dist/`. Change `--port` if needed.
 | --- | --- |
 | Jobs | Local suite runs |
 | Tasks | Per-task status / score |
-| Attempt | Outcome, actors, evidence tabs |
+| Attempt | Outcome, **Timing** (and **Tokens** when present), actors, evidence tabs |
 
+Timing comes from Attempt `phase_timing` (`prepare` / `run` / `evaluate` / `cleanup`); hover bar segments for durations.  
 Time / tokens are **hints**, not PASS. Trajectory is not scoring authority.
 
 Viewer does **not** talk to Registry — see [Hub](/docs/share/hub). SPA details: `apps/viewer/README.md`.

--- a/website/content/docs/run/local-viewer.mdx
+++ b/website/content/docs/run/local-viewer.mdx
@@ -26,8 +26,9 @@ uv run bora view examples/core --no-browser --port 8765
 | --- | --- |
 | Jobs | 本地 suite 跑次 |
 | Tasks | 每题状态 / 分数 |
-| Attempt | 结果条、角色、证据页签（Trajectory / Agent / …） |
+| Attempt | 结果条、**Timing**（有数据时还有 **Tokens**）、角色、证据页签（Trajectory / Agent / …） |
 
+Timing 来自 Attempt `phase_timing`（prepare / run / evaluate / cleanup）；hover 色条看分段耗时。  
 耗时和 token **只是参考**，不是 PASS。轨迹也不是评分依据。
 
 Viewer **不连** Registry。远程目录见 [Hub](/docs/share/hub)。改 SPA 看仓库 `apps/viewer/README.md`。

--- a/website/content/docs/run/single-task.en.mdx
+++ b/website/content/docs/run/single-task.en.mdx
@@ -13,6 +13,9 @@ Example:
 
 ```bash
 uv run bora run examples/core --task sdk-agent-session
+
+# Always-k: fixed k independent Attempts for one task (CLI only; default k=1)
+uv run bora run examples/core --task sdk-agent-session -k 5
 ```
 
 Config only, no agent:
@@ -21,12 +24,14 @@ Config only, no agent:
 uv run bora lock examples/core --task config-minimal
 ```
 
-`--task` must match the member directory name and `task_id` in `task.yaml`.
+`--task` must match the member directory name and `task_id` in `task.yaml`.  
+With `k=1` and no `--resume-suite`, stdout stays a single Attempt JSON (legacy-friendly). With `k>1`, the run is a suite job under `.bora/suite-runs/`. See [Suite](/docs/run/suite).
 
 ## What you get
 
 - A **Result** summary on the terminal  
-- A **`logs` path** for Attempt evidence  
+- A **`logs` path** for Attempt evidence (when `k=1`)  
+- For `k>1`: job metrics such as **pass@k / pass^k** in suite `summary.json`  
 
 PASS / FAIL comes from the **independent evaluator**, not harness completion. See [Results and PASS](/docs/reference/results-and-pass).
 

--- a/website/content/docs/run/single-task.mdx
+++ b/website/content/docs/run/single-task.mdx
@@ -13,6 +13,9 @@ uv run bora run <dataset> --task <task_id>
 
 ```bash
 uv run bora run examples/core --task sdk-agent-session
+
+# Always-k：同一 task 固定 k 次独立 Attempt（CLI only；默认 k=1）
+uv run bora run examples/core --task sdk-agent-session -k 5
 ```
 
 只检查配置、不跑 agent：
@@ -21,12 +24,14 @@ uv run bora run examples/core --task sdk-agent-session
 uv run bora lock examples/core --task config-minimal
 ```
 
-`--task` 必须等于成员目录名和 `task.yaml` 里的 `task_id`。
+`--task` 必须等于成员目录名和 `task.yaml` 里的 `task_id`。  
+`k=1` 且无 `--resume-suite` 时，stdout 仍是单次 Attempt 的 JSON（兼容旧脚本）；`k>1` 走 suite job，写 `.bora/suite-runs/`。更多见 [Suite](/docs/run/suite)。
 
 ## 跑完你会看到什么
 
 - 终端里的 **Result 摘要**（状态、分数相关字段、错误信息）  
-- **`logs` 路径**：这次 Attempt 的证据目录  
+- **`logs` 路径**：这次 Attempt 的证据目录（`k=1` 路径）  
+- `k>1` 时：suite `summary.json` 里的 **pass@k / pass^k** 等 job 指标  
 
 PASS / FAIL 来自**独立评测**，不是 harness「跑完了」。更细的读法见 [结果与 PASS](/docs/reference/results-and-pass)。
 

--- a/website/content/docs/run/suite.en.mdx
+++ b/website/content/docs/run/suite.en.mdx
@@ -1,6 +1,6 @@
 ---
 title: Run a Dataset suite
-description: Run every task in a Dataset; aggregates are not suite-level PASS.
+description: Run every task; optional Always-k and pass@k; aggregates are not suite-level PASS.
 ---
 
 Omit `--task` and `bora run` schedules **every** member — each locks, runs, and evaluates independently:
@@ -10,12 +10,55 @@ uv run bora run examples/core
 uv run bora run examples/core --max-concurrent-tasks 2
 ```
 
-| Behavior | Notes |
+## Two axes (do not mix)
+
+| Axis | Purpose | Not for |
+| --- | --- | --- |
+| **Concurrency** `--max-concurrent-tasks` | **Finish sooner** — more units in flight | Does not change k or PASS/FAIL |
+| **Always-k** `--n-attempts` / `-k` | Fixed k independent Attempts per task for **pass@k / pass^k** samples | Not conditional “retry on fail”; **not** a `task.yaml` / fingerprint field |
+
+```bash
+# Full suite, k=5 per task (CLI/job only)
+uv run bora run examples/core -k 5 --max-concurrent-tasks 2
+
+# Always-k on one task
+uv run bora run examples/core --task sdk-agent-session -k 5
+
+# Resume: append into an existing suite job and recompute metrics
+uv run bora run examples/core --resume-suite suite_<id> --task sdk-agent-session -k 5
+```
+
+Hard rules:
+
+- `n_attempts` is **not** allowed in `task.yaml` and is **not** part of `config_fingerprint`  
+- Resume only **appends** Attempts; finished Attempt scores / identity stay intact  
+- Progress / cancel below; Hub Leaderboard columns for pass@k are follow-up (**#60**) — local `metrics` already written  
+
+## Aggregate metrics
+
+Under `.bora/suite-runs/<suite_run_id>/summary.json` → `metrics`:
+
+| Field | Meaning |
 | --- | --- |
-| Concurrency | `--max-concurrent-tasks` or root `defaults.max_concurrent_tasks` |
-| PASS | **Per task** — no suite-level PASS authority |
-| Aggregates | `pass_rate` / `mean_score` are observational skim helpers |
+| `pass_rate` / `mean_score` | Observational skim (not suite PASS) |
+| `pass_at_k` | **pass@k** (Harbor-style unbiased); suite score = **mean over tasks** |
+| `pass_power_k` | **pass^k** (all-k success estimate); also mean over tasks |
+| `n_attempts` | Job k budget |
 
-Unlike [Campaign](/docs/run/campaign): suite is the **task axis**; campaign sweeps **parameters on one task**.
+Tasks with too few samples are **omitted** from that k’s denominator. PASS remains **per-task evaluator** only.
 
-Runs land under `.bora/suite-runs/` — browse with [Viewer](/docs/run/local-viewer).
+Same directory: `progress.json`. Attempt `result.json` may include `phase_timing` (`prepare` / `run` / `evaluate` / `cleanup`).
+
+## Progress and cancel
+
+```bash
+uv run bora status suite_<id> --database examples/core
+uv run bora cancel suite_<id> --database examples/core
+```
+
+- **status** — ControlStore record + suite progress when present  
+- **cancel** — writes `cancel.requested` (no new units); SIGTERM stored pid if any  
+
+Unlike [Campaign](/docs/run/campaign): suite is the **task axis**; campaign sweeps **parameters on one task**. Always-k is **not** the campaign matrix axis.
+
+Runs land under `.bora/suite-runs/` — browse Timing bars with [Viewer](/docs/run/local-viewer).

--- a/website/content/docs/run/suite.en.mdx
+++ b/website/content/docs/run/suite.en.mdx
@@ -32,6 +32,7 @@ Hard rules:
 
 - `n_attempts` is **not** allowed in `task.yaml` and is **not** part of `config_fingerprint`  
 - Resume only **appends** Attempts; finished Attempt scores / identity stay intact  
+- Slots that only have a **suite-cancel placeholder** (never actually ran) are **retried** on resume so pass@k is not permanently deflated
 - Progress / cancel below; Hub Leaderboard columns for pass@k are follow-up (**#60**) — local `metrics` already written  
 
 ## Aggregate metrics

--- a/website/content/docs/run/suite.mdx
+++ b/website/content/docs/run/suite.mdx
@@ -32,6 +32,7 @@ uv run bora run examples/core --resume-suite suite_<id> --task sdk-agent-session
 
 - `n_attempts` **禁止**写进 `task.yaml`；也不进 `config_fingerprint`  
 - 补跑只**追加** Attempt，不改写已完成 Attempt 的 score / 身份  
+- 因 **cancel 未真正跑过** 的占位会在 resume 时**重跑**（避免 pass@k 永久偏低）
 - 进度 / 取消见下方；Hub 榜上的 pass@k 列是 follow-up（#60），本机 summary 已写 metrics  
 
 ## 汇总指标

--- a/website/content/docs/run/suite.mdx
+++ b/website/content/docs/run/suite.mdx
@@ -1,6 +1,6 @@
 ---
 title: 运行 Dataset（Suite）
-description: 一次跑 Dataset 里所有 task；汇总分不是整包 PASS。
+description: 一次跑 Dataset 里所有 task；可 Always-k 与 pass@k；汇总分不是整包 PASS。
 ---
 
 省略 `--task` 时，`bora run` 按 suite 调度**每一个**成员 task，各自独立 lock / 执行 / 评测：
@@ -10,12 +10,55 @@ uv run bora run examples/core
 uv run bora run examples/core --max-concurrent-tasks 2
 ```
 
-| 行为 | 说明 |
+## 两轴别混
+
+| 轴 | 干什么 | 不干什么 |
+| --- | --- | --- |
+| **并发** `--max-concurrent-tasks` | **少等一会儿**——多开几路压总耗时 | 不改 k，也不改 PASS/FAIL |
+| **Always-k** `--n-attempts` / `-k` | 每题固定跑满 k 次独立 Attempt，给 **pass@k / pass^k** 攒样本 | 不是「失败再试」的条件 retry；**不进** `task.yaml` / fingerprint |
+
+```bash
+# 整包每题 k=5（CLI/job 参数 only）
+uv run bora run examples/core -k 5 --max-concurrent-tasks 2
+
+# 只对一题 Always-k
+uv run bora run examples/core --task sdk-agent-session -k 5
+
+# 补跑：并进已有 suite job，重算指标（可加 --task 只补一题）
+uv run bora run examples/core --resume-suite suite_<id> --task sdk-agent-session -k 5
+```
+
+硬约束：
+
+- `n_attempts` **禁止**写进 `task.yaml`；也不进 `config_fingerprint`  
+- 补跑只**追加** Attempt，不改写已完成 Attempt 的 score / 身份  
+- 进度 / 取消见下方；Hub 榜上的 pass@k 列是 follow-up（#60），本机 summary 已写 metrics  
+
+## 汇总指标
+
+写在 `.bora/suite-runs/<suite_run_id>/summary.json` 的 `metrics`：
+
+| 字段 | 含义 |
 | --- | --- |
-| 并发 | `--max-concurrent-tasks` 或根 `bora.yaml` 的 `defaults.max_concurrent_tasks` |
-| PASS | **仍是每题自己的**；没有「整包 PASS」权威 |
-| 汇总 | 可能看到 `pass_rate` / `mean_score` 一类观测指标，方便扫一眼 |
+| `pass_rate` / `mean_score` | 观测用扫一眼（不是整包 PASS） |
+| `pass_at_k` | **pass@k**（Harbor 无偏估计）；suite 分 = **各 task 上该指标的 mean** |
+| `pass_power_k` | **pass^k**（k 次都成功的估计）；同样按 task 取 mean |
+| `n_attempts` | 本次 job 的 k 预算 |
 
-和 [Campaign](/docs/run/campaign) 的区别：suite 是 **task 轴**（多题）；campaign 是 **同一题扫参数**。
+样本数不够的 task **不进**该 k 的分母。PASS 仍只来自**每题 evaluator**。
 
-跑次落在 Dataset 下的 `.bora/suite-runs/`，可用 [Viewer](/docs/run/local-viewer) 浏览。
+同目录还有 `progress.json`（多 unit 进度）；Attempt `result.json` 可含 `phase_timing`（prepare / run / evaluate / cleanup）。
+
+## 进度与取消
+
+```bash
+uv run bora status suite_<id> --database examples/core
+uv run bora cancel suite_<id> --database examples/core
+```
+
+- **status**：ControlStore 记录 + 可读 progress  
+- **cancel**：写 `cancel.requested`，不再开新 unit；有 pid 则 SIGTERM  
+
+和 [Campaign](/docs/run/campaign) 的区别：suite 是 **task 轴**（多题）；campaign 是 **同一题扫参数**。Always-k **不是** campaign 矩阵轴。
+
+跑次落在 Dataset 下的 `.bora/suite-runs/`，可用 [Viewer](/docs/run/local-viewer) 浏览 Timing 条。


### PR DESCRIPTION
## Summary

This PR delivers the **Core / Runtime orchestration** slice of Epic **#47** (Harbor-aligned multi-attempt metrics + job progress). Platform upload / Leaderboard presentation of pass@k is **out of scope** here (**#60**).

1. **A · Always-k** — CLI/job `n_attempts` / `-k`; each task in scope runs k independent Attempts  
2. **B · Metrics** — suite `summary.json` writes **pass@k** (unbiased) and **pass^k**; suite score = **mean over tasks**  
3. **C · Resume merge** — `--resume-suite` + task subset appends Attempts and **recomputes** metrics (no rewrite of finished Attempts)  
4. **D · Progress / phase timing** — Runtime `phase_timing` on attempts; suite `progress.json`; CLI progress lines; `bora cancel suite_*`; Viewer/Hub Timing (+ Tokens) bars  

- **No** `n_attempts` / concurrency fields on `task.yaml` or `config_fingerprint`  
- **No** section **E** (campaign docs/concurrency, staged network policy) — deferred  
- **No** Hub Leaderboard pass@k columns — **#60**  
- Parallelism (`max_concurrent_tasks`) only speeds scheduling; does **not** change k or PASS authority  

## Issues

| Issue | Role |
| --- | --- |
| **#47** | **Closes** — Core/Runtime k-attempt + metrics + progress (A–D) |
| #59 | Already done — job binding / profiles; scheduling params stay CLI/job |
| #60 | Follow-up — upload contract + Hub Leaderboard for pass@k / pass^k |

Closes #47  
Related: #59 #60  

## Features

### A · Always-k orchestration

```bash
uv run bora run <database> --n-attempts 5
uv run bora run <database> -k 5 --task <task_id>
uv run bora run <database> -k 5 --max-concurrent-tasks 4
```

- Scope: single task or full suite/dataset members  
- Parameters live on **CLI / job only** (not package identity)  
- Single-task `k=1` without resume keeps the historical single-result JSON path  

### B · pass@k / pass^k

- Written under suite `summary.json` → `metrics`  
- **pass@k**: Harbor-style unbiased estimator for “at least one success in k”  
- **pass^k**: all-k success probability estimate, same job summary surface  
- Suite aggregate = **mean over tasks**; tasks with insufficient samples are excluded from that k’s denominator  

### C · Resume / merge

```bash
uv run bora run <database> --resume-suite suite_<id> --task <task_id> -k 4
```

- Skips completed units; **appends** new Attempts  
- Recomputes per-task and suite metrics after merge  
- Finished Attempt scores / identity are not rewritten  

### D · Progress, cancel, phase timing, UI

| Surface | Behavior |
| --- | --- |
| L0 / L1 runtime | `result.json.phase_timing` (`prepare` / `run` / `evaluate` / `cleanup`) |
| Suite job | `progress.json`; stderr unit progress for `bora run` |
| Control | `bora cancel suite_<id>` (+ optional `--database`); `bora status` reads progress |
| Viewer / Hub | Trial Timing bar (Harbor-style); Tokens bar when usage present; Radix tooltips for segment values |

## Test plan

- [x] Focused suite / metrics / phase-timing / cancel tests on this branch  
- [x] Viewer + Hub `tsc --noEmit` after UI polish  
- [x] Manual journeys run + `--with-attempts` upload for Timing UI smoke  
- [ ] CI-equivalent full core pytest (ruff / pyright / offline ignore list) before merge  
- [ ] Reviewer: `bora run examples/… -k 2` and open suite `summary.json` metrics  

```bash
# Example local smoke
uv run bora run examples/journeys --task terminal-jsonl-agg -k 2
uv run bora status suite_<id> --database examples/journeys
```

## Commits (this branch)

```text
feat(suite): add pass@k and pass^k job metrics
feat(suite): Always-k n_attempts, resume merge, CLI -k
feat(runtime): record standard phase wall times
feat(suite): job progress.json and phase_timing on attempt rows
feat(viewer,hub): Harbor-style timing and token bars on trials
feat(suite): finish D — L1 phase timing, CLI progress, job cancel
refactor(suite): drop k==1 dual summary and double-write timing (Refs: #47)
feat(viewer,hub): polish trial timing bars and Radix tooltips
```

## Non-goals / follow-up

| Item | Notes |
| --- | --- |
| E1 Campaign docs / matrix file | Deferred with #47 E* |
| E2 Campaign concurrency + backpressure | Deferred |
| E3 Staged network policy + evidence | Deferred |
| D5 SDK optional sub-spans | Optional, not required for close |
| Hub Leaderboard pass@k / pass^k | **#60** (p2) |
| Upload-time recompute of metrics if summary missing | **#60** |