### PR TITLE
Registry/CLI: owner delete, set-visibility, unshare, and replace

### DIFF
--- a/services/registry/README.md
+++ b/services/registry/README.md
@@ -46,23 +46,35 @@ uv run bora registry org-create my-lab --display-name "My Lab"
 uv run bora registry org-list
 
 uv run bora publish tests/fixtures/databases/publish-min --org my-lab
+# Same version again conflicts (409) unless explicit replace (org owner):
+# uv run bora publish … --org my-lab --replace
 uv run bora registry list
 uv run bora registry show 'test/publish-min@0.1.0'
+uv run bora registry set-visibility 'test/publish-min@0.1.0' --visibility public
+# uv run bora registry delete 'test/publish-min@0.1.0' --yes
 uv run bora lock 'test/publish-min@0.1.0' --task hello
 
 # After a local run produced .bora/runs/<run_id>/
 uv run bora results upload <database> --run <run_id>
+# uv run bora results upload … --run <run_id> --replace   # owner overwrite
 uv run bora results get <run_id> --out /tmp/restored
 uv run bora results list
-# Share a private result (owner only)
+uv run bora results set-visibility <run_id> --kind attempt --visibility public
+# Share / unshare a private result (owner only)
 uv run bora results share <run_id> --kind attempt --share-org my-lab
+uv run bora results unshare <run_id> --kind attempt --share-org my-lab
+# uv run bora results delete <run_id> --kind attempt --yes
 
 # After a suite run produced .bora/suite-runs/<suite_run_id>/summary.json
 uv run bora results upload-suite <database> --suite-run <suite_run_id> [--public] [--agent x] [--model y]
 # Optional: also pack each task's Attempt tree (Hub can open Job detail)
 uv run bora results upload-suite <database> --suite-run <suite_run_id> --with-attempts
+# uv run bora results upload-suite … --suite-run <id> --replace
 uv run bora results get-suite <suite_run_id> [--out /tmp/restored-suite]
 uv run bora results list-suites [--database-id <id>]
+# Suite delete keeps attempts by default; optional cascade:
+# uv run bora results delete <suite_run_id> --kind suite --yes
+# uv run bora results delete <suite_run_id> --kind suite --with-attempts --yes
 # Local fallback (no registry process):
 uv run bora results list-suites --local <database>
 uv run bora results get-suite <suite_run_id> --local <database>
@@ -124,12 +136,13 @@ Browse published package contents **without** downloading the whole tar to the b
 
 ### Organizations + ACL (design #52)
 
-| Surface | Ownership | Private read |
-| --- | --- | --- |
-| Package release | **org** (`org_id` required on publish) | org members (or `admin`) |
-| Attempt / suite result | **uploader** (`uploaded_by` server-set) | owner, share→org/user, or `admin` |
+| Surface | Ownership | Private read | Delete / set-visibility / replace |
+| --- | --- | --- | --- |
+| Package release | **org** (`org_id` required on publish) | org members (or `admin`) | **org owner** (or `admin`) |
+| Attempt / suite result | **uploader** (`uploaded_by` server-set) | owner, share→org/user, or `admin` | **uploader** (or `admin`) |
 
 Joining an org does **not** reveal private results until the owner shares them.
+Publish may be done by any org **member**; destructive package ops require **owner**.
 
 | Method | Path |
 | --- | --- |
@@ -143,7 +156,23 @@ Joining an org does **not** reveal private results until the owner shares them.
 | DELETE | `/v1/orgs/{id}/members/{user}` |
 | GET/POST | `/v1/orgs/{id}/invite-keys` (owner; create returns `invite_key` **once**) |
 | DELETE | `/v1/orgs/{id}/invite-keys/{key_id}` (revoke) |
+| POST | `/v1/packages` (optional metadata `replace: true` → overwrite same version) |
+| DELETE | `/v1/packages/{id}/versions/{ver}` (org owner) |
+| PATCH | `/v1/packages/{id}/versions/{ver}` body `{ "visibility" }` |
+| DELETE | `/v1/results/attempts/{run_id}` (uploader) |
+| PATCH | `/v1/results/attempts/{run_id}` body `{ "visibility" }` |
+| DELETE | `/v1/results/suites/{id}[?with_attempts=1]` (uploader; cascade optional) |
+| PATCH | `/v1/results/suites/{id}` body `{ "visibility" }` |
 | GET/POST/DELETE | `/v1/results/attempts\|suites/{id}/shares` |
+
+**Replace policy:** same `database_id@version` / `run_id` / `suite_run_id` defaults
+to **409 conflict**. Explicit `replace: true` (CLI `--replace`) deletes the prior
+row then inserts: blob, digests, metrics/labels, and visibility from the new
+upload. No silent overwrite.
+
+**Blob GC:** meta (+ result shares) deleted first; blob object removed only when
+no remaining row references that digest (packages / attempt / suite prefixes
+separately).
 
 **Invite keys:** store only `token_hash` + `token_prefix`. Redeem hashes the
 submitted key; `max_uses` uses a conditional `UPDATE` so concurrent joins cannot
@@ -165,9 +194,11 @@ files (no `..`, 2 MiB cap, **413** when larger):
 
 | Method | Path | Scope |
 | --- | --- | --- |
-| POST | `/v1/results/suites` | `results:upload` (+ user identity) |
+| POST | `/v1/results/suites` | `results:upload` (+ user identity); optional `replace` |
 | GET | `/v1/results/suites` | public ∪ owner ∪ share hit ∪ `admin` |
 | GET | `/v1/results/suites/{suite_run_id}` | same visibility rules as attempts |
+| DELETE | `/v1/results/suites/{suite_run_id}` | uploader (or `admin`); `?with_attempts=1` cascades owned attempts |
+| PATCH | `/v1/results/suites/{suite_run_id}` | uploader (or `admin`); `{ "visibility" }` |
 | GET | `/v1/results/suites/{suite_run_id}/content` | same |
 
 Row fields: `database_id`, `database_version`, `pass_rate`, `mean_score`, `metrics`,

--- a/services/registry/app.py
+++ b/services/registry/app.py
@@ -18,9 +18,13 @@ Endpoints:
   GET  /v1/packages/{id}/by-digest/{dig}/content
   GET  /v1/packages/{id}/by-digest/{dig}/files
   GET  /v1/packages/{id}/by-digest/{dig}/files/{path}
+  DELETE /v1/packages/{id}/versions/{ver}
+  PATCH /v1/packages/{id}/versions/{ver}   (visibility)
   POST /v1/results/attempts
   GET  /v1/results/attempts
   GET  /v1/results/attempts/{run_id}
+  DELETE /v1/results/attempts/{run_id}
+  PATCH /v1/results/attempts/{run_id}     (visibility)
   GET  /v1/results/attempts/{run_id}/content
   GET  /v1/results/attempts/{run_id}/files
   GET  /v1/results/attempts/{run_id}/files/{path}
@@ -28,12 +32,16 @@ Endpoints:
   POST /v1/results/suites
   GET  /v1/results/suites
   GET  /v1/results/suites/{suite_run_id}
+  DELETE /v1/results/suites/{suite_run_id}[?with_attempts=1]
+  PATCH /v1/results/suites/{suite_run_id}  (visibility)
   GET  /v1/results/suites/{suite_run_id}/content
   GET|POST|DELETE /v1/results/suites/{suite_run_id}/shares
 
 Scopes: registry:publish | results:upload | admin (read-private legacy ignored for ACL)
 Visibility: public | private. Package private → org member; result private → owner/share.
+Owner ops: results → uploaded_by (or admin); packages → org owner (or admin).
 Unauthorized private → 404 (not 403). Suite results: no suite-level PASS authority.
+Blob GC: delete meta first; drop blob only when digest has zero remaining refs.
 """
 
 from __future__ import annotations
@@ -478,7 +486,9 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             _json_response(self, 404, {"error": "not_found", "message": "unknown path"})
 
         def do_DELETE(self) -> None:  # noqa: N802
-            path = unquote(self.path.split("?", 1)[0])
+            parsed = urlparse(self.path)
+            path = unquote(parsed.path)
+            qs = parse_qs(parsed.query)
             m = re.fullmatch(r"/v1/orgs/([^/]+)/invite-keys/([^/]+)", path)
             if m:
                 self._revoke_invite_key(org_id=m.group(1), key_id=m.group(2))
@@ -498,6 +508,39 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             m = re.fullmatch(r"/v1/results/suites/([^/]+)/shares", path)
             if m:
                 self._remove_result_share(result_kind="suite", result_id=m.group(1))
+                return
+            m = re.fullmatch(r"/v1/results/attempts/([^/]+)", path)
+            if m:
+                self._delete_attempt(run_id=m.group(1))
+                return
+            m = re.fullmatch(r"/v1/results/suites/([^/]+)", path)
+            if m:
+                with_attempts = (qs.get("with_attempts") or ["0"])[0] in {
+                    "1",
+                    "true",
+                    "yes",
+                }
+                self._delete_suite(suite_run_id=m.group(1), with_attempts=with_attempts)
+                return
+            m = re.fullmatch(r"/v1/packages/(.+)/versions/([^/]+)", path)
+            if m:
+                self._delete_package_release(database_id=m.group(1), version=m.group(2))
+                return
+            _json_response(self, 404, {"error": "not_found", "message": "unknown path"})
+
+        def do_PATCH(self) -> None:  # noqa: N802
+            path = unquote(self.path.split("?", 1)[0])
+            m = re.fullmatch(r"/v1/results/attempts/([^/]+)", path)
+            if m:
+                self._patch_attempt(run_id=m.group(1))
+                return
+            m = re.fullmatch(r"/v1/results/suites/([^/]+)", path)
+            if m:
+                self._patch_suite(suite_run_id=m.group(1))
+                return
+            m = re.fullmatch(r"/v1/packages/(.+)/versions/([^/]+)", path)
+            if m:
+                self._patch_package_release(database_id=m.group(1), version=m.group(2))
                 return
             _json_response(self, 404, {"error": "not_found", "message": "unknown path"})
 
@@ -927,6 +970,40 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 )
                 return
 
+            replace = bool(meta.get("replace")) or str(meta.get("replace") or "").lower() in {
+                "1",
+                "true",
+                "yes",
+            }
+            existing_rel = state.meta.get_by_version(database_id, version)
+            if existing_rel is not None:
+                if not replace:
+                    _json_response(
+                        self,
+                        409,
+                        {"error": "conflict", "message": "release already exists"},
+                    )
+                    return
+                # Package replace: org owner (or admin), same as delete.
+                if not (
+                    _is_admin(scopes)
+                    or (
+                        auth.user_id
+                        and existing_rel.org_id
+                        and (mem := state.meta.membership(existing_rel.org_id, auth.user_id))
+                        is not None
+                        and mem.role == "owner"
+                    )
+                ):
+                    _json_response(
+                        self,
+                        404,
+                        {"error": "not_found", "message": "release not found"},
+                    )
+                    return
+                state.meta.delete_release(database_id, version)
+                self._gc_package_blob(existing_rel.blob_digest)
+
             row = ReleaseRow(
                 database_id=database_id,
                 version=version,
@@ -948,7 +1025,10 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                     {"error": "conflict", "message": "release already exists"},
                 )
                 return
-            _json_response(self, 201, release_to_dict(row))
+            rel_payload = release_to_dict(row)
+            if existing_rel is not None and replace:
+                rel_payload["replaced"] = True
+            _json_response(self, 201, rel_payload)
 
         def _list_packages(self, *, auth: TokenInfo, qs: dict[str, list[str]]) -> None:
             prefix = (qs.get("database_id_prefix") or [None])[0]
@@ -1236,6 +1316,34 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 )
                 return
 
+            replace = bool(meta.get("replace")) or str(meta.get("replace") or "").lower() in {
+                "1",
+                "true",
+                "yes",
+            }
+            existing = state.meta.get_attempt(run_id)
+            if existing is not None:
+                if not replace:
+                    _json_response(
+                        self,
+                        409,
+                        {"error": "conflict", "message": "attempt result already exists"},
+                    )
+                    return
+                # Replace is owner-only (uploaded_by) or admin — never silent.
+                if not (
+                    _is_admin(scopes)
+                    or (auth.user_id and existing.uploaded_by == auth.user_id)
+                ):
+                    _json_response(
+                        self,
+                        404,
+                        {"error": "not_found", "message": "attempt not found"},
+                    )
+                    return
+                state.meta.delete_attempt(run_id)
+                self._gc_attempt_blob(existing.blob_digest)
+
             row = AttemptResultRow(
                 run_id=run_id,
                 database_id=database_id,
@@ -1259,7 +1367,10 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                     {"error": "conflict", "message": "attempt result already exists"},
                 )
                 return
-            _json_response(self, 201, attempt_to_dict(row))
+            payload = attempt_to_dict(row)
+            if existing is not None and replace:
+                payload["replaced"] = True
+            _json_response(self, 201, payload)
 
         def _list_attempts(self, *, auth: TokenInfo, qs: dict[str, list[str]]) -> None:
             database_id = (qs.get("database_id") or [None])[0]
@@ -1550,6 +1661,33 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             if isinstance(overlay_raw, dict) and overlay_raw:
                 config_payload["job_overlay"] = overlay_raw
 
+            replace = bool(meta.get("replace")) or str(meta.get("replace") or "").lower() in {
+                "1",
+                "true",
+                "yes",
+            }
+            existing_suite = state.meta.get_suite(suite_run_id)
+            if existing_suite is not None:
+                if not replace:
+                    _json_response(
+                        self,
+                        409,
+                        {"error": "conflict", "message": "suite result already exists"},
+                    )
+                    return
+                if not (
+                    _is_admin(scopes)
+                    or (auth.user_id and existing_suite.uploaded_by == auth.user_id)
+                ):
+                    _json_response(
+                        self,
+                        404,
+                        {"error": "not_found", "message": "suite not found"},
+                    )
+                    return
+                state.meta.delete_suite(suite_run_id)
+                self._gc_suite_blob(existing_suite.blob_digest)
+
             row = SuiteResultRow(
                 suite_run_id=suite_run_id,
                 database_id=database_id,
@@ -1578,7 +1716,10 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                     {"error": "conflict", "message": "suite result already exists"},
                 )
                 return
-            _json_response(self, 201, suite_to_dict(row))
+            suite_payload = suite_to_dict(row)
+            if existing_suite is not None and replace:
+                suite_payload["replaced"] = True
+            _json_response(self, 201, suite_payload)
 
         def _suite_visible_attempt_ids(self, rows: list[Any], *, auth: TokenInfo) -> set[str]:
             """run_ids with attempt blobs the *auth* principal may open (fail-closed)."""
@@ -2181,6 +2322,220 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             return _is_admin(auth.scopes) or (
                 bool(auth.user_id) and row_s.uploaded_by == auth.user_id
             )
+
+        def _can_manage_package(self, row: ReleaseRow, auth: TokenInfo) -> bool:
+            """Package delete / set-visibility: org owner or admin."""
+            if _is_admin(auth.scopes):
+                return True
+            if not auth.user_id or not row.org_id:
+                return False
+            mem = state.meta.membership(row.org_id, auth.user_id)
+            return mem is not None and mem.role == "owner"
+
+        def _gc_attempt_blob(self, blob_digest: str) -> bool:
+            if not blob_digest:
+                return False
+            if state.meta.count_attempt_blob_refs(blob_digest) > 0:
+                return False
+            return bool(state.blobs.delete(blob_digest, prefix="results"))
+
+        def _gc_suite_blob(self, blob_digest: str) -> bool:
+            if not blob_digest:
+                return False
+            if state.meta.count_suite_blob_refs(blob_digest) > 0:
+                return False
+            return bool(state.blobs.delete(blob_digest, prefix="suite-results"))
+
+        def _gc_package_blob(self, blob_digest: str) -> bool:
+            if not blob_digest:
+                return False
+            if state.meta.count_package_blob_refs(blob_digest) > 0:
+                return False
+            return bool(state.blobs.delete(blob_digest, prefix="packages"))
+
+        def _delete_attempt_row(self, row: AttemptResultRow) -> bool:
+            """Delete attempt meta + GC blob. Returns whether blob was removed."""
+            state.meta.delete_attempt(row.run_id)
+            return self._gc_attempt_blob(row.blob_digest)
+
+        def _collect_suite_linked_attempts(
+            self, suite_row: SuiteResultRow
+        ) -> list[AttemptResultRow]:
+            """Attempts linked by suite_run_id column or task_refs run ids."""
+            from services.registry.store import _run_ids_from_tasks_json
+
+            by_id: dict[str, AttemptResultRow] = {}
+            for att in state.meta.list_attempts_for_suite(suite_row.suite_run_id):
+                by_id[att.run_id] = att
+            run_ids = list(_run_ids_from_tasks_json(suite_row.tasks_json))
+            # Also harvest multi-attempt audit lists.
+            try:
+                refs = json.loads(suite_row.tasks_json)
+            except (json.JSONDecodeError, TypeError):
+                refs = []
+            if isinstance(refs, list):
+                for ref in refs:
+                    if not isinstance(ref, dict):
+                        continue
+                    extra = ref.get("attempt_run_ids")
+                    if isinstance(extra, list):
+                        for rid in extra:
+                            text = str(rid or "").strip()
+                            if text:
+                                run_ids.append(text)
+            for att in state.meta.attempts_for_ids(run_ids):
+                by_id[att.run_id] = att
+            return list(by_id.values())
+
+        def _delete_attempt(self, *, run_id: str) -> None:
+            token = _bearer(self)
+            auth = state.tokens.auth_for(token)
+            if not self._can_manage_result("attempt", run_id, auth, for_read=False):
+                # Fail-closed: conceal existence (matches private read policy).
+                _json_response(self, 404, {"error": "not_found", "message": "attempt not found"})
+                return
+            row = state.meta.get_attempt(run_id)
+            if row is None:
+                _json_response(self, 404, {"error": "not_found", "message": "attempt not found"})
+                return
+            blob_deleted = self._delete_attempt_row(row)
+            _json_response(
+                self,
+                200,
+                {
+                    "ok": True,
+                    "result_kind": "attempt",
+                    "result_id": run_id,
+                    "blob_deleted": blob_deleted,
+                },
+            )
+
+        def _delete_suite(self, *, suite_run_id: str, with_attempts: bool) -> None:
+            token = _bearer(self)
+            auth = state.tokens.auth_for(token)
+            if not self._can_manage_result("suite", suite_run_id, auth, for_read=False):
+                _json_response(self, 404, {"error": "not_found", "message": "suite not found"})
+                return
+            row = state.meta.get_suite(suite_run_id)
+            if row is None:
+                _json_response(self, 404, {"error": "not_found", "message": "suite not found"})
+                return
+            deleted_attempts: list[str] = []
+            skipped_attempts: list[str] = []
+            if with_attempts:
+                for att in self._collect_suite_linked_attempts(row):
+                    # Only cascade attempts owned by the same principal (or admin).
+                    if not (
+                        _is_admin(auth.scopes)
+                        or (auth.user_id and att.uploaded_by == auth.user_id)
+                    ):
+                        skipped_attempts.append(att.run_id)
+                        continue
+                    self._delete_attempt_row(att)
+                    deleted_attempts.append(att.run_id)
+            state.meta.delete_suite(suite_run_id)
+            blob_deleted = self._gc_suite_blob(row.blob_digest)
+            payload: dict[str, Any] = {
+                "ok": True,
+                "result_kind": "suite",
+                "result_id": suite_run_id,
+                "blob_deleted": blob_deleted,
+                "with_attempts": with_attempts,
+                "deleted_attempts": deleted_attempts,
+            }
+            if skipped_attempts:
+                payload["skipped_attempts"] = skipped_attempts
+            _json_response(self, 200, payload)
+
+        def _patch_visibility_body(self) -> str | None:
+            length = int(self.headers.get("Content-Length") or "0")
+            raw = self.rfile.read(length) if length > 0 else b"{}"
+            try:
+                body = json.loads(raw.decode("utf-8"))
+            except json.JSONDecodeError:
+                _json_response(self, 400, {"error": "invalid_request", "message": "bad JSON"})
+                return None
+            visibility = str(body.get("visibility") or "").strip()
+            if visibility not in {"public", "private"}:
+                _json_response(
+                    self,
+                    400,
+                    {
+                        "error": "invalid_request",
+                        "message": "visibility must be public or private",
+                    },
+                )
+                return None
+            return visibility
+
+        def _patch_attempt(self, *, run_id: str) -> None:
+            token = _bearer(self)
+            auth = state.tokens.auth_for(token)
+            if not self._can_manage_result("attempt", run_id, auth, for_read=False):
+                _json_response(self, 404, {"error": "not_found", "message": "attempt not found"})
+                return
+            visibility = self._patch_visibility_body()
+            if visibility is None:
+                return
+            try:
+                row = state.meta.set_attempt_visibility(run_id, visibility)
+            except LookupError:
+                _json_response(self, 404, {"error": "not_found", "message": "attempt not found"})
+                return
+            _json_response(self, 200, attempt_to_dict(row))
+
+        def _patch_suite(self, *, suite_run_id: str) -> None:
+            token = _bearer(self)
+            auth = state.tokens.auth_for(token)
+            if not self._can_manage_result("suite", suite_run_id, auth, for_read=False):
+                _json_response(self, 404, {"error": "not_found", "message": "suite not found"})
+                return
+            visibility = self._patch_visibility_body()
+            if visibility is None:
+                return
+            try:
+                row = state.meta.set_suite_visibility(suite_run_id, visibility)
+            except LookupError:
+                _json_response(self, 404, {"error": "not_found", "message": "suite not found"})
+                return
+            _json_response(self, 200, suite_to_dict(row))
+
+        def _delete_package_release(self, *, database_id: str, version: str) -> None:
+            token = _bearer(self)
+            auth = state.tokens.auth_for(token)
+            row = state.meta.get_by_version(database_id, version)
+            if row is None or not self._can_manage_package(row, auth):
+                _json_response(self, 404, {"error": "not_found", "message": "release not found"})
+                return
+            state.meta.delete_release(database_id, version)
+            blob_deleted = self._gc_package_blob(row.blob_digest)
+            _json_response(
+                self,
+                200,
+                {
+                    "ok": True,
+                    "database_id": database_id,
+                    "version": version,
+                    "blob_deleted": blob_deleted,
+                },
+            )
+
+        def _patch_package_release(self, *, database_id: str, version: str) -> None:
+            token = _bearer(self)
+            auth = state.tokens.auth_for(token)
+            row = state.meta.get_by_version(database_id, version)
+            if row is None or not self._can_manage_package(row, auth):
+                _json_response(self, 404, {"error": "not_found", "message": "release not found"})
+                return
+            visibility = self._patch_visibility_body()
+            if visibility is None:
+                return
+            try:
+                updated = state.meta.set_release_visibility(database_id, version, visibility)
+            except LookupError:
+                _json_response(self, 404, {"error": "not_found", "message": "release not found"})
+                return
+            _json_response(self, 200, release_to_dict(updated))
 
     return Handler
 

--- a/services/registry/store.py
+++ b/services/registry/store.py
@@ -173,6 +173,11 @@ class MemoryBlobStore:
         with self._lock:
             return self._data.get(self._key(blob_digest, prefix))
 
+    def delete(self, blob_digest: str, *, prefix: str = "packages") -> bool:
+        """Remove blob if present. Returns True when a key was deleted."""
+        with self._lock:
+            return self._data.pop(self._key(blob_digest, prefix), None) is not None
+
 
 class FilesystemBlobStore:
     """Dev fallback: local directory. Prefer S3 for compose e2e."""
@@ -199,6 +204,13 @@ class FilesystemBlobStore:
         if not path.is_file():
             return None
         return path.read_bytes()
+
+    def delete(self, blob_digest: str, *, prefix: str = "packages") -> bool:
+        path = self._path(blob_digest, prefix)
+        if not path.is_file():
+            return False
+        path.unlink()
+        return True
 
 
 class S3BlobStore:
@@ -261,6 +273,18 @@ class S3BlobStore:
         except self._ClientError:
             return None
         return bytes(resp["Body"].read())
+
+    def delete(self, blob_digest: str, *, prefix: str = "packages") -> bool:
+        key = self._object_key(blob_digest, prefix)
+        try:
+            self._client.head_object(Bucket=self.bucket, Key=key)
+        except self._ClientError:
+            return False
+        try:
+            self._client.delete_object(Bucket=self.bucket, Key=key)
+        except self._ClientError:
+            return False
+        return True
 
 
 # ---------------------------------------------------------------------------
@@ -882,6 +906,129 @@ class MetadataStore:
                 params,
             )
             return [self._suite_row(r) for r in cur.fetchall()]
+
+    def delete_attempt(self, run_id: str) -> AttemptResultRow:
+        """Delete attempt row and its shares. Raises LookupError if missing."""
+        row = self.get_attempt(run_id)
+        if row is None:
+            raise LookupError("attempt not found")
+        with self._connect() as conn:
+            conn.execute(
+                "DELETE FROM result_shares WHERE result_kind='attempt' AND result_id=?",
+                (run_id,),
+            )
+            conn.execute("DELETE FROM attempt_results WHERE run_id=?", (run_id,))
+            conn.commit()
+        return row
+
+    def set_attempt_visibility(self, run_id: str, visibility: str) -> AttemptResultRow:
+        if visibility not in {"public", "private"}:
+            raise ValueError("bad visibility")
+        row = self.get_attempt(run_id)
+        if row is None:
+            raise LookupError("attempt not found")
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE attempt_results SET visibility=? WHERE run_id=?",
+                (visibility, run_id),
+            )
+            conn.commit()
+        updated = self.get_attempt(run_id)
+        assert updated is not None
+        return updated
+
+    def delete_suite(self, suite_run_id: str) -> SuiteResultRow:
+        """Delete suite row and its shares (does not cascade attempts)."""
+        row = self.get_suite(suite_run_id)
+        if row is None:
+            raise LookupError("suite not found")
+        with self._connect() as conn:
+            conn.execute(
+                "DELETE FROM result_shares WHERE result_kind='suite' AND result_id=?",
+                (suite_run_id,),
+            )
+            conn.execute("DELETE FROM suite_results WHERE suite_run_id=?", (suite_run_id,))
+            conn.commit()
+        return row
+
+    def set_suite_visibility(self, suite_run_id: str, visibility: str) -> SuiteResultRow:
+        if visibility not in {"public", "private"}:
+            raise ValueError("bad visibility")
+        row = self.get_suite(suite_run_id)
+        if row is None:
+            raise LookupError("suite not found")
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE suite_results SET visibility=? WHERE suite_run_id=?",
+                (visibility, suite_run_id),
+            )
+            conn.commit()
+        updated = self.get_suite(suite_run_id)
+        assert updated is not None
+        return updated
+
+    def list_attempts_for_suite(self, suite_run_id: str) -> list[AttemptResultRow]:
+        """Attempts whose suite_run_id column matches (any visibility)."""
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT * FROM attempt_results WHERE suite_run_id=? ORDER BY created_at DESC",
+                (suite_run_id,),
+            )
+            return [self._attempt_row(r) for r in cur.fetchall()]
+
+    def count_attempt_blob_refs(self, blob_digest: str) -> int:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT COUNT(*) AS n FROM attempt_results WHERE blob_digest=?",
+                (blob_digest,),
+            )
+            return int(cur.fetchone()["n"])
+
+    def count_suite_blob_refs(self, blob_digest: str) -> int:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT COUNT(*) AS n FROM suite_results WHERE blob_digest=?",
+                (blob_digest,),
+            )
+            return int(cur.fetchone()["n"])
+
+    def count_package_blob_refs(self, blob_digest: str) -> int:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT COUNT(*) AS n FROM releases WHERE blob_digest=?",
+                (blob_digest,),
+            )
+            return int(cur.fetchone()["n"])
+
+    def delete_release(self, database_id: str, version: str) -> ReleaseRow:
+        row = self.get_by_version(database_id, version)
+        if row is None:
+            raise LookupError("release not found")
+        with self._connect() as conn:
+            conn.execute(
+                "DELETE FROM releases WHERE database_id=? AND version=?",
+                (database_id, version),
+            )
+            conn.commit()
+        return row
+
+    def set_release_visibility(
+        self, database_id: str, version: str, visibility: str
+    ) -> ReleaseRow:
+        if visibility not in {"public", "private"}:
+            raise ValueError("bad visibility")
+        row = self.get_by_version(database_id, version)
+        if row is None:
+            raise LookupError("release not found")
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE releases SET visibility=? WHERE database_id=? AND version=?",
+                (visibility, database_id, version),
+            )
+            conn.commit()
+        updated = self.get_by_version(database_id, version)
+        assert updated is not None
+        return updated
 
     @staticmethod
     def _release_row(r: sqlite3.Row) -> ReleaseRow:
@@ -1946,6 +2093,128 @@ class PostgresMetadataStore:
             rows = cur.fetchall()
             cols = [d.name for d in cur.description] if cur.description else []
             return [self._suite_from_cols(cols, r) for r in rows]
+
+    def delete_attempt(self, run_id: str) -> AttemptResultRow:
+        row = self.get_attempt(run_id)
+        if row is None:
+            raise LookupError("attempt not found")
+        with self._connect() as conn:
+            conn.execute(
+                "DELETE FROM result_shares WHERE result_kind='attempt' AND result_id=%s",
+                (run_id,),
+            )
+            conn.execute("DELETE FROM attempt_results WHERE run_id=%s", (run_id,))
+            conn.commit()
+        return row
+
+    def set_attempt_visibility(self, run_id: str, visibility: str) -> AttemptResultRow:
+        if visibility not in {"public", "private"}:
+            raise ValueError("bad visibility")
+        row = self.get_attempt(run_id)
+        if row is None:
+            raise LookupError("attempt not found")
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE attempt_results SET visibility=%s WHERE run_id=%s",
+                (visibility, run_id),
+            )
+            conn.commit()
+        updated = self.get_attempt(run_id)
+        assert updated is not None
+        return updated
+
+    def delete_suite(self, suite_run_id: str) -> SuiteResultRow:
+        row = self.get_suite(suite_run_id)
+        if row is None:
+            raise LookupError("suite not found")
+        with self._connect() as conn:
+            conn.execute(
+                "DELETE FROM result_shares WHERE result_kind='suite' AND result_id=%s",
+                (suite_run_id,),
+            )
+            conn.execute("DELETE FROM suite_results WHERE suite_run_id=%s", (suite_run_id,))
+            conn.commit()
+        return row
+
+    def set_suite_visibility(self, suite_run_id: str, visibility: str) -> SuiteResultRow:
+        if visibility not in {"public", "private"}:
+            raise ValueError("bad visibility")
+        row = self.get_suite(suite_run_id)
+        if row is None:
+            raise LookupError("suite not found")
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE suite_results SET visibility=%s WHERE suite_run_id=%s",
+                (visibility, suite_run_id),
+            )
+            conn.commit()
+        updated = self.get_suite(suite_run_id)
+        assert updated is not None
+        return updated
+
+    def list_attempts_for_suite(self, suite_run_id: str) -> list[AttemptResultRow]:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT * FROM attempt_results WHERE suite_run_id=%s ORDER BY created_at DESC",
+                (suite_run_id,),
+            )
+            rows = cur.fetchall()
+            cols = [d.name for d in cur.description] if cur.description else []
+            return [self._attempt_from_cols(cols, r) for r in rows]
+
+    def count_attempt_blob_refs(self, blob_digest: str) -> int:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT COUNT(*) FROM attempt_results WHERE blob_digest=%s",
+                (blob_digest,),
+            )
+            return int(cur.fetchone()[0])
+
+    def count_suite_blob_refs(self, blob_digest: str) -> int:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT COUNT(*) FROM suite_results WHERE blob_digest=%s",
+                (blob_digest,),
+            )
+            return int(cur.fetchone()[0])
+
+    def count_package_blob_refs(self, blob_digest: str) -> int:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT COUNT(*) FROM releases WHERE blob_digest=%s",
+                (blob_digest,),
+            )
+            return int(cur.fetchone()[0])
+
+    def delete_release(self, database_id: str, version: str) -> ReleaseRow:
+        row = self.get_by_version(database_id, version)
+        if row is None:
+            raise LookupError("release not found")
+        with self._connect() as conn:
+            conn.execute(
+                "DELETE FROM releases WHERE database_id=%s AND version=%s",
+                (database_id, version),
+            )
+            conn.commit()
+        return row
+
+    def set_release_visibility(
+        self, database_id: str, version: str, visibility: str
+    ) -> ReleaseRow:
+        if visibility not in {"public", "private"}:
+            raise ValueError("bad visibility")
+        row = self.get_by_version(database_id, version)
+        if row is None:
+            raise LookupError("release not found")
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE releases SET visibility=%s WHERE database_id=%s AND version=%s",
+                (visibility, database_id, version),
+            )
+            conn.commit()
+        updated = self.get_by_version(database_id, version)
+        assert updated is not None
+        return updated
 
     @staticmethod
     def _release_from_cur(cur: Any, r: Any) -> ReleaseRow:

--- a/skills/bora-cli/SKILL.md
+++ b/skills/bora-cli/SKILL.md
@@ -41,7 +41,12 @@ uv run bora --help
 | `bora evidence <logs-path> --out <dir>`                    | Sealed trajectory export (no score change)                           |
 | `bora results upload-suite …`                              | Suite aggregates → Registry; recompute pass@k if missing; job_overlay |
 | `bora results upload-suite … --with-attempts`              | Also upload attempt dirs from task_refs.attempt_run_ids / run_id     |
+| `bora results upload\|upload-suite … --replace`            | Owner overwrite same run_id / suite_run_id (default 409)             |
+| `bora results delete\|set-visibility … --kind attempt\|suite` | Owner delete (`--yes`) or flip visibility after upload            |
+| `bora results share\|unshare …`                            | Grant / revoke private result access (owner only)                    |
 | `bora results export-profiles <suite_run_id> --out …`      | Rehydrate job binding as profiles.yaml (#59; locators only)          |
+| `bora publish … --org … [--replace]`                       | Package publish; replace same version is org-owner only              |
+| `bora registry delete\|set-visibility <id@ver>`            | Org-owner package delete (`--yes`) / visibility flip                 |
 | `bora submit` / `bora status` / `bora cancel`              | Durable Run **or suite job** (8-hex id; status/cancel may take `--database`) |
 
 Discover flags with `uv run bora <cmd> --help`. Source of truth: `src/bora/cli/main.py`.

--- a/skills/bora-cli/references/commands.md
+++ b/skills/bora-cli/references/commands.md
@@ -84,7 +84,24 @@ Stdout JSON (high level):
 - `task_refs` may carry `n`, `c`, `attempt_run_ids` for multi-attempt audit.
 - **`--with-attempts`:** packs `.bora/runs/<run_id>/` for each id in
   `attempt_run_ids` (preferred) or primary `run_id`; missing dirs fail closed.
+- **`--replace`:** owner overwrite of same `suite_run_id` (default remains 409);
+  with `--with-attempts`, linked attempts also replace.
 - Registry stores full `metrics` blob (no strip). pass@k is **not**
   `config_fingerprint` / job identity.
 - Hub Leaderboard: optional n_attempts / pass@k / pass^k columns when present;
   default sort remains pass_rate → mean_score.
+
+## Registry owner ops
+
+| Command | Who | Notes |
+| --- | --- | --- |
+| `bora results delete --kind attempt\|suite --yes` | `uploaded_by` (or admin) | Suite default does **not** delete attempts; `--with-attempts` cascades owned attempts |
+| `bora results set-visibility --kind … --visibility public\|private` | uploader | After create; no re-upload required |
+| `bora results unshare` | uploader | Same targeting as `share` (`--share-org` / `--share-user`) |
+| `bora results upload\|upload-suite --replace` | uploader | Replaces blob + metrics/labels + visibility |
+| `bora registry delete <id@ver> --yes` | **org owner** (or admin) | Meta + unreferenced package blob GC |
+| `bora registry set-visibility <id@ver> --visibility …` | org owner | Flip without new version |
+| `bora publish --replace` | org owner for overwrite | First publish still any org **member** |
+
+Destructive CLI requires explicit `--yes`. Unauthorized private targets → **404**
+fail-closed (no existence leak beyond existing list rules).

--- a/src/bora/application/publish_command.py
+++ b/src/bora/application/publish_command.py
@@ -20,8 +20,13 @@ def publish_database(
     org: str | None = None,
     registry_url: str | None = None,
     token: str | None = None,
+    replace: bool = False,
 ) -> dict[str, Any]:
-    """Validate Database, compute digests, publish to Registry; return summary dict."""
+    """Validate Database, compute digests, publish to Registry; return summary dict.
+
+    *replace* overwrites the same ``database_id@version`` for org owners only
+    (blob, digests, visibility, size). Default remains conflict (409).
+    """
     root = database_root.expanduser().resolve(strict=False)
     try:
         manifest = load_database_manifest(root)
@@ -67,11 +72,12 @@ def publish_database(
             visibility=visibility,
             archive=archive,
             org_id=org_id,
+            replace=replace,
         )
     except RegistryError as exc:
         raise ConfigError(exc.code, exc.message, location="registry") from exc
 
-    return {
+    out: dict[str, Any] = {
         "ok": True,
         "database_id": info.database_id,
         "version": info.version,
@@ -84,3 +90,6 @@ def publish_database(
         "digest_ref": f"{info.database_id}@{info.package_digest}",
         "org_id": info.org_id or org_id,
     }
+    if info.replaced:
+        out["replaced"] = True
+    return out

--- a/src/bora/application/registry_list_command.py
+++ b/src/bora/application/registry_list_command.py
@@ -92,6 +92,69 @@ def show_package(ref: str, *, registry_url: str | None = None) -> dict[str, Any]
     }
 
 
+def delete_package_release(ref: str, *, registry_url: str | None = None) -> dict[str, Any]:
+    """Delete a package release (org owner / admin). *ref* = database_id@version."""
+    parsed = parse_package_ref(ref)
+    if parsed.kind == "path" or not parsed.database_id or not parsed.version:
+        raise ConfigError(
+            "invalid_package",
+            "expected database_id@version",
+            location=ref,
+        )
+    if parsed.package_digest:
+        raise ConfigError(
+            "invalid_package",
+            "delete requires database_id@version (not digest ref)",
+            location=ref,
+        )
+    client = _client(registry_url=registry_url)
+    try:
+        return client.delete_package_release(
+            database_id=parsed.database_id,
+            version=parsed.version,
+        )
+    except RegistryError as exc:
+        raise ConfigError(exc.code, exc.message, location="registry") from exc
+
+
+def set_package_visibility(
+    ref: str,
+    *,
+    visibility: str,
+    registry_url: str | None = None,
+) -> dict[str, Any]:
+    """Set package release visibility (org owner / admin). *ref* = database_id@version."""
+    if visibility not in {"public", "private"}:
+        raise ConfigError(
+            "invalid_request",
+            "visibility must be public or private",
+            location="registry",
+        )
+    parsed = parse_package_ref(ref)
+    if parsed.kind == "path" or not parsed.database_id or not parsed.version:
+        raise ConfigError(
+            "invalid_package",
+            "expected database_id@version",
+            location=ref,
+        )
+    if parsed.package_digest:
+        raise ConfigError(
+            "invalid_package",
+            "set-visibility requires database_id@version (not digest ref)",
+            location=ref,
+        )
+    client = _client(registry_url=registry_url)
+    try:
+        data = client.set_package_visibility(
+            database_id=parsed.database_id,
+            version=parsed.version,
+            visibility=visibility,
+        )
+    except RegistryError as exc:
+        raise ConfigError(exc.code, exc.message, location="registry") from exc
+    return {"ok": True, **data}
+
+
 def cache_list(*, cache_root: Path | None = None) -> dict[str, Any]:
     root = (cache_root or default_cache_root()).resolve()
     base = root / "databases"

--- a/src/bora/application/results_command.py
+++ b/src/bora/application/results_command.py
@@ -106,13 +106,21 @@ def upload_attempt_result(
     suite_run_id: str | None = None,
     registry_url: str | None = None,
     allow_existing: bool = False,
+    replace: bool = False,
 ) -> dict[str, Any]:
     """Pack ``.bora/runs/<run_id>`` and POST to results store.
 
     When *allow_existing* is true, a registry ``conflict`` (same run_id already
     uploaded) is treated as success with ``already_exists: true`` (idempotent
-    re-upload / suite --with-attempts retry).
+    re-upload / suite --with-attempts retry). *replace* overwrites the same
+    run_id for the owner only (explicit; never silent).
     """
+    if replace and allow_existing:
+        raise ConfigError(
+            "invalid_request",
+            "replace and allow_existing are mutually exclusive",
+            location="registry",
+        )
     root = database_root.expanduser().resolve(strict=False)
     try:
         manifest = load_database_manifest(root)
@@ -143,6 +151,7 @@ def upload_attempt_result(
             size=size,
             archive=archive,
             suite_run_id=suite_link,
+            replace=replace,
         )
     except RegistryError as exc:
         if allow_existing and (
@@ -171,6 +180,8 @@ def upload_attempt_result(
         "visibility": info.get("visibility", "private"),
         "status": info.get("status", status),
     }
+    if info.get("replaced"):
+        out["replaced"] = True
     if suite_link:
         out["suite_run_id"] = info.get("suite_run_id", suite_link)
     elif info.get("suite_run_id"):
@@ -362,13 +373,15 @@ def upload_suite_result(
     model_label: str = "",
     with_attempts: bool = False,
     registry_url: str | None = None,
+    replace: bool = False,
 ) -> dict[str, Any]:
     """Pack ``.bora/suite-runs/<id>`` and POST suite result to results store.
 
     When *with_attempts* is true, also upload each local ``.bora/runs/<run_id>``
     referenced by suite ``task_refs`` (same visibility). Missing local run dirs
-    fail closed before any network upload. Re-uploads of existing run_ids are
-    treated as success (``already_exists``).
+    fail closed before any network upload. Without *replace*, re-uploads of
+    existing suite_run_id conflict (409); attempt re-uploads under
+    ``--with-attempts`` remain idempotent (``already_exists``).
     """
     root = database_root.expanduser().resolve(strict=False)
     suite_dir = _resolve_suite_dir(root, suite_run_id)
@@ -443,6 +456,7 @@ def upload_suite_result(
             job_overlay=config_proj.get("job_overlay")
             if isinstance(config_proj.get("job_overlay"), dict)
             else None,
+            replace=replace,
         )
     except RegistryError as exc:
         raise ConfigError(exc.code, exc.message, location="registry") from exc
@@ -461,6 +475,8 @@ def upload_suite_result(
         "visibility": info.get("visibility", "private"),
         "note": info.get("note", "per-task evaluator verdicts only; no suite-level PASS"),
     }
+    if info.get("replaced"):
+        out["replaced"] = True
     for key in ("config_fingerprint", "config_homogeneous", "actors_summary", "job_overlay"):
         if key in info:
             out[key] = info[key]
@@ -478,7 +494,10 @@ def upload_suite_result(
                     public=public,
                     suite_run_id=suite_run_id,
                     registry_url=registry_url,
-                    allow_existing=True,
+                    # Under suite --replace, also overwrite attempt blobs; else
+                    # keep idempotent skip of existing run_ids.
+                    allow_existing=not replace,
+                    replace=replace,
                 )
             )
         out["with_attempts"] = True
@@ -669,3 +688,114 @@ def share_result(
         "shares": created,
         "count": len(created),
     }
+
+
+def unshare_result(
+    *,
+    result_kind: str,
+    result_id: str,
+    share_orgs: list[str] | None = None,
+    share_users: list[str] | None = None,
+    registry_url: str | None = None,
+) -> dict[str, Any]:
+    """Revoke private result share grants (owner only)."""
+    if result_kind not in {"attempt", "suite"}:
+        raise ConfigError(
+            "invalid_request",
+            "result_kind must be attempt or suite",
+            location="registry",
+        )
+    if not share_orgs and not share_users:
+        raise ConfigError(
+            "invalid_request",
+            "provide at least one share_org or share_user to unshare",
+            location="registry",
+        )
+    client = _client(registry_url=registry_url)
+    removed: list[dict[str, Any]] = []
+    try:
+        for org in share_orgs or []:
+            removed.append(
+                client.unshare_result(
+                    result_kind=result_kind,
+                    result_id=result_id,
+                    target_type="org",
+                    target_id=org,
+                )
+            )
+        for user in share_users or []:
+            removed.append(
+                client.unshare_result(
+                    result_kind=result_kind,
+                    result_id=result_id,
+                    target_type="user",
+                    target_id=user,
+                )
+            )
+    except RegistryError as exc:
+        raise ConfigError(exc.code, exc.message, location="registry") from exc
+    return {
+        "ok": True,
+        "result_kind": result_kind,
+        "result_id": result_id,
+        "unshared": removed,
+        "count": len(removed),
+    }
+
+
+def delete_result(
+    *,
+    result_kind: str,
+    result_id: str,
+    with_attempts: bool = False,
+    registry_url: str | None = None,
+) -> dict[str, Any]:
+    """Delete an attempt or suite result owned by the current principal."""
+    if result_kind not in {"attempt", "suite"}:
+        raise ConfigError(
+            "invalid_request",
+            "result_kind must be attempt or suite",
+            location="registry",
+        )
+    client = _client(registry_url=registry_url)
+    try:
+        if result_kind == "attempt":
+            if with_attempts:
+                raise ConfigError(
+                    "invalid_request",
+                    "--with-attempts is only valid for suite results",
+                    location="registry",
+                )
+            return client.delete_attempt(result_id)
+        return client.delete_suite(result_id, with_attempts=with_attempts)
+    except RegistryError as exc:
+        raise ConfigError(exc.code, exc.message, location="registry") from exc
+
+
+def set_result_visibility(
+    *,
+    result_kind: str,
+    result_id: str,
+    visibility: str,
+    registry_url: str | None = None,
+) -> dict[str, Any]:
+    """Set attempt/suite visibility after create (owner only)."""
+    if result_kind not in {"attempt", "suite"}:
+        raise ConfigError(
+            "invalid_request",
+            "result_kind must be attempt or suite",
+            location="registry",
+        )
+    if visibility not in {"public", "private"}:
+        raise ConfigError(
+            "invalid_request",
+            "visibility must be public or private",
+            location="registry",
+        )
+    client = _client(registry_url=registry_url)
+    try:
+        if result_kind == "attempt":
+            return client.set_attempt_visibility(result_id, visibility=visibility)
+        return client.set_suite_visibility(result_id, visibility=visibility)
+    except RegistryError as exc:
+        raise ConfigError(exc.code, exc.message, location="registry") from exc

--- a/src/bora/cli/README.md
+++ b/src/bora/cli/README.md
@@ -87,14 +87,16 @@ Credentials file `~/.bora/credentials` (mode `0600`):
 | `bora evidence` | Export sealed trajectory copy (does not change score) |
 | `bora submit` / `status` / `cancel` | Durable Run / suite job control (suite id + optional `--database`) |
 | `bora login` | GitHub **Device Flow** → write credentials (Hub uses browser OAuth instead) |
-| `bora publish` | Publish a Database package (**requires `--org`**) |
+| `bora publish` | Publish a Database package (**requires `--org`**); optional `--replace` |
 | `bora registry list\|show` | Browse remote packages |
+| `bora registry delete\|set-visibility` | Owner ops on `database_id@version` (org owner; delete needs `--yes`) |
 | `bora registry org-create\|org-list` | Create / list organizations (packages belong to orgs) |
 | `bora cache list\|path\|purge` | Local verified cache |
-| `bora results upload\|get\|list` | Attempt run evidence bundles |
+| `bora results upload\|get\|list` | Attempt run evidence bundles; upload accepts `--replace` |
 | `bora results upload-suite\|get-suite\|list-suites` | Suite/job aggregates + task refs (no suite PASS); meta may include `job_overlay` |
 | `bora results export-profiles` | Export suite `job_overlay` → re-runnable `profiles.yaml` (#59) |
-| `bora results share` | Share a private result with org(s) and/or user(s) |
+| `bora results share\|unshare` | Share / revoke private result access (owner only) |
+| `bora results delete\|set-visibility` | Delete or flip visibility (`--kind attempt\|suite`; delete needs `--yes`) |
 | `bora view` | Local read-only Database Web UI (no Registry) |
 
 Discover flags with `uv run bora <cmd> -h`.
@@ -226,6 +228,8 @@ uv run bora registry org-list
 # Default visibility private; explicit public. --org is required.
 uv run bora publish tests/fixtures/databases/publish-min --org my-lab
 uv run bora publish path/to/db --org my-lab --public
+# Same database_id@version → 409 unless org owner passes --replace (rewrites blob/digests/visibility):
+# uv run bora publish path/to/db --org my-lab --replace
 ```
 
 ### Lock / run by ref
@@ -242,6 +246,9 @@ uv run bora lock 'test/publish-min@sha256:…' --task hello
 uv run bora registry list
 uv run bora registry list --prefix test/
 uv run bora registry show 'test/publish-min@0.1.0'
+# Org owner (or admin): flip visibility after publish; delete requires --yes
+uv run bora registry set-visibility 'test/publish-min@0.1.0' --visibility public
+# uv run bora registry delete 'test/publish-min@0.1.0' --yes
 
 uv run bora cache list
 uv run bora cache path 'test/publish-min@sha256:…'
@@ -254,16 +261,21 @@ Upload sealed trees under `<database>/.bora/runs/<run_id>/` (not package release
 
 ```bash
 uv run bora results upload /path/to/database --run <run_id>
+# Same run_id → 409 unless owner passes --replace (rewrites archive + meta):
+# uv run bora results upload /path/to/database --run <run_id> --replace
 uv run bora results list --database-id test/publish-min
 uv run bora results get <run_id> --out /tmp/restored-run
-# Share a private result (owner only):
+uv run bora results set-visibility <run_id> --kind attempt --visibility public
+# Share / unshare a private result (owner only):
 uv run bora results share <run_id> --kind attempt --share-org my-lab
+uv run bora results unshare <run_id> --kind attempt --share-org my-lab
+# uv run bora results delete <run_id> --kind attempt --yes
 ```
 
 Visibility is **public** or **private** only. Packages are owned by an **org**;
 results are owned by the **uploader** (`uploaded_by`). Private results stay
 invisible to org members until the owner shares them. Default private; `--public`
-for public.
+for public at create time, or `set-visibility` later.
 
 ### Suite / job results
 
@@ -290,10 +302,16 @@ uv run bora results upload-suite /path/to/database --suite-run <suite_run_id> \
 # Optional full Attempt evidence (Hub Jobs deep-link / evidence browser):
 uv run bora results upload-suite /path/to/database --suite-run <suite_run_id> \
   --with-attempts
+# Owner overwrite of same suite_run_id (default is 409):
+# uv run bora results upload-suite … --suite-run <id> --replace
 # Or backfill one run later:
 uv run bora results upload /path/to/database --run <run_id>
 uv run bora results list-suites --database-id test/suite-min
 uv run bora results get-suite <suite_run_id> --out /tmp/restored-suite
+uv run bora results set-visibility <suite_run_id> --kind suite --visibility private
+# Delete suite meta only (attempts remain); cascade with --with-attempts:
+# uv run bora results delete <suite_run_id> --kind suite --yes
+# uv run bora results delete <suite_run_id> --kind suite --with-attempts --yes
 # No registry: fall back to local suite-runs
 uv run bora results list-suites --local /path/to/database
 uv run bora results get-suite <suite_run_id> --local /path/to/database
@@ -303,7 +321,8 @@ uv run bora results get-suite <suite_run_id> --local /path/to/database
 each run id from `task_refs[].attempt_run_ids` (preferred) or `task_refs[].run_id`
 is packed from `.bora/runs/<run_id>/` with the **same visibility** as the suite.
 Missing local run dirs **fail closed** before any network upload. Re-uploading an
-existing `run_id` is treated as success (`already_exists`). Registry suite list/get
+existing `run_id` without `--replace` is treated as success (`already_exists`).
+With suite `--replace`, linked attempt uploads also replace. Registry suite list/get
 annotate each task_ref with `has_attempt_content` so Hub Jobs can open evidence or
 show “Not uploaded”.
 

--- a/src/bora/cli/cmd_executors_publish_login.py
+++ b/src/bora/cli/cmd_executors_publish_login.py
@@ -52,6 +52,13 @@ def register(app: typer.Typer) -> None:
                 help="Create a public release (default: private).",
             ),
         ] = False,
+        replace: Annotated[
+            bool,
+            typer.Option(
+                "--replace",
+                help="Overwrite same database_id@version if org owner (default: conflict 409).",
+            ),
+        ] = False,
         registry_url: Annotated[
             str | None,
             typer.Option(
@@ -69,6 +76,7 @@ def register(app: typer.Typer) -> None:
                 database,
                 public=public,
                 org=org,
+                replace=replace,
                 registry_url=registry_url,
             )
         except ConfigError as exc:

--- a/src/bora/cli/cmd_registry.py
+++ b/src/bora/cli/cmd_registry.py
@@ -120,4 +120,64 @@ def register(app: typer.Typer) -> None:
             raise typer.Exit(code=2) from exc
         typer.echo(json.dumps(summary, ensure_ascii=False, separators=(",", ":"), sort_keys=True))
 
+    @sub.command("delete")
+    def registry_delete_command(
+        ref: Annotated[
+            str,
+            typer.Argument(help="Package release: database_id@version"),
+        ],
+        yes: Annotated[
+            bool,
+            typer.Option("--yes", help="Confirm destructive delete (required)."),
+        ] = False,
+        registry_url: Annotated[
+            str | None,
+            typer.Option("--registry-url", help="Override registry URL."),
+        ] = None,
+    ) -> None:
+        """Delete a package release. Org owner (or admin) only; requires --yes."""
+        from bora.application.registry_list_command import delete_package_release
+        from bora.config.errors import ConfigError
+
+        if not yes:
+            typer.echo("refusing to delete without --yes", err=True)
+            raise typer.Exit(code=2)
+        try:
+            summary = delete_package_release(ref, registry_url=registry_url)
+        except ConfigError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=2) from exc
+        typer.echo(json.dumps(summary, ensure_ascii=False, separators=(",", ":"), sort_keys=True))
+
+    @sub.command("set-visibility")
+    def registry_set_visibility_command(
+        ref: Annotated[
+            str,
+            typer.Argument(help="Package release: database_id@version"),
+        ],
+        visibility: Annotated[
+            str,
+            typer.Option("--visibility", help="public | private"),
+        ],
+        registry_url: Annotated[
+            str | None,
+            typer.Option("--registry-url", help="Override registry URL."),
+        ] = None,
+    ) -> None:
+        """Set package release visibility after publish. Org owner (or admin) only."""
+        from bora.application.registry_list_command import set_package_visibility
+        from bora.config.errors import ConfigError
+
+        if visibility not in {"public", "private"}:
+            typer.echo("visibility must be public or private", err=True)
+            raise typer.Exit(code=2)
+        try:
+            summary = set_package_visibility(
+                ref, visibility=visibility, registry_url=registry_url
+            )
+        except ConfigError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=2) from exc
+        typer.echo(json.dumps(summary, ensure_ascii=False, separators=(",", ":"), sort_keys=True))
+
     app.add_typer(sub, name="registry")

--- a/src/bora/cli/cmd_registry.py
+++ b/src/bora/cli/cmd_registry.py
@@ -172,9 +172,7 @@ def register(app: typer.Typer) -> None:
             typer.echo("visibility must be public or private", err=True)
             raise typer.Exit(code=2)
         try:
-            summary = set_package_visibility(
-                ref, visibility=visibility, registry_url=registry_url
-            )
+            summary = set_package_visibility(ref, visibility=visibility, registry_url=registry_url)
         except ConfigError as exc:
             typer.echo(str(exc), err=True)
             raise typer.Exit(code=2) from exc

--- a/src/bora/cli/cmd_results.py
+++ b/src/bora/cli/cmd_results.py
@@ -33,6 +33,13 @@ def register(app: typer.Typer) -> None:
             bool,
             typer.Option("--public", help="Create a public result (default: private)."),
         ] = False,
+        replace: Annotated[
+            bool,
+            typer.Option(
+                "--replace",
+                help="Overwrite same run_id if you own it (default: conflict 409).",
+            ),
+        ] = False,
         registry_url: Annotated[
             str | None,
             typer.Option("--registry-url", help="Override registry / results URL."),
@@ -47,6 +54,7 @@ def register(app: typer.Typer) -> None:
                 database,
                 run_id=run,
                 public=public,
+                replace=replace,
                 registry_url=registry_url,
             )
         except ConfigError as exc:
@@ -140,6 +148,13 @@ def register(app: typer.Typer) -> None:
                 ),
             ),
         ] = False,
+        replace: Annotated[
+            bool,
+            typer.Option(
+                "--replace",
+                help="Overwrite same suite_run_id if you own it (default: conflict 409).",
+            ),
+        ] = False,
         registry_url: Annotated[
             str | None,
             typer.Option("--registry-url", help="Override registry / results URL."),
@@ -157,6 +172,7 @@ def register(app: typer.Typer) -> None:
                 agent_label=agent,
                 model_label=model,
                 with_attempts=with_attempts,
+                replace=replace,
                 registry_url=registry_url,
             )
         except ConfigError as exc:
@@ -325,6 +341,141 @@ def register(app: typer.Typer) -> None:
                 result_id=result_id,
                 share_orgs=share_org or [],
                 share_users=share_user or [],
+                registry_url=registry_url,
+            )
+        except ConfigError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=2) from exc
+        typer.echo(json.dumps(summary, ensure_ascii=False, separators=(",", ":"), sort_keys=True))
+
+    @sub.command("unshare")
+    def results_unshare_command(
+        result_id: Annotated[
+            str,
+            typer.Argument(help="attempt run_id or suite_run_id."),
+        ],
+        kind: Annotated[
+            str,
+            typer.Option("--kind", help="attempt | suite"),
+        ] = "attempt",
+        share_org: Annotated[
+            list[str] | None,
+            typer.Option("--share-org", help="Revoke share for org (repeatable)."),
+        ] = None,
+        share_user: Annotated[
+            list[str] | None,
+            typer.Option("--share-user", help="Revoke share for user (repeatable)."),
+        ] = None,
+        registry_url: Annotated[
+            str | None,
+            typer.Option("--registry-url", help="Override registry / results URL."),
+        ] = None,
+    ) -> None:
+        """Revoke a private result share. Owner only."""
+        from bora.application.results_command import unshare_result
+        from bora.config.errors import ConfigError
+
+        if kind not in {"attempt", "suite"}:
+            typer.echo("kind must be attempt or suite", err=True)
+            raise typer.Exit(code=2)
+        if not share_org and not share_user:
+            typer.echo("provide --share-org and/or --share-user", err=True)
+            raise typer.Exit(code=2)
+        try:
+            summary = unshare_result(
+                result_kind=kind,
+                result_id=result_id,
+                share_orgs=share_org or [],
+                share_users=share_user or [],
+                registry_url=registry_url,
+            )
+        except ConfigError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=2) from exc
+        typer.echo(json.dumps(summary, ensure_ascii=False, separators=(",", ":"), sort_keys=True))
+
+    @sub.command("delete")
+    def results_delete_command(
+        result_id: Annotated[
+            str,
+            typer.Argument(help="attempt run_id or suite_run_id."),
+        ],
+        kind: Annotated[
+            str,
+            typer.Option("--kind", help="attempt | suite"),
+        ] = "attempt",
+        with_attempts: Annotated[
+            bool,
+            typer.Option(
+                "--with-attempts",
+                help="When deleting a suite, also delete linked attempt results (same owner).",
+            ),
+        ] = False,
+        yes: Annotated[
+            bool,
+            typer.Option("--yes", help="Confirm destructive delete (required)."),
+        ] = False,
+        registry_url: Annotated[
+            str | None,
+            typer.Option("--registry-url", help="Override registry / results URL."),
+        ] = None,
+    ) -> None:
+        """Delete an owned attempt or suite result. Requires --yes."""
+        from bora.application.results_command import delete_result
+        from bora.config.errors import ConfigError
+
+        if kind not in {"attempt", "suite"}:
+            typer.echo("kind must be attempt or suite", err=True)
+            raise typer.Exit(code=2)
+        if not yes:
+            typer.echo("refusing to delete without --yes", err=True)
+            raise typer.Exit(code=2)
+        try:
+            summary = delete_result(
+                result_kind=kind,
+                result_id=result_id,
+                with_attempts=with_attempts,
+                registry_url=registry_url,
+            )
+        except ConfigError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=2) from exc
+        typer.echo(json.dumps(summary, ensure_ascii=False, separators=(",", ":"), sort_keys=True))
+
+    @sub.command("set-visibility")
+    def results_set_visibility_command(
+        result_id: Annotated[
+            str,
+            typer.Argument(help="attempt run_id or suite_run_id."),
+        ],
+        visibility: Annotated[
+            str,
+            typer.Option("--visibility", help="public | private"),
+        ],
+        kind: Annotated[
+            str,
+            typer.Option("--kind", help="attempt | suite"),
+        ] = "attempt",
+        registry_url: Annotated[
+            str | None,
+            typer.Option("--registry-url", help="Override registry / results URL."),
+        ] = None,
+    ) -> None:
+        """Set visibility of an owned attempt or suite result after upload."""
+        from bora.application.results_command import set_result_visibility
+        from bora.config.errors import ConfigError
+
+        if kind not in {"attempt", "suite"}:
+            typer.echo("kind must be attempt or suite", err=True)
+            raise typer.Exit(code=2)
+        if visibility not in {"public", "private"}:
+            typer.echo("visibility must be public or private", err=True)
+            raise typer.Exit(code=2)
+        try:
+            summary = set_result_visibility(
+                result_kind=kind,
+                result_id=result_id,
+                visibility=visibility,
                 registry_url=registry_url,
             )
         except ConfigError as exc:

--- a/src/bora/registry/client.py
+++ b/src/bora/registry/client.py
@@ -648,9 +648,7 @@ class RegistryClient:
         return json.loads(raw.decode("utf-8"))
 
     def delete_package_release(self, *, database_id: str, version: str) -> dict[str, Any]:
-        path = (
-            f"/v1/packages/{quote(database_id, safe='/')}/versions/{quote(version, safe='')}"
-        )
+        path = f"/v1/packages/{quote(database_id, safe='/')}/versions/{quote(version, safe='')}"
         status, raw, _ = self._request("DELETE", path)
         if status != 200:
             raise RegistryError("delete_failed", f"status {status}", status=status)
@@ -661,9 +659,7 @@ class RegistryClient:
     ) -> dict[str, Any]:
         if visibility not in {"public", "private"}:
             raise RegistryError("invalid_request", "visibility must be public or private")
-        path = (
-            f"/v1/packages/{quote(database_id, safe='/')}/versions/{quote(version, safe='')}"
-        )
+        path = f"/v1/packages/{quote(database_id, safe='/')}/versions/{quote(version, safe='')}"
         status, raw, _ = self._request(
             "PATCH",
             path,

--- a/src/bora/registry/client.py
+++ b/src/bora/registry/client.py
@@ -30,6 +30,7 @@ class ReleaseInfo:
     size: int
     media_type: str
     org_id: str | None = None
+    replaced: bool = False
 
 
 class RegistryClient:
@@ -103,8 +104,9 @@ class RegistryClient:
         visibility: str,
         archive: bytes,
         org_id: str,
+        replace: bool = False,
     ) -> ReleaseInfo:
-        meta = {
+        meta: dict[str, Any] = {
             "database_id": database_id,
             "version": version,
             "package_digest": package_digest,
@@ -114,6 +116,8 @@ class RegistryClient:
             "visibility": visibility,
             "org_id": org_id,
         }
+        if replace:
+            meta["replace"] = True
         import secrets as _secrets
 
         boundary = f"bora-{_secrets.token_hex(12)}"
@@ -146,6 +150,7 @@ class RegistryClient:
             size=int(data["size"]),
             media_type=str(data["media_type"]),
             org_id=str(data["org_id"]) if data.get("org_id") else None,
+            replaced=bool(data.get("replaced")),
         )
 
     def get_metadata(
@@ -316,6 +321,7 @@ class RegistryClient:
         size: int,
         archive: bytes,
         suite_run_id: str | None = None,
+        replace: bool = False,
     ) -> dict[str, Any]:
         meta: dict[str, Any] = {
             "run_id": run_id,
@@ -329,6 +335,8 @@ class RegistryClient:
         }
         if suite_run_id:
             meta["suite_run_id"] = suite_run_id
+        if replace:
+            meta["replace"] = True
         import secrets as _secrets
 
         boundary = f"bora-result-{_secrets.token_hex(12)}"
@@ -407,6 +415,7 @@ class RegistryClient:
         config_homogeneous: bool | None = None,
         actors_summary: list[dict[str, Any]] | None = None,
         job_overlay: dict[str, Any] | None = None,
+        replace: bool = False,
     ) -> dict[str, Any]:
         meta: dict[str, Any] = {
             "suite_run_id": suite_run_id,
@@ -423,6 +432,8 @@ class RegistryClient:
             "blob_digest": blob_digest,
             "size": size,
         }
+        if replace:
+            meta["replace"] = True
         # #42 Leaderboard comparability — thin projection from suite summary.
         if config_fingerprint is not None:
             meta["config_fingerprint"] = config_fingerprint
@@ -588,4 +599,77 @@ class RegistryClient:
         )
         if status != 200:
             raise RegistryError("unshare_failed", f"status {status}", status=status)
+        return json.loads(raw.decode("utf-8"))
+
+    def delete_attempt(self, run_id: str) -> dict[str, Any]:
+        path = f"/v1/results/attempts/{quote(run_id, safe='')}"
+        status, raw, _ = self._request("DELETE", path)
+        if status != 200:
+            raise RegistryError("delete_failed", f"status {status}", status=status)
+        return json.loads(raw.decode("utf-8"))
+
+    def delete_suite(self, suite_run_id: str, *, with_attempts: bool = False) -> dict[str, Any]:
+        from urllib.parse import urlencode
+
+        path = f"/v1/results/suites/{quote(suite_run_id, safe='')}"
+        if with_attempts:
+            path = f"{path}?{urlencode({'with_attempts': '1'})}"
+        status, raw, _ = self._request("DELETE", path)
+        if status != 200:
+            raise RegistryError("delete_failed", f"status {status}", status=status)
+        return json.loads(raw.decode("utf-8"))
+
+    def set_attempt_visibility(self, run_id: str, *, visibility: str) -> dict[str, Any]:
+        if visibility not in {"public", "private"}:
+            raise RegistryError("invalid_request", "visibility must be public or private")
+        path = f"/v1/results/attempts/{quote(run_id, safe='')}"
+        status, raw, _ = self._request(
+            "PATCH",
+            path,
+            body=json.dumps({"visibility": visibility}, sort_keys=True).encode("utf-8"),
+            headers=self._headers(content_type="application/json"),
+        )
+        if status != 200:
+            raise RegistryError("set_visibility_failed", f"status {status}", status=status)
+        return json.loads(raw.decode("utf-8"))
+
+    def set_suite_visibility(self, suite_run_id: str, *, visibility: str) -> dict[str, Any]:
+        if visibility not in {"public", "private"}:
+            raise RegistryError("invalid_request", "visibility must be public or private")
+        path = f"/v1/results/suites/{quote(suite_run_id, safe='')}"
+        status, raw, _ = self._request(
+            "PATCH",
+            path,
+            body=json.dumps({"visibility": visibility}, sort_keys=True).encode("utf-8"),
+            headers=self._headers(content_type="application/json"),
+        )
+        if status != 200:
+            raise RegistryError("set_visibility_failed", f"status {status}", status=status)
+        return json.loads(raw.decode("utf-8"))
+
+    def delete_package_release(self, *, database_id: str, version: str) -> dict[str, Any]:
+        path = (
+            f"/v1/packages/{quote(database_id, safe='/')}/versions/{quote(version, safe='')}"
+        )
+        status, raw, _ = self._request("DELETE", path)
+        if status != 200:
+            raise RegistryError("delete_failed", f"status {status}", status=status)
+        return json.loads(raw.decode("utf-8"))
+
+    def set_package_visibility(
+        self, *, database_id: str, version: str, visibility: str
+    ) -> dict[str, Any]:
+        if visibility not in {"public", "private"}:
+            raise RegistryError("invalid_request", "visibility must be public or private")
+        path = (
+            f"/v1/packages/{quote(database_id, safe='/')}/versions/{quote(version, safe='')}"
+        )
+        status, raw, _ = self._request(
+            "PATCH",
+            path,
+            body=json.dumps({"visibility": visibility}, sort_keys=True).encode("utf-8"),
+            headers=self._headers(content_type="application/json"),
+        )
+        if status != 200:
+            raise RegistryError("set_visibility_failed", f"status {status}", status=status)
         return json.loads(raw.decode("utf-8"))

--- a/tests/registry/test_registry_owner_ops.py
+++ b/tests/registry/test_registry_owner_ops.py
@@ -130,9 +130,7 @@ def test_attempt_delete_and_visibility_owner_only(
     assert up["ok"] is True
 
     # set visibility private → public
-    vis = set_result_visibility(
-        result_kind="attempt", result_id=run_id, visibility="public"
-    )
+    vis = set_result_visibility(result_kind="attempt", result_id=run_id, visibility="public")
     assert vis["visibility"] == "public"
     bob = RegistryClient(url, token=bob_tok)
     assert bob.get_attempt(run_id)["visibility"] == "public"

--- a/tests/registry/test_registry_owner_ops.py
+++ b/tests/registry/test_registry_owner_ops.py
@@ -1,0 +1,351 @@
+"""Owner delete / set-visibility / unshare / replace."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import threading
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+from services.registry.app import build_default_state, make_handler
+from services.registry.store import DEFAULT_LOGIN_SCOPES
+
+from bora.application.publish_command import publish_database
+from bora.application.registry_list_command import (
+    delete_package_release,
+    set_package_visibility,
+)
+from bora.application.results_command import (
+    delete_result,
+    set_result_visibility,
+    share_result,
+    unshare_result,
+    upload_attempt_result,
+    upload_suite_result,
+)
+from bora.config.errors import ConfigError
+from bora.registry.client import RegistryClient, RegistryError
+from bora.registry.credentials import write_credentials
+
+REPO = Path(__file__).resolve().parents[2]
+FIXTURE = REPO / "tests" / "fixtures" / "databases" / "publish-min"
+
+
+@pytest.fixture()
+def registry_server(tmp_path: Path):
+    data = tmp_path / "reg-data"
+    state, token = build_default_state(data, bootstrap_token="boot-token", memory_blob=True)
+    handler = make_handler(state)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_address[1]}"
+    yield {"url": url, "token": token, "state": state}
+    server.shutdown()
+
+
+def _user_token(state, *, user: str, scopes=DEFAULT_LOGIN_SCOPES) -> str:
+    raw = f"tok-{user}"
+    state.tokens.add(raw, scopes, github_user=user)
+    return raw
+
+
+def _env_as(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    url: str,
+    token: str,
+) -> None:
+    write_credentials(url=url, token=token, path=tmp_path / "c")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BORA_REGISTRY_URL", url)
+    monkeypatch.setenv("BORA_REGISTRY_TOKEN", token)
+
+
+def _seed_attempt(
+    tmp_path: Path,
+    *,
+    run_id: str = "sha256_owner_run1",
+    suite_run_id: str | None = None,
+) -> Path:
+    db = tmp_path / "db"
+    if not db.exists():
+        shutil.copytree(FIXTURE, db)
+    run_dir = db / ".bora" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "result.json").write_text(
+        json.dumps({"task_id": "hello", "status": "PASS"}),
+        encoding="utf-8",
+    )
+    return db
+
+
+def _seed_suite(tmp_path: Path, *, suite_run_id: str, attempt_run_id: str) -> Path:
+    db = _seed_attempt(tmp_path, run_id=attempt_run_id, suite_run_id=suite_run_id)
+    suite_dir = db / ".bora" / "suite-runs" / suite_run_id
+    suite_dir.mkdir(parents=True, exist_ok=True)
+    summary = {
+        "suite_run_id": suite_run_id,
+        "database_id": "test/publish-min",
+        "database_version": "0.1.0",
+        "pass_rate": 1.0,
+        "mean_score": 1.0,
+        "metrics": {"pass_rate": 1.0, "mean_score": 1.0},
+        "task_refs": [
+            {
+                "task_id": "hello",
+                "run_id": attempt_run_id,
+                "attempt_run_ids": [attempt_run_id],
+            }
+        ],
+        "exit_code": 0,
+    }
+    (suite_dir / "summary.json").write_text(
+        json.dumps(summary),
+        encoding="utf-8",
+    )
+    return db
+
+
+# ---------------------------------------------------------------------------
+# B — results delete + set-visibility + cascade
+# ---------------------------------------------------------------------------
+
+
+def test_attempt_delete_and_visibility_owner_only(
+    registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = registry_server["state"]
+    url = registry_server["url"]
+    alice_tok = _user_token(state, user="alice")
+    bob_tok = _user_token(state, user="bob")
+    _env_as(monkeypatch, tmp_path, url=url, token=alice_tok)
+
+    db = _seed_attempt(tmp_path)
+    run_id = "sha256_owner_run1"
+    up = upload_attempt_result(db, run_id=run_id, public=False)
+    assert up["ok"] is True
+
+    # set visibility private → public
+    vis = set_result_visibility(
+        result_kind="attempt", result_id=run_id, visibility="public"
+    )
+    assert vis["visibility"] == "public"
+    bob = RegistryClient(url, token=bob_tok)
+    assert bob.get_attempt(run_id)["visibility"] == "public"
+
+    # flip back private; bob loses sight
+    set_result_visibility(result_kind="attempt", result_id=run_id, visibility="private")
+    with pytest.raises(RegistryError) as ei:
+        bob.get_attempt(run_id)
+    assert ei.value.status == 404
+
+    # non-owner cannot delete
+    with pytest.raises(ConfigError):
+        monkeypatch.setenv("BORA_REGISTRY_TOKEN", bob_tok)
+        delete_result(result_kind="attempt", result_id=run_id)
+
+    # owner deletes
+    monkeypatch.setenv("BORA_REGISTRY_TOKEN", alice_tok)
+    deleted = delete_result(result_kind="attempt", result_id=run_id)
+    assert deleted["ok"] is True
+    assert deleted["result_id"] == run_id
+
+    with pytest.raises(RegistryError) as ei2:
+        RegistryClient(url, token=alice_tok).get_attempt(run_id)
+    assert ei2.value.status == 404
+
+
+def test_suite_delete_default_no_cascade_and_with_attempts(
+    registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = registry_server["state"]
+    url = registry_server["url"]
+    alice_tok = _user_token(state, user="alice")
+    _env_as(monkeypatch, tmp_path, url=url, token=alice_tok)
+
+    suite_id = "suite_owner_1"
+    att_id = "sha256_suite_att1"
+    db = _seed_suite(tmp_path, suite_run_id=suite_id, attempt_run_id=att_id)
+
+    upload_attempt_result(db, run_id=att_id, public=False, suite_run_id=suite_id)
+    upload_suite_result(db, suite_run_id=suite_id, public=False)
+
+    # default: suite delete keeps attempts
+    out = delete_result(result_kind="suite", result_id=suite_id, with_attempts=False)
+    assert out["ok"] is True
+    assert out.get("deleted_attempts") == []
+    RegistryClient(url, token=alice_tok).get_attempt(att_id)
+
+    # re-upload suite, then cascade
+    upload_suite_result(db, suite_run_id=suite_id, public=False)
+    casc = delete_result(result_kind="suite", result_id=suite_id, with_attempts=True)
+    assert casc["ok"] is True
+    assert att_id in casc.get("deleted_attempts", [])
+    with pytest.raises(RegistryError):
+        RegistryClient(url, token=alice_tok).get_attempt(att_id)
+    with pytest.raises(RegistryError):
+        RegistryClient(url, token=alice_tok).get_suite(suite_id)
+
+
+# ---------------------------------------------------------------------------
+# C — unshare CLI/application
+# ---------------------------------------------------------------------------
+
+
+def test_unshare_application_and_non_owner_denied(
+    registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = registry_server["state"]
+    url = registry_server["url"]
+    boot = RegistryClient(url, token=registry_server["token"])
+    boot.create_org(name="sharelab2")
+    alice_tok = _user_token(state, user="alice")
+    bob_tok = _user_token(state, user="bob")
+    boot.add_org_member(org_id="sharelab2", user_id="bob", role="member")
+    _env_as(monkeypatch, tmp_path, url=url, token=alice_tok)
+
+    db = _seed_attempt(tmp_path)
+    run_id = "sha256_owner_run1"
+    upload_attempt_result(db, run_id=run_id, public=False)
+    share_result(
+        result_kind="attempt",
+        result_id=run_id,
+        share_orgs=["sharelab2"],
+    )
+    assert RegistryClient(url, token=bob_tok).get_attempt(run_id)["run_id"] == run_id
+
+    unshare_result(
+        result_kind="attempt",
+        result_id=run_id,
+        share_orgs=["sharelab2"],
+    )
+    with pytest.raises(RegistryError) as ei:
+        RegistryClient(url, token=bob_tok).get_attempt(run_id)
+    assert ei.value.status == 404
+
+    # non-owner cannot unshare (even if no share remains, manage denied → 404)
+    with pytest.raises(ConfigError):
+        monkeypatch.setenv("BORA_REGISTRY_TOKEN", bob_tok)
+        unshare_result(
+            result_kind="attempt",
+            result_id=run_id,
+            share_users=["bob"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# A — package delete + set-visibility
+# ---------------------------------------------------------------------------
+
+
+def test_package_delete_and_visibility_org_owner_only(
+    registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = registry_server["state"]
+    url = registry_server["url"]
+    boot = RegistryClient(url, token=registry_server["token"])
+    boot.create_org(name="ownlab")
+    alice_tok = _user_token(state, user="alice")
+    bob_tok = _user_token(state, user="bob")
+    # bootstrap is org owner; add alice as member only
+    boot.add_org_member(org_id="ownlab", user_id="alice", role="member")
+    boot.add_org_member(org_id="ownlab", user_id="bob", role="member")
+
+    _env_as(monkeypatch, tmp_path, url=url, token=registry_server["token"])
+    pub = publish_database(FIXTURE, public=False, org="ownlab")
+    ref = f"{pub['database_id']}@{pub['version']}"
+
+    # owner (bootstrap) can set visibility
+    flipped = set_package_visibility(ref, visibility="public")
+    assert flipped["visibility"] == "public"
+    bob = RegistryClient(url, token=bob_tok)
+    assert bob.get_metadata(database_id=pub["database_id"], version=pub["version"]).visibility == (
+        "public"
+    )
+
+    set_package_visibility(ref, visibility="private")
+
+    # member cannot delete
+    with pytest.raises(ConfigError):
+        monkeypatch.setenv("BORA_REGISTRY_TOKEN", alice_tok)
+        delete_package_release(ref)
+
+    # owner deletes
+    monkeypatch.setenv("BORA_REGISTRY_TOKEN", registry_server["token"])
+    deleted = delete_package_release(ref)
+    assert deleted["ok"] is True
+    with pytest.raises(RegistryError) as ei:
+        boot.get_metadata(database_id=pub["database_id"], version=pub["version"])
+    assert ei.value.status == 404
+
+
+# ---------------------------------------------------------------------------
+# D — replace / conflict policy
+# ---------------------------------------------------------------------------
+
+
+def test_attempt_replace_requires_flag_and_owner(
+    registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = registry_server["state"]
+    url = registry_server["url"]
+    alice_tok = _user_token(state, user="alice")
+    bob_tok = _user_token(state, user="bob")
+    _env_as(monkeypatch, tmp_path, url=url, token=alice_tok)
+
+    db = _seed_attempt(tmp_path)
+    run_id = "sha256_owner_run1"
+    first = upload_attempt_result(db, run_id=run_id, public=False)
+    assert first["ok"] is True
+
+    # default: conflict
+    with pytest.raises(ConfigError) as ei:
+        upload_attempt_result(db, run_id=run_id, public=False)
+    assert "already exists" in str(ei.value).lower() or "conflict" in str(ei.value).lower()
+
+    # non-owner replace → fail-closed
+    (db / ".bora" / "runs" / run_id / "result.json").write_text(
+        json.dumps({"task_id": "hello", "status": "FAIL"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("BORA_REGISTRY_TOKEN", bob_tok)
+    with pytest.raises(ConfigError):
+        upload_attempt_result(db, run_id=run_id, public=False, replace=True)
+
+    # owner replace succeeds and rewrites blob/meta
+    monkeypatch.setenv("BORA_REGISTRY_TOKEN", alice_tok)
+    replaced = upload_attempt_result(db, run_id=run_id, public=True, replace=True)
+    assert replaced["ok"] is True
+    assert replaced.get("replaced") is True
+    assert replaced["visibility"] == "public"
+    meta = RegistryClient(url, token=alice_tok).get_attempt(run_id)
+    assert meta["visibility"] == "public"
+    assert meta["status"] == "FAIL"
+    # digest may or may not change depending on archive contents; status field is authority
+
+
+def test_package_replace_conflict_and_owner(
+    registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    url = registry_server["url"]
+    boot = RegistryClient(url, token=registry_server["token"])
+    boot.create_org(name="replacelab")
+    _env_as(monkeypatch, tmp_path, url=url, token=registry_server["token"])
+
+    first = publish_database(FIXTURE, public=False, org="replacelab")
+    assert first["ok"] is True
+
+    with pytest.raises(ConfigError) as ei:
+        publish_database(FIXTURE, public=False, org="replacelab")
+    assert "already exists" in str(ei.value).lower() or "conflict" in str(ei.value).lower()
+
+    again = publish_database(FIXTURE, public=True, org="replacelab", replace=True)
+    assert again["ok"] is True
+    assert again.get("replaced") is True
+    assert again["visibility"] == "public"
+    meta = boot.get_metadata(database_id=first["database_id"], version=first["version"])
+    assert meta.visibility == "public"

--- a/website/content/docs/reference/cli.en.mdx
+++ b/website/content/docs/reference/cli.en.mdx
@@ -19,9 +19,13 @@ uv run bora cancel <suite_run_id> --database <dataset>
 uv run bora executors -v
 uv run bora evidence --help
 uv run bora view <dataset>
+# Registry / results (login required; see [Registry](/docs/share/registry))
+uv run bora publish <dataset> --org <org> [--public] [--replace]
+uv run bora registry list|show|set-visibility|delete …
+uv run bora results upload|upload-suite|share|unshare|set-visibility|delete …
 ```
 
-Path = Dataset root.
+Path = Dataset root. Destructive commands require `--yes`; overwrite same identity requires `--replace` (default 409).
 
 ## Common `bora run` flags
 

--- a/website/content/docs/reference/cli.mdx
+++ b/website/content/docs/reference/cli.mdx
@@ -19,9 +19,13 @@ uv run bora cancel <suite_run_id> --database <dataset>
 uv run bora executors -v
 uv run bora evidence --help
 uv run bora view <dataset>
+# Registry / 结果（需 login；细节见 [Registry](/docs/share/registry)）
+uv run bora publish <dataset> --org <org> [--public] [--replace]
+uv run bora registry list|show|set-visibility|delete …
+uv run bora results upload|upload-suite|share|unshare|set-visibility|delete …
 ```
 
-路径 = Dataset 根（含 `bora.yaml`）。
+路径 = Dataset 根（含 `bora.yaml`）。删除类命令须显式 `--yes`；同 identity 覆盖须显式 `--replace`（默认 409）。
 
 ## `bora run` 常用选项
 

--- a/website/content/docs/share/registry.en.mdx
+++ b/website/content/docs/share/registry.en.mdx
@@ -17,12 +17,35 @@ Exact commands: `bora --help` and the registry README.
 
 ## Ownership (summary)
 
-| Object | Owner | Who can read private |
-| --- | --- | --- |
-| Package (Dataset release) | **organization** | org members / admin |
-| Attempt / suite result | **uploader** | owner / share targets / admin |
+| Object | Owner | Who can read private | Delete / set visibility / replace |
+| --- | --- | --- | --- |
+| Package (Dataset release) | **organization** | org members / admin | **org owner** / admin |
+| Attempt / suite result | **uploader** | owner / share targets / admin | **uploader** / admin |
 
 Joining an org does **not** reveal others’ private results until they share.  
+Any org **member** may `publish` under that org; **package delete / set-visibility / `--replace`** require **org owner**.  
 Invite keys show the full secret only once at create time; later you only see a prefix.
+
+## Owner ops after create (CLI)
+
+`--public` at create time only sets **initial** visibility. Owners can change it later without republishing:
+
+```bash
+# Package: visibility / delete (delete requires --yes)
+uv run bora registry set-visibility 'my-org/dataset@0.1.0' --visibility public
+# uv run bora registry delete 'my-org/dataset@0.1.0' --yes
+
+# Results: visibility / unshare / delete
+uv run bora results set-visibility <run_or_suite_id> --kind attempt|suite --visibility private
+uv run bora results unshare <id> --kind attempt --share-org my-lab
+# uv run bora results delete <id> --kind suite --yes
+# Suite delete does not cascade attempts by default:
+# uv run bora results delete <suite_id> --kind suite --with-attempts --yes
+```
+
+**Replace:** same `database_id@version` / `run_id` / `suite_run_id` still **409** by default.  
+Owners may pass `--replace` on `bora publish` / `results upload` / `upload-suite` to overwrite blob, metrics/labels, and visibility — never silent.
+
+Details: `bora --help`, [`src/bora/cli/README.md`](https://github.com/ffy6511/BORA/blob/main/src/bora/cli/README.md), and the registry README.
 
 Whether the service is public is an ops choice.

--- a/website/content/docs/share/registry.mdx
+++ b/website/content/docs/share/registry.mdx
@@ -17,12 +17,35 @@ Registry 是独立的 HTTP 服务：发包、管组织、存结果、登录。
 
 ## 所有权（摘要）
 
-| 对象 | 归属 | 谁能读私有内容 |
-| --- | --- | --- |
-| 包（Dataset release） | **组织** | 组织成员 / admin |
-| Attempt / suite 结果 | **上传者** | 本人 / 被分享对象 / admin |
+| 对象 | 归属 | 谁能读私有内容 | 删除 / 改可见性 / 覆盖上传 |
+| --- | --- | --- | --- |
+| 包（Dataset release） | **组织** | 组织成员 / admin | **组织 owner** / admin |
+| Attempt / suite 结果 | **上传者** | 本人 / 被分享对象 / admin | **上传者** / admin |
 
 加入组织**不会**自动看到别人的私有结果，除非对方分享给你。  
+任意组织 **member** 都可在该组织下 `publish`；**删除包 / 改包可见性 / `--replace` 覆盖同版本** 需要 **org owner**。  
 邀请码在创建时只完整展示一次，之后只能看到前缀。
+
+## 发布后 owner 操作（CLI）
+
+创建时 `--public` 只决定**当时**的可见性；之后可用 CLI 改，不必重新发包或重传结果：
+
+```bash
+# 包：可见性 / 删除（删除必须 --yes）
+uv run bora registry set-visibility 'my-org/dataset@0.1.0' --visibility public
+# uv run bora registry delete 'my-org/dataset@0.1.0' --yes
+
+# 结果：可见性 / 取消分享 / 删除
+uv run bora results set-visibility <run_or_suite_id> --kind attempt|suite --visibility private
+uv run bora results unshare <id> --kind attempt --share-org my-lab
+# uv run bora results delete <id> --kind suite --yes
+# 删 suite 默认不删 attempt；显式级联：
+# uv run bora results delete <suite_id> --kind suite --with-attempts --yes
+```
+
+**覆盖上传：** 同一 `database_id@version` / `run_id` / `suite_run_id` 默认 **409**。  
+仅 owner 可加 `--replace`（`bora publish` / `results upload` / `upload-suite`），覆盖 blob、指标/标签与可见性；无静默覆盖。
+
+命令细节见 `bora --help`、[`src/bora/cli/README.md`](https://github.com/ffy6511/BORA/blob/main/src/bora/cli/README.md) 与 registry README。
 
 公网是否开放、谁能上传，由部署方决定。


### PR DESCRIPTION
## Summary

Owners can already **publish** packages and **upload** suite/attempt results, and **share** private results. This PR adds the missing owner lifecycle on Registry + public CLI:

1. **Delete** package releases and suite/attempt result rows  
2. **Set visibility** after create (`private` ↔ `public`) without republishing  
3. **Unshare** private results from the CLI (wires existing share DELETE API)  
4. **Replace** same-identity upload/publish with an explicit flag (default remains **409**)

## Issues

| Issue | Role |
| --- | --- |
| **#62** | **Closes** — owner delete package & results, set visibility, unshare, replace upload |

Closes #62

## Constraints

- **Authorization:** packages → **org owner** (or admin); results → **`uploaded_by`** (or admin)  
- Destructive CLI requires **`--yes`**; fail closed on missing auth (unauthorized private → **404**)  
- Suite delete **does not** cascade attempts by default; optional `--with-attempts`  
- Blob GC only when digest has zero remaining refs  
- No suite-level PASS; no change to pass@k formulas / `config_fingerprint`  
- No Hub UI buttons (API + CLI first)

## Features

### Results (attempt / suite)

```bash
uv run bora results set-visibility <id> --kind attempt|suite --visibility public|private
uv run bora results unshare <id> --kind attempt --share-org <org>
uv run bora results delete <id> --kind suite --yes
uv run bora results delete <id> --kind suite --with-attempts --yes
uv run bora results upload … --replace
uv run bora results upload-suite … --replace
```

- Registry: `DELETE` / `PATCH` on attempts and suites  
- Cascade policy documented and tested  

### Packages

```bash
uv run bora registry set-visibility 'database_id@version' --visibility public|private
uv run bora registry delete 'database_id@version' --yes
uv run bora publish <path> --org <org> --replace
```

- Registry: `DELETE` / `PATCH` on `/v1/packages/{id}/versions/{ver}`  
- Publish may still be any org **member**; destructive package ops require **owner**  

### Replace policy

- Same identity without flag → **409** (no silent overwrite)  
- With `--replace` / metadata `replace: true`: owner overwrites blob, digests, metrics/labels, visibility  

## Docs

- `services/registry/README.md`, `src/bora/cli/README.md`, `skills/bora-cli`  
- Website: share/registry + CLI reference (zh/en)  

## Test plan

- [x] Acceptance tests: `tests/registry/test_registry_owner_ops.py`  
- [x] Full `pytest tests/registry` (45)  
- [x] `ruff format --check` / `ruff check` / `pyright` on `src` + `tests`  
- [x] CLI help: `bora results` / `bora registry`  
- [ ] CI: `python-core` + `python-registry` + `website` on PR  
- [x] Manual (optional): flip visibility on a live suite / private package  

```bash
export BORA_OFFLINE_AGENT=1 BORA_SKIP_DOCKER=1
uv sync --frozen --extra registry
uv run ruff format --check src tests
uv run ruff check src tests
uv run pyright
uv run pytest tests/registry -q
```

## Commits (this branch)

```text
feat(registry): owner delete, visibility, unshare, and replace
docs(website): document registry owner ops; ruff-format CLI/client
```