### PR TITLE
feat: Dataset-level shared/ (digest + import + Hub/Viewer) (#65)

### DIFF
--- a/apps/hub/src/components/file-preview.tsx
+++ b/apps/hub/src/components/file-preview.tsx
@@ -1,9 +1,13 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { Markdown } from "@/components/markdown";
 import { codeToHtml, isMarkdownPath } from "@/lib/shiki-preview";
 import { useTheme } from "@/lib/theme";
 import { cn } from "@/lib/utils";
+
+/** Skip Shiki (and cap plain text) when content is huge — avoids main-thread stalls. */
+const HIGHLIGHT_MAX_CHARS = 120_000;
+const PLAIN_PREVIEW_MAX_CHARS = 400_000;
 
 /**
  * Files-tab right pane: Markdown (GFM) for .md; Shiki multi-color for code.
@@ -22,9 +26,17 @@ export function FilePreview({
   const [error, setError] = useState<string | null>(null);
 
   const markdown = isMarkdownPath(path);
+  const tooLargeForHighlight = content.length > HIGHLIGHT_MAX_CHARS;
+  const displayContent = useMemo(() => {
+    if (content.length <= PLAIN_PREVIEW_MAX_CHARS) return content;
+    return (
+      content.slice(0, PLAIN_PREVIEW_MAX_CHARS) +
+      `\n\n… truncated for preview (${content.length.toLocaleString()} chars total)`
+    );
+  }, [content]);
 
   useEffect(() => {
-    if (markdown) {
+    if (markdown || tooLargeForHighlight) {
       setHtml(null);
       setError(null);
       return;
@@ -46,32 +58,52 @@ export function FilePreview({
     return () => {
       cancelled = true;
     };
-  }, [content, path, resolved, markdown]);
-
-  if (note) {
-    // note still shown above content by parent optionally
-  }
+  }, [content, path, resolved, markdown, tooLargeForHighlight]);
 
   if (markdown) {
+    const mdSource =
+      content.length > PLAIN_PREVIEW_MAX_CHARS
+        ? content.slice(0, PLAIN_PREVIEW_MAX_CHARS) +
+          `\n\n… truncated for preview (${content.length.toLocaleString()} chars total)`
+        : content;
     return (
       <div className="p-4 overflow-auto h-full">
         {note ? <p className="text-xs text-mute mb-2">{note}</p> : null}
-        <Markdown source={content} className="border-0 rounded-none p-0" />
+        {content.length > PLAIN_PREVIEW_MAX_CHARS ? (
+          <p className="text-xs text-mute mb-2">
+            Large file — showing first {PLAIN_PREVIEW_MAX_CHARS.toLocaleString()}{" "}
+            characters.
+          </p>
+        ) : null}
+        <Markdown source={mdSource} className="border-0 rounded-none p-0" />
       </div>
     );
   }
 
-  if (error) {
+  if (tooLargeForHighlight || error) {
     return (
-      <pre
-        className={cn(
-          "m-0 p-3 min-h-full overflow-auto",
-          "whitespace-pre-wrap break-words font-mono text-[12px] leading-5",
-          "bg-code-bg text-shell-plain",
-        )}
-      >
-        {content}
-      </pre>
+      <div className="h-full overflow-auto">
+        {tooLargeForHighlight ? (
+          <p className="text-xs text-mute px-3 pt-3">
+            Large file ({content.length.toLocaleString()} chars) — plain preview
+            without syntax highlighting
+            {content.length > PLAIN_PREVIEW_MAX_CHARS
+              ? `, first ${PLAIN_PREVIEW_MAX_CHARS.toLocaleString()} chars`
+              : ""}
+            .
+          </p>
+        ) : null}
+        {note ? <p className="text-xs text-mute px-3 pt-2">{note}</p> : null}
+        <pre
+          className={cn(
+            "m-0 p-3 min-h-full overflow-auto",
+            "whitespace-pre-wrap break-words font-mono text-[12px] leading-5",
+            "bg-code-bg text-shell-plain",
+          )}
+        >
+          {displayContent}
+        </pre>
+      </div>
     );
   }
 

--- a/apps/hub/src/components/file-split-panel.tsx
+++ b/apps/hub/src/components/file-split-panel.tsx
@@ -1,5 +1,13 @@
 import { ChevronDown, ChevronRight, Search } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+  type UIEvent,
+} from "react";
 
 import { FilePreview } from "@/components/file-preview";
 import { FileTypeIcon } from "@/components/file-type-icon";
@@ -7,6 +15,22 @@ import { Input } from "@/components/ui/input";
 import { countFiles } from "@/lib/file-icons";
 import type { TreeNode } from "@/lib/file-tree";
 import { cn } from "@/lib/utils";
+
+/** Fixed row height for windowed tree rendering (matches h-7). */
+const ROW_H = 28;
+/** Extra rows above/below the viewport. */
+const OVERSCAN = 16;
+/**
+ * Soft cap on visible rows when a dir is first opened without scrolling.
+ * (Virtualization still applies; this is only for default-expand policy.)
+ */
+const DEFAULT_OPEN_DEPTH = 0;
+
+type FlatRow = {
+  key: string;
+  node: TreeNode;
+  depth: number;
+};
 
 function filterTree(nodes: TreeNode[], query: string): TreeNode[] {
   const q = query.trim().toLowerCase();
@@ -30,84 +54,6 @@ function filterTree(nodes: TreeNode[], query: string): TreeNode[] {
   return out;
 }
 
-function TreeBranch({
-  nodes,
-  depth,
-  selectedPath,
-  onSelect,
-  openDirs,
-  toggleDir,
-}: {
-  nodes: TreeNode[];
-  depth: number;
-  selectedPath: string | null;
-  onSelect: (path: string) => void;
-  openDirs: Set<string>;
-  toggleDir: (path: string) => void;
-}) {
-  return (
-    <ul className={cn(depth === 0 && "pb-2")}>
-      {nodes.map((node) => {
-        if (node.type === "dir") {
-          const open = openDirs.has(node.path);
-          return (
-            <li key={`d:${node.path}`}>
-              <button
-                type="button"
-                onClick={() => toggleDir(node.path)}
-                className={cn(
-                  "w-full flex items-center gap-1 text-left h-7 pr-2 text-[12.5px]",
-                  "text-body hover:bg-row-hover transition-colors rounded-[4px]",
-                )}
-                style={{ paddingLeft: 8 + depth * 12 }}
-                title={node.path}
-              >
-                {open ? (
-                  <ChevronDown className="h-3.5 w-3.5 shrink-0 text-mute" />
-                ) : (
-                  <ChevronRight className="h-3.5 w-3.5 shrink-0 text-mute" />
-                )}
-                <FileTypeIcon name={node.name} kind="dir" expanded={open} />
-                <span className="truncate font-medium">{node.name}</span>
-              </button>
-              {open && node.children && node.children.length > 0 ? (
-                <TreeBranch
-                  nodes={node.children}
-                  depth={depth + 1}
-                  selectedPath={selectedPath}
-                  onSelect={onSelect}
-                  openDirs={openDirs}
-                  toggleDir={toggleDir}
-                />
-              ) : null}
-            </li>
-          );
-        }
-        const selected = selectedPath === node.path;
-        return (
-          <li key={`f:${node.path}`}>
-            <button
-              type="button"
-              onClick={() => onSelect(node.path)}
-              className={cn(
-                "w-full flex items-center gap-1.5 text-left h-7 pr-2 text-[12.5px] truncate transition-colors rounded-[4px]",
-                selected
-                  ? "bg-canvas text-ink font-medium shadow-[inset_0_0_0_1px_var(--color-hairline)]"
-                  : "text-body hover:bg-row-hover",
-              )}
-              style={{ paddingLeft: 8 + depth * 12 + 18 }}
-              title={node.path}
-            >
-              <FileTypeIcon name={node.name} kind="file" />
-              <span className="truncate">{node.name}</span>
-            </button>
-          </li>
-        );
-      })}
-    </ul>
-  );
-}
-
 function allDirPaths(nodes: TreeNode[], acc: string[] = []): string[] {
   for (const n of nodes) {
     if (n.type === "dir") {
@@ -116,6 +62,48 @@ function allDirPaths(nodes: TreeNode[], acc: string[] = []): string[] {
     }
   }
   return acc;
+}
+
+/** Only dirs at depth < maxDepth (root level = 0). */
+function dirPathsUpToDepth(
+  nodes: TreeNode[],
+  maxDepth: number,
+  depth = 0,
+  acc: string[] = [],
+): string[] {
+  if (depth >= maxDepth) return acc;
+  for (const n of nodes) {
+    if (n.type === "dir") {
+      acc.push(n.path);
+      if (n.children) dirPathsUpToDepth(n.children, maxDepth, depth + 1, acc);
+    }
+  }
+  return acc;
+}
+
+/** Flatten open tree into ordered rows (only expanded branches). */
+function flattenVisible(
+  nodes: TreeNode[],
+  openDirs: Set<string>,
+  depth = 0,
+  out: FlatRow[] = [],
+): FlatRow[] {
+  for (const node of nodes) {
+    out.push({
+      key: `${node.type}:${node.path}`,
+      node,
+      depth,
+    });
+    if (
+      node.type === "dir" &&
+      openDirs.has(node.path) &&
+      node.children &&
+      node.children.length > 0
+    ) {
+      flattenVisible(node.children, openDirs, depth + 1, out);
+    }
+  }
+  return out;
 }
 
 function displayPath(fullPath: string, rootPrefix?: string): string {
@@ -128,7 +116,10 @@ function displayPath(fullPath: string, rootPrefix?: string): string {
 
 /**
  * Left nested tree + right code preview (Hub package files).
- * Material Icon Theme icons by extension; strip task prefix for display.
+ *
+ * Tree uses windowed rendering: only rows near the scroll viewport become DOM
+ * nodes, so large packages (e.g. many tasks or shared/assets) stay responsive.
+ * Directories start collapsed (depth 0) unless searching.
  */
 export function FileSplitPanel({
   tree,
@@ -139,6 +130,7 @@ export function FileSplitPanel({
   fileLoading,
   fileNote,
   rootPrefix,
+  headerEnd,
 }: {
   tree: TreeNode[];
   treeLoading: boolean;
@@ -148,25 +140,63 @@ export function FileSplitPanel({
   fileLoading: boolean;
   fileNote: string | null;
   rootPrefix?: string;
+  /** Replaces the default "N files" label (e.g. Local | Shared switch on Task Files). */
+  headerEnd?: ReactNode;
 }) {
   const treeKey = useMemo(() => tree.map((n) => n.path).join("|"), [tree]);
   const [openDirs, setOpenDirs] = useState<Set<string>>(() => new Set());
   const [query, setQuery] = useState("");
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportH, setViewportH] = useState(480);
 
+  // Default: keep dirs collapsed so we do not mount the full package tree.
   useEffect(() => {
-    setOpenDirs(new Set(allDirPaths(tree)));
+    setOpenDirs(new Set(dirPathsUpToDepth(tree, DEFAULT_OPEN_DEPTH)));
+    setScrollTop(0);
+    if (scrollRef.current) scrollRef.current.scrollTop = 0;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- treeKey is the intentional dep
   }, [treeKey]);
 
   const fileCount = useMemo(() => countFiles(tree), [tree]);
   const visibleTree = useMemo(() => filterTree(tree, query), [tree, query]);
 
-  // When searching, expand all dirs in the filtered tree
+  // Search: expand matching branch dirs so hits are reachable; still windowed.
   useEffect(() => {
     if (query.trim()) {
       setOpenDirs(new Set(allDirPaths(visibleTree)));
+    } else {
+      setOpenDirs(new Set(dirPathsUpToDepth(tree, DEFAULT_OPEN_DEPTH)));
     }
-  }, [query, visibleTree]);
+  }, [query, visibleTree, tree]);
+
+  const flatRows = useMemo(
+    () => flattenVisible(visibleTree, openDirs),
+    [visibleTree, openDirs],
+  );
+
+  // Measure scroll viewport for window size.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const measure = () => setViewportH(el.clientHeight || 480);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [treeLoading, flatRows.length]);
+
+  const onScroll = useCallback((e: UIEvent<HTMLDivElement>) => {
+    setScrollTop(e.currentTarget.scrollTop);
+  }, []);
+
+  const totalH = flatRows.length * ROW_H;
+  const visibleCount = Math.ceil(viewportH / ROW_H) + OVERSCAN * 2;
+  const startIdx = Math.max(0, Math.floor(scrollTop / ROW_H) - OVERSCAN);
+  const endIdx = Math.min(flatRows.length, startIdx + visibleCount);
+  const slice = flatRows.slice(startIdx, endIdx);
+  const padTop = startIdx * ROW_H;
+  const padBottom = Math.max(0, totalH - padTop - slice.length * ROW_H);
 
   function toggleDir(path: string) {
     setOpenDirs((prev) => {
@@ -176,6 +206,26 @@ export function FileSplitPanel({
       return next;
     });
   }
+
+  // Keep selected file row roughly in view after tree rebuilds (best-effort).
+  useEffect(() => {
+    if (!selectedPath || !scrollRef.current) return;
+    const idx = flatRows.findIndex(
+      (r) => r.node.type === "file" && r.node.path === selectedPath,
+    );
+    if (idx < 0) return;
+    const el = scrollRef.current;
+    const rowTop = idx * ROW_H;
+    const rowBottom = rowTop + ROW_H;
+    if (rowTop < el.scrollTop) {
+      el.scrollTop = rowTop;
+      setScrollTop(rowTop);
+    } else if (rowBottom > el.scrollTop + el.clientHeight) {
+      const next = rowBottom - el.clientHeight;
+      el.scrollTop = next;
+      setScrollTop(next);
+    }
+  }, [selectedPath, treeKey]); // eslint-disable-line react-hooks/exhaustive-deps -- only on selection/tree identity
 
   return (
     <div
@@ -192,13 +242,17 @@ export function FileSplitPanel({
           "flex flex-col",
         )}
       >
-        <div className="flex items-center justify-between px-3 py-2 border-b border-hairline shrink-0">
+        <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-hairline shrink-0">
           <span className="text-[11px] font-medium uppercase tracking-wide text-mute">
             Files
           </span>
-          <span className="text-[11px] tabular-nums text-mute">
-            {fileCount} file{fileCount === 1 ? "" : "s"}
-          </span>
+          {headerEnd != null ? (
+            headerEnd
+          ) : (
+            <span className="text-[11px] tabular-nums text-mute">
+              {fileCount} file{fileCount === 1 ? "" : "s"}
+            </span>
+          )}
         </div>
         <div className="px-2 py-2 border-b border-hairline shrink-0">
           <div className="relative">
@@ -212,22 +266,81 @@ export function FileSplitPanel({
             />
           </div>
         </div>
-        <div className="flex-1 overflow-y-auto px-1 pt-1">
+        <div
+          ref={scrollRef}
+          className="flex-1 overflow-y-auto px-1 pt-1"
+          onScroll={onScroll}
+        >
           {treeLoading ? (
             <p className="text-xs text-mute p-3">Loading tree…</p>
-          ) : visibleTree.length === 0 ? (
+          ) : flatRows.length === 0 ? (
             <p className="text-xs text-mute p-3">
               {query.trim() ? "No matches." : "No files in this scope."}
             </p>
           ) : (
-            <TreeBranch
-              nodes={visibleTree}
-              depth={0}
-              selectedPath={selectedPath}
-              onSelect={onSelect}
-              openDirs={openDirs}
-              toggleDir={toggleDir}
-            />
+            <div style={{ height: totalH, position: "relative" }}>
+              <div style={{ height: padTop }} aria-hidden />
+              <ul className="m-0 p-0 list-none">
+                {slice.map((row) => {
+                  const { node, depth } = row;
+                  if (node.type === "dir") {
+                    const open = openDirs.has(node.path);
+                    return (
+                      <li key={row.key} style={{ height: ROW_H }}>
+                        <button
+                          type="button"
+                          onClick={() => toggleDir(node.path)}
+                          className={cn(
+                            "w-full flex items-center gap-1 text-left h-7 pr-2 text-[12.5px]",
+                            "text-body hover:bg-row-hover transition-colors rounded-[4px]",
+                          )}
+                          style={{ paddingLeft: 8 + depth * 12 }}
+                          title={node.path}
+                        >
+                          {open ? (
+                            <ChevronDown className="h-3.5 w-3.5 shrink-0 text-mute" />
+                          ) : (
+                            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-mute" />
+                          )}
+                          <FileTypeIcon
+                            name={node.name}
+                            kind="dir"
+                            expanded={open}
+                          />
+                          <span className="truncate font-medium">{node.name}</span>
+                          {node.children && node.children.length > 0 ? (
+                            <span className="ml-auto pl-1 text-[10px] tabular-nums text-mute shrink-0">
+                              {node.children.length}
+                            </span>
+                          ) : null}
+                        </button>
+                      </li>
+                    );
+                  }
+                  const selected = selectedPath === node.path;
+                  return (
+                    <li key={row.key} style={{ height: ROW_H }}>
+                      <button
+                        type="button"
+                        onClick={() => onSelect(node.path)}
+                        className={cn(
+                          "w-full flex items-center gap-1.5 text-left h-7 pr-2 text-[12.5px] truncate transition-colors rounded-[4px]",
+                          selected
+                            ? "bg-canvas text-ink font-medium shadow-[inset_0_0_0_1px_var(--color-hairline)]"
+                            : "text-body hover:bg-row-hover",
+                        )}
+                        style={{ paddingLeft: 8 + depth * 12 + 18 }}
+                        title={node.path}
+                      >
+                        <FileTypeIcon name={node.name} kind="file" />
+                        <span className="truncate">{node.name}</span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+              <div style={{ height: padBottom }} aria-hidden />
+            </div>
           )}
         </div>
       </aside>
@@ -257,6 +370,14 @@ export function FileSplitPanel({
               content={fileContent}
               note={fileNote}
             />
+          ) : selectedPath && fileNote ? (
+            <div className="p-3 space-y-2">
+              <p className="text-sm text-error font-mono break-words">{fileNote}</p>
+              <p className="text-xs text-mute">
+                Could not load this file for preview. Oversized package members
+                should return a truncated head; other errors are shown above.
+              </p>
+            </div>
           ) : (
             <p className="text-sm text-mute p-3">Select a file to preview.</p>
           )}

--- a/apps/hub/src/components/trial/file-split-panel.tsx
+++ b/apps/hub/src/components/trial/file-split-panel.tsx
@@ -1,5 +1,12 @@
 import { ChevronDown, ChevronRight, Search } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type UIEvent,
+} from "react";
 
 import { FileTypeIcon } from "@/components/file-type-icon";
 import { Input } from "@/components/ui/input";
@@ -10,6 +17,21 @@ import type { TreeEntry } from "@/lib/trial-types";
 import { cn } from "@/lib/utils";
 
 import { actorLabel, type ActorRow } from "./types";
+
+/** Fixed row height for windowed tree rendering (matches h-7). */
+const ROW_H = 28;
+const OVERSCAN = 16;
+/** Root-level dirs start collapsed (depth 0 = no auto-open). */
+const DEFAULT_OPEN_DEPTH = 0;
+/** Skip heavy token highlight for huge bodies. */
+const HIGHLIGHT_MAX_CHARS = 120_000;
+const PLAIN_PREVIEW_MAX_CHARS = 400_000;
+
+type FlatRow = {
+  key: string;
+  node: TreeNode;
+  depth: number;
+};
 
 function filterTree(nodes: TreeNode[], query: string): TreeNode[] {
   const q = query.trim().toLowerCase();
@@ -46,86 +68,49 @@ function allDirPaths(nodes: TreeNode[], acc: string[] = []): string[] {
   return acc;
 }
 
-function TreeBranch({
-  nodes,
-  depth,
-  selectedPath,
-  onSelect,
-  openDirs,
-  toggleDir,
-}: {
-  nodes: TreeNode[];
-  depth: number;
-  selectedPath: string | null;
-  onSelect: (path: string) => void;
-  openDirs: Set<string>;
-  toggleDir: (path: string) => void;
-}) {
-  return (
-    <ul className={cn(depth === 0 && "pb-2")}>
-      {nodes.map((node) => {
-        if (node.type === "dir") {
-          const open = openDirs.has(node.path);
-          return (
-            <li key={`d:${node.path}`}>
-              <button
-                type="button"
-                onClick={() => toggleDir(node.path)}
-                className={cn(
-                  "w-full flex items-center gap-1 text-left h-7 pr-2 text-[12.5px]",
-                  "text-body hover:bg-row-hover transition-colors rounded-[4px]",
-                )}
-                style={{ paddingLeft: 8 + depth * 12 }}
-                title={node.path}
-              >
-                {open ? (
-                  <ChevronDown className="h-3.5 w-3.5 shrink-0 text-mute" />
-                ) : (
-                  <ChevronRight className="h-3.5 w-3.5 shrink-0 text-mute" />
-                )}
-                <FileTypeIcon name={node.name} kind="dir" expanded={open} />
-                <span className="truncate font-medium">{node.name}</span>
-              </button>
-              {open && node.children && node.children.length > 0 ? (
-                <TreeBranch
-                  nodes={node.children}
-                  depth={depth + 1}
-                  selectedPath={selectedPath}
-                  onSelect={onSelect}
-                  openDirs={openDirs}
-                  toggleDir={toggleDir}
-                />
-              ) : null}
-            </li>
-          );
-        }
-        const selected = selectedPath === node.path;
-        return (
-          <li key={`f:${node.path}`}>
-            <button
-              type="button"
-              onClick={() => onSelect(node.path)}
-              className={cn(
-                "w-full flex items-center gap-1.5 text-left h-7 pr-2 text-[12.5px] truncate transition-colors rounded-[4px]",
-                selected
-                  ? "bg-canvas text-ink font-medium shadow-[inset_0_0_0_1px_var(--color-hairline)]"
-                  : "text-body hover:bg-row-hover",
-              )}
-              style={{ paddingLeft: 8 + depth * 12 + 18 }}
-              title={node.path}
-            >
-              <FileTypeIcon name={node.name} kind="file" />
-              <span className="truncate">{node.name}</span>
-            </button>
-          </li>
-        );
-      })}
-    </ul>
-  );
+function dirPathsUpToDepth(
+  nodes: TreeNode[],
+  maxDepth: number,
+  depth = 0,
+  acc: string[] = [],
+): string[] {
+  if (depth >= maxDepth) return acc;
+  for (const n of nodes) {
+    if (n.type === "dir") {
+      acc.push(n.path);
+      if (n.children) dirPathsUpToDepth(n.children, maxDepth, depth + 1, acc);
+    }
+  }
+  return acc;
+}
+
+function flattenVisible(
+  nodes: TreeNode[],
+  openDirs: Set<string>,
+  depth = 0,
+  out: FlatRow[] = [],
+): FlatRow[] {
+  for (const node of nodes) {
+    out.push({
+      key: `${node.type}:${node.path}`,
+      node,
+      depth,
+    });
+    if (
+      node.type === "dir" &&
+      openDirs.has(node.path) &&
+      node.children &&
+      node.children.length > 0
+    ) {
+      flattenVisible(node.children, openDirs, depth + 1, out);
+    }
+  }
+  return out;
 }
 
 /**
  * Left nested file tree (Hub-style) + right code preview.
+ * Windowed tree rows + collapsed-by-default dirs for large evidence archives.
  * Preserves multi-role virtual profile grouping when groupByProfile is on.
  */
 export function FileSplitPanel({
@@ -185,7 +170,11 @@ export function FileSplitPanel({
             (e) => (e.profile_id || "__ungrouped__") === key,
           );
           const nested = buildNestedTree(
-            groupFiles.map((e) => ({ path: e.path, type: "file", size: e.size ?? 0 })),
+            groupFiles.map((e) => ({
+              path: e.path,
+              type: "file",
+              size: e.size ?? 0,
+            })),
           );
           const label =
             key === "__ungrouped__"
@@ -216,9 +205,14 @@ export function FileSplitPanel({
   );
   const [openDirs, setOpenDirs] = useState<Set<string>>(() => new Set());
   const [query, setQuery] = useState("");
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportH, setViewportH] = useState(420);
 
   useEffect(() => {
-    setOpenDirs(new Set(allDirPaths(nestedRoots)));
+    setOpenDirs(new Set(dirPathsUpToDepth(nestedRoots, DEFAULT_OPEN_DEPTH)));
+    setScrollTop(0);
+    if (scrollRef.current) scrollRef.current.scrollTop = 0;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- treeKey is the intentional dep
   }, [treeKey]);
 
@@ -231,8 +225,37 @@ export function FileSplitPanel({
   useEffect(() => {
     if (query.trim()) {
       setOpenDirs(new Set(allDirPaths(visibleTree)));
+    } else {
+      setOpenDirs(new Set(dirPathsUpToDepth(nestedRoots, DEFAULT_OPEN_DEPTH)));
     }
-  }, [query, visibleTree]);
+  }, [query, visibleTree, nestedRoots]);
+
+  const flatRows = useMemo(
+    () => flattenVisible(visibleTree, openDirs),
+    [visibleTree, openDirs],
+  );
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const measure = () => setViewportH(el.clientHeight || 420);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [treeLoading, flatRows.length]);
+
+  const onScroll = useCallback((e: UIEvent<HTMLDivElement>) => {
+    setScrollTop(e.currentTarget.scrollTop);
+  }, []);
+
+  const totalH = flatRows.length * ROW_H;
+  const visibleCount = Math.ceil(viewportH / ROW_H) + OVERSCAN * 2;
+  const startIdx = Math.max(0, Math.floor(scrollTop / ROW_H) - OVERSCAN);
+  const endIdx = Math.min(flatRows.length, startIdx + visibleCount);
+  const slice = flatRows.slice(startIdx, endIdx);
+  const padTop = startIdx * ROW_H;
+  const padBottom = Math.max(0, totalH - padTop - slice.length * ROW_H);
 
   function toggleDir(path: string) {
     setOpenDirs((prev) => {
@@ -246,6 +269,16 @@ export function FileSplitPanel({
   const selectedName = selectedPath
     ? selectedPath.split("/").pop() || selectedPath
     : null;
+
+  const previewTooLarge =
+    fileContent != null && fileContent.length > HIGHLIGHT_MAX_CHARS;
+  const previewDisplay =
+    fileContent == null
+      ? null
+      : fileContent.length > PLAIN_PREVIEW_MAX_CHARS
+        ? fileContent.slice(0, PLAIN_PREVIEW_MAX_CHARS) +
+          `\n\n… truncated for preview (${fileContent.length.toLocaleString()} chars total)`
+        : fileContent;
 
   return (
     <div
@@ -282,22 +315,83 @@ export function FileSplitPanel({
             />
           </div>
         </div>
-        <div className="flex-1 overflow-y-auto px-1 pt-1">
+        <div
+          ref={scrollRef}
+          className="flex-1 overflow-y-auto px-1 pt-1"
+          onScroll={onScroll}
+        >
           {treeLoading ? (
             <p className="text-xs text-mute p-3">Loading tree…</p>
-          ) : visibleTree.length === 0 ? (
+          ) : flatRows.length === 0 ? (
             <p className="text-xs text-mute p-3">
               {query.trim() ? "No matches." : "No files in this scope."}
             </p>
           ) : (
-            <TreeBranch
-              nodes={visibleTree}
-              depth={0}
-              selectedPath={selectedPath}
-              onSelect={onSelect}
-              openDirs={openDirs}
-              toggleDir={toggleDir}
-            />
+            <div style={{ height: totalH, position: "relative" }}>
+              <div style={{ height: padTop }} aria-hidden />
+              <ul className="m-0 p-0 list-none">
+                {slice.map((row) => {
+                  const { node, depth } = row;
+                  if (node.type === "dir") {
+                    const open = openDirs.has(node.path);
+                    return (
+                      <li key={row.key} style={{ height: ROW_H }}>
+                        <button
+                          type="button"
+                          onClick={() => toggleDir(node.path)}
+                          className={cn(
+                            "w-full flex items-center gap-1 text-left h-7 pr-2 text-[12.5px]",
+                            "text-body hover:bg-row-hover transition-colors rounded-[4px]",
+                          )}
+                          style={{ paddingLeft: 8 + depth * 12 }}
+                          title={node.path}
+                        >
+                          {open ? (
+                            <ChevronDown className="h-3.5 w-3.5 shrink-0 text-mute" />
+                          ) : (
+                            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-mute" />
+                          )}
+                          <FileTypeIcon
+                            name={node.name}
+                            kind="dir"
+                            expanded={open}
+                          />
+                          <span className="truncate font-medium">
+                            {node.name}
+                          </span>
+                          {node.children && node.children.length > 0 ? (
+                            <span className="ml-auto pl-1 text-[10px] tabular-nums text-mute shrink-0">
+                              {node.children.length}
+                            </span>
+                          ) : null}
+                        </button>
+                      </li>
+                    );
+                  }
+                  const selected = selectedPath === node.path;
+                  return (
+                    <li key={row.key} style={{ height: ROW_H }}>
+                      <button
+                        type="button"
+                        onClick={() => onSelect(node.path)}
+                        className={cn(
+                          "w-full flex items-center gap-1.5 text-left h-7 pr-2 text-[12.5px] truncate transition-colors rounded-[4px]",
+                          selected
+                            ? "bg-canvas text-ink font-medium shadow-[inset_0_0_0_1px_var(--color-hairline)]"
+                            : "text-body hover:bg-row-hover",
+                        )}
+                        style={{ paddingLeft: 8 + depth * 12 + 18 }}
+                        title={node.path}
+                      >
+                        <FileTypeIcon name={node.name} kind="file" />
+                        <span className="truncate">{node.name}</span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+              <div style={{ height: padBottom }} aria-hidden />
+            </div>
           )}
         </div>
       </aside>
@@ -323,7 +417,17 @@ export function FileSplitPanel({
               {fileNote ? (
                 <p className="text-xs text-mute px-3 pt-2">{fileNote}</p>
               ) : null}
-              {fileContent != null ? (
+              {previewTooLarge && fileContent != null ? (
+                <p className="text-xs text-mute px-3 pt-2">
+                  Large file ({fileContent.length.toLocaleString()} chars) —
+                  plain preview without highlighting
+                  {fileContent.length > PLAIN_PREVIEW_MAX_CHARS
+                    ? `, first ${PLAIN_PREVIEW_MAX_CHARS.toLocaleString()} chars`
+                    : ""}
+                  .
+                </p>
+              ) : null}
+              {previewDisplay != null ? (
                 <pre
                   className={cn(
                     "m-0 p-3 min-h-full overflow-auto",
@@ -332,7 +436,14 @@ export function FileSplitPanel({
                   )}
                 >
                   <code className="font-mono">
-                    <CodeHighlight path={selectedPath} content={fileContent} />
+                    {previewTooLarge ? (
+                      <span className="text-shell-plain">{previewDisplay}</span>
+                    ) : (
+                      <CodeHighlight
+                        path={selectedPath}
+                        content={previewDisplay}
+                      />
+                    )}
                   </code>
                 </pre>
               ) : (

--- a/apps/hub/src/lib/api.ts
+++ b/apps/hub/src/lib/api.ts
@@ -544,6 +544,30 @@ export function taskIdsFromFiles(items: FileItem[]): string[] {
   return Array.from(ids).sort();
 }
 
+/** True when package digest listing includes Dataset-level shared/ (#65). */
+export function hasSharedFiles(items: FileItem[]): boolean {
+  return items.some(
+    (i) => i.path === "shared" || i.path.startsWith("shared/"),
+  );
+}
+
+/** Total byte size of file entries under shared/ (dirs size 0). */
+export function sharedFilesStats(items: FileItem[]): {
+  fileCount: number;
+  totalBytes: number;
+} {
+  let fileCount = 0;
+  let totalBytes = 0;
+  for (const i of items) {
+    if (i.type === "dir") continue;
+    if (i.path === "shared" || i.path.startsWith("shared/")) {
+      fileCount += 1;
+      totalBytes += i.size || 0;
+    }
+  }
+  return { fileCount, totalBytes };
+}
+
 export function decodeFileContent(file: FileContent): string {
   if (file.encoding === "base64") {
     try {

--- a/apps/hub/src/lib/code-highlight.tsx
+++ b/apps/hub/src/lib/code-highlight.tsx
@@ -360,6 +360,9 @@ function renderTokens(tokens: Token[]): ReactNode {
   );
 }
 
+/** Skip tokenization for huge bodies (caller may also pre-truncate). */
+const HIGHLIGHT_MAX_CHARS = 120_000;
+
 export function CodeHighlight({
   path,
   content,
@@ -367,6 +370,10 @@ export function CodeHighlight({
   path?: string | null;
   content: string;
 }): ReactNode {
+  if (content.length > HIGHLIGHT_MAX_CHARS) {
+    return <span className="text-shell-plain">{content}</span>;
+  }
+
   const { lang, text } = preparePreview(path, content);
 
   if (lang === "json") {

--- a/apps/hub/src/pages/AttemptEvidencePage.tsx
+++ b/apps/hub/src/pages/AttemptEvidencePage.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 
 import { BreadcrumbNav } from "@/components/breadcrumb";
 import { CommandStrip } from "@/components/command-strip";
-import { FileSplitPanel } from "@/components/file-split-panel";
 import { Shell } from "@/components/layout";
 import { ActorsTable } from "@/components/trial/actors-table";
 import { EvidenceTabs } from "@/components/trial/evidence-tabs";
@@ -11,25 +9,15 @@ import { OutcomeStrip } from "@/components/trial/outcome-strip";
 import { PhaseTimingBar } from "@/components/trial/phase-timing-bar";
 import { TrialHeader } from "@/components/trial/trial-header";
 import { useAttemptEvidence } from "@/hooks/use-attempt-evidence";
-import {
-  decodeDatasetId,
-  decodeFileContent,
-  getPackageFile,
-  hasSharedFiles,
-  listPackageFiles,
-  listPackageVersions,
-  RegistryHttpError,
-  type FileItem,
-} from "@/lib/api";
+import { decodeDatasetId } from "@/lib/api";
 import { getToken } from "@/lib/auth";
-import { buildNestedTree } from "@/lib/file-tree";
-import { cn } from "@/lib/utils";
-
-type FilesScope = "local" | "shared";
 
 /**
  * Hub Jobs deep-link: uploaded Attempt evidence with viewer-parity IA
  * (outcome, actors, Trajectory / Agent / Verifier / Lock / Runtime tabs).
+ *
+ * Package Dataset ``shared/`` is browsed on Task Files / Dataset Shared tab —
+ * not inside Attempt evidence (Local | Shared does not apply here).
  */
 export function AttemptEvidencePage() {
   const { datasetId: rawId, taskId: rawTask, runId: rawRun } = useParams();
@@ -61,90 +49,6 @@ export function AttemptEvidencePage() {
   } = useAttemptEvidence(runId, taskId, token);
 
   const jobsHref = `/datasets/${encodeURIComponent(datasetId)}/tasks/${encodeURIComponent(taskId)}?tab=jobs`;
-
-  // #65: Local = attempt evidence; Shared = Dataset package shared/ (read-only).
-  const [filesScope, setFilesScope] = useState<FilesScope>("local");
-  const [pkgDigest, setPkgDigest] = useState<string | null>(null);
-  const [pkgItems, setPkgItems] = useState<FileItem[]>([]);
-  const [sharedSelected, setSharedSelected] = useState<string | null>(null);
-  const [sharedContent, setSharedContent] = useState<string | null>(null);
-  const [sharedNote, setSharedNote] = useState<string | null>(null);
-  const [sharedLoading, setSharedLoading] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    async function loadPkg() {
-      try {
-        const versions = await listPackageVersions(datasetId, token);
-        if (!versions.length || cancelled) return;
-        const latest = [...versions].sort(
-          (a, b) => (b.created_at ?? 0) - (a.created_at ?? 0),
-        )[0];
-        const files = await listPackageFiles(
-          datasetId,
-          latest.package_digest,
-          token,
-        );
-        if (cancelled) return;
-        setPkgDigest(latest.package_digest);
-        setPkgItems(files.items);
-        if (hasSharedFiles(files.items)) {
-          const prefer =
-            files.items.find((e) => e.path === "shared/README.md") ||
-            files.items.find(
-              (e) => e.type !== "dir" && e.path.startsWith("shared/"),
-            );
-          if (prefer) setSharedSelected(prefer.path);
-        }
-      } catch {
-        if (!cancelled) {
-          setPkgDigest(null);
-          setPkgItems([]);
-        }
-      }
-    }
-    void loadPkg();
-    return () => {
-      cancelled = true;
-    };
-  }, [datasetId, token]);
-
-  const sharedPresent = useMemo(() => hasSharedFiles(pkgItems), [pkgItems]);
-  const sharedTree = useMemo(
-    () => buildNestedTree(pkgItems, "shared"),
-    [pkgItems],
-  );
-
-  useEffect(() => {
-    if (!pkgDigest || !sharedSelected || filesScope !== "shared") {
-      setSharedContent(null);
-      return;
-    }
-    let cancelled = false;
-    setSharedLoading(true);
-    setSharedNote(null);
-    getPackageFile(datasetId, pkgDigest, sharedSelected, token)
-      .then((f) => {
-        if (cancelled) return;
-        setSharedContent(decodeFileContent(f));
-        if (f.truncated) setSharedNote("truncated");
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        setSharedContent(null);
-        if (err instanceof RegistryHttpError) {
-          setSharedNote(`${err.code}: ${err.message}`);
-        } else {
-          setSharedNote(err instanceof Error ? err.message : String(err));
-        }
-      })
-      .finally(() => {
-        if (!cancelled) setSharedLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [datasetId, pkgDigest, sharedSelected, token, filesScope]);
 
   return (
     <Shell>
@@ -202,75 +106,24 @@ export function AttemptEvidencePage() {
               <ActorsTable actors={trial.actors} />
             ) : null}
 
-            <div className="inline-flex rounded-[8px] border border-hairline p-0.5 bg-canvas-soft">
-              {(
-                [
-                  ["local", "Local"],
-                  ["shared", "Shared"],
-                ] as const
-              ).map(([id, label]) => (
-                <button
-                  key={id}
-                  type="button"
-                  onClick={() => setFilesScope(id)}
-                  className={cn(
-                    "px-3 py-1.5 text-xs rounded-[6px] transition-colors",
-                    filesScope === id
-                      ? "bg-canvas text-ink font-medium shadow-sm"
-                      : "text-body hover:text-ink",
-                  )}
-                >
-                  {label}
-                  {id === "shared" && !sharedPresent ? (
-                    <span className="ml-1 text-mute font-normal">(none)</span>
-                  ) : null}
-                </button>
-              ))}
-            </div>
-
-            {filesScope === "local" ? (
-              <EvidenceTabs
-                availableTabs={availableTabs}
-                activeTab={activeTab}
-                onTabChange={setActiveTab}
-                trajLoading={trajLoading}
-                steps={steps}
-                trajNote={trajNote}
-                result={result}
-                actors={trial.actors || []}
-                tree={tree}
-                treeLoading={treeLoading}
-                selectedPath={selectedPath}
-                onSelectPath={setSelectedPath}
-                fileContent={fileContent}
-                fileLoading={fileLoading}
-                fileNote={fileNote}
-                treeGroups={treeGroups}
-              />
-            ) : !sharedPresent ? (
-              <div className="rounded-[8px] border border-hairline bg-canvas-soft p-6 text-sm text-mute">
-                No <code className="font-mono">shared/</code> in this Dataset
-                package. Local tab shows Attempt evidence only.
-              </div>
-            ) : (
-              <div className="space-y-2">
-                <p className="text-xs text-mute">
-                  Dataset <code className="font-mono">shared/**</code> (package
-                  digest; not Attempt archive). Gold stays under{" "}
-                  <code className="font-mono">evaluation/</code>.
-                </p>
-                <FileSplitPanel
-                  tree={sharedTree}
-                  treeLoading={false}
-                  selectedPath={sharedSelected}
-                  onSelect={setSharedSelected}
-                  fileContent={sharedContent}
-                  fileLoading={sharedLoading}
-                  fileNote={sharedNote}
-                  rootPrefix="shared"
-                />
-              </div>
-            )}
+            <EvidenceTabs
+              availableTabs={availableTabs}
+              activeTab={activeTab}
+              onTabChange={setActiveTab}
+              trajLoading={trajLoading}
+              steps={steps}
+              trajNote={trajNote}
+              result={result}
+              actors={trial.actors || []}
+              tree={tree}
+              treeLoading={treeLoading}
+              selectedPath={selectedPath}
+              onSelectPath={setSelectedPath}
+              fileContent={fileContent}
+              fileLoading={fileLoading}
+              fileNote={fileNote}
+              treeGroups={treeGroups}
+            />
           </>
         ) : null}
 

--- a/apps/hub/src/pages/AttemptEvidencePage.tsx
+++ b/apps/hub/src/pages/AttemptEvidencePage.tsx
@@ -1,7 +1,9 @@
+import { useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 
 import { BreadcrumbNav } from "@/components/breadcrumb";
 import { CommandStrip } from "@/components/command-strip";
+import { FileSplitPanel } from "@/components/file-split-panel";
 import { Shell } from "@/components/layout";
 import { ActorsTable } from "@/components/trial/actors-table";
 import { EvidenceTabs } from "@/components/trial/evidence-tabs";
@@ -9,8 +11,21 @@ import { OutcomeStrip } from "@/components/trial/outcome-strip";
 import { PhaseTimingBar } from "@/components/trial/phase-timing-bar";
 import { TrialHeader } from "@/components/trial/trial-header";
 import { useAttemptEvidence } from "@/hooks/use-attempt-evidence";
-import { decodeDatasetId } from "@/lib/api";
+import {
+  decodeDatasetId,
+  decodeFileContent,
+  getPackageFile,
+  hasSharedFiles,
+  listPackageFiles,
+  listPackageVersions,
+  RegistryHttpError,
+  type FileItem,
+} from "@/lib/api";
 import { getToken } from "@/lib/auth";
+import { buildNestedTree } from "@/lib/file-tree";
+import { cn } from "@/lib/utils";
+
+type FilesScope = "local" | "shared";
 
 /**
  * Hub Jobs deep-link: uploaded Attempt evidence with viewer-parity IA
@@ -46,6 +61,90 @@ export function AttemptEvidencePage() {
   } = useAttemptEvidence(runId, taskId, token);
 
   const jobsHref = `/datasets/${encodeURIComponent(datasetId)}/tasks/${encodeURIComponent(taskId)}?tab=jobs`;
+
+  // #65: Local = attempt evidence; Shared = Dataset package shared/ (read-only).
+  const [filesScope, setFilesScope] = useState<FilesScope>("local");
+  const [pkgDigest, setPkgDigest] = useState<string | null>(null);
+  const [pkgItems, setPkgItems] = useState<FileItem[]>([]);
+  const [sharedSelected, setSharedSelected] = useState<string | null>(null);
+  const [sharedContent, setSharedContent] = useState<string | null>(null);
+  const [sharedNote, setSharedNote] = useState<string | null>(null);
+  const [sharedLoading, setSharedLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadPkg() {
+      try {
+        const versions = await listPackageVersions(datasetId, token);
+        if (!versions.length || cancelled) return;
+        const latest = [...versions].sort(
+          (a, b) => (b.created_at ?? 0) - (a.created_at ?? 0),
+        )[0];
+        const files = await listPackageFiles(
+          datasetId,
+          latest.package_digest,
+          token,
+        );
+        if (cancelled) return;
+        setPkgDigest(latest.package_digest);
+        setPkgItems(files.items);
+        if (hasSharedFiles(files.items)) {
+          const prefer =
+            files.items.find((e) => e.path === "shared/README.md") ||
+            files.items.find(
+              (e) => e.type !== "dir" && e.path.startsWith("shared/"),
+            );
+          if (prefer) setSharedSelected(prefer.path);
+        }
+      } catch {
+        if (!cancelled) {
+          setPkgDigest(null);
+          setPkgItems([]);
+        }
+      }
+    }
+    void loadPkg();
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetId, token]);
+
+  const sharedPresent = useMemo(() => hasSharedFiles(pkgItems), [pkgItems]);
+  const sharedTree = useMemo(
+    () => buildNestedTree(pkgItems, "shared"),
+    [pkgItems],
+  );
+
+  useEffect(() => {
+    if (!pkgDigest || !sharedSelected || filesScope !== "shared") {
+      setSharedContent(null);
+      return;
+    }
+    let cancelled = false;
+    setSharedLoading(true);
+    setSharedNote(null);
+    getPackageFile(datasetId, pkgDigest, sharedSelected, token)
+      .then((f) => {
+        if (cancelled) return;
+        setSharedContent(decodeFileContent(f));
+        if (f.truncated) setSharedNote("truncated");
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setSharedContent(null);
+        if (err instanceof RegistryHttpError) {
+          setSharedNote(`${err.code}: ${err.message}`);
+        } else {
+          setSharedNote(err instanceof Error ? err.message : String(err));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setSharedLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetId, pkgDigest, sharedSelected, token, filesScope]);
 
   return (
     <Shell>
@@ -103,24 +202,75 @@ export function AttemptEvidencePage() {
               <ActorsTable actors={trial.actors} />
             ) : null}
 
-            <EvidenceTabs
-              availableTabs={availableTabs}
-              activeTab={activeTab}
-              onTabChange={setActiveTab}
-              trajLoading={trajLoading}
-              steps={steps}
-              trajNote={trajNote}
-              result={result}
-              actors={trial.actors || []}
-              tree={tree}
-              treeLoading={treeLoading}
-              selectedPath={selectedPath}
-              onSelectPath={setSelectedPath}
-              fileContent={fileContent}
-              fileLoading={fileLoading}
-              fileNote={fileNote}
-              treeGroups={treeGroups}
-            />
+            <div className="inline-flex rounded-[8px] border border-hairline p-0.5 bg-canvas-soft">
+              {(
+                [
+                  ["local", "Local"],
+                  ["shared", "Shared"],
+                ] as const
+              ).map(([id, label]) => (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setFilesScope(id)}
+                  className={cn(
+                    "px-3 py-1.5 text-xs rounded-[6px] transition-colors",
+                    filesScope === id
+                      ? "bg-canvas text-ink font-medium shadow-sm"
+                      : "text-body hover:text-ink",
+                  )}
+                >
+                  {label}
+                  {id === "shared" && !sharedPresent ? (
+                    <span className="ml-1 text-mute font-normal">(none)</span>
+                  ) : null}
+                </button>
+              ))}
+            </div>
+
+            {filesScope === "local" ? (
+              <EvidenceTabs
+                availableTabs={availableTabs}
+                activeTab={activeTab}
+                onTabChange={setActiveTab}
+                trajLoading={trajLoading}
+                steps={steps}
+                trajNote={trajNote}
+                result={result}
+                actors={trial.actors || []}
+                tree={tree}
+                treeLoading={treeLoading}
+                selectedPath={selectedPath}
+                onSelectPath={setSelectedPath}
+                fileContent={fileContent}
+                fileLoading={fileLoading}
+                fileNote={fileNote}
+                treeGroups={treeGroups}
+              />
+            ) : !sharedPresent ? (
+              <div className="rounded-[8px] border border-hairline bg-canvas-soft p-6 text-sm text-mute">
+                No <code className="font-mono">shared/</code> in this Dataset
+                package. Local tab shows Attempt evidence only.
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <p className="text-xs text-mute">
+                  Dataset <code className="font-mono">shared/**</code> (package
+                  digest; not Attempt archive). Gold stays under{" "}
+                  <code className="font-mono">evaluation/</code>.
+                </p>
+                <FileSplitPanel
+                  tree={sharedTree}
+                  treeLoading={false}
+                  selectedPath={sharedSelected}
+                  onSelect={setSharedSelected}
+                  fileContent={sharedContent}
+                  fileLoading={sharedLoading}
+                  fileNote={sharedNote}
+                  rootPrefix="shared"
+                />
+              </div>
+            )}
           </>
         ) : null}
 

--- a/apps/hub/src/pages/DatasetDetailPage.tsx
+++ b/apps/hub/src/pages/DatasetDetailPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 import { BreadcrumbNav } from "@/components/breadcrumb";
 import { CommandStrip } from "@/components/command-strip";
+import { FileSplitPanel } from "@/components/file-split-panel";
 import { LeaderboardTable } from "@/components/leaderboard-table";
 import { Shell } from "@/components/layout";
 import { Markdown } from "@/components/markdown";
@@ -19,19 +20,23 @@ import {
   decodeFileContent,
   encodeDatasetId,
   getPackageFile,
+  hasSharedFiles,
   listPackageFiles,
   listPackageVersions,
   listSuites,
+  type FileItem,
   type PackageRelease,
   type SuiteRow,
   RegistryHttpError,
+  sharedFilesStats,
   taskIdsFromFiles,
 } from "@/lib/api";
 import { getToken } from "@/lib/auth";
+import { buildNestedTree } from "@/lib/file-tree";
 import { LEADERBOARD_K_FIXTURES } from "@/lib/leaderboard-fixtures";
 import { cn } from "@/lib/utils";
 
-type Tab = "readme" | "tasks" | "leaderboard";
+type Tab = "readme" | "tasks" | "shared" | "leaderboard";
 
 export function DatasetDetailPage() {
   const navigate = useNavigate();
@@ -44,10 +49,15 @@ export function DatasetDetailPage() {
 
   const [release, setRelease] = useState<PackageRelease | null>(null);
   const [taskIds, setTaskIds] = useState<string[]>([]);
+  const [fileItems, setFileItems] = useState<FileItem[]>([]);
   const [readme, setReadme] = useState<string | null>(null);
   const [suites, setSuites] = useState<SuiteRow[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [sharedSelected, setSharedSelected] = useState<string | null>(null);
+  const [sharedContent, setSharedContent] = useState<string | null>(null);
+  const [sharedNote, setSharedNote] = useState<string | null>(null);
+  const [sharedFileLoading, setSharedFileLoading] = useState(false);
   const token = getToken();
 
   useEffect(() => {
@@ -71,7 +81,16 @@ export function DatasetDetailPage() {
           token,
         );
         if (cancelled) return;
+        setFileItems(files.items);
         setTaskIds(taskIdsFromFiles(files.items));
+        if (hasSharedFiles(files.items)) {
+          const prefer =
+            files.items.find((e) => e.path === "shared/README.md") ||
+            files.items.find(
+              (e) => e.type !== "dir" && e.path.startsWith("shared/"),
+            );
+          if (prefer) setSharedSelected(prefer.path);
+        }
         try {
           const readmeFile = await getPackageFile(
             datasetId,
@@ -110,6 +129,44 @@ export function DatasetDetailPage() {
     if (!release) return `bora lock ${datasetId} --task <task_id>`;
     return `bora lock registry://${datasetId}@${release.version} --task <task_id>`;
   }, [datasetId, release]);
+
+  const sharedPresent = useMemo(() => hasSharedFiles(fileItems), [fileItems]);
+  const sharedStats = useMemo(() => sharedFilesStats(fileItems), [fileItems]);
+  const sharedTree = useMemo(
+    () => buildNestedTree(fileItems, "shared"),
+    [fileItems],
+  );
+
+  useEffect(() => {
+    if (!release || !sharedSelected || tab !== "shared") {
+      setSharedContent(null);
+      return;
+    }
+    let cancelled = false;
+    setSharedFileLoading(true);
+    setSharedNote(null);
+    getPackageFile(datasetId, release.package_digest, sharedSelected, token)
+      .then((f) => {
+        if (cancelled) return;
+        setSharedContent(decodeFileContent(f));
+        if (f.truncated) setSharedNote("truncated");
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setSharedContent(null);
+        if (err instanceof RegistryHttpError) {
+          setSharedNote(`${err.code}: ${err.message}`);
+        } else {
+          setSharedNote(err instanceof Error ? err.message : String(err));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setSharedFileLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetId, release, sharedSelected, token, tab]);
 
   function setTab(next: Tab) {
     const n = new URLSearchParams(search);
@@ -164,6 +221,7 @@ export function DatasetDetailPage() {
           [
             ["readme", "README"],
             ["tasks", "Tasks"],
+            ["shared", "Shared"],
             ["leaderboard", "Leaderboard"],
           ] as const
         ).map(([id, label]) => (
@@ -179,6 +237,11 @@ export function DatasetDetailPage() {
             )}
           >
             {label}
+            {id === "shared" && sharedPresent ? (
+              <span className="ml-1.5 text-xs text-mute font-normal">
+                {sharedStats.fileCount}
+              </span>
+            ) : null}
           </button>
         ))}
       </div>
@@ -228,6 +291,40 @@ export function DatasetDetailPage() {
                 ))}
               </TableBody>
             </Table>
+          </div>
+        )
+      ) : tab === "shared" ? (
+        !sharedPresent ? (
+          <div className="rounded-[8px] border border-hairline bg-canvas-soft p-6 text-sm text-mute space-y-2">
+            <p className="text-ink font-medium">No Dataset-level shared/</p>
+            <p>
+              Optional <code className="font-mono">shared/</code> at the
+              Database root is part of <code className="font-mono">packageDigest</code>{" "}
+              when present. Cross-task code lives in{" "}
+              <code className="font-mono">shared/lib</code>; domain fixtures in{" "}
+              <code className="font-mono">shared/assets</code>.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <p className="text-xs text-mute">
+              Dataset <code className="font-mono">shared/**</code> ·{" "}
+              {sharedStats.fileCount} file
+              {sharedStats.fileCount === 1 ? "" : "s"} ·{" "}
+              {sharedStats.totalBytes.toLocaleString()} bytes · in package digest
+              (not Agent-mounted by default; gold stays under{" "}
+              <code className="font-mono">tasks/*/evaluation/</code>)
+            </p>
+            <FileSplitPanel
+              tree={sharedTree}
+              treeLoading={false}
+              selectedPath={sharedSelected}
+              onSelect={setSharedSelected}
+              fileContent={sharedContent}
+              fileLoading={sharedFileLoading}
+              fileNote={sharedNote}
+              rootPrefix="shared"
+            />
           </div>
         )
       ) : (

--- a/apps/hub/src/pages/DatasetDetailPage.tsx
+++ b/apps/hub/src/pages/DatasetDetailPage.tsx
@@ -28,7 +28,6 @@ import {
   type PackageRelease,
   type SuiteRow,
   RegistryHttpError,
-  sharedFilesStats,
   taskIdsFromFiles,
 } from "@/lib/api";
 import { getToken } from "@/lib/auth";
@@ -131,14 +130,20 @@ export function DatasetDetailPage() {
   }, [datasetId, release]);
 
   const sharedPresent = useMemo(() => hasSharedFiles(fileItems), [fileItems]);
-  const sharedStats = useMemo(() => sharedFilesStats(fileItems), [fileItems]);
   const sharedTree = useMemo(
     () => buildNestedTree(fileItems, "shared"),
     [fileItems],
   );
 
+  // Stale ?tab=shared when package has no shared/ → fall back to README.
   useEffect(() => {
-    if (!release || !sharedSelected || tab !== "shared") {
+    if (!loading && tab === "shared" && !sharedPresent) {
+      setTab("readme");
+    }
+  }, [loading, tab, sharedPresent]);
+
+  useEffect(() => {
+    if (!release || !sharedSelected || tab !== "shared" || !sharedPresent) {
       setSharedContent(null);
       return;
     }
@@ -149,7 +154,15 @@ export function DatasetDetailPage() {
       .then((f) => {
         if (cancelled) return;
         setSharedContent(decodeFileContent(f));
-        if (f.truncated) setSharedNote("truncated");
+        if (f.truncated) {
+          const full = f.size ?? 0;
+          const shown = (f.content || "").length;
+          setSharedNote(
+            full > 0
+              ? `Truncated preview: showing first ~${shown.toLocaleString()} of ${full.toLocaleString()} bytes (Hub preview cap).`
+              : "Truncated preview (Hub preview size cap).",
+          );
+        }
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -221,9 +234,12 @@ export function DatasetDetailPage() {
           [
             ["readme", "README"],
             ["tasks", "Tasks"],
-            ["shared", "Shared"],
+            // Hide entirely when package has no shared/** (optional tree).
+            ...(sharedPresent
+              ? ([["shared", "Shared"]] as Array<[Tab, string]>)
+              : []),
             ["leaderboard", "Leaderboard"],
-          ] as const
+          ] as Array<[Tab, string]>
         ).map(([id, label]) => (
           <button
             key={id}
@@ -237,11 +253,6 @@ export function DatasetDetailPage() {
             )}
           >
             {label}
-            {id === "shared" && sharedPresent ? (
-              <span className="ml-1.5 text-xs text-mute font-normal">
-                {sharedStats.fileCount}
-              </span>
-            ) : null}
           </button>
         ))}
       </div>
@@ -293,40 +304,17 @@ export function DatasetDetailPage() {
             </Table>
           </div>
         )
-      ) : tab === "shared" ? (
-        !sharedPresent ? (
-          <div className="rounded-[8px] border border-hairline bg-canvas-soft p-6 text-sm text-mute space-y-2">
-            <p className="text-ink font-medium">No Dataset-level shared/</p>
-            <p>
-              Optional <code className="font-mono">shared/</code> at the
-              Database root is part of <code className="font-mono">packageDigest</code>{" "}
-              when present. Cross-task code lives in{" "}
-              <code className="font-mono">shared/lib</code>; domain fixtures in{" "}
-              <code className="font-mono">shared/assets</code>.
-            </p>
-          </div>
-        ) : (
-          <div className="space-y-3">
-            <p className="text-xs text-mute">
-              Dataset <code className="font-mono">shared/**</code> ·{" "}
-              {sharedStats.fileCount} file
-              {sharedStats.fileCount === 1 ? "" : "s"} ·{" "}
-              {sharedStats.totalBytes.toLocaleString()} bytes · in package digest
-              (not Agent-mounted by default; gold stays under{" "}
-              <code className="font-mono">tasks/*/evaluation/</code>)
-            </p>
-            <FileSplitPanel
-              tree={sharedTree}
-              treeLoading={false}
-              selectedPath={sharedSelected}
-              onSelect={setSharedSelected}
-              fileContent={sharedContent}
-              fileLoading={sharedFileLoading}
-              fileNote={sharedNote}
-              rootPrefix="shared"
-            />
-          </div>
-        )
+      ) : tab === "shared" && sharedPresent ? (
+        <FileSplitPanel
+          tree={sharedTree}
+          treeLoading={false}
+          selectedPath={sharedSelected}
+          onSelect={setSharedSelected}
+          fileContent={sharedContent}
+          fileLoading={sharedFileLoading}
+          fileNote={sharedNote}
+          rootPrefix="shared"
+        />
       ) : (
         <div className="space-y-2">
           {demoLeaderboard ? (

--- a/apps/hub/src/pages/TaskDetailPage.tsx
+++ b/apps/hub/src/pages/TaskDetailPage.tsx
@@ -18,9 +18,11 @@ import {
   decodeDatasetId,
   decodeFileContent,
   getPackageFile,
+  hasSharedFiles,
   listPackageFiles,
   listPackageVersions,
   listSuites,
+  type FileItem,
   type PackageRelease,
   type SuiteRow,
   RegistryHttpError,
@@ -30,6 +32,7 @@ import { buildNestedTree, type TreeNode } from "@/lib/file-tree";
 import { cn, formatScore } from "@/lib/utils";
 
 type Tab = "readme" | "files" | "jobs";
+type FilesScope = "local" | "shared";
 
 export function TaskDetailPage() {
   const { datasetId: rawId, taskId: rawTask } = useParams();
@@ -41,12 +44,14 @@ export function TaskDetailPage() {
   const tab = (search.get("tab") as Tab) || "readme";
 
   const [release, setRelease] = useState<PackageRelease | null>(null);
+  const [fileItems, setFileItems] = useState<FileItem[]>([]);
   const [tree, setTree] = useState<TreeNode[]>([]);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [fileContent, setFileContent] = useState<string | null>(null);
   const [fileNote, setFileNote] = useState<string | null>(null);
   const [treeLoading, setTreeLoading] = useState(true);
   const [fileLoading, setFileLoading] = useState(false);
+  const [filesScope, setFilesScope] = useState<FilesScope>("local");
   const [readme, setReadme] = useState<string | null>(null);
   const [jobs, setJobs] = useState<
     Array<{
@@ -63,7 +68,9 @@ export function TaskDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const token = getToken();
 
-  const prefix = `tasks/${taskId}`;
+  const localPrefix = `tasks/${taskId}`;
+  const prefix = filesScope === "shared" ? "shared" : localPrefix;
+  const sharedPresent = useMemo(() => hasSharedFiles(fileItems), [fileItems]);
 
   useEffect(() => {
     let cancelled = false;
@@ -86,15 +93,16 @@ export function TaskDetailPage() {
           token,
         );
         if (cancelled) return;
-        const nested = buildNestedTree(files.items, prefix);
+        setFileItems(files.items);
+        const nested = buildNestedTree(files.items, localPrefix);
         setTree(nested);
 
         // Prefer task.yaml for initial Files selection (when user opens Files)
         const prefer =
-          files.items.find((e) => e.path === `${prefix}/task.yaml`) ||
-          files.items.find((e) => e.path === `${prefix}/README.md`) ||
+          files.items.find((e) => e.path === `${localPrefix}/task.yaml`) ||
+          files.items.find((e) => e.path === `${localPrefix}/README.md`) ||
           files.items.find(
-            (e) => e.type !== "dir" && e.path.startsWith(prefix + "/"),
+            (e) => e.type !== "dir" && e.path.startsWith(localPrefix + "/"),
           );
         if (prefer) setSelectedPath(prefer.path);
 
@@ -102,7 +110,7 @@ export function TaskDetailPage() {
           const r = await getPackageFile(
             datasetId,
             latest.package_digest,
-            `${prefix}/README.md`,
+            `${localPrefix}/README.md`,
             token,
           );
           if (!cancelled) setReadme(decodeFileContent(r));
@@ -148,7 +156,28 @@ export function TaskDetailPage() {
     return () => {
       cancelled = true;
     };
-  }, [datasetId, taskId, token, prefix]);
+  }, [datasetId, taskId, token, localPrefix]);
+
+  // Rebuild tree when Local | Shared scope changes (#65).
+  useEffect(() => {
+    if (!fileItems.length) return;
+    const nextPrefix = filesScope === "shared" ? "shared" : localPrefix;
+    setTree(buildNestedTree(fileItems, nextPrefix));
+    const prefer =
+      filesScope === "shared"
+        ? fileItems.find((e) => e.path === "shared/README.md") ||
+          fileItems.find(
+            (e) => e.type !== "dir" && e.path.startsWith("shared/"),
+          )
+        : fileItems.find((e) => e.path === `${localPrefix}/task.yaml`) ||
+          fileItems.find((e) => e.path === `${localPrefix}/README.md`) ||
+          fileItems.find(
+            (e) => e.type !== "dir" && e.path.startsWith(localPrefix + "/"),
+          );
+    setSelectedPath(prefer?.path ?? null);
+    setFileContent(null);
+    setFileNote(null);
+  }, [filesScope, fileItems, localPrefix]);
 
   useEffect(() => {
     if (!release || !selectedPath) {
@@ -257,16 +286,50 @@ export function TaskDetailPage() {
       ) : null}
 
       {tab === "files" ? (
-        <FileSplitPanel
-          tree={tree}
-          treeLoading={treeLoading}
-          selectedPath={selectedPath}
-          onSelect={setSelectedPath}
-          fileContent={fileContent}
-          fileLoading={fileLoading}
-          fileNote={fileNote}
-          rootPrefix={prefix}
-        />
+        <div className="space-y-3">
+          <div className="inline-flex rounded-[8px] border border-hairline p-0.5 bg-canvas-soft">
+            {(
+              [
+                ["local", "Local"],
+                ["shared", "Shared"],
+              ] as const
+            ).map(([id, label]) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setFilesScope(id)}
+                className={cn(
+                  "px-3 py-1.5 text-xs rounded-[6px] transition-colors",
+                  filesScope === id
+                    ? "bg-canvas text-ink font-medium shadow-sm"
+                    : "text-body hover:text-ink",
+                )}
+              >
+                {label}
+                {id === "shared" && !sharedPresent ? (
+                  <span className="ml-1 text-mute font-normal">(none)</span>
+                ) : null}
+              </button>
+            ))}
+          </div>
+          {filesScope === "shared" && !sharedPresent ? (
+            <div className="rounded-[8px] border border-hairline bg-canvas-soft p-6 text-sm text-mute">
+              This Dataset has no <code className="font-mono">shared/</code>{" "}
+              tree in the published package digest.
+            </div>
+          ) : (
+            <FileSplitPanel
+              tree={tree}
+              treeLoading={treeLoading}
+              selectedPath={selectedPath}
+              onSelect={setSelectedPath}
+              fileContent={fileContent}
+              fileLoading={fileLoading}
+              fileNote={fileNote}
+              rootPrefix={prefix}
+            />
+          )}
+        </div>
       ) : null}
 
       {tab === "jobs" ? (

--- a/apps/hub/src/pages/TaskDetailPage.tsx
+++ b/apps/hub/src/pages/TaskDetailPage.tsx
@@ -191,7 +191,15 @@ export function TaskDetailPage() {
       .then((f) => {
         if (cancelled) return;
         setFileContent(decodeFileContent(f));
-        if (f.truncated) setFileNote("truncated");
+        if (f.truncated) {
+          const full = f.size ?? 0;
+          const shown = (f.content || "").length;
+          setFileNote(
+            full > 0
+              ? `Truncated preview: showing first ~${shown.toLocaleString()} of ${full.toLocaleString()} bytes (Hub preview cap).`
+              : "Truncated preview (Hub preview size cap).",
+          );
+        }
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -286,50 +294,52 @@ export function TaskDetailPage() {
       ) : null}
 
       {tab === "files" ? (
-        <div className="space-y-3">
-          <div className="inline-flex rounded-[8px] border border-hairline p-0.5 bg-canvas-soft">
-            {(
-              [
-                ["local", "Local"],
-                ["shared", "Shared"],
-              ] as const
-            ).map(([id, label]) => (
-              <button
-                key={id}
-                type="button"
-                onClick={() => setFilesScope(id)}
-                className={cn(
-                  "px-3 py-1.5 text-xs rounded-[6px] transition-colors",
-                  filesScope === id
-                    ? "bg-canvas text-ink font-medium shadow-sm"
-                    : "text-body hover:text-ink",
-                )}
-              >
-                {label}
-                {id === "shared" && !sharedPresent ? (
-                  <span className="ml-1 text-mute font-normal">(none)</span>
-                ) : null}
-              </button>
-            ))}
-          </div>
-          {filesScope === "shared" && !sharedPresent ? (
-            <div className="rounded-[8px] border border-hairline bg-canvas-soft p-6 text-sm text-mute">
-              This Dataset has no <code className="font-mono">shared/</code>{" "}
-              tree in the published package digest.
+        <FileSplitPanel
+          tree={tree}
+          treeLoading={treeLoading}
+          selectedPath={selectedPath}
+          onSelect={setSelectedPath}
+          fileContent={
+            filesScope === "shared" && !sharedPresent
+              ? "This Dataset has no shared/ tree in the published package digest."
+              : fileContent
+          }
+          fileLoading={fileLoading}
+          fileNote={
+            filesScope === "shared" && !sharedPresent
+              ? "no shared/"
+              : fileNote
+          }
+          rootPrefix={prefix}
+          headerEnd={
+            <div
+              className="inline-flex rounded-[6px] border border-hairline p-0.5 bg-canvas shrink-0"
+              role="group"
+              aria-label="Files scope"
+            >
+              {(
+                [
+                  ["local", "Local"],
+                  ["shared", "Shared"],
+                ] as const
+              ).map(([id, label]) => (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setFilesScope(id)}
+                  className={cn(
+                    "px-2 py-0.5 text-[11px] rounded-[4px] transition-colors",
+                    filesScope === id
+                      ? "bg-canvas-soft text-ink font-medium shadow-sm"
+                      : "text-mute hover:text-ink",
+                  )}
+                >
+                  {label}
+                </button>
+              ))}
             </div>
-          ) : (
-            <FileSplitPanel
-              tree={tree}
-              treeLoading={treeLoading}
-              selectedPath={selectedPath}
-              onSelect={setSelectedPath}
-              fileContent={fileContent}
-              fileLoading={fileLoading}
-              fileNote={fileNote}
-              rootPrefix={prefix}
-            />
-          )}
-        </div>
+          }
+        />
       ) : null}
 
       {tab === "jobs" ? (

--- a/apps/viewer/src/components/trial/file-split-panel.tsx
+++ b/apps/viewer/src/components/trial/file-split-panel.tsx
@@ -1,5 +1,12 @@
 import { ChevronDown, ChevronRight, Search } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type UIEvent,
+} from "react";
 
 import { FileTypeIcon } from "@/components/file-type-icon";
 import { Input } from "@/components/ui/input";
@@ -10,6 +17,21 @@ import { buildNestedTree, type TreeNode } from "@/lib/file-tree";
 import { cn } from "@/lib/utils";
 
 import { actorLabel, type ActorRow } from "./types";
+
+/** Fixed row height for windowed tree rendering (matches h-7). */
+const ROW_H = 28;
+const OVERSCAN = 16;
+/** Root-level dirs start collapsed (depth 0 = no auto-open). */
+const DEFAULT_OPEN_DEPTH = 0;
+/** Skip heavy token highlight for huge bodies. */
+const HIGHLIGHT_MAX_CHARS = 120_000;
+const PLAIN_PREVIEW_MAX_CHARS = 400_000;
+
+type FlatRow = {
+  key: string;
+  node: TreeNode;
+  depth: number;
+};
 
 function filterTree(nodes: TreeNode[], query: string): TreeNode[] {
   const q = query.trim().toLowerCase();
@@ -46,86 +68,49 @@ function allDirPaths(nodes: TreeNode[], acc: string[] = []): string[] {
   return acc;
 }
 
-function TreeBranch({
-  nodes,
-  depth,
-  selectedPath,
-  onSelect,
-  openDirs,
-  toggleDir,
-}: {
-  nodes: TreeNode[];
-  depth: number;
-  selectedPath: string | null;
-  onSelect: (path: string) => void;
-  openDirs: Set<string>;
-  toggleDir: (path: string) => void;
-}) {
-  return (
-    <ul className={cn(depth === 0 && "pb-2")}>
-      {nodes.map((node) => {
-        if (node.type === "dir") {
-          const open = openDirs.has(node.path);
-          return (
-            <li key={`d:${node.path}`}>
-              <button
-                type="button"
-                onClick={() => toggleDir(node.path)}
-                className={cn(
-                  "w-full flex items-center gap-1 text-left h-7 pr-2 text-[12.5px]",
-                  "text-body hover:bg-row-hover transition-colors rounded-[4px]",
-                )}
-                style={{ paddingLeft: 8 + depth * 12 }}
-                title={node.path}
-              >
-                {open ? (
-                  <ChevronDown className="h-3.5 w-3.5 shrink-0 text-mute" />
-                ) : (
-                  <ChevronRight className="h-3.5 w-3.5 shrink-0 text-mute" />
-                )}
-                <FileTypeIcon name={node.name} kind="dir" expanded={open} />
-                <span className="truncate font-medium">{node.name}</span>
-              </button>
-              {open && node.children && node.children.length > 0 ? (
-                <TreeBranch
-                  nodes={node.children}
-                  depth={depth + 1}
-                  selectedPath={selectedPath}
-                  onSelect={onSelect}
-                  openDirs={openDirs}
-                  toggleDir={toggleDir}
-                />
-              ) : null}
-            </li>
-          );
-        }
-        const selected = selectedPath === node.path;
-        return (
-          <li key={`f:${node.path}`}>
-            <button
-              type="button"
-              onClick={() => onSelect(node.path)}
-              className={cn(
-                "w-full flex items-center gap-1.5 text-left h-7 pr-2 text-[12.5px] truncate transition-colors rounded-[4px]",
-                selected
-                  ? "bg-canvas text-ink font-medium shadow-[inset_0_0_0_1px_var(--color-hairline)]"
-                  : "text-body hover:bg-row-hover",
-              )}
-              style={{ paddingLeft: 8 + depth * 12 + 18 }}
-              title={node.path}
-            >
-              <FileTypeIcon name={node.name} kind="file" />
-              <span className="truncate">{node.name}</span>
-            </button>
-          </li>
-        );
-      })}
-    </ul>
-  );
+function dirPathsUpToDepth(
+  nodes: TreeNode[],
+  maxDepth: number,
+  depth = 0,
+  acc: string[] = [],
+): string[] {
+  if (depth >= maxDepth) return acc;
+  for (const n of nodes) {
+    if (n.type === "dir") {
+      acc.push(n.path);
+      if (n.children) dirPathsUpToDepth(n.children, maxDepth, depth + 1, acc);
+    }
+  }
+  return acc;
+}
+
+function flattenVisible(
+  nodes: TreeNode[],
+  openDirs: Set<string>,
+  depth = 0,
+  out: FlatRow[] = [],
+): FlatRow[] {
+  for (const node of nodes) {
+    out.push({
+      key: `${node.type}:${node.path}`,
+      node,
+      depth,
+    });
+    if (
+      node.type === "dir" &&
+      openDirs.has(node.path) &&
+      node.children &&
+      node.children.length > 0
+    ) {
+      flattenVisible(node.children, openDirs, depth + 1, out);
+    }
+  }
+  return out;
 }
 
 /**
  * Left nested file tree (Hub-style) + right code preview.
+ * Windowed tree rows + collapsed-by-default dirs for large evidence archives.
  * Preserves multi-role virtual profile grouping when groupByProfile is on.
  */
 export function FileSplitPanel({
@@ -185,7 +170,11 @@ export function FileSplitPanel({
             (e) => (e.profile_id || "__ungrouped__") === key,
           );
           const nested = buildNestedTree(
-            groupFiles.map((e) => ({ path: e.path, type: "file", size: e.size ?? 0 })),
+            groupFiles.map((e) => ({
+              path: e.path,
+              type: "file",
+              size: e.size ?? 0,
+            })),
           );
           const label =
             key === "__ungrouped__"
@@ -216,9 +205,14 @@ export function FileSplitPanel({
   );
   const [openDirs, setOpenDirs] = useState<Set<string>>(() => new Set());
   const [query, setQuery] = useState("");
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportH, setViewportH] = useState(420);
 
   useEffect(() => {
-    setOpenDirs(new Set(allDirPaths(nestedRoots)));
+    setOpenDirs(new Set(dirPathsUpToDepth(nestedRoots, DEFAULT_OPEN_DEPTH)));
+    setScrollTop(0);
+    if (scrollRef.current) scrollRef.current.scrollTop = 0;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- treeKey is the intentional dep
   }, [treeKey]);
 
@@ -231,8 +225,37 @@ export function FileSplitPanel({
   useEffect(() => {
     if (query.trim()) {
       setOpenDirs(new Set(allDirPaths(visibleTree)));
+    } else {
+      setOpenDirs(new Set(dirPathsUpToDepth(nestedRoots, DEFAULT_OPEN_DEPTH)));
     }
-  }, [query, visibleTree]);
+  }, [query, visibleTree, nestedRoots]);
+
+  const flatRows = useMemo(
+    () => flattenVisible(visibleTree, openDirs),
+    [visibleTree, openDirs],
+  );
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const measure = () => setViewportH(el.clientHeight || 420);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [treeLoading, flatRows.length]);
+
+  const onScroll = useCallback((e: UIEvent<HTMLDivElement>) => {
+    setScrollTop(e.currentTarget.scrollTop);
+  }, []);
+
+  const totalH = flatRows.length * ROW_H;
+  const visibleCount = Math.ceil(viewportH / ROW_H) + OVERSCAN * 2;
+  const startIdx = Math.max(0, Math.floor(scrollTop / ROW_H) - OVERSCAN);
+  const endIdx = Math.min(flatRows.length, startIdx + visibleCount);
+  const slice = flatRows.slice(startIdx, endIdx);
+  const padTop = startIdx * ROW_H;
+  const padBottom = Math.max(0, totalH - padTop - slice.length * ROW_H);
 
   function toggleDir(path: string) {
     setOpenDirs((prev) => {
@@ -246,6 +269,16 @@ export function FileSplitPanel({
   const selectedName = selectedPath
     ? selectedPath.split("/").pop() || selectedPath
     : null;
+
+  const previewTooLarge =
+    fileContent != null && fileContent.length > HIGHLIGHT_MAX_CHARS;
+  const previewDisplay =
+    fileContent == null
+      ? null
+      : fileContent.length > PLAIN_PREVIEW_MAX_CHARS
+        ? fileContent.slice(0, PLAIN_PREVIEW_MAX_CHARS) +
+          `\n\n… truncated for preview (${fileContent.length.toLocaleString()} chars total)`
+        : fileContent;
 
   return (
     <div
@@ -282,22 +315,83 @@ export function FileSplitPanel({
             />
           </div>
         </div>
-        <div className="flex-1 overflow-y-auto px-1 pt-1">
+        <div
+          ref={scrollRef}
+          className="flex-1 overflow-y-auto px-1 pt-1"
+          onScroll={onScroll}
+        >
           {treeLoading ? (
             <p className="text-xs text-mute p-3">Loading tree…</p>
-          ) : visibleTree.length === 0 ? (
+          ) : flatRows.length === 0 ? (
             <p className="text-xs text-mute p-3">
               {query.trim() ? "No matches." : "No files in this scope."}
             </p>
           ) : (
-            <TreeBranch
-              nodes={visibleTree}
-              depth={0}
-              selectedPath={selectedPath}
-              onSelect={onSelect}
-              openDirs={openDirs}
-              toggleDir={toggleDir}
-            />
+            <div style={{ height: totalH, position: "relative" }}>
+              <div style={{ height: padTop }} aria-hidden />
+              <ul className="m-0 p-0 list-none">
+                {slice.map((row) => {
+                  const { node, depth } = row;
+                  if (node.type === "dir") {
+                    const open = openDirs.has(node.path);
+                    return (
+                      <li key={row.key} style={{ height: ROW_H }}>
+                        <button
+                          type="button"
+                          onClick={() => toggleDir(node.path)}
+                          className={cn(
+                            "w-full flex items-center gap-1 text-left h-7 pr-2 text-[12.5px]",
+                            "text-body hover:bg-row-hover transition-colors rounded-[4px]",
+                          )}
+                          style={{ paddingLeft: 8 + depth * 12 }}
+                          title={node.path}
+                        >
+                          {open ? (
+                            <ChevronDown className="h-3.5 w-3.5 shrink-0 text-mute" />
+                          ) : (
+                            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-mute" />
+                          )}
+                          <FileTypeIcon
+                            name={node.name}
+                            kind="dir"
+                            expanded={open}
+                          />
+                          <span className="truncate font-medium">
+                            {node.name}
+                          </span>
+                          {node.children && node.children.length > 0 ? (
+                            <span className="ml-auto pl-1 text-[10px] tabular-nums text-mute shrink-0">
+                              {node.children.length}
+                            </span>
+                          ) : null}
+                        </button>
+                      </li>
+                    );
+                  }
+                  const selected = selectedPath === node.path;
+                  return (
+                    <li key={row.key} style={{ height: ROW_H }}>
+                      <button
+                        type="button"
+                        onClick={() => onSelect(node.path)}
+                        className={cn(
+                          "w-full flex items-center gap-1.5 text-left h-7 pr-2 text-[12.5px] truncate transition-colors rounded-[4px]",
+                          selected
+                            ? "bg-canvas text-ink font-medium shadow-[inset_0_0_0_1px_var(--color-hairline)]"
+                            : "text-body hover:bg-row-hover",
+                        )}
+                        style={{ paddingLeft: 8 + depth * 12 + 18 }}
+                        title={node.path}
+                      >
+                        <FileTypeIcon name={node.name} kind="file" />
+                        <span className="truncate">{node.name}</span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+              <div style={{ height: padBottom }} aria-hidden />
+            </div>
           )}
         </div>
       </aside>
@@ -323,7 +417,17 @@ export function FileSplitPanel({
               {fileNote ? (
                 <p className="text-xs text-mute px-3 pt-2">{fileNote}</p>
               ) : null}
-              {fileContent != null ? (
+              {previewTooLarge && fileContent != null ? (
+                <p className="text-xs text-mute px-3 pt-2">
+                  Large file ({fileContent.length.toLocaleString()} chars) —
+                  plain preview without highlighting
+                  {fileContent.length > PLAIN_PREVIEW_MAX_CHARS
+                    ? `, first ${PLAIN_PREVIEW_MAX_CHARS.toLocaleString()} chars`
+                    : ""}
+                  .
+                </p>
+              ) : null}
+              {previewDisplay != null ? (
                 <pre
                   className={cn(
                     "m-0 p-3 min-h-full overflow-auto",
@@ -332,7 +436,14 @@ export function FileSplitPanel({
                   )}
                 >
                   <code className="font-mono">
-                    <CodeHighlight path={selectedPath} content={fileContent} />
+                    {previewTooLarge ? (
+                      <span className="text-shell-plain">{previewDisplay}</span>
+                    ) : (
+                      <CodeHighlight
+                        path={selectedPath}
+                        content={previewDisplay}
+                      />
+                    )}
                   </code>
                 </pre>
               ) : (

--- a/apps/viewer/src/lib/code-highlight.tsx
+++ b/apps/viewer/src/lib/code-highlight.tsx
@@ -183,6 +183,9 @@ export function preparePreview(
   return { lang: "text", text: content };
 }
 
+/** Skip tokenization for huge bodies (caller may also pre-truncate). */
+const HIGHLIGHT_MAX_CHARS = 120_000;
+
 export function CodeHighlight({
   path,
   content,
@@ -190,6 +193,10 @@ export function CodeHighlight({
   path?: string | null;
   content: string;
 }): ReactNode {
+  if (content.length > HIGHLIGHT_MAX_CHARS) {
+    return <span className="text-shell-plain">{content}</span>;
+  }
+
   const { lang, text } = preparePreview(path, content);
 
   if (lang === "text") {

--- a/docs/design/02-task-package-and-config.md
+++ b/docs/design/02-task-package-and-config.md
@@ -168,6 +168,7 @@ Task 成员目录 **一级目录只允许从已知集合取用**；除固定根�
 5. **同名冲突（硬失败）：** `shared/lib/` 与任一 `tasks/<id>/lib/` 的 **top-level import 名**（顶层 `.py` 去后缀、或顶层包目录名）**禁止碰撞**。Config/lock 校验 fail closed；作者 skill 必须提示；检测脚本作验收门槛。
 6. **L1 / 镜像：** Core **禁止** 隐式把 `shared/` COPY 进 Attempt 镜像或默认塞进 build context。若容器内需要 `shared/` 内容，由 **task 级** `environment/` Dockerfile（或包内镜像配方）**显式** `COPY`。无静默 Core copy。
 7. **无 shared sub-digest：** Registry 不维护单独的 shared digest；整包 `packageDigest` 已覆盖 `shared/**`。
+8. **证据等级：** 存在 `shared/`、digest 包含 `shared/**`、或 Hub Shared UI **不**抬高证据等级；仍按公开 smoke / Issue 验收声明 `runnable-mvp` / `isolated` 等。
 
 **`shared/lib` vs task `lib/`：**
 

--- a/docs/design/02-task-package-and-config.md
+++ b/docs/design/02-task-package-and-config.md
@@ -40,6 +40,10 @@ my-database/                      # Database 根（CLI path）
 ├── env.example                   # 文档化 credential locator 名（无密钥）
 ├── .env                          # 本机密钥（gitignore；永不 publish/upload）
 ├── README.md                     # suite 级说明（可选）
+├── shared/                       # 可选；跨 task 共享（#65；见下节）
+│   ├── lib/                      # Harness/Evaluator import only
+│   ├── assets/                   # 只读领域数据（代码路径读取）
+│   └── README.md
 └── tasks/
     ├── task-a/
     │   ├── task.yaml             # format: bora.task/1；角色槽 + intent；无 entry/model
@@ -142,6 +146,37 @@ Task 成员目录 **一级目录只允许从已知集合取用**；除固定根�
 未满足条件的逻辑留在 `lib/` 或 harness 入口文件。没有真·上游 vendoring 的 task **不要**硬造空的 `upstream/`。
 
 `lib/` 内部可用二级目录（如 `lib/tools/diagnostics.py`），但 **不要** 为每个模块再开一级 package 目录（禁止并列出现 `diagnostics/`、`tools/`、`utils/`、`helpers/` 作为一级）。
+
+#### Dataset 级 `shared/`（#65）
+
+同构多 task Dataset 可在 **Database 根** 放可选 `shared/`，避免把同一 bridge / 领域资产复制进每个 `tasks/<id>/lib/`。这是 BORA 显式增强，**不是** Harbor 布局 parity。
+
+**规范子树（v1）：**
+
+| 路径 | 角色 | 默认可见性 |
+| --- | --- | --- |
+| `shared/lib/` | 跨 task Python 支撑（import only） | Runtime 为 Harness **与** Evaluator 注入 import path；**不**默认投影到 Agent workspace |
+| `shared/assets/` | 只读领域数据（db / policy / fixtures） | Harness/Evaluator 用 **代码路径** 读取；v1 **无** `task.yaml` 资产声明面 |
+| `shared/README.md` | 给人读的共享区说明 | 非 Runtime 输入 |
+
+**硬规则：**
+
+1. **Digest / publish：** 若 `shared/` 存在，其下文件 **必须** 进入 `member_paths_for_digest` 与 publish blob（与 `tasks/**` 同算法过滤 `__pycache__` / 多数隐藏文件）。改 `shared/` ⇒ 改整包 `packageDigest`。无 `shared/` 的包行为与今日一致。
+2. **Import：** L0 worker 默认把 `shared/lib` 注入 PYTHONPATH（或等价 `sys.path`）；Harness 与 Evaluator 均可 `import`。**禁止**依赖 host 绝对路径。
+3. **Agent 可见性：** 默认 **不** mount / 不投影 `shared/` 到 Agent workspace。可选 `shared/assets` Agent mount 为后续能力，不在 v1 默认路径。
+4. **禁区：** `shared/` 下 **禁止** evaluation gold、host secrets（如 `.env`）、Docker socket 绑定物等。Gold **只** 在成员 `evaluation/`。
+5. **同名冲突（硬失败）：** `shared/lib/` 与任一 `tasks/<id>/lib/` 的 **top-level import 名**（顶层 `.py` 去后缀、或顶层包目录名）**禁止碰撞**。Config/lock 校验 fail closed；作者 skill 必须提示；检测脚本作验收门槛。
+6. **L1 / 镜像：** Core **禁止** 隐式把 `shared/` COPY 进 Attempt 镜像或默认塞进 build context。若容器内需要 `shared/` 内容，由 **task 级** `environment/` Dockerfile（或包内镜像配方）**显式** `COPY`。无静默 Core copy。
+7. **无 shared sub-digest：** Registry 不维护单独的 shared digest；整包 `packageDigest` 已覆盖 `shared/**`。
+
+**`shared/lib` vs task `lib/`：**
+
+| 放哪里 | 何时 |
+| --- | --- |
+| `shared/lib/` | 多 task 共用的 bridge、领域工具、稳定 glue |
+| `tasks/<id>/lib/` | 仅该 task 的扩展；名字不得与 `shared/lib` top-level 冲突 |
+
+**资产引用：** v1 仅代码路径（例如相对 Database 根的 `shared/assets/...`，或 Runtime 注入的 database root + 相对路径）。不增加 `task.yaml` 声明语法。
 
 #### 文本分层：README、prompts 与 runtime payload
 
@@ -572,7 +607,7 @@ provenance:
 
 ## Database Registry 分发
 
-**Release 单位 = Database 整包**（根 `bora.yaml` + 全部 `tasks/**`）。Registry 是独立服务（`services/registry/`），不进入 Core 五组。
+**Release 单位 = Database 整包**（根 `bora.yaml` + 可选 `shared/**` + 全部 `tasks/**`）。Registry 是独立服务（`services/registry/`），不进入 Core 五组。
 
 ### PackageRef
 

--- a/scripts/check_shared_lib_collisions.py
+++ b/scripts/check_shared_lib_collisions.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Acceptance gate: Dataset shared/lib vs task lib top-level name collisions (#65).
+
+Usage::
+
+    uv run python scripts/check_shared_lib_collisions.py <database-root> [...]
+    uv run python scripts/check_shared_lib_collisions.py examples/core
+
+Exit codes:
+  0 — no shared/ or no collisions / forbidden paths
+  1 — collision or forbidden shared/ layout
+  2 — usage / invalid path
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail closed when shared/lib collides with task lib top-level names (#65)."
+    )
+    parser.add_argument(
+        "database_roots",
+        nargs="+",
+        type=Path,
+        help="Database root(s) containing bora.yaml",
+    )
+    args = parser.parse_args(argv)
+
+    # Prefer installed package when run via uv/repo root.
+    repo = Path(__file__).resolve().parents[1]
+    src = repo / "src"
+    if src.is_dir() and str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+
+    from bora.config.errors import ConfigError
+    from bora.config.shared import find_lib_collisions, validate_shared_layout
+
+    failed = 0
+    for raw in args.database_roots:
+        root = raw.expanduser().resolve(strict=False)
+        if not (root / "bora.yaml").is_file():
+            print(f"FAIL {root}: missing bora.yaml", file=sys.stderr)
+            failed += 1
+            continue
+        try:
+            validate_shared_layout(root)
+        except ConfigError as exc:
+            print(f"FAIL {root}: {exc.message} ({exc.location})", file=sys.stderr)
+            failed += 1
+            continue
+        hits = find_lib_collisions(root)
+        if hits:
+            # validate_shared_layout should have raised; belt-and-suspenders.
+            for name, shared_loc, task_loc in hits:
+                print(
+                    f"FAIL {root}: collision {name!r} in {shared_loc} and {task_loc}",
+                    file=sys.stderr,
+                )
+            failed += 1
+            continue
+        shared = root / "shared"
+        if shared.is_dir():
+            print(f"OK   {root}: shared/ present, no lib collisions")
+        else:
+            print(f"OK   {root}: no shared/ (noop)")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/python/src/bora_sdk/context.py
+++ b/sdk/python/src/bora_sdk/context.py
@@ -57,6 +57,8 @@ class HarnessContext:
     scope: RunScope
     workspace_root: Path
     artifact_dir: Path
+    # Database root when known (#65): code-path access to shared/assets (not Agent mount).
+    database_root: Path | None = None
     _closed: bool = False
     _published: dict[str, Path] | None = None
 

--- a/services/registry/app.py
+++ b/services/registry/app.py
@@ -1199,7 +1199,10 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 _json_response(self, 404, {"error": "not_found", "message": "blob missing"})
                 return
             try:
-                data, size = read_member(archive, safe_path, max_bytes=MAX_FILE_BYTES)
+                # Hub preview: oversize members return a truncated head (not 413).
+                data, size, truncated = read_member(
+                    archive, safe_path, max_bytes=MAX_FILE_BYTES, allow_truncate=True
+                )
             except PackagePathError as exc:
                 _json_response(
                     self,
@@ -1230,7 +1233,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                     },
                 )
                 return
-            payload = file_payload(safe_path, data, size=size, truncated=False)
+            payload = file_payload(safe_path, data, size=size, truncated=truncated)
             _json_response(self, 200, payload)
 
         # ---- results -----------------------------------------------------
@@ -1507,7 +1510,9 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 _json_response(self, 404, {"error": "not_found", "message": "blob missing"})
                 return
             try:
-                data, size = read_member(archive, safe_path, max_bytes=MAX_FILE_BYTES)
+                data, size, truncated = read_member(
+                    archive, safe_path, max_bytes=MAX_FILE_BYTES, allow_truncate=True
+                )
             except PackagePathError as exc:
                 _json_response(
                     self,
@@ -1535,7 +1540,7 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                     },
                 )
                 return
-            payload = file_payload(safe_path, data, size=size, truncated=False)
+            payload = file_payload(safe_path, data, size=size, truncated=truncated)
             _json_response(self, 200, payload)
 
         # ---- suite results -----------------------------------------------

--- a/services/registry/package_files.py
+++ b/services/registry/package_files.py
@@ -151,8 +151,13 @@ def read_member(
     path: str,
     *,
     max_bytes: int = MAX_FILE_BYTES,
-) -> tuple[bytes, int]:
-    """Return ``(content, size)`` for a file member.
+    allow_truncate: bool = True,
+) -> tuple[bytes, int, bool]:
+    """Return ``(content, full_size, truncated)`` for a file member.
+
+    When *allow_truncate* is True (Hub preview default), oversize members return
+    the first *max_bytes* with ``truncated=True`` instead of failing closed.
+    Set *allow_truncate* False to raise :class:`PackageFileTooLarge`.
 
     Raises
     ------
@@ -161,7 +166,7 @@ def read_member(
     PackageFileNotFound
         Missing or directory.
     PackageFileTooLarge
-        Size exceeds *max_bytes* (checked via tar header before full read when possible).
+        Size exceeds *max_bytes* and *allow_truncate* is False.
     """
     safe = normalize_package_path(path)
     with (
@@ -178,15 +183,27 @@ def read_member(
         if not info.isfile():
             raise PackageFileNotFound(safe)
         size = int(info.size)
-        if size > max_bytes:
+        if size > max_bytes and not allow_truncate:
             raise PackageFileTooLarge(safe, size)
         f = tar.extractfile(info)
         if f is None:
             raise PackageFileNotFound(safe)
-        data = f.read(max_bytes + 1)
-        if len(data) > max_bytes:
-            raise PackageFileTooLarge(safe, len(data))
-        return data, size
+        # Read at most max_bytes for preview; full size still reported via *size*.
+        data = f.read(max_bytes)
+        truncated = size > len(data)
+        if truncated and not allow_truncate:
+            raise PackageFileTooLarge(safe, size)
+        # Avoid cutting mid UTF-8 code unit so Hub can show text previews.
+        if truncated and data:
+            for drop in range(0, min(4, len(data))):
+                chunk = data if drop == 0 else data[:-drop]
+                try:
+                    chunk.decode("utf-8")
+                    data = chunk
+                    break
+                except UnicodeDecodeError:
+                    continue
+        return data, size, truncated
 
 
 def content_type_for_path(path: str) -> str:

--- a/skills/bora-config-package/SKILL.md
+++ b/skills/bora-config-package/SKILL.md
@@ -27,6 +27,10 @@ my-database/                 # CLI path (bora.database/1)
 ├── profiles.yaml            # job binding defaults (role id → entry/model/locator)
 ├── env.example              # documented credential locator names only
 ├── .env                     # local secrets (gitignore; never publish)
+├── shared/                  # optional Dataset-level share (#65)
+│   ├── lib/                 # import only (Harness + Evaluator PYTHONPATH)
+│   ├── assets/              # read-only domain data via code paths
+│   └── README.md
 └── tasks/
     └── my-task/             # task_id == directory name
         ├── task.yaml        # bora.task/1 — role slots + intent (no entry/model)
@@ -34,8 +38,33 @@ my-database/                 # CLI path (bora.database/1)
         ├── evaluator.py
         ├── environment/     # optional seed.sql; Docker L1 needs Dockerfile
         ├── evaluation/      # gold / hidden — not for Agent mount
-        ├── lib/
+        ├── lib/             # task-only; MUST NOT collide with shared/lib names
         └── data/
+```
+
+### Dataset `shared/` (when multi-task reuse)
+
+| Put in… | Use for |
+| --- | --- |
+| `shared/lib/` | Bridge / domain glue **shared by many tasks** |
+| `tasks/<id>/lib/` | **Only this task** extensions |
+| `shared/assets/` | Read-only fixtures/policies via **code paths** (no `task.yaml` asset declaration) |
+| `tasks/<id>/evaluation/` | Gold only — **never** under `shared/` |
+
+**Hard rules agents must respect:**
+
+1. **No top-level import name collision** between `shared/lib/` and any `tasks/*/lib/`
+   (e.g. both cannot define `bridge.py` or package dir `bridge/`). Lock **hard-fails**.
+2. Before adding modules, list both trees; prefer unique prefixes (`airline_bridge` vs task-local).
+3. Changing `shared/` changes whole-package `packageDigest` (no separate shared sub-digest).
+4. Core does **not** auto-COPY `shared/` into L1 images — task `environment/Dockerfile` must
+   `COPY` explicitly if the container needs those files.
+5. Default: `shared/` is **not** mounted into the Agent workspace (Harness/Evaluator only).
+
+**Acceptance gate (run before claiming package OK):**
+
+```bash
+uv run python scripts/check_shared_lib_collisions.py <database-root>
 ```
 
 ## Minimal Database `bora.yaml`

--- a/skills/bora-config-package/references/isolation.md
+++ b/skills/bora-config-package/references/isolation.md
@@ -19,8 +19,18 @@
 - Coding agents on L1: `executor: acp` + `options.entry`; parent ACP client +
   `docker exec` placement — no private CLI scrape.
 
+## Dataset `shared/` (#65)
+
+- `shared/lib` is for Harness/Evaluator import only — **not** default Agent mount.
+- Gold stays under `tasks/*/evaluation/` only; **forbid** gold / `.env` under `shared/`.
+- L1: no Core implicit COPY of `shared/`; task `environment/Dockerfile` owns any `COPY`.
+- Collision: `shared/lib` vs `tasks/*/lib` top-level names → lock fail. Check with
+  `uv run python scripts/check_shared_lib_collisions.py <database-root>`.
+
 ## Do not
 
 - Rely on “delete field from yaml” as isolation.
 - Mount gold into harness “for convenience”.
 - Put credentials in package tree.
+- Put evaluation gold or host secrets under Database-root `shared/`.
+- Reuse the same top-level module name in `shared/lib` and a task `lib/`.

--- a/src/bora/application/run_command.py
+++ b/src/bora/application/run_command.py
@@ -289,6 +289,7 @@ async def run_task(
             agent_service_sock=str(agent_sock_path) if agent_sock_path else None,
             # Reuse ParentAgentService identity so AgentSession + harness share one Attempt.
             attempt=shared_attempt,
+            database_root=resolved.database_root,
         )
         timer.add_ms("run", (_mono() - run_t0) * 1000.0)
     finally:
@@ -362,7 +363,12 @@ async def run_task(
 
     evaluator_raw: dict[str, Any] | None = None
     if error_phase is None:
-        evaluator_raw = run_evaluator_worker(package_root, lock, artifacts_map)
+        evaluator_raw = run_evaluator_worker(
+            package_root,
+            lock,
+            artifacts_map,
+            database_root=resolved.database_root,
+        )
     timer.add_ms("evaluate", (_mono() - eval_t0) * 1000.0)
 
     # Cleanup agent materialization

--- a/src/bora/application/run_command_evaluator.py
+++ b/src/bora/application/run_command_evaluator.py
@@ -15,19 +15,31 @@ def run_evaluator_worker(
     package_root: Path,
     lock: Any,
     artifacts_map: dict[str, str],
+    *,
+    database_root: Path | None = None,
 ) -> dict[str, Any]:
     """Run package evaluator in a dedicated subprocess (not parent import)."""
     _ = lock  # reserved for future lock-scoped evaluator options
     path = package_root / "evaluator.py"
     if not path.is_file():
         return {"status": "ERROR", "score": None, "metrics": {}}
+    # #65: inject task root + optional shared/lib (same contract as harness worker).
+    path_entries: list[str] = [str(package_root.resolve())]
+    if database_root is not None:
+        shared_lib = database_root.resolve() / "shared" / "lib"
+        if shared_lib.is_dir():
+            path_entries.insert(0, str(shared_lib))
+    path_inject = repr(path_entries)
     with tempfile.TemporaryDirectory(prefix="bora-eval-") as tmp:
         script = Path(tmp) / "run_eval.py"
         out_path = Path(tmp) / "out.json"
         script.write_text(
             "\n".join(
                 [
-                    "import json, importlib.util",
+                    "import json, importlib.util, sys",
+                    f"for _p in {path_inject}:",
+                    "    if _p not in sys.path:",
+                    "        sys.path.insert(0, _p)",
                     f"spec = importlib.util.spec_from_file_location('ev', {str(path)!r})",
                     "mod = importlib.util.module_from_spec(spec)",
                     "assert spec.loader is not None",
@@ -38,13 +50,16 @@ def run_evaluator_worker(
             ),
             encoding="utf-8",
         )
+        child_env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin")}
+        if database_root is not None:
+            child_env["BORA_DATABASE_ROOT"] = str(database_root.resolve())
         proc = subprocess.run(
             [sys.executable, str(script)],
             check=False,
             capture_output=True,
             text=True,
             timeout=60,
-            env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+            env=child_env,
         )
         if proc.returncode != 0 or not out_path.is_file():
             return {

--- a/src/bora/application/run_harness.py
+++ b/src/bora/application/run_harness.py
@@ -55,6 +55,7 @@ async def run_harness_package(
     agent_service_sock: str | None = None,
     attempt: AttemptIdentity | None = None,
     workspace_root: Path | None = None,
+    database_root: Path | None = None,
 ) -> dict[str, Any]:
     """Start task worker under L0 Provider and return terminal envelope.
 
@@ -68,6 +69,9 @@ async def run_harness_package(
 
     *workspace_root* defaults to *package_root*. L1 SDK path may point it at the
     Attempt host workspace so harness can read agent-written files.
+
+    *database_root* is the Database root (optional). When set, the worker injects
+    ``shared/lib`` on ``sys.path`` and exposes it for code-path asset reads (#65).
     """
     factory = identity_factory or IdentityFactory()
     if attempt is not None:
@@ -92,6 +96,7 @@ async def run_harness_package(
         work_base.mkdir()
 
         ws_root = (workspace_root or package_root).resolve()
+        db_root = database_root.resolve() if database_root is not None else None
         launch = {
             "package_root": str(package_root.resolve()),
             "workspace_root": str(ws_root),
@@ -102,6 +107,8 @@ async def run_harness_package(
             "run_id": run.value,
             "artifact_dir": str(artifact_dir),
         }
+        if db_root is not None:
+            launch["database_root"] = str(db_root)
 
         provider = LocalProcessProvider()
         env = {

--- a/src/bora/application/run_l1.py
+++ b/src/bora/application/run_l1.py
@@ -302,6 +302,8 @@ def run_l1_sdk_session_attempt(
             harness_timeout = float(params.get("harness_timeout_seconds") or 360.0)
             if wall_s > 0:
                 harness_timeout = min(harness_timeout, wall_s)
+            from bora.config.shared import infer_database_root_from_task
+
             harness_coro = run_harness_package(
                 lock,
                 package_root,
@@ -309,6 +311,7 @@ def run_l1_sdk_session_attempt(
                 agent_service_sock=str(short),
                 attempt=attempt_ident,
                 workspace_root=workspace_host,
+                database_root=infer_database_root_from_task(package_root),
             )
             # run_task is already async; nest safely without asyncio.run in-loop.
             try:

--- a/src/bora/config/__init__.py
+++ b/src/bora/config/__init__.py
@@ -11,6 +11,7 @@ from bora.config.database import (
 from bora.config.errors import ConfigError
 from bora.config.load_and_lock import ConfigCore
 from bora.config.model import LockedTaskConfig, LockSummary
+from bora.config.shared import find_lib_collisions, validate_shared_layout
 
 __all__ = [
     "ConfigCore",
@@ -19,8 +20,10 @@ __all__ = [
     "LockSummary",
     "LockedTaskConfig",
     "ResolvedTask",
+    "find_lib_collisions",
     "list_tasks",
     "load_database_manifest",
     "member_paths_for_digest",
     "resolve_task",
+    "validate_shared_layout",
 ]

--- a/src/bora/config/database.py
+++ b/src/bora/config/database.py
@@ -435,14 +435,30 @@ def resolve_task(
     )
 
 
+def _digest_member_file(root: Path, file_path: Path) -> str | None:
+    """Return package-relative posix path if *file_path* should enter packageDigest."""
+    if not file_path.is_file():
+        return None
+    # Skip interpreter caches / most hidden files (design/02 digest notes).
+    if "__pycache__" in file_path.parts or file_path.name.endswith(".pyc"):
+        return None
+    if file_path.name.startswith(".") and file_path.name not in {".gitignore"}:
+        return None
+    try:
+        return file_path.relative_to(root).as_posix()
+    except ValueError:
+        return None
+
+
 def member_paths_for_digest(
     database_root: Path, *, manifest: DatabaseManifest | None = None
 ) -> list[str]:
-    """Stable ordered package-relative paths for suite digest input (Spec 21).
+    """Stable ordered package-relative paths for suite digest input.
 
     Returns posix-relative paths under the database root: root ``bora.yaml``,
-    optional job-binding / env docs (``profiles.yaml``, ``env.example``), plus
-    every file under each member directory, sorted. Does not compute hashes.
+    optional job-binding / env docs (``profiles.yaml``, ``env.example``,
+    ``README.md``), optional Dataset-level ``shared/**`` (#65), plus every file
+    under each member directory, sorted. Does not compute hashes.
     Secrets (``.env``) are never included.
     """
     root = database_root.expanduser().resolve(strict=False)
@@ -453,19 +469,17 @@ def member_paths_for_digest(
     for name in ("profiles.yaml", "env.example", "README.md"):
         if (root / name).is_file():
             paths.append(name)
+    # #65 Dataset-level shared tree (if present) enters packageDigest / publish.
+    shared_dir = root / "shared"
+    if shared_dir.is_dir():
+        for file_path in sorted(shared_dir.rglob("*")):
+            rel = _digest_member_file(root, file_path)
+            if rel is not None:
+                paths.append(rel)
     for tid in task_ids:
         task_dir = root / man.tasks_root / tid
         for file_path in sorted(task_dir.rglob("*")):
-            if not file_path.is_file():
-                continue
-            # Skip interpreter caches / most hidden files (Spec 21 may refine).
-            if "__pycache__" in file_path.parts or file_path.name.endswith(".pyc"):
-                continue
-            if file_path.name.startswith(".") and file_path.name not in {".gitignore"}:
-                continue
-            try:
-                rel = file_path.relative_to(root).as_posix()
-            except ValueError:
-                continue
-            paths.append(rel)
+            rel = _digest_member_file(root, file_path)
+            if rel is not None:
+                paths.append(rel)
     return paths

--- a/src/bora/config/load_and_lock.py
+++ b/src/bora/config/load_and_lock.py
@@ -98,6 +98,16 @@ class ConfigCore:
 
         validate_top_level_layout(self._reader, root)
 
+        # #65 Dataset shared/ bans + shared/lib vs task lib collision (when Database root known).
+        from bora.config.shared import infer_database_root_from_task, validate_shared_layout
+
+        db_root = infer_database_root_from_task(root)
+        if db_root is not None:
+            from bora.config.database import load_database_manifest
+
+            man = load_database_manifest(db_root)
+            validate_shared_layout(db_root, tasks_root=man.tasks_root)
+
         if not self._reader.exists(root, "task.yaml"):
             raise ConfigError(
                 ERROR_INVALID_PACKAGE,

--- a/src/bora/config/shared.py
+++ b/src/bora/config/shared.py
@@ -29,13 +29,14 @@ def shared_lib_dir(database_root: Path) -> Path:
 def infer_database_root_from_task(task_dir: Path) -> Path | None:
     """Best-effort Database root from a member task directory.
 
-    Standard layout: ``<database_root>/<tasks_root>/<task_id>/``. When the
-    grandparent contains ``bora.yaml``, treat it as the Database root.
+    Walks ancestors until a ``bora.yaml`` is found (supports nested
+    ``tasks.root``, e.g. ``members/group/<task_id>``).
     """
-    task_dir = task_dir.expanduser().resolve(strict=False)
-    candidate = task_dir.parent.parent
-    if (candidate / "bora.yaml").is_file():
-        return candidate
+    cur = task_dir.expanduser().resolve(strict=False)
+    # Do not treat the task dir itself as the Database root.
+    for parent in cur.parents:
+        if (parent / "bora.yaml").is_file():
+            return parent
     return None
 
 

--- a/src/bora/config/shared.py
+++ b/src/bora/config/shared.py
@@ -1,0 +1,160 @@
+"""Dataset-level ``shared/`` layout helpers (#65).
+
+Design authority: ``docs/design/02-task-package-and-config.md`` (Dataset 级 shared/).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bora.config.errors import ERROR_INVALID_PACKAGE, ConfigError
+
+# Top-level names under shared/ that must not exist (ban gold/secrets confusion).
+_FORBIDDEN_SHARED_TOP_LEVEL = frozenset(
+    {
+        "evaluation",  # gold lives only under tasks/*/evaluation/
+        ".env",
+    }
+)
+
+
+def shared_dir(database_root: Path) -> Path:
+    return database_root.expanduser().resolve(strict=False) / "shared"
+
+
+def shared_lib_dir(database_root: Path) -> Path:
+    return shared_dir(database_root) / "lib"
+
+
+def infer_database_root_from_task(task_dir: Path) -> Path | None:
+    """Best-effort Database root from a member task directory.
+
+    Standard layout: ``<database_root>/<tasks_root>/<task_id>/``. When the
+    grandparent contains ``bora.yaml``, treat it as the Database root.
+    """
+    task_dir = task_dir.expanduser().resolve(strict=False)
+    candidate = task_dir.parent.parent
+    if (candidate / "bora.yaml").is_file():
+        return candidate
+    return None
+
+
+def top_level_import_names(lib_dir: Path) -> set[str]:
+    """Top-level Python import names under a ``lib/`` directory.
+
+    Collects bare module stems (``foo.py`` → ``foo``) and package directories
+    that contain ``__init__.py`` or any nested content used as a namespace.
+    Skips ``__pycache__`` and private ``_*`` only when they are not importable
+    packages authors would deliberately share — ``_*`` names are still checked
+    if present as modules (collision risk is real).
+    """
+    if not lib_dir.is_dir():
+        return set()
+    names: set[str] = set()
+    for child in lib_dir.iterdir():
+        if child.name == "__pycache__" or child.name.endswith(".pyc"):
+            continue
+        if child.name.startswith("."):
+            continue
+        if child.is_file() and child.suffix == ".py":
+            if child.name == "__init__.py":
+                continue
+            names.add(child.stem)
+        elif child.is_dir():
+            # Treat any non-cache directory as an importable package name.
+            names.add(child.name)
+    return names
+
+
+def collect_shared_lib_names(database_root: Path) -> set[str]:
+    return top_level_import_names(shared_lib_dir(database_root))
+
+
+def collect_task_lib_names(task_dir: Path) -> set[str]:
+    return top_level_import_names(task_dir / "lib")
+
+
+def find_lib_collisions(
+    database_root: Path,
+    *,
+    tasks_root: str = "tasks",
+    task_ids: list[str] | None = None,
+) -> list[tuple[str, str, str]]:
+    """Return collision triples ``(name, shared, tasks/<id>/lib)``.
+
+    Empty list means no top-level import name clashes.
+    """
+    root = database_root.expanduser().resolve(strict=False)
+    shared_names = collect_shared_lib_names(root)
+    if not shared_names:
+        return []
+
+    if task_ids is None:
+        tasks_dir = root / tasks_root
+        if not tasks_dir.is_dir():
+            return []
+        task_ids = sorted(
+            p.name for p in tasks_dir.iterdir() if p.is_dir() and not p.name.startswith(".")
+        )
+
+    collisions: list[tuple[str, str, str]] = []
+    for tid in task_ids:
+        task_names = collect_task_lib_names(root / tasks_root / tid)
+        for name in sorted(shared_names & task_names):
+            collisions.append((name, "shared/lib", f"{tasks_root}/{tid}/lib"))
+    return collisions
+
+
+def validate_shared_layout(
+    database_root: Path,
+    *,
+    tasks_root: str = "tasks",
+    task_ids: list[str] | None = None,
+) -> None:
+    """Fail closed on forbidden ``shared/`` content or lib name collisions (#65).
+
+    No-op when ``shared/`` is absent.
+    """
+    root = database_root.expanduser().resolve(strict=False)
+    shared = root / "shared"
+    if not shared.exists():
+        return
+    if not shared.is_dir():
+        raise ConfigError(
+            ERROR_INVALID_PACKAGE,
+            "shared must be a directory when present",
+            location="shared",
+        )
+
+    for name in sorted(_FORBIDDEN_SHARED_TOP_LEVEL):
+        bad = shared / name
+        if bad.exists():
+            raise ConfigError(
+                ERROR_INVALID_PACKAGE,
+                f"forbidden path under shared/: {name} "
+                "(gold/secrets must not live under Dataset shared/)",
+                location=f"shared/{name}",
+            )
+
+    # Also reject nested .env anywhere under shared/
+    for env_file in shared.rglob(".env"):
+        if env_file.is_file():
+            try:
+                rel = env_file.relative_to(root).as_posix()
+            except ValueError:
+                rel = "shared/.env"
+            raise ConfigError(
+                ERROR_INVALID_PACKAGE,
+                "host secrets must not live under shared/ (.env forbidden)",
+                location=rel,
+            )
+
+    collisions = find_lib_collisions(root, tasks_root=tasks_root, task_ids=task_ids)
+    if collisions:
+        parts = [f"{name!r} in {shared_loc} and {task_loc}" for name, shared_loc, task_loc in collisions]
+        raise ConfigError(
+            ERROR_INVALID_PACKAGE,
+            "shared/lib vs task lib top-level import name collision (ban): "
+            + "; ".join(parts),
+            location="shared/lib",
+        )

--- a/src/bora/config/shared.py
+++ b/src/bora/config/shared.py
@@ -151,10 +151,11 @@ def validate_shared_layout(
 
     collisions = find_lib_collisions(root, tasks_root=tasks_root, task_ids=task_ids)
     if collisions:
-        parts = [f"{name!r} in {shared_loc} and {task_loc}" for name, shared_loc, task_loc in collisions]
+        parts = [
+            f"{name!r} in {shared_loc} and {task_loc}" for name, shared_loc, task_loc in collisions
+        ]
         raise ConfigError(
             ERROR_INVALID_PACKAGE,
-            "shared/lib vs task lib top-level import name collision (ban): "
-            + "; ".join(parts),
+            "shared/lib vs task lib top-level import name collision (ban): " + "; ".join(parts),
             location="shared/lib",
         )

--- a/src/bora/registry/digest.py
+++ b/src/bora/registry/digest.py
@@ -3,7 +3,8 @@
 Algorithm (Spec 21 Phase 0 freeze):
 
 1. Enumerate files via ``member_paths_for_digest`` (stable order; includes root
-   ``bora.yaml`` and every non-hidden member file except ``__pycache__`` / ``*.pyc``).
+   ``bora.yaml``, optional ``shared/**`` (#65), and every non-hidden member file
+   except ``__pycache__`` / ``*.pyc``).
 2. For each path, compute ``sha256`` of raw file bytes.
 3. Build canonical text (UTF-8, LF only)::
 

--- a/src/bora/runtime/task_worker.py
+++ b/src/bora/runtime/task_worker.py
@@ -43,8 +43,8 @@ def _send_msg(fd: int, obj: dict[str, Any]) -> None:
 
 def _inject_import_paths(package_root: Path, database_root: Path | None) -> None:
     """Make task root and optional Dataset ``shared/lib`` importable (#65)."""
-    # Task member root first so task-local modules resolve; shared/lib second.
-    # Collision of top-level names is banned at lock time, so order is non-semantic.
+    # Both roots are injected; top-level name collisions are banned at lock time,
+    # so insert order is non-semantic for correctness.
     sys.path.insert(0, str(package_root))
     if database_root is not None:
         shared_lib = database_root / "shared" / "lib"

--- a/src/bora/runtime/task_worker.py
+++ b/src/bora/runtime/task_worker.py
@@ -41,7 +41,20 @@ def _send_msg(fd: int, obj: dict[str, Any]) -> None:
     os.write(fd, struct.pack("!I", len(raw)) + raw)
 
 
-def _load_entrypoint(package_root: Path, entrypoint: str) -> Any:
+def _inject_import_paths(package_root: Path, database_root: Path | None) -> None:
+    """Make task root and optional Dataset ``shared/lib`` importable (#65)."""
+    # Task member root first so task-local modules resolve; shared/lib second.
+    # Collision of top-level names is banned at lock time, so order is non-semantic.
+    sys.path.insert(0, str(package_root))
+    if database_root is not None:
+        shared_lib = database_root / "shared" / "lib"
+        if shared_lib.is_dir():
+            sys.path.insert(0, str(shared_lib.resolve()))
+
+
+def _load_entrypoint(
+    package_root: Path, entrypoint: str, *, database_root: Path | None = None
+) -> Any:
     module_name, _, func_name = entrypoint.partition(":")
     if not module_name or not func_name:
         raise ValueError(f"invalid entrypoint: {entrypoint}")
@@ -53,8 +66,7 @@ def _load_entrypoint(package_root: Path, entrypoint: str) -> Any:
     if spec is None or spec.loader is None:
         raise ImportError("cannot load harness.py")
     mod = importlib.util.module_from_spec(spec)
-    # Ensure package root is importable for local modules only under package.
-    sys.path.insert(0, str(package_root))
+    _inject_import_paths(package_root, database_root)
     spec.loader.exec_module(mod)
     fn = getattr(mod, func_name)
     return fn
@@ -71,6 +83,9 @@ async def _run(fd: int) -> int:
     # Optional Attempt workspace (L1 host bind); default package root for L0.
     ws_raw = launch.get("workspace_root")
     workspace_root = Path(ws_raw) if ws_raw else package_root
+    # #65 Dataset root for shared/lib import + code-path assets.
+    db_raw = launch.get("database_root")
+    database_root = Path(db_raw) if db_raw else None
 
     # Build SDK context inside worker only.
     from bora_sdk.context import HarnessContext, HarnessParameterView, RunScope
@@ -85,9 +100,10 @@ async def _run(fd: int) -> int:
         ),
         workspace_root=workspace_root,
         artifact_dir=artifact_dir,
+        database_root=database_root,
     )
     try:
-        fn = _load_entrypoint(package_root, entrypoint)
+        fn = _load_entrypoint(package_root, entrypoint, database_root=database_root)
         result = fn(ctx)
         if asyncio.iscoroutine(result):
             result = await result

--- a/tests/config/test_database.py
+++ b/tests/config/test_database.py
@@ -181,6 +181,39 @@ def test_member_paths_stable_order(tmp_path: Path) -> None:
     assert a_idx < b_idx
 
 
+def test_member_paths_include_shared_tree(tmp_path: Path) -> None:
+    """#65: optional shared/** enters packageDigest input paths."""
+    _write_db(tmp_path)
+    _write_task(tmp_path / "tasks" / "a", "a")
+    shared_lib = tmp_path / "shared" / "lib"
+    shared_lib.mkdir(parents=True)
+    (shared_lib / "bridge.py").write_text("X = 1\n", encoding="utf-8")
+    (tmp_path / "shared" / "assets").mkdir()
+    (tmp_path / "shared" / "assets" / "policy.json").write_text("{}", encoding="utf-8")
+    # Hidden / pycache must stay out
+    (shared_lib / "__pycache__").mkdir()
+    (shared_lib / "__pycache__" / "bridge.cpython-312.pyc").write_bytes(b"x")
+    (tmp_path / "shared" / ".env").write_text("SECRET=1\n", encoding="utf-8")
+
+    paths = member_paths_for_digest(tmp_path)
+    assert "shared/lib/bridge.py" in paths
+    assert "shared/assets/policy.json" in paths
+    assert not any("__pycache__" in p for p in paths)
+    assert "shared/.env" not in paths
+    # shared before tasks (sorted path walk of shared, then tasks by id)
+    shared_idx = paths.index("shared/assets/policy.json")
+    task_idx = next(i for i, p in enumerate(paths) if p.startswith("tasks/a/"))
+    assert shared_idx < task_idx
+
+
+def test_member_paths_without_shared_unchanged_shape(tmp_path: Path) -> None:
+    _write_db(tmp_path)
+    _write_task(tmp_path / "tasks" / "a", "a")
+    paths = member_paths_for_digest(tmp_path)
+    assert not any(p.startswith("shared/") for p in paths)
+    assert paths[0] == "bora.yaml"
+
+
 def test_journeys_list() -> None:
     ids = list_tasks(JOURNEYS_DB)
     assert set(ids) >= {

--- a/tests/config/test_shared.py
+++ b/tests/config/test_shared.py
@@ -1,0 +1,141 @@
+"""Dataset-level shared/ validation and collision rules (#65)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bora.adapters.package_fs import LocalPackageReader
+from bora.config.capabilities import DeclarationCapabilityCatalog
+from bora.config.errors import ConfigError
+from bora.config.load_and_lock import ConfigCore
+from bora.config.shared import (
+    find_lib_collisions,
+    top_level_import_names,
+    validate_shared_layout,
+)
+
+
+def _write_db(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "bora.yaml").write_text(
+        "format: bora.database/1\n"
+        "database_id: test/shared-suite\n"
+        'version: "0.1.0"\n'
+        "tasks:\n  root: tasks\n",
+        encoding="utf-8",
+    )
+
+
+def _write_task(task_dir: Path, task_id: str, *, lib_mod: str | None = None) -> None:
+    task_dir.mkdir(parents=True, exist_ok=True)
+    (task_dir / "task.yaml").write_text(
+        f"""format: bora.task/1
+task_id: {task_id}
+harness:
+  runtime: python
+  entrypoint: harness:run
+provider:
+  kind: local
+  assurance: l0
+agent_profiles: []
+limits:
+  wall_time_seconds: 60
+  agent_invocations: 0
+  environment_actions: 0
+artifacts:
+  publishable: []
+evaluation:
+  runtime: python
+  entrypoint: evaluator:evaluate
+  network: none
+  inputs: []
+  output:
+    format: json
+""",
+        encoding="utf-8",
+    )
+    (task_dir / "harness.py").write_text(
+        "def run(ctx):\n    return None\n",
+        encoding="utf-8",
+    )
+    (task_dir / "evaluator.py").write_text(
+        "def evaluate(payload):\n    return {'status': 'PASS', 'score': 1.0, 'metrics': {}}\n",
+        encoding="utf-8",
+    )
+    if lib_mod:
+        lib = task_dir / "lib"
+        lib.mkdir(exist_ok=True)
+        (lib / f"{lib_mod}.py").write_text(f"NAME = {lib_mod!r}\n", encoding="utf-8")
+
+
+def test_top_level_import_names(tmp_path: Path) -> None:
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    (lib / "bridge.py").write_text("x=1\n", encoding="utf-8")
+    (lib / "pkg").mkdir()
+    (lib / "pkg" / "__init__.py").write_text("", encoding="utf-8")
+    (lib / "__pycache__").mkdir()
+    assert top_level_import_names(lib) == {"bridge", "pkg"}
+
+
+def test_no_shared_is_noop(tmp_path: Path) -> None:
+    _write_db(tmp_path)
+    _write_task(tmp_path / "tasks" / "a", "a")
+    validate_shared_layout(tmp_path)  # no raise
+
+
+def test_collision_ban(tmp_path: Path) -> None:
+    _write_db(tmp_path)
+    shared_lib = tmp_path / "shared" / "lib"
+    shared_lib.mkdir(parents=True)
+    (shared_lib / "bridge.py").write_text("x=1\n", encoding="utf-8")
+    _write_task(tmp_path / "tasks" / "a", "a", lib_mod="bridge")
+    hits = find_lib_collisions(tmp_path)
+    assert hits == [("bridge", "shared/lib", "tasks/a/lib")]
+    with pytest.raises(ConfigError) as ei:
+        validate_shared_layout(tmp_path)
+    assert "collision" in ei.value.message
+    assert ei.value.error_code == "invalid_package"
+
+
+def test_forbidden_env_under_shared(tmp_path: Path) -> None:
+    _write_db(tmp_path)
+    _write_task(tmp_path / "tasks" / "a", "a")
+    (tmp_path / "shared" / "lib").mkdir(parents=True)
+    (tmp_path / "shared" / ".env").write_text("K=v\n", encoding="utf-8")
+    with pytest.raises(ConfigError) as ei:
+        validate_shared_layout(tmp_path)
+    assert ".env" in ei.value.message
+
+
+def test_lock_fails_on_lib_collision(tmp_path: Path) -> None:
+    _write_db(tmp_path)
+    shared_lib = tmp_path / "shared" / "lib"
+    shared_lib.mkdir(parents=True)
+    (shared_lib / "common.py").write_text("V=1\n", encoding="utf-8")
+    _write_task(tmp_path / "tasks" / "t1", "t1", lib_mod="common")
+    core = ConfigCore(package_reader=LocalPackageReader())
+    with pytest.raises(ConfigError) as ei:
+        core.load_and_lock(
+            tmp_path / "tasks" / "t1",
+            "t1",
+            capabilities=DeclarationCapabilityCatalog(),
+        )
+    assert "collision" in ei.value.message
+
+
+def test_lock_ok_with_shared_no_collision(tmp_path: Path) -> None:
+    _write_db(tmp_path)
+    shared_lib = tmp_path / "shared" / "lib"
+    shared_lib.mkdir(parents=True)
+    (shared_lib / "bridge.py").write_text("V=1\n", encoding="utf-8")
+    _write_task(tmp_path / "tasks" / "t1", "t1", lib_mod="task_only")
+    core = ConfigCore(package_reader=LocalPackageReader())
+    lock = core.load_and_lock(
+        tmp_path / "tasks" / "t1",
+        "t1",
+        capabilities=DeclarationCapabilityCatalog(),
+    )
+    assert lock.digest.startswith("sha256:")

--- a/tests/config/test_shared.py
+++ b/tests/config/test_shared.py
@@ -139,3 +139,29 @@ def test_lock_ok_with_shared_no_collision(tmp_path: Path) -> None:
         capabilities=DeclarationCapabilityCatalog(),
     )
     assert lock.digest.startswith("sha256:")
+
+
+def test_infer_walks_up_for_nested_tasks_root(tmp_path: Path) -> None:
+    """Collision gate must fire even when tasks.root is nested (not just tasks/)."""
+    from bora.config.shared import infer_database_root_from_task
+
+    (tmp_path / "bora.yaml").write_text(
+        "format: bora.database/1\n"
+        "database_id: test/nested\n"
+        'version: "0.1.0"\n'
+        "tasks:\n  root: members/group\n",
+        encoding="utf-8",
+    )
+    shared_lib = tmp_path / "shared" / "lib"
+    shared_lib.mkdir(parents=True)
+    (shared_lib / "bridge.py").write_text("x=1\n", encoding="utf-8")
+    task = tmp_path / "members" / "group" / "t1"
+    _write_task(task, "t1", lib_mod="bridge")
+    assert infer_database_root_from_task(task) == tmp_path.resolve()
+    with pytest.raises(ConfigError) as ei:
+        validate_shared_layout(tmp_path, tasks_root="members/group")
+    assert "collision" in ei.value.message
+    core = ConfigCore(package_reader=LocalPackageReader())
+    with pytest.raises(ConfigError) as ei2:
+        core.load_and_lock(task, "t1", capabilities=DeclarationCapabilityCatalog())
+    assert "collision" in ei2.value.message

--- a/tests/registry/test_registry_package_files.py
+++ b/tests/registry/test_registry_package_files.py
@@ -179,15 +179,27 @@ def _gzip_tar_with_file(path: str, data: bytes) -> bytes:
     return out.getvalue()
 
 
-def test_oversize_file_raises() -> None:
+def test_oversize_file_truncated_by_default() -> None:
+    big = b"x" * (MAX_FILE_BYTES + 10)
+    archive = _gzip_tar_with_file("big.bin", big)
+    data, size, truncated = read_member(archive, "big.bin")
+    assert truncated is True
+    assert size == MAX_FILE_BYTES + 10
+    assert len(data) == MAX_FILE_BYTES
+    assert data == b"x" * MAX_FILE_BYTES
+
+
+def test_oversize_file_raises_when_truncate_disabled() -> None:
     big = b"x" * (MAX_FILE_BYTES + 10)
     archive = _gzip_tar_with_file("big.bin", big)
     with pytest.raises(PackageFileTooLarge):
-        read_member(archive, "big.bin")
+        read_member(archive, "big.bin", allow_truncate=False)
 
 
-def test_oversize_http_413(registry_server, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Inject a large blob under an existing public release and expect 413."""
+def test_oversize_http_returns_truncated_preview(
+    registry_server, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Inject a large blob; Hub preview gets a truncated head (not 413)."""
     summary = _publish_public(registry_server, monkeypatch)
     state = registry_server["state"]
     row = state.meta.get_by_digest(summary["database_id"], summary["package_digest"])
@@ -205,11 +217,13 @@ def test_oversize_http_413(registry_server, monkeypatch: pytest.MonkeyPatch) -> 
 
     clear_index_cache()
     client = RegistryClient(registry_server["url"], token=None)
-    with pytest.raises(RegistryError) as ei:
-        client.get_package_file(
-            database_id=summary["database_id"],
-            package_digest=summary["package_digest"],
-            file_path="huge.txt",
-        )
-    assert ei.value.status == 413
-    assert ei.value.code == "payload_too_large"
+    body = client.get_package_file(
+        database_id=summary["database_id"],
+        package_digest=summary["package_digest"],
+        file_path="huge.txt",
+    )
+    assert body["truncated"] is True
+    assert body["size"] == MAX_FILE_BYTES + 50
+    content = body["content"]
+    assert isinstance(content, str)
+    assert len(content.encode("utf-8")) == MAX_FILE_BYTES

--- a/tests/runtime/test_shared_lib_import.py
+++ b/tests/runtime/test_shared_lib_import.py
@@ -1,0 +1,123 @@
+"""Harness / evaluator can import modules from Dataset shared/lib (#65)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bora.adapters.package_fs import LocalPackageReader
+from bora.application.run_command_evaluator import run_evaluator_worker
+from bora.application.run_harness import run_harness_package
+from bora.config.capabilities import DeclarationCapabilityCatalog
+from bora.config.load_and_lock import ConfigCore
+
+
+def _scaffold(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "bora.yaml").write_text(
+        "format: bora.database/1\n"
+        "database_id: test/shared-import\n"
+        'version: "0.1.0"\n'
+        "tasks:\n  root: tasks\n",
+        encoding="utf-8",
+    )
+    shared_lib = root / "shared" / "lib"
+    shared_lib.mkdir(parents=True)
+    (shared_lib / "bridge_mod.py").write_text(
+        "TOKEN = 'from-shared'\n",
+        encoding="utf-8",
+    )
+    task = root / "tasks" / "t1"
+    task.mkdir(parents=True)
+    (task / "task.yaml").write_text(
+        """format: bora.task/1
+task_id: t1
+harness:
+  runtime: python
+  entrypoint: harness:run
+provider:
+  kind: local
+  assurance: l0
+agent_profiles: []
+limits:
+  wall_time_seconds: 60
+  agent_invocations: 0
+  environment_actions: 0
+artifacts:
+  publishable:
+    - id: session-output
+      producer: harness
+      path: artifacts/session-output.json
+      media_type: application/json
+evaluation:
+  runtime: python
+  entrypoint: evaluator:evaluate
+  network: none
+  inputs:
+    - artifact: session-output
+      target: artifacts/session-output.json
+  output:
+    format: json
+""",
+        encoding="utf-8",
+    )
+    (task / "harness.py").write_text(
+        """
+from bora_sdk.terminal import HarnessTerminal
+
+def run(ctx):
+    import bridge_mod
+    ctx.publish_json("session-output", {"token": bridge_mod.TOKEN})
+    return HarnessTerminal.completed()
+""",
+        encoding="utf-8",
+    )
+    (task / "evaluator.py").write_text(
+        """
+def evaluate(payload):
+    import bridge_mod
+    arts = payload.get("artifacts") or {}
+    # token path not required; import success is the gate
+    return {
+        "status": "PASS" if bridge_mod.TOKEN == "from-shared" else "FAIL",
+        "score": 1.0 if bridge_mod.TOKEN == "from-shared" else 0.0,
+        "metrics": {"token": bridge_mod.TOKEN},
+    }
+""",
+        encoding="utf-8",
+    )
+    return task
+
+
+@pytest.mark.asyncio
+async def test_harness_imports_shared_lib(tmp_path: Path) -> None:
+    task = _scaffold(tmp_path)
+    core = ConfigCore(package_reader=LocalPackageReader())
+    lock = core.load_and_lock(task, "t1", capabilities=DeclarationCapabilityCatalog())
+    result = await run_harness_package(
+        lock, task, timeout_seconds=20.0, database_root=tmp_path
+    )
+    env = result["envelope"]
+    assert env.get("ok") is True, env
+    published = env.get("published") or {}
+    assert "session-output" in published
+    text = Path(published["session-output"]).read_text(encoding="utf-8")
+    assert "from-shared" in text
+
+
+def test_evaluator_imports_shared_lib(tmp_path: Path) -> None:
+    task = _scaffold(tmp_path)
+    core = ConfigCore(package_reader=LocalPackageReader())
+    lock = core.load_and_lock(task, "t1", capabilities=DeclarationCapabilityCatalog())
+    # Minimal artifact file for evaluate inputs
+    art = tmp_path / "session-output.json"
+    art.write_text('{"token":"x"}\n', encoding="utf-8")
+    raw = run_evaluator_worker(
+        task,
+        lock,
+        {"session-output": str(art)},
+        database_root=tmp_path,
+    )
+    assert raw.get("status") == "PASS"
+    assert (raw.get("metrics") or {}).get("token") == "from-shared"

--- a/tests/runtime/test_shared_lib_import.py
+++ b/tests/runtime/test_shared_lib_import.py
@@ -95,9 +95,7 @@ async def test_harness_imports_shared_lib(tmp_path: Path) -> None:
     task = _scaffold(tmp_path)
     core = ConfigCore(package_reader=LocalPackageReader())
     lock = core.load_and_lock(task, "t1", capabilities=DeclarationCapabilityCatalog())
-    result = await run_harness_package(
-        lock, task, timeout_seconds=20.0, database_root=tmp_path
-    )
+    result = await run_harness_package(lock, task, timeout_seconds=20.0, database_root=tmp_path)
     env = result["envelope"]
     assert env.get("ok") is True, env
     published = env.get("published") or {}

--- a/website/content/docs/author/package-layout.en.mdx
+++ b/website/content/docs/author/package-layout.en.mdx
@@ -15,6 +15,11 @@ CLI path is always the Dataset root; `--task` selects a member.
 ```text
 my-dataset/
 ├── bora.yaml
+├── profiles.yaml           # optional job binding defaults
+├── shared/                 # optional cross-task share (in packageDigest)
+│   ├── lib/                # Harness / Evaluator import only
+│   ├── assets/             # read-only domain data (code paths)
+│   └── README.md
 └── tasks/
     └── hello/
         ├── task.yaml
@@ -22,12 +27,31 @@ my-dataset/
         ├── evaluator.py
         ├── prompts/
         ├── environment/
-        ├── evaluation/
+        ├── evaluation/     # gold — not for Agent by default
         ├── data/
-        └── lib/
+        └── lib/            # task-only; no top-level name clash with shared/lib
 ```
 
-Allowed top-level dirs: `prompts`, `schemas`, `environment`, `evaluation`, `data`, `lib`, `upstream`, `solution`.
+Allowed task top-level dirs: `prompts`, `schemas`, `environment`, `evaluation`, `data`, `lib`, `upstream`, `solution`.
+
+## Optional Dataset-level `shared/`
+
+Homogeneous multi-task packages can keep shared bridges and domain assets under root `shared/` instead of copying into every `tasks/*/lib/`.
+
+| Path | Role |
+| --- | --- |
+| `shared/lib/` | Cross-task Python modules; Runtime injects import path |
+| `shared/assets/` | Read-only fixtures / policy / db via code paths |
+
+Hard rules (summary):
+
+- If present, `shared/**` **must** enter `packageDigest` / the publish blob  
+- Not Agent-mounted by default; gold stays under `tasks/*/evaluation/` only  
+- Top-level import names must **not** collide between `shared/lib` and any task `lib/` (lock fails closed)  
+- Core never silently COPYs `shared/` into L1 images — task `environment/Dockerfile` must declare it  
+- Author gate: `uv run python scripts/check_shared_lib_collisions.py <dataset-root>`  
+
+Authority: design `02-task-package-and-config` (Dataset-level shared/). **Having `shared/` or Hub Shared browse ≠ evidence-grade upgrade.**
 
 ## Root `bora.yaml`
 

--- a/website/content/docs/author/package-layout.mdx
+++ b/website/content/docs/author/package-layout.mdx
@@ -15,19 +15,43 @@ CLI 路径永远是 Dataset 根；`--task` 选成员。
 ```text
 my-dataset/
 ├── bora.yaml
+├── profiles.yaml           # 可选：job binding 默认
+├── shared/                 # 可选：跨 task 共享（进 packageDigest）
+│   ├── lib/                # Harness / Evaluator import only
+│   ├── assets/             # 只读领域数据（代码路径读取）
+│   └── README.md
 └── tasks/
-    └── hello/          # 目录名 == task_id
+    └── hello/              # 目录名 == task_id
         ├── task.yaml
         ├── harness.py
         ├── evaluator.py
         ├── prompts/
         ├── environment/
-        ├── evaluation/   # gold 等，默认不给 agent
+        ├── evaluation/     # gold 等，默认不给 agent
         ├── data/
-        └── lib/
+        └── lib/            # 仅本 task；顶层名勿与 shared/lib 冲突
 ```
 
 成员一级目录只认：`prompts` · `schemas` · `environment` · `evaluation` · `data` · `lib` · `upstream` · `solution`。别的名字可能 lock 失败。
+
+## Dataset 级 `shared/`（可选）
+
+同构多 task 包可把公共 bridge / 领域资产放在根 `shared/`，**不要**复制进每个 `tasks/*/lib/`。
+
+| 路径 | 用途 |
+| --- | --- |
+| `shared/lib/` | 跨 task Python 模块；Runtime 注入 import path |
+| `shared/assets/` | 只读 fixture / policy / db（代码路径访问） |
+
+硬规则（摘要）：
+
+- 有 `shared/` 则 **必须** 进入 `packageDigest` / publish blob；改它会改整包 digest  
+- 默认 **不** 挂到 Agent workspace；gold **只** 放 `tasks/*/evaluation/`  
+- `shared/lib` 与任一 `tasks/*/lib` 的 **top-level 模块名禁止冲突**（lock 硬失败）  
+- L1 镜像 **不会** 由 Core 隐式 COPY `shared/`；需要时在 task `environment/Dockerfile` 里显式写  
+- 本地自检：`uv run python scripts/check_shared_lib_collisions.py <dataset-root>`  
+
+权威细节见 design `02-task-package-and-config`（Dataset 级 shared/）。**有 shared/ 或 Hub Shared 浏览 ≠ 证据等级升级。**
 
 ## 根 `bora.yaml`
 

--- a/website/content/docs/share/hub.en.mdx
+++ b/website/content/docs/share/hub.en.mdx
@@ -6,6 +6,8 @@ description: Remote Dataset catalog, organizations, job results, and leaderboard
 Hub (`apps/hub`) is the web UI on top of Registry—browse shared packages and run results.
 
 - Dataset list (**Your organizations** / **Explore**), README, task file preview  
+- When the package has root `shared/`: Dataset **Shared** tab; Task **Files** header **Local | Shared** (Local default; Attempt evidence does not switch)  
+- Large file preview: oversize members return a truncated head with a `truncated` flag (not full download)  
 - **Organizations**: members, org packages, shared suite results  
 - **Org settings**: invite keys (shown once on create), leave or dissolve  
 - Task **Jobs**: open a row when run artifacts were uploaded (layout close to the local Viewer, including trajectory)  
@@ -29,8 +31,8 @@ pnpm dev   # http://127.0.0.1:5174
 | Path | Page |
 | --- | --- |
 | `/datasets` | List (Your organizations / Explore) |
-| `/datasets/:id` | README · Tasks · Leaderboard |
-| `/datasets/:id/tasks/:task` | README · Files · Jobs |
+| `/datasets/:id` | README · Tasks · Shared (when `shared/` present) · Leaderboard |
+| `/datasets/:id/tasks/:task` | README · Files (Local \| Shared) · Jobs |
 | `/organizations` | Your orgs · Join |
 | `/organizations/:orgId` | Overview · Settings |
 | `/jobs/...` | Remote Attempt detail (needs uploaded run artifacts) |

--- a/website/content/docs/share/hub.mdx
+++ b/website/content/docs/share/hub.mdx
@@ -6,6 +6,8 @@ description: 远程 Dataset 目录、组织、Jobs 运行结果与 Leaderboard�
 Hub（`apps/hub`）是连 Registry 的网页端，用来浏览共享的包与跑次结果。
 
 - Dataset 列表（你的组织 / 探索）、README、Task 文件预览  
+- 包内有根 `shared/` 时：Dataset **Shared** tab；Task **Files** 顶栏 **Local | Shared**（默认 Local；Attempt 证据页不切换）  
+- 大文件预览：超过 Registry 上限时返回截断头并标注 truncated（非整文件下载）  
 - **组织**：成员、组织内的包、别人分享过来的 suite 结果  
 - **组织设置**：邀请码（创建后只展示一次）、离开或解散组织  
 - Task 下的 **Jobs**：已上传运行产物时可点进详情（界面与本机 Viewer 相近，含轨迹）  
@@ -29,8 +31,8 @@ pnpm dev   # http://127.0.0.1:5174
 | 路径 | 页面 |
 | --- | --- |
 | `/datasets` | 列表（Your organizations / Explore） |
-| `/datasets/:id` | README · Tasks · Leaderboard |
-| `/datasets/:id/tasks/:task` | README · Files · Jobs |
+| `/datasets/:id` | README · Tasks · Shared（有 shared/ 时）· Leaderboard |
+| `/datasets/:id/tasks/:task` | README · Files（Local \| Shared）· Jobs |
 | `/organizations` | 我的组织 · 加入组织 |
 | `/organizations/:orgId` | 概览 · 设置 |
 | `/jobs/...` | 远程 Attempt 详情（需已上传对应运行产物） |


### PR DESCRIPTION
## Summary

This PR delivers **#65**: make Dataset-root **`shared/`** a first-class package contract and wire it through digest → runtime import → skills → Hub/Viewer (plus Registry large-file preview so Shared assets are actually browsable).

1. **Design / Config** — `shared/lib` + `shared/assets` layout; collision ban; L1 no Core implicit COPY; no shared sub-digest; evidence-grade not inflated  
2. **Digest / publish** — `member_paths_for_digest` includes `shared/**` when present  
3. **Runtime** — harness + evaluator inject `shared/lib` on PYTHONPATH / `sys.path`; lock fails on top-level lib name collisions; collision check script + skill docs  
4. **Hub / Viewer** — Dataset **Shared** tab (only if package has `shared/`); Task **Files** **Local | Shared** in FILES header; Attempt evidence stays trajectory-only  
5. **Perf / preview** — windowed file trees; large previews skip heavy highlight; Registry returns **truncated head** (2 MiB) instead of 413 for oversize members  

- **No** Harbor-compatible shared layout  
- **No** Core silent L1 `COPY shared/`  
- **No** evidence-grade upgrade from `shared/` or Hub Shared UI  
- **Not** in this PR: `examples/tau3-airline` (local/Hub publish only; still untracked)

## Screenshot

<img width="1454" height="792" alt="image" src="https://github.com/user-attachments/assets/8c894dbe-9ed1-4a18-ac32-68ce5abd48f6" />



## Issues

| Issue | Role |
| --- | --- |
| **#65** | **Closes** — Dataset-level `shared/` (digest + import + Hub/Viewer presentation) |

Closes #65

Related (not closed): #50 / #66 conversion packages that benefit from shared to avoid per-task `lib/` copies.

## Constraints

- Authority: **docs first** (`docs/design/02-task-package-and-config.md`), then code / skills / website  
- Gold / secrets never under `shared/`; gold only under `tasks/*/evaluation/`  
- Agent workspace does **not** get `shared/` by default  
- L1: task `environment/Dockerfile` owns any explicit `COPY` of shared content  

## Validation (local CI-equivalent)

| Gate | Result |
| --- | --- |
| `ruff format/check` + `pyright` (`src` / `tests`) | pass |
| python-core pytest (CI ignore list) | **365 passed** |
| `pytest tests/registry` | **46 passed** |
| `apps/hub` lint + build | pass |
| `apps/viewer` lint + build | pass |
| `website` build | pass |

Author gate: `uv run python scripts/check_shared_lib_collisions.py <database-root>`

## Test plan

- [x] `bora lock` package with `shared/lib` import from harness/evaluator; package without `shared/` unchanged  
- [x] Collision: same top-level name under `shared/lib` and `tasks/*/lib` → lock fail  
- [x] Publish package including `shared/**`; digest changes when shared files change  
- [x] Hub Dataset: Shared tab only when `shared/` present; Task Files Local|Shared switch; Attempt evidence has **no** Local|Shared  
- [x] Open large file under `shared/assets` (e.g. multi-MB json): truncated preview + note, not empty “Select a file”  
- [x] Viewer trial Files: large tree scrolls without freezing; expand-on-demand  