### PR TITLE
fix(config): shared/ import namespaces + L1 evaluator guidance (#68)

### DIFF
--- a/docs/design/02-task-package-and-config.md
+++ b/docs/design/02-task-package-and-config.md
@@ -155,29 +155,46 @@ Task 成员目录 **一级目录只允许从已知集合取用**；除固定根�
 
 | 路径 | 角色 | 默认可见性 |
 | --- | --- | --- |
-| `shared/lib/` | 跨 task Python 支撑（import only） | Runtime 为 Harness **与** Evaluator 注入 import path；**不**默认投影到 Agent workspace |
+| `shared/lib/` | 跨 task Python 支撑（import only） | 经 Database 根 on path 以 **`shared.lib.*`** 导入；**不**默认投影到 Agent workspace |
 | `shared/assets/` | 只读领域数据（db / policy / fixtures） | Harness/Evaluator 用 **代码路径** 读取；v1 **无** `task.yaml` 资产声明面 |
 | `shared/README.md` | 给人读的共享区说明 | 非 Runtime 输入 |
+
+**Import 注入契约（权威）：**
+
+```text
+sys.path 前缀（Harness worker 与 L0 evaluator 一致）:
+  [task_dir, database_root, ...]
+# 禁止把 shared/lib 或 tasks/<id>/lib 作为 path root 注入
+```
+
+| 作者写法 | 含义 |
+| --- | --- |
+| `from shared.lib.xxx import …` | Dataset 级 glue（`shared/lib/`） |
+| `from lib.yyy import …` | 仅本 task 的 `tasks/<id>/lib/` |
+
+`shared/` 与 `shared/lib/` 须为可 import 包（推荐带 `__init__.py`；namespace package 为后置可选）。task 侧 `lib/` 同理（需要 `from lib…` 时）。
 
 **硬规则：**
 
 1. **Digest / publish：** 若 `shared/` 存在，其下文件 **必须** 进入 `member_paths_for_digest` 与 publish blob（与 `tasks/**` 同算法过滤 `__pycache__` / 多数隐藏文件）。改 `shared/` ⇒ 改整包 `packageDigest`。无 `shared/` 的包行为与今日一致。
-2. **Import：** L0 worker 默认把 `shared/lib` 注入 PYTHONPATH（或等价 `sys.path`）；Harness 与 Evaluator 均可 `import`。**禁止**依赖 host 绝对路径。
+2. **Import：** L0 worker 注入 **`task_dir` + `database_root`**（顺序见上表）；**禁止** 再把 `shared/lib` leaf 插入 path。Harness 与 Evaluator 均可 `from shared.lib…` / `from lib…`。**禁止**依赖 host 绝对路径。
 3. **Agent 可见性：** 默认 **不** mount / 不投影 `shared/` 到 Agent workspace。可选 `shared/assets` Agent mount 为后续能力，不在 v1 默认路径。
 4. **禁区：** `shared/` 下 **禁止** evaluation gold、host secrets（如 `.env`）、Docker socket 绑定物等。Gold **只** 在成员 `evaluation/`。
-5. **同名冲突（硬失败）：** `shared/lib/` 与任一 `tasks/<id>/lib/` 的 **top-level import 名**（顶层 `.py` 去后缀、或顶层包目录名）**禁止碰撞**。Config/lock 校验 fail closed；作者 skill 必须提示；检测脚本作验收门槛。
-6. **L1 / 镜像：** Core **禁止** 隐式把 `shared/` COPY 进 Attempt 镜像或默认塞进 build context。若容器内需要 `shared/` 内容，由 **task 级** `environment/` Dockerfile（或包内镜像配方）**显式** `COPY`。无静默 Core copy。
+5. **顶层名 `shared` 保留（硬失败）：** 成员 task **禁止** 拥有 `tasks/<id>/shared/` 目录或 `tasks/<id>/shared.py`（与 Dataset 包名 `shared` 在 path 上同级时会 shadow）。Config/lock 校验 fail closed；检测脚本作验收门槛。**不再** 因 `shared/lib` 与 `tasks/*/lib` 同名 stem（如双方都有 `bridge.py`）而 ban——命名空间已区分 `shared.lib.bridge` vs `lib.bridge`。
+6. **L1 / 镜像：** Core **禁止** 隐式把 `shared/` COPY 进 Attempt 镜像或默认塞进 build context。若容器内需要 `shared/` 内容，由 **task 级** `environment/` Dockerfile（或包内镜像配方）**显式** `COPY shared/`，并使 **Database 根**（或等价布局）进入容器 `PYTHONPATH`，以便 `shared.lib.*` 可 import。无静默 Core copy。L0 inject **≠** L1 自动可用。
 7. **无 shared sub-digest：** Registry 不维护单独的 shared digest；整包 `packageDigest` 已覆盖 `shared/**`。
-8. **证据等级：** 存在 `shared/`、digest 包含 `shared/**`、或 Hub Shared UI **不**抬高证据等级；仍按公开 smoke / Issue 验收声明 `runnable-mvp` / `isolated` 等。
+8. **证据等级：** 存在 `shared/`、digest 包含 `shared/**`、或 Hub Shared UI **不**抬高证据等级；仍按公开 smoke / Issue 验收声明 `runnable-mvp` / `isolated` 等。本 import 契约变更 **不** 抬高证据等级。
 
 **`shared/lib` vs task `lib/`：**
 
-| 放哪里 | 何时 |
-| --- | --- |
-| `shared/lib/` | 多 task 共用的 bridge、领域工具、稳定 glue |
-| `tasks/<id>/lib/` | 仅该 task 的扩展；名字不得与 `shared/lib` top-level 冲突 |
+| 放哪里 | 何时 | Import |
+| --- | --- | --- |
+| `shared/lib/` | 多 task 共用的 bridge、领域工具、稳定 glue | `from shared.lib…` |
+| `tasks/<id>/lib/` | 仅该 task 的扩展；**允许** 与 shared 同 stem 文件名 | `from lib…` |
 
 **资产引用：** v1 仅代码路径（例如相对 Database 根的 `shared/assets/...`，或 Runtime 注入的 database root + 相对路径）。不增加 `task.yaml` 声明语法。
+
+**迁移（从 leaf inject）：** 旧写法 `from bridge import …`（依赖 `shared/lib` 在 path 上）改为 `from shared.lib.bridge import …`；生成器与包内 thin harness/evaluator 同步。
 
 #### 文本分层：README、prompts 与 runtime payload
 

--- a/examples/tau3-airline/README.md
+++ b/examples/tau3-airline/README.md
@@ -8,22 +8,23 @@ Port of **τ³-bench / tau2-bench** `airline` domain onto BORA outer lifecycle.
 | Domain | airline (50 tasks, base split) |
 | Agents | `user` + `service` via `profiles.yaml` → `grok-build` |
 | Bridge | BORA Agent ACP ↔ tau2 `Environment` tools + `evaluate_simulation` |
-| Shared | Dataset-level `shared/lib` + `shared/assets` |
+| Shared | Dataset-level `shared/lib` + `shared/assets` (`from shared.lib…`) |
 
 ## Layout
 
 ```text
 bora.yaml / profiles.yaml
-shared/
-  lib/          # harness_core, bridge, evaluator_core (PYTHONPATH)
-  assets/       # db.json, policy.md, tasks.json (in packageDigest)
+shared/                 # real package (shared/__init__.py)
+  lib/                  # shared.lib.harness_core / bridge / evaluator_core
+  assets/               # db.json, policy.md, tasks.json (in packageDigest)
 tasks/airline-NN/
-  task.yaml / harness.py / evaluator.py
-  data/         # agent-visible scenario + policy copy
-  evaluation/   # gold / full task JSON (evaluator-only)
+  task.yaml / harness.py / evaluator.py   # thin; import shared.lib.*
+  data/                 # agent-visible scenario + policy copy
+  evaluation/           # gold / full task JSON (evaluator-only)
 ```
 
-No per-task `lib/` copies — modules live once under `shared/lib`.
+No per-task `lib/` copies — modules live once under `shared/lib` and are imported
+as `shared.lib.*` (Runtime puts Database root on `sys.path`, not the `lib/` leaf).
 
 ## Run
 

--- a/examples/tau3-airline/scripts/generate_package.py
+++ b/examples/tau3-airline/scripts/generate_package.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate BORA task members from upstream airline tasks.json (#65 shared/lib)."""
+"""Generate BORA task members from upstream airline tasks.json (shared.lib.*)."""
 
 from __future__ import annotations
 
@@ -80,7 +80,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "{upstream_id}"
@@ -117,7 +117,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "{upstream_id}"
@@ -181,7 +181,7 @@ def generate(ids: list[str] | None, all_tasks: bool) -> None:
         (tdir / "evaluator.py").write_text(
             EVALUATOR_PY.format(upstream_id=uid), encoding="utf-8"
         )
-        # No per-task lib/ — shared/lib is on PYTHONPATH (#65).
+        # No per-task lib/ — Database root on path; thin entries import shared.lib.*.
         purpose = ""
         desc = task.get("description")
         if isinstance(desc, dict):

--- a/examples/tau3-airline/shared/README.md
+++ b/examples/tau3-airline/shared/README.md
@@ -2,8 +2,9 @@
 
 | Path | Role |
 | --- | --- |
-| `lib/` | Harness + evaluator bridge modules (import only; not Agent-mounted) |
+| `lib/` | Harness + evaluator bridge modules — import as `shared.lib.*` (not Agent-mounted) |
 | `assets/` | Domain fixtures (`db.json`, `policy.md`, `tasks.json`, …) via code paths |
 
-Top-level import names under `lib/` must **not** collide with any `tasks/*/lib/`.
+Task members must **not** own a top-level name `shared` (dir or `shared.py`).
+Same basename under `shared/lib` and a task `lib/` is fine under namespaced imports.
 Changing anything here changes whole-package `packageDigest`.

--- a/examples/tau3-airline/shared/__init__.py
+++ b/examples/tau3-airline/shared/__init__.py
@@ -1,0 +1,1 @@
+"""Dataset-level shared package (import root for shared.lib.*)."""

--- a/examples/tau3-airline/shared/lib/bridge.py
+++ b/examples/tau3-airline/shared/lib/bridge.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
-from paths import assets_root, package_root
+from shared.lib.paths import assets_root, package_root
 
 
 def _load_tasks_raw() -> list[dict[str, Any]]:

--- a/examples/tau3-airline/shared/lib/evaluator_core.py
+++ b/examples/tau3-airline/shared/lib/evaluator_core.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from bridge import load_eval_task, make_environment
+from shared.lib.bridge import load_eval_task, make_environment
 
 
 def _rebuild_messages(raw: list[dict[str, Any]]) -> list[Any]:

--- a/examples/tau3-airline/shared/lib/harness_core.py
+++ b/examples/tau3-airline/shared/lib/harness_core.py
@@ -10,9 +10,9 @@ import json
 from pathlib import Path
 from typing import Any
 
-from agent_json import agent_struct
 from bora_sdk import Agent, HarnessContext, HarnessTerminal
-from bridge import (
+from shared.lib.agent_json import agent_struct
+from shared.lib.bridge import (
     agent_facing_user_scenario,
     execute_tool_call,
     format_user_scenario,
@@ -20,7 +20,7 @@ from bridge import (
     make_environment,
     tool_catalog,
 )
-from paths import assets_root
+from shared.lib.paths import assets_root
 
 
 STOP_TOKEN = "###STOP###"

--- a/examples/tau3-airline/tasks/airline-00/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-00/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "0"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-00/harness.py
+++ b/examples/tau3-airline/tasks/airline-00/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "0"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-01/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-01/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "1"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-01/harness.py
+++ b/examples/tau3-airline/tasks/airline-01/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "1"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-02/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-02/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "2"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-02/harness.py
+++ b/examples/tau3-airline/tasks/airline-02/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "2"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-03/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-03/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "3"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-03/harness.py
+++ b/examples/tau3-airline/tasks/airline-03/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "3"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-04/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-04/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "4"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-04/harness.py
+++ b/examples/tau3-airline/tasks/airline-04/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "4"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-05/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-05/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "5"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-05/harness.py
+++ b/examples/tau3-airline/tasks/airline-05/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "5"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-06/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-06/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "6"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-06/harness.py
+++ b/examples/tau3-airline/tasks/airline-06/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "6"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-07/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-07/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "7"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-07/harness.py
+++ b/examples/tau3-airline/tasks/airline-07/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "7"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-08/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-08/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "8"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-08/harness.py
+++ b/examples/tau3-airline/tasks/airline-08/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "8"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-09/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-09/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "9"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-09/harness.py
+++ b/examples/tau3-airline/tasks/airline-09/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "9"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-10/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-10/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "10"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-10/harness.py
+++ b/examples/tau3-airline/tasks/airline-10/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "10"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-11/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-11/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "11"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-11/harness.py
+++ b/examples/tau3-airline/tasks/airline-11/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "11"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-12/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-12/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "12"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-12/harness.py
+++ b/examples/tau3-airline/tasks/airline-12/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "12"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-13/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-13/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "13"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-13/harness.py
+++ b/examples/tau3-airline/tasks/airline-13/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "13"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-14/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-14/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "14"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-14/harness.py
+++ b/examples/tau3-airline/tasks/airline-14/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "14"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-15/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-15/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "15"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-15/harness.py
+++ b/examples/tau3-airline/tasks/airline-15/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "15"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-16/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-16/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "16"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-16/harness.py
+++ b/examples/tau3-airline/tasks/airline-16/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "16"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-17/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-17/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "17"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-17/harness.py
+++ b/examples/tau3-airline/tasks/airline-17/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "17"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-18/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-18/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "18"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-18/harness.py
+++ b/examples/tau3-airline/tasks/airline-18/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "18"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-19/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-19/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "19"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-19/harness.py
+++ b/examples/tau3-airline/tasks/airline-19/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "19"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-20/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-20/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "20"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-20/harness.py
+++ b/examples/tau3-airline/tasks/airline-20/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "20"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-21/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-21/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "21"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-21/harness.py
+++ b/examples/tau3-airline/tasks/airline-21/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "21"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-22/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-22/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "22"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-22/harness.py
+++ b/examples/tau3-airline/tasks/airline-22/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "22"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-23/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-23/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "23"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-23/harness.py
+++ b/examples/tau3-airline/tasks/airline-23/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "23"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-24/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-24/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "24"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-24/harness.py
+++ b/examples/tau3-airline/tasks/airline-24/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "24"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-25/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-25/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "25"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-25/harness.py
+++ b/examples/tau3-airline/tasks/airline-25/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "25"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-26/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-26/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "26"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-26/harness.py
+++ b/examples/tau3-airline/tasks/airline-26/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "26"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-27/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-27/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "27"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-27/harness.py
+++ b/examples/tau3-airline/tasks/airline-27/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "27"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-28/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-28/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "28"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-28/harness.py
+++ b/examples/tau3-airline/tasks/airline-28/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "28"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-29/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-29/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "29"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-29/harness.py
+++ b/examples/tau3-airline/tasks/airline-29/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "29"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-30/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-30/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "30"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-30/harness.py
+++ b/examples/tau3-airline/tasks/airline-30/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "30"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-31/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-31/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "31"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-31/harness.py
+++ b/examples/tau3-airline/tasks/airline-31/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "31"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-32/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-32/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "32"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-32/harness.py
+++ b/examples/tau3-airline/tasks/airline-32/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "32"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-33/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-33/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "33"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-33/harness.py
+++ b/examples/tau3-airline/tasks/airline-33/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "33"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-34/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-34/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "34"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-34/harness.py
+++ b/examples/tau3-airline/tasks/airline-34/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "34"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-35/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-35/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "35"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-35/harness.py
+++ b/examples/tau3-airline/tasks/airline-35/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "35"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-36/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-36/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "36"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-36/harness.py
+++ b/examples/tau3-airline/tasks/airline-36/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "36"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-37/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-37/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "37"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-37/harness.py
+++ b/examples/tau3-airline/tasks/airline-37/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "37"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-38/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-38/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "38"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-38/harness.py
+++ b/examples/tau3-airline/tasks/airline-38/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "38"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-39/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-39/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "39"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-39/harness.py
+++ b/examples/tau3-airline/tasks/airline-39/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "39"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-40/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-40/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "40"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-40/harness.py
+++ b/examples/tau3-airline/tasks/airline-40/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "40"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-41/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-41/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "41"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-41/harness.py
+++ b/examples/tau3-airline/tasks/airline-41/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "41"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-42/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-42/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "42"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-42/harness.py
+++ b/examples/tau3-airline/tasks/airline-42/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "42"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-43/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-43/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "43"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-43/harness.py
+++ b/examples/tau3-airline/tasks/airline-43/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "43"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-44/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-44/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "44"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-44/harness.py
+++ b/examples/tau3-airline/tasks/airline-44/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "44"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-45/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-45/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "45"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-45/harness.py
+++ b/examples/tau3-airline/tasks/airline-45/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "45"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-46/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-46/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "46"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-46/harness.py
+++ b/examples/tau3-airline/tasks/airline-46/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "46"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-47/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-47/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "47"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-47/harness.py
+++ b/examples/tau3-airline/tasks/airline-47/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "47"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-48/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-48/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "48"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-48/harness.py
+++ b/examples/tau3-airline/tasks/airline-48/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "48"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/examples/tau3-airline/tasks/airline-49/evaluator.py
+++ b/examples/tau3-airline/tasks/airline-49/evaluator.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import Any
-from evaluator_core import evaluate as _evaluate
+from shared.lib.evaluator_core import evaluate as _evaluate
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "49"
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/examples/tau3-airline/tasks/airline-49/harness.py
+++ b/examples/tau3-airline/tasks/airline-49/harness.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from bora_sdk import HarnessContext, HarnessTerminal
-from harness_core import run as _run
+from shared.lib.harness_core import run as _run
 _TASK = Path(__file__).resolve().parent
 UPSTREAM_TASK_ID = "49"
 async def run(ctx: HarnessContext) -> HarnessTerminal:

--- a/scripts/check_shared_lib_collisions.py
+++ b/scripts/check_shared_lib_collisions.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
-"""Acceptance gate: Dataset shared/lib vs task lib top-level name collisions (#65).
+"""Acceptance gate: Dataset shared/ layout + task top-level ``shared`` shadow (#68).
 
 Usage::
 
     uv run python scripts/check_shared_lib_collisions.py <database-root> [...]
-    uv run python scripts/check_shared_lib_collisions.py examples/core
+    uv run python scripts/check_shared_lib_collisions.py examples/tau3-airline
 
 Exit codes:
-  0 — no shared/ or no collisions / forbidden paths
-  1 — collision or forbidden shared/ layout
+  0 — no forbidden shared/ paths and no task-level ``shared`` shadow
+  1 — forbidden layout or task ``shared`` shadow
   2 — usage / invalid path
+
+Note: same module stem under ``shared/lib`` and ``tasks/*/lib`` is **allowed**
+under namespaced imports (``shared.lib.x`` vs ``lib.x``). This script no longer
+bans stem collisions.
 """
 
 from __future__ import annotations
@@ -21,7 +25,10 @@ from pathlib import Path
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Fail closed when shared/lib collides with task lib top-level names (#65)."
+        description=(
+            "Fail closed on forbidden Dataset shared/ content or task-level "
+            "top-level name 'shared' (#68)."
+        )
     )
     parser.add_argument(
         "database_roots",
@@ -38,7 +45,7 @@ def main(argv: list[str] | None = None) -> int:
         sys.path.insert(0, str(src))
 
     from bora.config.errors import ConfigError
-    from bora.config.shared import find_lib_collisions, validate_shared_layout
+    from bora.config.shared import find_task_shared_shadows, validate_shared_layout
 
     failed = 0
     for raw in args.database_roots:
@@ -53,21 +60,18 @@ def main(argv: list[str] | None = None) -> int:
             print(f"FAIL {root}: {exc.message} ({exc.location})", file=sys.stderr)
             failed += 1
             continue
-        hits = find_lib_collisions(root)
-        if hits:
-            # validate_shared_layout should have raised; belt-and-suspenders.
-            for name, shared_loc, task_loc in hits:
-                print(
-                    f"FAIL {root}: collision {name!r} in {shared_loc} and {task_loc}",
-                    file=sys.stderr,
-                )
+        # Belt-and-suspenders: report shadows even if validate missed them.
+        shadows = find_task_shared_shadows(root)
+        if shadows:
+            for loc in shadows:
+                print(f"FAIL {root}: task owns reserved name shared at {loc}", file=sys.stderr)
             failed += 1
             continue
         shared = root / "shared"
         if shared.is_dir():
-            print(f"OK   {root}: shared/ present, no lib collisions")
+            print(f"OK   {root}: shared/ present, no task 'shared' shadow")
         else:
-            print(f"OK   {root}: no shared/ (noop)")
+            print(f"OK   {root}: no shared/, no task 'shared' shadow")
     return 1 if failed else 0
 
 

--- a/skills/bora-config-package/SKILL.md
+++ b/skills/bora-config-package/SKILL.md
@@ -31,19 +31,19 @@ my-database/                 # CLI path (bora.database/1)
 ├── scripts/                 # maintainer generators / regenerate (not on Agent path)
 │   ├── README.md            # how to regenerate / fork onboarding (recommended)
 │   └── generate_package.py  # multi-task thin members from upstream
-├── shared/                  # optional Dataset-level share
-│   ├── lib/                 # import only (Harness + Evaluator PYTHONPATH)
+├── shared/                  # optional Dataset package (shared/__init__.py recommended)
+│   ├── lib/                 # import as shared.lib.* (Harness + Evaluator)
 │   ├── assets/              # read-only domain data via code paths
 │   └── README.md
 └── tasks/
     └── my-task/             # task_id == directory name
         ├── task.yaml        # bora.task/1 — role slots + intent (no entry/model)
-        ├── harness.py       # prefer thin entry; orchestration in shared/lib
-        ├── evaluator.py     # prefer thin entry; scoring in shared/lib
+        ├── harness.py       # prefer thin entry; orchestration in shared.lib
+        ├── evaluator.py     # prefer thin entry; scoring in shared.lib
         ├── environment/     # optional seed.sql; Docker L1 needs Dockerfile
         ├── evaluation/      # gold / hidden — not for Agent mount
         ├── solution/        # human/CI offline fixture only; default NOT agent-seeded
-        ├── lib/             # task-only; MUST NOT collide with shared/lib names
+        ├── lib/             # task-only; import as lib.* (same stem as shared OK)
         └── data/            # agent-visible seed (L1: Runtime copies into workspace)
 ```
 
@@ -55,32 +55,48 @@ my-database/                 # CLI path (bora.database/1)
 | `tasks/*/evaluation/` | Evaluator process after writer barrier | **No** | **Yes** | Gold / hidden labels only |
 | `tasks/*/environment/` | Provider build/prepare (Dockerfile, seed.sql) | Indirect (image) | No | L1 image contract; not Agent mount of gold |
 | `tasks/*/solution/` | Only when offline fixture flag / `BORA_L1_USE_SOLUTION=1` / offline agent | Default **No** | No | Human/CI fixture; **not** default Agent seed |
-| `shared/lib/` | PYTHONPATH inject for Harness + Evaluator | **No** (import only) | No | Bridge/glue; never gold |
+| `shared/lib/` | Import only via Database root on path | **No** (import only) | No | Bridge/glue; never gold |
 | `shared/assets/` | Code paths in Harness/Evaluator | **No** default mount | No | Domain fixtures via imports, not workspace |
 | `scripts/` | Maintainer host only | No | No | Generators; not package runtime |
 
 ### Dataset `shared/` (when multi-task reuse)
 
-| Put in… | Use for |
+| Put in… | Use for | Import |
+| --- | --- | --- |
+| `shared/lib/` | Bridge / domain glue **shared by many tasks** | `from shared.lib.xxx import …` |
+| `tasks/<id>/lib/` | **Only this task** extensions | `from lib.yyy import …` |
+| `shared/assets/` | Read-only fixtures/policies via **code paths** (no `task.yaml` asset declaration) | code paths |
+| `tasks/<id>/evaluation/` | Gold only — **never** under `shared/` | evaluator only |
+
+**Import inject contract (Runtime — both harness worker and L0 evaluator):**
+
+```text
+sys.path prefix:  [task_dir, database_root, ...]
+# Never inject shared/lib or tasks/<id>/lib as path roots
+```
+
+| Wanted | Meaning |
 | --- | --- |
-| `shared/lib/` | Bridge / domain glue **shared by many tasks** |
-| `tasks/<id>/lib/` | **Only this task** extensions |
-| `shared/assets/` | Read-only fixtures/policies via **code paths** (no `task.yaml` asset declaration) |
-| `tasks/<id>/evaluation/` | Gold only — **never** under `shared/` |
+| `from shared.lib.bridge import …` | Dataset glue under `shared/lib/` |
+| `from lib.helper import …` | Task-only under `tasks/<id>/lib/` |
+
+Recommend real packages: `shared/__init__.py`, `shared/lib/__init__.py`, and
+`tasks/<id>/lib/__init__.py` when using `from lib…`.
 
 **Hard rules agents must respect:**
 
-1. **No top-level import name collision** between `shared/lib/` and any `tasks/*/lib/`
-   (e.g. both cannot define `bridge.py` or package dir `bridge/`). Lock **hard-fails**.
-2. Before adding modules, list both trees; prefer unique prefixes (`airline_bridge` vs task-local).
-3. Changing `shared/` changes whole-package `packageDigest` (no separate shared sub-digest).
-4. Core does **not** auto-COPY `shared/` into L1 images — task `environment/Dockerfile` must
-   `COPY` explicitly if the container needs those files (see `references/isolation.md`).
-5. Default: `shared/` is **not** mounted into the Agent workspace (Harness/Evaluator only).
-6. **Import contract:** task code must **not** own a top-level package name `shared`. Prefer
-   namespaced `shared.lib.*` (or documented path inject
-   `[task_dir, database_root]`) so `from shared.lib…` / `from lib…` resolve predictably.
-   Collision gates stay in Runtime/lock; authors follow the names here.
+1. **Reserved top-level name `shared`:** task members must **not** own
+   `tasks/<id>/shared/` or `tasks/<id>/shared.py` (shadows Dataset package on path).
+   Lock **hard-fails**. Same stem under `shared/lib` and `tasks/*/lib` (e.g. both
+   `bridge.py`) is **allowed** — namespaces differ (`shared.lib.bridge` vs `lib.bridge`).
+2. Changing `shared/` changes whole-package `packageDigest` (no separate shared sub-digest).
+3. Core does **not** auto-COPY `shared/` into L1 images — task `environment/Dockerfile`
+   must `COPY shared/` and put **Database root** (not only `shared/lib` leaf) on
+   `PYTHONPATH` if the container must import `shared.lib.*` (see `references/isolation.md`).
+   L0 inject ≠ L1 automatic availability.
+4. Default: `shared/` is **not** mounted into the Agent workspace (Harness/Evaluator only).
+5. **Migration:** bare `from bridge import …` (old leaf inject) →
+   `from shared.lib.bridge import …`. Generators must emit namespaced imports.
 
 **Acceptance gate (run before claiming package OK):**
 
@@ -95,10 +111,10 @@ ids), **do not** hand-copy 50 task trees. Use a Dataset-root generator:
 
 | Pattern | Guidance |
 | --- | --- |
-| Thin task entries | `tasks/<id>/{task.yaml,harness.py,evaluator.py}` are thin wrappers; orchestration lives in `shared/lib` |
-| Regenerate from upstream | `scripts/generate_package.py` (or similar) reads upstream assets → writes members |
+| Thin task entries | `tasks/<id>/{task.yaml,harness.py,evaluator.py}` are thin wrappers; orchestration lives in `shared.lib` |
+| Regenerate from upstream | `scripts/generate_package.py` emits `from shared.lib…`, not bare leaf imports |
 | Maintainer docs | Short `scripts/README.md` (or package README section): how to regenerate, required host deps, fork onboarding |
-| Reference shape | `examples/tau3-airline/scripts/`, `examples/marble-coding/scripts/`, `examples/terminal-bench-2/scripts/` |
+| Reference shape | `examples/tau3-airline/scripts/` (and other multi-task `examples/*/scripts/` when present) |
 
 See [references/conversion.md](references/conversion.md) for owner-map checklist and
 upstream → BORA placement template.
@@ -109,11 +125,20 @@ Prefer:
 
 ```python
 # tasks/<id>/harness.py — thin entry only
-from shared.lib.harness_core import run  # or lib.harness_core after path inject
-# re-export or one-liner async def run(ctx): return await run_core(ctx, task_id=...)
+from shared.lib.harness_core import run as _run
+
+async def run(ctx):
+    return await _run(ctx, task_dir=Path(__file__).resolve().parent)
+```
+
+Optional task-only helpers:
+
+```python
+from lib.task_only import helper  # tasks/<id>/lib/task_only.py
 ```
 
 Not: full dual-agent loop + tools inlined in every `tasks/*/harness.py`.  
+Not: bare `from harness_core import …` (depends on removed `shared/lib` leaf inject).  
 SDK surface stays the same (`Agent.session…invoke`); see `bora-sdk-harness` for API,
 this skill for **where** multi-task code lives.
 

--- a/skills/bora-config-package/references/conversion.md
+++ b/skills/bora-config-package/references/conversion.md
@@ -17,12 +17,23 @@ Existing examples under `examples/*/scripts/generate_package.py` typically:
 
 1. Read upstream assets (often under `shared/assets/` or an external path).
 2. Emit `tasks/<task_id>/task.yaml` with `provenance` filled.
-3. Emit thin `harness.py` / `evaluator.py` that import Dataset glue (`shared.lib.*` or path-injected `lib.*`).
+3. Emit thin `harness.py` / `evaluator.py` that import **`shared.lib.*`**
+   (never bare leaf imports that assumed `shared/lib` on `PYTHONPATH`).
 4. Write per-task `data/` (agent-visible) and `evaluation/` (gold) as needed.
-5. Stay idempotent: re-run regenerates members without hand-editing fifty files.
+5. Ensure package markers: `shared/__init__.py`, `shared/lib/__init__.py` (recommended).
+6. Stay idempotent: re-run regenerates members without hand-editing fifty files.
 
 Document regenerate steps in `scripts/README.md` or the package README so forks
 do not invent Core hooks.
+
+### Import migration (generators & ports)
+
+| Old (leaf inject) | New (Database root on path) |
+| --- | --- |
+| `from harness_core import run` | `from shared.lib.harness_core import run` |
+| `from bridge import make_environment` | `from shared.lib.bridge import make_environment` |
+| `from evaluator_core import evaluate` | `from shared.lib.evaluator_core import evaluate` |
+| task-local `from helper import …` via `lib/` on path | `from lib.helper import …` with `tasks/<id>/lib/` |
 
 ## Upstream → BORA owner map (checklist)
 
@@ -52,13 +63,16 @@ Job axis remains Database-root `profiles.yaml` / CLI overlays — not per-task e
 ## Thin multi-task harness template
 
 ```text
-shared/lib/
-  harness_core.py      # async run(ctx, *, task_id) orchestration
-  evaluator_core.py    # evaluate(...) scoring
-  bridge.py            # tools / domain glue
+shared/
+  __init__.py
+  lib/
+    __init__.py
+    harness_core.py      # async run(ctx, *, task_dir) orchestration
+    evaluator_core.py    # evaluate(...) scoring
+    bridge.py            # tools / domain glue
 tasks/task-00/
-  harness.py           # from shared.lib.harness_core import run  (or re-export)
-  evaluator.py         # thin
+  harness.py             # from shared.lib.harness_core import run as _run
+  evaluator.py           # from shared.lib.evaluator_core import evaluate as _evaluate
   data/ … evaluation/
 ```
 
@@ -69,6 +83,7 @@ Do not fork Core Runtime for “setup hooks”; use `data/` seed + Dockerfile ti
 
 - Conversion completeness, Hub package publish, or `bora lock` success **do not**
   upgrade evidence grade (`runnable-mvp` / `isolated` / `real-benchmark-verified`).
+- Import-style / path-inject changes **do not** upgrade evidence grade.
 - PASS only from the independent evaluator after barrier.
 - Fill `provenance` for ports; known gaps stay honest.
 
@@ -76,6 +91,6 @@ Do not fork Core Runtime for “setup hooks”; use `data/` seed + Dockerfile ti
 
 | Doc | Use for |
 | --- | --- |
-| `references/isolation.md` | L1 Dockerfile depth, `data/` seed, explicit `COPY shared/` |
-| Parent skill layout / role map | Where `shared/`, `scripts/`, `solution/` live |
-| `examples/*/scripts/generate_package.py` | Reference generator shape for multi-task ports |
+| `references/isolation.md` | L1 Dockerfile depth, `data/` seed, explicit `COPY shared/` + Database-root `PYTHONPATH` |
+| Parent skill layout / role map | Where `shared/`, `scripts/`, `solution/` live; inject contract |
+| `examples/tau3-airline/scripts/generate_package.py` | Reference generator emitting `shared.lib.*` |

--- a/skills/bora-config-package/references/isolation.md
+++ b/skills/bora-config-package/references/isolation.md
@@ -49,26 +49,46 @@ non-workspace layout, build-time material). Do not invent package “setup hooks
 
 ## Dataset `shared/`
 
+- Import contract: Runtime injects **`[task_dir, database_root]`** — **not** the
+  `shared/lib` leaf. Authors write `from shared.lib…` / `from lib…`.
 - `shared/lib` is for Harness/Evaluator import only — **not** default Agent mount.
 - Gold stays under `tasks/*/evaluation/` only; **forbid** gold / `.env` under `shared/`.
-- L1: no Core implicit COPY of `shared/`; task `environment/Dockerfile` owns any `COPY`.
-- Collision: `shared/lib` vs `tasks/*/lib` top-level names → lock fail. Check with
-  `uv run python scripts/check_shared_lib_collisions.py <database-root>`.
-- Import contract: prefer namespaced `shared.lib.*` / path inject roots;
-  task must not own top-level name `shared`. Collision gates stay in Runtime/lock.
+- Task members must **not** own top-level name `shared` (`shared/` dir or `shared.py`).
+  Same basename under `shared/lib` and `tasks/*/lib` is **allowed**.
+- Check with: `uv run python scripts/check_shared_lib_collisions.py <database-root>`.
+- L1: **no** Core implicit COPY of `shared/`. L0 path inject **≠** L1 automatic
+  availability for the clean evaluator container.
 
-### L1 evaluator + explicit `COPY shared/` snippet
+### L0 vs L1 evaluator asymmetry (B1)
+
+| Surface | `shared.lib.*` available? |
+| --- | --- |
+| L0 harness worker / L0 evaluator subprocess | Yes — Runtime injects Database root |
+| L1 Attempt / clean-evaluator container | **Only if** task Dockerfile explicitly `COPY shared/` and sets `PYTHONPATH` so **Database root** (or layout that still exposes package `shared`) is on path |
+
+Same `evaluator.py` with `from shared.lib…` can **pass on L0** and **ImportError on L1**
+unless the image recipe includes `shared/`. Do not expect Core to fix that.
+
+### L1 Dockerfile snippet (B3) — matches host inject
 
 When Harness or Evaluator inside the container must import Dataset glue, **declare** it
 in the task Dockerfile (Core will not inject):
 
 ```dockerfile
 FROM bora-attempt:l1
-# Context is typically the Database root (or documented build context).
+# Build context is typically the Database root (or documented equivalent).
 COPY shared/ /attempt/shared/
-# Ensure import roots match host path-inject contract (adjust to package layout):
-ENV PYTHONPATH=/attempt/shared/lib:/attempt/task:${PYTHONPATH}
-# Optional: COPY only what the container needs (lib/, not gold).
+# Put Database-layout root on path so `import shared` / `shared.lib.*` resolve.
+# Do NOT set PYTHONPATH to only /attempt/shared/lib (leaf inject is retired).
+ENV PYTHONPATH=/attempt:/attempt/task:${PYTHONPATH}
+# Optional: also COPY task sources the container needs under /attempt/task
+```
+
+If your layout mounts the whole Database at `/attempt/db`:
+
+```dockerfile
+COPY shared/ /attempt/db/shared/
+ENV PYTHONPATH=/attempt/db:/attempt/task:${PYTHONPATH}
 ```
 
 Notes:
@@ -83,5 +103,7 @@ Notes:
 - Mount gold into harness “for convenience”.
 - Put credentials in package tree.
 - Put evaluation gold or host secrets under Database-root `shared/`.
-- Reuse the same top-level module name in `shared/lib` and a task `lib/`.
+- Own top-level `shared` under a task member (dir or `.py`).
+- Depend on bare leaf imports (`from bridge import …`) — use `shared.lib.*`.
+- Expect Core to auto-COPY `shared/` into L1 images.
 - Use runtime package installs as the default parity path for converted suites.

--- a/src/bora/application/run_command_evaluator.py
+++ b/src/bora/application/run_command_evaluator.py
@@ -25,6 +25,8 @@ def run_evaluator_worker(
         return {"status": "ERROR", "score": None, "metrics": {}}
     # #68: [task_dir, database_root] — same contract as harness worker.
     # Do not inject shared/lib leaf; authors use shared.lib.* / lib.*.
+    # Build highest-priority first, then reverse-insert so final path prefix
+    # is [task_dir, database_root, ...] (insert(0) reverses forward iteration).
     path_entries: list[str] = [str(package_root.resolve())]
     if database_root is not None:
         path_entries.append(str(database_root.resolve()))
@@ -36,9 +38,10 @@ def run_evaluator_worker(
             "\n".join(
                 [
                     "import json, importlib.util, sys",
-                    f"for _p in {path_inject}:",
-                    "    if _p not in sys.path:",
-                    "        sys.path.insert(0, _p)",
+                    f"for _p in reversed({path_inject}):",
+                    "    if _p in sys.path:",
+                    "        sys.path.remove(_p)",
+                    "    sys.path.insert(0, _p)",
                     f"spec = importlib.util.spec_from_file_location('ev', {str(path)!r})",
                     "mod = importlib.util.module_from_spec(spec)",
                     "assert spec.loader is not None",

--- a/src/bora/application/run_command_evaluator.py
+++ b/src/bora/application/run_command_evaluator.py
@@ -23,12 +23,11 @@ def run_evaluator_worker(
     path = package_root / "evaluator.py"
     if not path.is_file():
         return {"status": "ERROR", "score": None, "metrics": {}}
-    # #65: inject task root + optional shared/lib (same contract as harness worker).
+    # #68: [task_dir, database_root] — same contract as harness worker.
+    # Do not inject shared/lib leaf; authors use shared.lib.* / lib.*.
     path_entries: list[str] = [str(package_root.resolve())]
     if database_root is not None:
-        shared_lib = database_root.resolve() / "shared" / "lib"
-        if shared_lib.is_dir():
-            path_entries.insert(0, str(shared_lib))
+        path_entries.append(str(database_root.resolve()))
     path_inject = repr(path_entries)
     with tempfile.TemporaryDirectory(prefix="bora-eval-") as tmp:
         script = Path(tmp) / "run_eval.py"

--- a/src/bora/application/run_harness.py
+++ b/src/bora/application/run_harness.py
@@ -71,7 +71,8 @@ async def run_harness_package(
     Attempt host workspace so harness can read agent-written files.
 
     *database_root* is the Database root (optional). When set, the worker injects
-    ``shared/lib`` on ``sys.path`` and exposes it for code-path asset reads (#65).
+    ``[task_dir, database_root]`` on ``sys.path`` so authors import ``shared.lib.*``
+    / ``lib.*`` and can resolve code-path assets under the Dataset (#68).
     """
     factory = identity_factory or IdentityFactory()
     if attempt is not None:

--- a/src/bora/config/load_and_lock.py
+++ b/src/bora/config/load_and_lock.py
@@ -98,7 +98,7 @@ class ConfigCore:
 
         validate_top_level_layout(self._reader, root)
 
-        # #68 Dataset shared/ bans + task top-level ``shared`` shadow ban (when Database root known).
+        # #68 Dataset shared/ bans + task top-level ``shared`` shadow ban.
         from bora.config.shared import infer_database_root_from_task, validate_shared_layout
 
         db_root = infer_database_root_from_task(root)

--- a/src/bora/config/load_and_lock.py
+++ b/src/bora/config/load_and_lock.py
@@ -98,7 +98,7 @@ class ConfigCore:
 
         validate_top_level_layout(self._reader, root)
 
-        # #65 Dataset shared/ bans + shared/lib vs task lib collision (when Database root known).
+        # #68 Dataset shared/ bans + task top-level ``shared`` shadow ban (when Database root known).
         from bora.config.shared import infer_database_root_from_task, validate_shared_layout
 
         db_root = infer_database_root_from_task(root)

--- a/src/bora/config/shared.py
+++ b/src/bora/config/shared.py
@@ -1,4 +1,4 @@
-"""Dataset-level ``shared/`` layout helpers (#65).
+"""Dataset-level ``shared/`` layout helpers (#65 layout, #68 import namespaces).
 
 Design authority: ``docs/design/02-task-package-and-config.md`` (Dataset 级 shared/).
 """
@@ -16,6 +16,9 @@ _FORBIDDEN_SHARED_TOP_LEVEL = frozenset(
         ".env",
     }
 )
+
+# Reserved Dataset package name — task members must not own this top-level name.
+_RESERVED_TOP_LEVEL_PACKAGE = "shared"
 
 
 def shared_dir(database_root: Path) -> Path:
@@ -68,6 +71,7 @@ def top_level_import_names(lib_dir: Path) -> set[str]:
 
 
 def collect_shared_lib_names(database_root: Path) -> set[str]:
+    """Top-level stems under ``shared/lib`` (informational; no longer a lock ban)."""
     return top_level_import_names(shared_lib_dir(database_root))
 
 
@@ -81,29 +85,52 @@ def find_lib_collisions(
     tasks_root: str = "tasks",
     task_ids: list[str] | None = None,
 ) -> list[tuple[str, str, str]]:
-    """Return collision triples ``(name, shared, tasks/<id>/lib)``.
+    """Deprecated under #68: same stem under shared/lib and task lib is allowed.
 
-    Empty list means no top-level import name clashes.
+    Kept as an empty-list API for callers that still import the name; always
+    returns ``[]``. Prefer :func:`find_task_shared_shadows`.
+    """
+    _ = (database_root, tasks_root, task_ids)
+    return []
+
+
+def _task_ids_under(
+    root: Path,
+    tasks_root: str,
+    task_ids: list[str] | None,
+) -> list[str]:
+    if task_ids is not None:
+        return list(task_ids)
+    tasks_dir = root / tasks_root
+    if not tasks_dir.is_dir():
+        return []
+    return sorted(p.name for p in tasks_dir.iterdir() if p.is_dir() and not p.name.startswith("."))
+
+
+def find_task_shared_shadows(
+    database_root: Path,
+    *,
+    tasks_root: str = "tasks",
+    task_ids: list[str] | None = None,
+) -> list[str]:
+    """Return relative paths of task-owned top-level ``shared`` that would shadow Dataset.
+
+    Forbidden when present:
+
+    - ``tasks/<id>/shared/`` (directory)
+    - ``tasks/<id>/shared.py`` (module)
     """
     root = database_root.expanduser().resolve(strict=False)
-    shared_names = collect_shared_lib_names(root)
-    if not shared_names:
-        return []
-
-    if task_ids is None:
-        tasks_dir = root / tasks_root
-        if not tasks_dir.is_dir():
-            return []
-        task_ids = sorted(
-            p.name for p in tasks_dir.iterdir() if p.is_dir() and not p.name.startswith(".")
-        )
-
-    collisions: list[tuple[str, str, str]] = []
-    for tid in task_ids:
-        task_names = collect_task_lib_names(root / tasks_root / tid)
-        for name in sorted(shared_names & task_names):
-            collisions.append((name, "shared/lib", f"{tasks_root}/{tid}/lib"))
-    return collisions
+    hits: list[str] = []
+    for tid in _task_ids_under(root, tasks_root, task_ids):
+        task_dir = root / tasks_root / tid
+        shared_dir_path = task_dir / _RESERVED_TOP_LEVEL_PACKAGE
+        shared_mod = task_dir / f"{_RESERVED_TOP_LEVEL_PACKAGE}.py"
+        if shared_dir_path.exists():
+            hits.append(f"{tasks_root}/{tid}/{_RESERVED_TOP_LEVEL_PACKAGE}")
+        if shared_mod.is_file():
+            hits.append(f"{tasks_root}/{tid}/{_RESERVED_TOP_LEVEL_PACKAGE}.py")
+    return hits
 
 
 def validate_shared_layout(
@@ -112,51 +139,50 @@ def validate_shared_layout(
     tasks_root: str = "tasks",
     task_ids: list[str] | None = None,
 ) -> None:
-    """Fail closed on forbidden ``shared/`` content or lib name collisions (#65).
+    """Fail closed on forbidden ``shared/`` content or task ``shared`` shadows (#68).
 
-    No-op when ``shared/`` is absent.
+    No-op when ``shared/`` is absent **and** no task owns top-level ``shared``.
+    Task-level ``shared`` shadow is always checked when a Database root is known.
     """
     root = database_root.expanduser().resolve(strict=False)
     shared = root / "shared"
-    if not shared.exists():
-        return
-    if not shared.is_dir():
-        raise ConfigError(
-            ERROR_INVALID_PACKAGE,
-            "shared must be a directory when present",
-            location="shared",
-        )
-
-    for name in sorted(_FORBIDDEN_SHARED_TOP_LEVEL):
-        bad = shared / name
-        if bad.exists():
+    if shared.exists():
+        if not shared.is_dir():
             raise ConfigError(
                 ERROR_INVALID_PACKAGE,
-                f"forbidden path under shared/: {name} "
-                "(gold/secrets must not live under Dataset shared/)",
-                location=f"shared/{name}",
+                "shared must be a directory when present",
+                location="shared",
             )
 
-    # Also reject nested .env anywhere under shared/
-    for env_file in shared.rglob(".env"):
-        if env_file.is_file():
-            try:
-                rel = env_file.relative_to(root).as_posix()
-            except ValueError:
-                rel = "shared/.env"
-            raise ConfigError(
-                ERROR_INVALID_PACKAGE,
-                "host secrets must not live under shared/ (.env forbidden)",
-                location=rel,
-            )
+        for name in sorted(_FORBIDDEN_SHARED_TOP_LEVEL):
+            bad = shared / name
+            if bad.exists():
+                raise ConfigError(
+                    ERROR_INVALID_PACKAGE,
+                    f"forbidden path under shared/: {name} "
+                    "(gold/secrets must not live under Dataset shared/)",
+                    location=f"shared/{name}",
+                )
 
-    collisions = find_lib_collisions(root, tasks_root=tasks_root, task_ids=task_ids)
-    if collisions:
-        parts = [
-            f"{name!r} in {shared_loc} and {task_loc}" for name, shared_loc, task_loc in collisions
-        ]
+        # Also reject nested .env anywhere under shared/
+        for env_file in shared.rglob(".env"):
+            if env_file.is_file():
+                try:
+                    rel = env_file.relative_to(root).as_posix()
+                except ValueError:
+                    rel = "shared/.env"
+                raise ConfigError(
+                    ERROR_INVALID_PACKAGE,
+                    "host secrets must not live under shared/ (.env forbidden)",
+                    location=rel,
+                )
+
+    shadows = find_task_shared_shadows(root, tasks_root=tasks_root, task_ids=task_ids)
+    if shadows:
         raise ConfigError(
             ERROR_INVALID_PACKAGE,
-            "shared/lib vs task lib top-level import name collision (ban): " + "; ".join(parts),
-            location="shared/lib",
+            "task must not own top-level name 'shared' "
+            "(shadows Dataset package shared when both parents are on sys.path): "
+            + "; ".join(shadows),
+            location=shadows[0],
         )

--- a/src/bora/runtime/task_worker.py
+++ b/src/bora/runtime/task_worker.py
@@ -42,14 +42,21 @@ def _send_msg(fd: int, obj: dict[str, Any]) -> None:
 
 
 def _inject_import_paths(package_root: Path, database_root: Path | None) -> None:
-    """Make task root and optional Dataset ``shared/lib`` importable (#65)."""
-    # Both roots are injected; top-level name collisions are banned at lock time,
-    # so insert order is non-semantic for correctness.
-    sys.path.insert(0, str(package_root))
+    """Make task root and Dataset root importable (#68).
+
+    Authoritative prefix: ``[task_dir, database_root, ...]``.
+    Do **not** inject ``shared/lib`` or ``tasks/<id>/lib`` as path roots —
+    authors import ``shared.lib.*`` / ``lib.*``.
+    """
+    # Insert database_root first, then task_dir so task_dir ends up at front.
     if database_root is not None:
-        shared_lib = database_root / "shared" / "lib"
-        if shared_lib.is_dir():
-            sys.path.insert(0, str(shared_lib.resolve()))
+        db = str(database_root.resolve())
+        if db not in sys.path:
+            sys.path.insert(0, db)
+    task = str(package_root.resolve())
+    if task in sys.path:
+        sys.path.remove(task)
+    sys.path.insert(0, task)
 
 
 def _load_entrypoint(
@@ -83,7 +90,7 @@ async def _run(fd: int) -> int:
     # Optional Attempt workspace (L1 host bind); default package root for L0.
     ws_raw = launch.get("workspace_root")
     workspace_root = Path(ws_raw) if ws_raw else package_root
-    # #65 Dataset root for shared/lib import + code-path assets.
+    # #68 Dataset root for shared.lib.* import + code-path assets.
     db_raw = launch.get("database_root")
     database_root = Path(db_raw) if db_raw else None
 

--- a/tests/config/test_shared.py
+++ b/tests/config/test_shared.py
@@ -1,4 +1,4 @@
-"""Dataset-level shared/ validation and collision rules (#65)."""
+"""Dataset-level shared/ validation and reserved-name rules (#65 layout, #68 namespaces)."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ from bora.config.errors import ConfigError
 from bora.config.load_and_lock import ConfigCore
 from bora.config.shared import (
     find_lib_collisions,
+    find_task_shared_shadows,
     top_level_import_names,
     validate_shared_layout,
 )
@@ -86,18 +87,36 @@ def test_no_shared_is_noop(tmp_path: Path) -> None:
     validate_shared_layout(tmp_path)  # no raise
 
 
-def test_collision_ban(tmp_path: Path) -> None:
+def test_same_stem_across_shared_and_task_lib_allowed(tmp_path: Path) -> None:
+    """#68: shared.lib.bridge vs lib.bridge — same basename is fine."""
     _write_db(tmp_path)
     shared_lib = tmp_path / "shared" / "lib"
     shared_lib.mkdir(parents=True)
     (shared_lib / "bridge.py").write_text("x=1\n", encoding="utf-8")
     _write_task(tmp_path / "tasks" / "a", "a", lib_mod="bridge")
-    hits = find_lib_collisions(tmp_path)
-    assert hits == [("bridge", "shared/lib", "tasks/a/lib")]
+    assert find_lib_collisions(tmp_path) == []
+    validate_shared_layout(tmp_path)  # no raise
+
+
+def test_task_shared_dir_forbidden(tmp_path: Path) -> None:
+    _write_db(tmp_path)
+    _write_task(tmp_path / "tasks" / "a", "a")
+    (tmp_path / "tasks" / "a" / "shared").mkdir()
+    hits = find_task_shared_shadows(tmp_path)
+    assert hits == ["tasks/a/shared"]
     with pytest.raises(ConfigError) as ei:
         validate_shared_layout(tmp_path)
-    assert "collision" in ei.value.message
+    assert "shared" in ei.value.message
     assert ei.value.error_code == "invalid_package"
+
+
+def test_task_shared_py_forbidden(tmp_path: Path) -> None:
+    _write_db(tmp_path)
+    _write_task(tmp_path / "tasks" / "a", "a")
+    (tmp_path / "tasks" / "a" / "shared.py").write_text("x=1\n", encoding="utf-8")
+    with pytest.raises(ConfigError) as ei:
+        validate_shared_layout(tmp_path)
+    assert "shared" in ei.value.message
 
 
 def test_forbidden_env_under_shared(tmp_path: Path) -> None:
@@ -110,23 +129,40 @@ def test_forbidden_env_under_shared(tmp_path: Path) -> None:
     assert ".env" in ei.value.message
 
 
-def test_lock_fails_on_lib_collision(tmp_path: Path) -> None:
+def test_lock_fails_on_task_shared_shadow(tmp_path: Path) -> None:
     _write_db(tmp_path)
     shared_lib = tmp_path / "shared" / "lib"
     shared_lib.mkdir(parents=True)
     (shared_lib / "common.py").write_text("V=1\n", encoding="utf-8")
-    _write_task(tmp_path / "tasks" / "t1", "t1", lib_mod="common")
+    task = tmp_path / "tasks" / "t1"
+    _write_task(task, "t1")
+    (task / "shared").mkdir()
     core = ConfigCore(package_reader=LocalPackageReader())
     with pytest.raises(ConfigError) as ei:
         core.load_and_lock(
-            tmp_path / "tasks" / "t1",
+            task,
             "t1",
             capabilities=DeclarationCapabilityCatalog(),
         )
-    assert "collision" in ei.value.message
+    assert "shared" in ei.value.message
 
 
-def test_lock_ok_with_shared_no_collision(tmp_path: Path) -> None:
+def test_lock_ok_with_same_stem(tmp_path: Path) -> None:
+    _write_db(tmp_path)
+    shared_lib = tmp_path / "shared" / "lib"
+    shared_lib.mkdir(parents=True)
+    (shared_lib / "bridge.py").write_text("V=1\n", encoding="utf-8")
+    _write_task(tmp_path / "tasks" / "t1", "t1", lib_mod="bridge")
+    core = ConfigCore(package_reader=LocalPackageReader())
+    lock = core.load_and_lock(
+        tmp_path / "tasks" / "t1",
+        "t1",
+        capabilities=DeclarationCapabilityCatalog(),
+    )
+    assert lock.digest.startswith("sha256:")
+
+
+def test_lock_ok_with_shared_no_shadow(tmp_path: Path) -> None:
     _write_db(tmp_path)
     shared_lib = tmp_path / "shared" / "lib"
     shared_lib.mkdir(parents=True)
@@ -142,7 +178,7 @@ def test_lock_ok_with_shared_no_collision(tmp_path: Path) -> None:
 
 
 def test_infer_walks_up_for_nested_tasks_root(tmp_path: Path) -> None:
-    """Collision gate must fire even when tasks.root is nested (not just tasks/)."""
+    """Shadow gate must fire even when tasks.root is nested (not just tasks/)."""
     from bora.config.shared import infer_database_root_from_task
 
     (tmp_path / "bora.yaml").write_text(
@@ -157,11 +193,12 @@ def test_infer_walks_up_for_nested_tasks_root(tmp_path: Path) -> None:
     (shared_lib / "bridge.py").write_text("x=1\n", encoding="utf-8")
     task = tmp_path / "members" / "group" / "t1"
     _write_task(task, "t1", lib_mod="bridge")
+    (task / "shared.py").write_text("bad=1\n", encoding="utf-8")
     assert infer_database_root_from_task(task) == tmp_path.resolve()
     with pytest.raises(ConfigError) as ei:
         validate_shared_layout(tmp_path, tasks_root="members/group")
-    assert "collision" in ei.value.message
+    assert "shared" in ei.value.message
     core = ConfigCore(package_reader=LocalPackageReader())
     with pytest.raises(ConfigError) as ei2:
         core.load_and_lock(task, "t1", capabilities=DeclarationCapabilityCatalog())
-    assert "collision" in ei2.value.message
+    assert "shared" in ei2.value.message

--- a/tests/runtime/test_shared_lib_import.py
+++ b/tests/runtime/test_shared_lib_import.py
@@ -1,4 +1,4 @@
-"""Harness / evaluator can import modules from Dataset shared/lib (#65)."""
+"""Harness / evaluator import Dataset glue via shared.lib.* (#68)."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ from bora.config.capabilities import DeclarationCapabilityCatalog
 from bora.config.load_and_lock import ConfigCore
 
 
-def _scaffold(root: Path) -> Path:
+def _scaffold(root: Path, *, with_task_lib: bool = False) -> Path:
     root.mkdir(parents=True, exist_ok=True)
     (root / "bora.yaml").write_text(
         "format: bora.database/1\n"
@@ -22,8 +22,11 @@ def _scaffold(root: Path) -> Path:
         "tasks:\n  root: tasks\n",
         encoding="utf-8",
     )
-    shared_lib = root / "shared" / "lib"
+    shared = root / "shared"
+    shared_lib = shared / "lib"
     shared_lib.mkdir(parents=True)
+    (shared / "__init__.py").write_text("", encoding="utf-8")
+    (shared_lib / "__init__.py").write_text("", encoding="utf-8")
     (shared_lib / "bridge_mod.py").write_text(
         "TOKEN = 'from-shared'\n",
         encoding="utf-8",
@@ -62,36 +65,67 @@ evaluation:
 """,
         encoding="utf-8",
     )
-    (task / "harness.py").write_text(
-        """
+    if with_task_lib:
+        lib = task / "lib"
+        lib.mkdir()
+        (lib / "__init__.py").write_text("", encoding="utf-8")
+        # Same basename as shared module — must resolve via lib.* not shared.lib.*
+        (lib / "bridge_mod.py").write_text(
+            "TOKEN = 'from-task-lib'\n",
+            encoding="utf-8",
+        )
+        harness_body = """
 from bora_sdk.terminal import HarnessTerminal
+from lib.bridge_mod import TOKEN as TASK_TOKEN
+from shared.lib.bridge_mod import TOKEN as SHARED_TOKEN
 
 def run(ctx):
-    import bridge_mod
-    ctx.publish_json("session-output", {"token": bridge_mod.TOKEN})
+    ctx.publish_json(
+        "session-output",
+        {"task": TASK_TOKEN, "shared": SHARED_TOKEN},
+    )
     return HarnessTerminal.completed()
-""",
-        encoding="utf-8",
-    )
-    (task / "evaluator.py").write_text(
-        """
+"""
+        eval_body = """
+from lib.bridge_mod import TOKEN as TASK_TOKEN
+from shared.lib.bridge_mod import TOKEN as SHARED_TOKEN
+
 def evaluate(payload):
-    import bridge_mod
-    arts = payload.get("artifacts") or {}
-    # token path not required; import success is the gate
+    ok = TASK_TOKEN == "from-task-lib" and SHARED_TOKEN == "from-shared"
     return {
-        "status": "PASS" if bridge_mod.TOKEN == "from-shared" else "FAIL",
-        "score": 1.0 if bridge_mod.TOKEN == "from-shared" else 0.0,
-        "metrics": {"token": bridge_mod.TOKEN},
+        "status": "PASS" if ok else "FAIL",
+        "score": 1.0 if ok else 0.0,
+        "metrics": {"task": TASK_TOKEN, "shared": SHARED_TOKEN},
     }
-""",
-        encoding="utf-8",
-    )
+"""
+    else:
+        harness_body = """
+from bora_sdk.terminal import HarnessTerminal
+from shared.lib.bridge_mod import TOKEN
+
+def run(ctx):
+    ctx.publish_json("session-output", {"token": TOKEN})
+    return HarnessTerminal.completed()
+"""
+        eval_body = """
+from shared.lib.bridge_mod import TOKEN
+
+def evaluate(payload):
+    arts = payload.get("artifacts") or {}
+    _ = arts
+    return {
+        "status": "PASS" if TOKEN == "from-shared" else "FAIL",
+        "score": 1.0 if TOKEN == "from-shared" else 0.0,
+        "metrics": {"token": TOKEN},
+    }
+"""
+    (task / "harness.py").write_text(harness_body, encoding="utf-8")
+    (task / "evaluator.py").write_text(eval_body, encoding="utf-8")
     return task
 
 
 @pytest.mark.asyncio
-async def test_harness_imports_shared_lib(tmp_path: Path) -> None:
+async def test_harness_imports_shared_lib_namespace(tmp_path: Path) -> None:
     task = _scaffold(tmp_path)
     core = ConfigCore(package_reader=LocalPackageReader())
     lock = core.load_and_lock(task, "t1", capabilities=DeclarationCapabilityCatalog())
@@ -104,11 +138,10 @@ async def test_harness_imports_shared_lib(tmp_path: Path) -> None:
     assert "from-shared" in text
 
 
-def test_evaluator_imports_shared_lib(tmp_path: Path) -> None:
+def test_evaluator_imports_shared_lib_namespace(tmp_path: Path) -> None:
     task = _scaffold(tmp_path)
     core = ConfigCore(package_reader=LocalPackageReader())
     lock = core.load_and_lock(task, "t1", capabilities=DeclarationCapabilityCatalog())
-    # Minimal artifact file for evaluate inputs
     art = tmp_path / "session-output.json"
     art.write_text('{"token":"x"}\n', encoding="utf-8")
     raw = run_evaluator_worker(
@@ -119,3 +152,29 @@ def test_evaluator_imports_shared_lib(tmp_path: Path) -> None:
     )
     assert raw.get("status") == "PASS"
     assert (raw.get("metrics") or {}).get("token") == "from-shared"
+
+
+@pytest.mark.asyncio
+async def test_same_basename_shared_and_task_lib_coexist(tmp_path: Path) -> None:
+    """shared.lib.bridge_mod and lib.bridge_mod must both resolve (#68)."""
+    task = _scaffold(tmp_path, with_task_lib=True)
+    core = ConfigCore(package_reader=LocalPackageReader())
+    lock = core.load_and_lock(task, "t1", capabilities=DeclarationCapabilityCatalog())
+    result = await run_harness_package(lock, task, timeout_seconds=20.0, database_root=tmp_path)
+    env = result["envelope"]
+    assert env.get("ok") is True, env
+    text = Path((env.get("published") or {})["session-output"]).read_text(encoding="utf-8")
+    assert "from-task-lib" in text
+    assert "from-shared" in text
+    art = tmp_path / "session-output.json"
+    art.write_text("{}\n", encoding="utf-8")
+    raw = run_evaluator_worker(
+        task,
+        lock,
+        {"session-output": str(art)},
+        database_root=tmp_path,
+    )
+    assert raw.get("status") == "PASS", raw
+    metrics = raw.get("metrics") or {}
+    assert metrics.get("task") == "from-task-lib"
+    assert metrics.get("shared") == "from-shared"

--- a/tests/runtime/test_shared_lib_import.py
+++ b/tests/runtime/test_shared_lib_import.py
@@ -154,6 +154,39 @@ def test_evaluator_imports_shared_lib_namespace(tmp_path: Path) -> None:
     assert (raw.get("metrics") or {}).get("token") == "from-shared"
 
 
+def test_evaluator_path_order_task_dir_before_database_root(tmp_path: Path) -> None:
+    """L0 evaluator inject must match harness: [task_dir, database_root]."""
+    # Bypass full package lock: only the evaluator worker path inject is under test.
+    # Same bare top-level name under both path roots — first on path wins.
+    task = tmp_path / "tasks" / "t1"
+    task.mkdir(parents=True)
+    (task / "order_probe.py").write_text("SOURCE = 'task'\n", encoding="utf-8")
+    (tmp_path / "order_probe.py").write_text("SOURCE = 'database'\n", encoding="utf-8")
+    (task / "evaluator.py").write_text(
+        """
+import order_probe
+
+def evaluate(payload):
+    return {
+        "status": "PASS" if order_probe.SOURCE == "task" else "FAIL",
+        "score": 1.0 if order_probe.SOURCE == "task" else 0.0,
+        "metrics": {"source": order_probe.SOURCE},
+    }
+""",
+        encoding="utf-8",
+    )
+    art = tmp_path / "session-output.json"
+    art.write_text("{}\n", encoding="utf-8")
+    raw = run_evaluator_worker(
+        task,
+        lock=object(),
+        artifacts_map={"session-output": str(art)},
+        database_root=tmp_path,
+    )
+    assert raw.get("status") == "PASS", raw
+    assert (raw.get("metrics") or {}).get("source") == "task"
+
+
 @pytest.mark.asyncio
 async def test_same_basename_shared_and_task_lib_coexist(tmp_path: Path) -> None:
     """shared.lib.bridge_mod and lib.bridge_mod must both resolve (#68)."""

--- a/website/content/docs/author/package-layout.en.mdx
+++ b/website/content/docs/author/package-layout.en.mdx
@@ -17,7 +17,7 @@ my-dataset/
 ├── bora.yaml
 ├── profiles.yaml           # optional job binding defaults
 ├── shared/                 # optional cross-task share (in packageDigest)
-│   ├── lib/                # Harness / Evaluator import only
+│   ├── lib/                # import as shared.lib.*
 │   ├── assets/             # read-only domain data (code paths)
 │   └── README.md
 └── tasks/
@@ -29,7 +29,7 @@ my-dataset/
         ├── environment/
         ├── evaluation/     # gold — not for Agent by default
         ├── data/
-        └── lib/            # task-only; no top-level name clash with shared/lib
+        └── lib/            # task-only; import as lib.*
 ```
 
 Allowed task top-level dirs: `prompts`, `schemas`, `environment`, `evaluation`, `data`, `lib`, `upstream`, `solution`.
@@ -38,20 +38,24 @@ Allowed task top-level dirs: `prompts`, `schemas`, `environment`, `evaluation`, 
 
 Homogeneous multi-task packages can keep shared bridges and domain assets under root `shared/` instead of copying into every `tasks/*/lib/`.
 
-| Path | Role |
-| --- | --- |
-| `shared/lib/` | Cross-task Python modules; Runtime injects import path |
-| `shared/assets/` | Read-only fixtures / policy / db via code paths |
+| Path | Role | Import |
+| --- | --- | --- |
+| `shared/lib/` | Cross-task Python modules | `from shared.lib…` |
+| `shared/assets/` | Read-only fixtures / policy / db | code paths |
+| `tasks/*/lib/` | Task-only extensions | `from lib…` |
+
+Runtime path prefix is **`[task_dir, database_root]`** — the `shared/lib` leaf is **not** injected as a path root.
 
 Hard rules (summary):
 
 - If present, `shared/**` **must** enter `packageDigest` / the publish blob  
 - Not Agent-mounted by default; gold stays under `tasks/*/evaluation/` only  
-- Top-level import names must **not** collide between `shared/lib` and any task `lib/` (lock fails closed)  
-- Core never silently COPYs `shared/` into L1 images — task `environment/Dockerfile` must declare it  
+- Task members must **not** own top-level name `shared` (`shared/` dir or `shared.py`) — lock fails closed  
+- Same stem under `shared/lib` and `tasks/*/lib` is **allowed** (namespaces differ)  
+- Core never silently COPYs `shared/` into L1 images — task Dockerfile must declare it and put **Database root** on `PYTHONPATH`  
 - Author gate: `uv run python scripts/check_shared_lib_collisions.py <dataset-root>`  
 
-Authority: design `02-task-package-and-config` (Dataset-level shared/). **Having `shared/` or Hub Shared browse ≠ evidence-grade upgrade.**
+Authority: design `02-task-package-and-config` (Dataset-level shared/). **Having `shared/`, changing the import contract, or Hub Shared browse ≠ evidence-grade upgrade.**
 
 ## Root `bora.yaml`
 

--- a/website/content/docs/author/package-layout.mdx
+++ b/website/content/docs/author/package-layout.mdx
@@ -17,7 +17,7 @@ my-dataset/
 ├── bora.yaml
 ├── profiles.yaml           # 可选：job binding 默认
 ├── shared/                 # 可选：跨 task 共享（进 packageDigest）
-│   ├── lib/                # Harness / Evaluator import only
+│   ├── lib/                # 以 shared.lib.* 导入
 │   ├── assets/             # 只读领域数据（代码路径读取）
 │   └── README.md
 └── tasks/
@@ -29,7 +29,7 @@ my-dataset/
         ├── environment/
         ├── evaluation/     # gold 等，默认不给 agent
         ├── data/
-        └── lib/            # 仅本 task；顶层名勿与 shared/lib 冲突
+        └── lib/            # 仅本 task；以 lib.* 导入
 ```
 
 成员一级目录只认：`prompts` · `schemas` · `environment` · `evaluation` · `data` · `lib` · `upstream` · `solution`。别的名字可能 lock 失败。
@@ -38,20 +38,24 @@ my-dataset/
 
 同构多 task 包可把公共 bridge / 领域资产放在根 `shared/`，**不要**复制进每个 `tasks/*/lib/`。
 
-| 路径 | 用途 |
-| --- | --- |
-| `shared/lib/` | 跨 task Python 模块；Runtime 注入 import path |
-| `shared/assets/` | 只读 fixture / policy / db（代码路径访问） |
+| 路径 | 用途 | 导入 |
+| --- | --- | --- |
+| `shared/lib/` | 跨 task Python 模块 | `from shared.lib…` |
+| `shared/assets/` | 只读 fixture / policy / db | 代码路径 |
+| `tasks/*/lib/` | 仅本 task 扩展 | `from lib…` |
+
+Runtime 注入的 path 前缀是 **`[task_dir, database_root]`**，**不会**再把 `shared/lib` 叶子目录塞进 path。
 
 硬规则（摘要）：
 
 - 有 `shared/` 则 **必须** 进入 `packageDigest` / publish blob；改它会改整包 digest  
 - 默认 **不** 挂到 Agent workspace；gold **只** 放 `tasks/*/evaluation/`  
-- `shared/lib` 与任一 `tasks/*/lib` 的 **top-level 模块名禁止冲突**（lock 硬失败）  
-- L1 镜像 **不会** 由 Core 隐式 COPY `shared/`；需要时在 task `environment/Dockerfile` 里显式写  
+- 成员 task **禁止** 占用顶层名 `shared`（`shared/` 目录或 `shared.py`）— lock 硬失败  
+- `shared/lib` 与 `tasks/*/lib` **允许** 同名 stem（命名空间已区分）  
+- L1 镜像 **不会** 由 Core 隐式 COPY `shared/`；容器内要用时在 Dockerfile 里显式 `COPY`，并把 **Dataset 根** 放进 `PYTHONPATH`  
 - 本地自检：`uv run python scripts/check_shared_lib_collisions.py <dataset-root>`  
 
-权威细节见 design `02-task-package-and-config`（Dataset 级 shared/）。**有 shared/ 或 Hub Shared 浏览 ≠ 证据等级升级。**
+权威细节见 design `02-task-package-and-config`（Dataset 级 shared/）。**有 shared/、改 import 契约或 Hub Shared 浏览 ≠ 证据等级升级。**
 
 ## 根 `bora.yaml`
 


### PR DESCRIPTION
## Summary

This PR delivers **#68**: replace flat `shared/lib` leaf inject with **namespaced imports** and align Runtime, lock gates, author skills, and in-repo packages.

1. **Design** — path inject is `[task_dir, database_root]`; ban inserting `shared/lib` as a path root; document `shared.lib.*` / `lib.*`
2. **Runtime** — harness worker + L0 evaluator use the same inject roots **and order**
3. **Gates** — hard-fail task-level top-level name `shared` (`shared/` dir or `shared.py`); **drop** stem-vs-stem ban across `shared/lib` and `tasks/*/lib`
4. **Skills / website** — `bora-config-package` (+ isolation/conversion) rewritten; L0 vs L1 evaluator asymmetry + Dockerfile snippet with Database-root `PYTHONPATH`
5. **Examples** — migrate `examples/tau3-airline` bare leaf imports to `shared.lib.*` (+ package markers)

- **No** Core silent L1 `COPY shared/` (still package Dockerfile explicit only)
- **No** evidence-grade upgrade from import-contract change
- **No** Harbor-compatible shared layout

## What changed

### Import inject contract

| Surface | Before | After |
| --- | --- | --- |
| Path prefix | `shared/lib` leaf + task dir (order non-semantic under stem ban) | **`[task_dir, database_root]`** |
| Dataset glue | bare `from bridge import …` | `from shared.lib.bridge import …` |
| Task-only glue | bare / path leaf | `from lib…` |
| Collision gate | same stem under `shared/lib` vs `tasks/*/lib` banned | **allowed**; ban task-owned top-level `shared` |

### Code / tests / scripts

| Path | Change |
| --- | --- |
| `docs/design/02-task-package-and-config.md` | Normative import inject + reserved name + L1 asymmetry |
| `src/bora/runtime/task_worker.py` | Inject Database root, not `shared/lib` leaf |
| `src/bora/application/run_command_evaluator.py` | Same roots/order as harness (`reversed` insert) |
| `src/bora/config/shared.py` | `find_task_shared_shadows`; stem collision API no-ops |
| `scripts/check_shared_lib_collisions.py` | Gate on task `shared` shadow |
| `tests/config/test_shared.py` / `tests/runtime/test_shared_lib_import.py` | Shadow ban, same-stem OK, namespace imports, path order |

### Author surface + examples

| Path | Change |
| --- | --- |
| `skills/bora-config-package/**` | Layout, inject, migration table, L1 COPY/`PYTHONPATH` |
| `website/.../package-layout(.en).mdx` | Reader-facing summary (no issue markers) |
| `examples/tau3-airline` | `shared/__init__.py`; thin entries + glue → `shared.lib.*` |

## Non-goals

- Reopening #65 digest / Hub Shared UI scope  
- Core default L1 `COPY shared/`  
- Lock-time static analysis of Dockerfile COPY (B2)  
- Evidence-grade inflation  

## Issues

| Issue | Role |
| --- | --- |
| **#68** | **Closes** — shared/ import namespaces + L1 evaluator guidance |
| #65 | Parent — Dataset-level `shared/` first-class |
| PR #67 | Review mid findings that motivated this work |

Closes #68

Related: #65

## Constraints

- Authority: **docs first** (`docs/design/02`), then Runtime / gates / skills / examples  
- Reader-facing docs: **no** GitHub issue-number marks  
- L1 clean-evaluator still requires **explicit** package Dockerfile `COPY shared/` + Database-root on `PYTHONPATH`  
- PASS still only from independent evaluator  

## Verification

Local CI equivalents (path-filtered jobs this PR hits):

| Job | Result |
| --- | --- |
| `python-core` | ruff format/check, pyright, offline pytest — **pass** (383 tests) |
| `website` | `pnpm --dir website build` — **pass** |

Sample real runs after migration (opencode + `zai-coding-plan/glm-5.2`, not CI):

| Task | Status |
| --- | --- |
| `airline-00` | PASS |
| `airline-01` | PASS |
| `airline-05` | PASS |

Hub re-publish: `my-lab/tau3-airline@0.1.0` (new package digest) + suite `tau3-airline-shared-lib-ns-smoke` (3/3 PASS, attempts uploaded).

## Test plan

- [x] `uv run ruff format --check src tests && uv run ruff check src tests && uv run pyright`
- [x] Offline `python-core` pytest slice
- [x] `uv run python scripts/check_shared_lib_collisions.py examples/tau3-airline`
- [x] `bora lock examples/tau3-airline --task airline-00`
- [x] Website build
- [ ] CI green on this PR