### PR TITLE
chore(runtime): drop L1 l1-work host residual; exclude from upload (#76)

### DIFF
--- a/docs/design/05-runtime/evidence.md
+++ b/docs/design/05-runtime/evidence.md
@@ -49,8 +49,23 @@ BORA 的一次成功或失败 Attempt，必须在 filesystem evidence 根下留�
 ├── effects.jsonl                # Runtime 边界 effect 决策摘要（tool/env/process 等，若有）
 ├── evaluation/                  # evaluator raw + binding inputs refs
 ├── harness/                     # HarnessTerminal 等（可选）
-└── cleanup.json                 # cleanup outcome / warning
+├── cleanup.json                 # cleanup outcome / warning
+└── l1-work/                     # L1 host sandbox（workspace / package_view）；见下文
 ```
+
+### L1 host residual（`l1-work/`）
+
+L1 prepare 把 host work root 放在 **同一 run 目录**下：`.bora/runs/<run_id>/l1-work/`
+（workspace、filtered package_view、hold 等）。这是 Attempt **运行期** mount 源，
+**不是** Hub / Viewer 的 tab 投影面。
+
+| 策略 | 行为 |
+| --- | --- |
+| **默认** | Attempt cleanup（含已有 Docker cleanup 的失败路径）后 **删除** `l1-work/`，只保留 Hub-facing 证据 |
+| **`--keep-workspace`** | 保留 `l1-work/` 供本地调试；**不**要求 Hub / CI 开启 |
+| **Upload pack** | `build_attempt_archive` **排除** `l1-work/**`（即使 residual 仍在磁盘），Registry blob 只含 curated evidence |
+
+Hub Attempt tabs 与本地 `bora view` 仍只解析 Trajectory / Agent / Verifier / Artifacts / Lock / Runtime 等既有相对路径；不新增 Workspace tab。
 
 ## 每条 Agent invocation 最小字段
 

--- a/skills/bora-cli/SKILL.md
+++ b/skills/bora-cli/SKILL.md
@@ -36,6 +36,7 @@ uv run bora --help
 | `bora run <package> --task <id>`                           | One foreground Attempt                                               |
 | `bora run <package> [-k N] [--max-concurrent-tasks N]`     | Suite / Always-k job (`-k` = `--n-attempts`; CLI only)               |
 | `bora run … --resume-suite <id> [--task id] -k N`        | Append Attempts into existing suite job; recompute pass@k / pass^k   |
+| `bora run … --keep-workspace`                              | L1 only: retain host `l1-work/` after cleanup (default: delete)      |
 | `bora run ... --set '/bindings/solver/options/entry="pi"'` | Job binding override (entry/model)                                   |
 | `bora campaign <package> --task <id> --matrix ...`         | Serial matrix (`/parameters/*` or `/bindings/<role>/…`); ≠ Always-k  |
 | `bora evidence <logs-path> --out <dir>`                    | Sealed trajectory export (no score change)                           |
@@ -106,7 +107,8 @@ Value after `=` is JSON (strings need quotes):
 
 **Single Attempt** (`--task` and default `-k 1`, no resume): typical fields `status`, `score`, `assurance`, `agent_invocations`, `evidence_path`, **`logs`** (portable under Dataset root, e.g. `.bora/runs/<run_id>`).
 
-- On disk: `<dataset>/.bora/runs/<run_id>/`
+- On disk: `<dataset>/.bora/runs/<run_id>/` — Hub-facing curated evidence (`result.json`, `agent/`, `evaluation/`, `artifacts/`, lock/runtime JSON).
+- L1 host sandbox lives at `l1-work/` **during** the Attempt; **default cleanup deletes it**. Use `--keep-workspace` only for local debug. `bora results upload` never packs `l1-work/**`.
 - Inspect trajectory: open `<dataset>/.bora/runs/<run_id>/agent/invocations/<nnnn>-*/trajectory.jsonl` (**turn-level** training rows) and `events.jsonl` (optional stream/debug)
 - Export: `uv run bora evidence <dataset>/.bora/runs/<run_id> --out /tmp/bora-export`
 - Trajectory presence **never** upgrades score

--- a/skills/bora-cli/references/commands.md
+++ b/skills/bora-cli/references/commands.md
@@ -34,7 +34,7 @@ Stdout JSON (high level):
 ## `bora run`
 
 - One foreground Attempt via production composition root **when** `--task` is set, `-k` defaults to 1, and no `--resume-suite`.
-- Evidence under Dataset root `.bora/runs/<run_id>/`.
+- Evidence under Dataset root `.bora/runs/<run_id>/` (Hub-facing curated tree).
 - `logs` / `evidence_path` are portable relative to the Dataset root (e.g. `.bora/runs/<run_id>`);
   readers still accept legacy host absolute paths.
 - **Always-k** (`--n-attempts` / `-k`, integer ≥1): fixed k independent Attempts per task in scope.
@@ -42,6 +42,10 @@ Stdout JSON (high level):
 - **Suite**: omit `--task` → all members; also used as the job container when `k>1` or resume.
 - **`--max-concurrent-tasks`**: speeds wall time only; does not change k or PASS.
 - **`--resume-suite <suite_run_id>`**: skip finished `(task_id, attempt_index)`, append Attempts, recompute metrics.
+- **`--keep-workspace`** (L1 / `provider.kind: docker` only): retain host
+  `.bora/runs/<run_id>/l1-work/` after cleanup for local debug. **Default off** —
+  Runtime deletes `l1-work` after container cleanup. Not required for Hub; upload
+  pack excludes `l1-work/**` even if residual remains.
 - Suite artifacts: `.bora/suite-runs/<id>/summary.json`, `progress.json`.
 - Per invocation (ACP path): `agent/invocations/<nnnn>-*/trajectory.jsonl` is **turn-level**
   (user + merged assistant/thought + terminal). Stream chunks are not the training default;

--- a/src/bora/application/run_command.py
+++ b/src/bora/application/run_command.py
@@ -30,6 +30,7 @@ async def run_task(
     *,
     evidence_root: Path | None = None,
     allow_offline_agent: bool = False,
+    keep_workspace: bool = False,
     overrides: dict[str, Any] | None = None,
     profiles_path: Path | str | None = None,
     profile_bindings: dict[str, dict[str, Any]] | None = None,
@@ -224,6 +225,7 @@ async def run_task(
             run_dir=run_dir,
             agent_meta=agent_meta,
             allow_offline_agent=allow_offline_agent,
+            keep_workspace=keep_workspace,
         )
         score_raw = result_doc.get("score")
         score_f = float(score_raw) if isinstance(score_raw, int | float) else None

--- a/src/bora/application/run_l1.py
+++ b/src/bora/application/run_l1.py
@@ -258,9 +258,7 @@ def run_l1_sdk_session_attempt(
                 network_mode=network_mode,
             )
         except Exception as exc:  # noqa: BLE001
-            _l1_host_cleanup(
-                docker, runtime, cred, run_dir, keep_workspace=keep_workspace
-            )
+            _l1_host_cleanup(docker, runtime, cred, run_dir, keep_workspace=keep_workspace)
             return l1_error_result(
                 run_dir,
                 "provider",
@@ -420,9 +418,7 @@ def run_l1_sdk_session_attempt(
                     break
         if src_art is None or not src_art.is_file():
             with timer.phase("cleanup"):
-                _l1_host_cleanup(
-                    docker, runtime, cred, run_dir, keep_workspace=keep_workspace
-                )
+                _l1_host_cleanup(docker, runtime, cred, run_dir, keep_workspace=keep_workspace)
             return l1_error_result(
                 run_dir,
                 "harness" if not envelope.get("ok") else "evaluation_input",
@@ -450,9 +446,7 @@ def run_l1_sdk_session_attempt(
         # Wait for writer stop before evaluator.
         if not runtime.writer_stop_confirmed:
             with timer.phase("cleanup"):
-                _l1_host_cleanup(
-                    docker, runtime, cred, run_dir, keep_workspace=keep_workspace
-                )
+                _l1_host_cleanup(docker, runtime, cred, run_dir, keep_workspace=keep_workspace)
             return l1_error_result(
                 run_dir,
                 "evaluation_input",

--- a/src/bora/application/run_l1.py
+++ b/src/bora/application/run_l1.py
@@ -38,6 +38,36 @@ def _database_root_for_run(run_dir: Path) -> Path | None:
     return None
 
 
+def drop_l1_work(run_dir: Path, *, keep_workspace: bool = False) -> None:
+    """Remove host sandbox residual at ``run_dir/l1-work`` unless retained for debug.
+
+    Layout stays under the run dir during the Attempt; default policy is curated
+    Hub-facing evidence only — full workspace / package_view are not retained.
+    """
+    if keep_workspace:
+        return
+    work = Path(run_dir) / "l1-work"
+    if work.exists():
+        with contextlib.suppress(OSError):
+            shutil.rmtree(work)
+
+
+def _l1_host_cleanup(
+    docker: Any,
+    runtime: Any,
+    cred: Any | None,
+    run_dir: Path,
+    *,
+    keep_workspace: bool,
+) -> None:
+    """Stop containers/networks, drop credentials, then drop host ``l1-work``."""
+    docker.cleanup(runtime)
+    if cred is not None:
+        with contextlib.suppress(Exception):
+            cred.cleanup()
+    drop_l1_work(run_dir, keep_workspace=keep_workspace)
+
+
 def _attach_timing(
     doc: dict[str, Any],
     details: dict[str, Any],
@@ -59,6 +89,7 @@ def run_l1_attempt(
     run_dir: Path,
     agent_meta: dict[str, Any],
     allow_offline_agent: bool,
+    keep_workspace: bool = False,
 ) -> tuple[int, dict[str, Any], dict[str, Any]]:
     """Dispatch L1 SDK session path when agent_profiles is non-empty.
 
@@ -78,6 +109,7 @@ def run_l1_attempt(
             run_dir=run_dir,
             agent_meta=agent_meta,
             allow_offline_agent=allow_offline_agent,
+            keep_workspace=keep_workspace,
         )
 
     return l1_error_result(
@@ -97,6 +129,7 @@ def run_l1_sdk_session_attempt(
     run_dir: Path,
     agent_meta: dict[str, Any],
     allow_offline_agent: bool,
+    keep_workspace: bool = False,
 ) -> tuple[int, dict[str, Any], dict[str, Any]]:
     """L1 multi-actor SDK path: ParentAgentService → docker exec targets.
 
@@ -225,8 +258,9 @@ def run_l1_sdk_session_attempt(
                 network_mode=network_mode,
             )
         except Exception as exc:  # noqa: BLE001
-            docker.cleanup(runtime)
-            cred.cleanup()
+            _l1_host_cleanup(
+                docker, runtime, cred, run_dir, keep_workspace=keep_workspace
+            )
             return l1_error_result(
                 run_dir,
                 "provider",
@@ -386,8 +420,9 @@ def run_l1_sdk_session_attempt(
                     break
         if src_art is None or not src_art.is_file():
             with timer.phase("cleanup"):
-                docker.cleanup(runtime)
-                cred.cleanup()
+                _l1_host_cleanup(
+                    docker, runtime, cred, run_dir, keep_workspace=keep_workspace
+                )
             return l1_error_result(
                 run_dir,
                 "harness" if not envelope.get("ok") else "evaluation_input",
@@ -415,8 +450,9 @@ def run_l1_sdk_session_attempt(
         # Wait for writer stop before evaluator.
         if not runtime.writer_stop_confirmed:
             with timer.phase("cleanup"):
-                docker.cleanup(runtime)
-                cred.cleanup()
+                _l1_host_cleanup(
+                    docker, runtime, cred, run_dir, keep_workspace=keep_workspace
+                )
             return l1_error_result(
                 run_dir,
                 "evaluation_input",
@@ -448,8 +484,7 @@ def run_l1_sdk_session_attempt(
         l1_meta["execution_location"] = "attempt-container"
 
     with timer.phase("cleanup"):
-        docker.cleanup(runtime)
-        cred.cleanup()
+        _l1_host_cleanup(docker, runtime, cred, run_dir, keep_workspace=keep_workspace)
 
     full_l1 = bool(
         harness_kind == "completed"

--- a/src/bora/application/suite_run.py
+++ b/src/bora/application/suite_run.py
@@ -266,6 +266,7 @@ async def _run_one(
     overrides: dict[str, Any] | None,
     run_fn: Callable[..., Awaitable[tuple[int, Any, dict[str, Any]]]],
     profiles_path: Path | str | None = None,
+    keep_workspace: bool = False,
 ) -> dict[str, Any]:
     """Run one (task_id, attempt_index) unit. Concurrency is owned by the claim pool."""
     global _inflight_current, _inflight_peak
@@ -278,6 +279,7 @@ async def _run_one(
             task_id,
             overrides=overrides,
             profiles_path=profiles_path,
+            keep_workspace=keep_workspace,
         )
         status = getattr(result, "status", None) or details.get("status") or "ERROR"
         run_id = extract_run_id(
@@ -579,6 +581,7 @@ async def execute_suite_run(
     profiles_path: Path | str | None = None,
     resume: bool = False,
     on_progress: ProgressCallback | None = None,
+    keep_workspace: bool = False,
 ) -> dict[str, Any]:
     """Execute planned task×attempt units with a concurrency pool; write summary.
 
@@ -720,6 +723,7 @@ async def execute_suite_run(
                 overrides=overrides,
                 run_fn=runner,
                 profiles_path=profiles_path,
+                keep_workspace=keep_workspace,
             )
             async with progress_lock:
                 new_results.append(row)

--- a/src/bora/cli/cmd_campaign_run.py
+++ b/src/bora/cli/cmd_campaign_run.py
@@ -136,6 +136,16 @@ def register(app: typer.Typer) -> None:
                 help="Alternate profiles.yaml replacing Database-root job bindings.",
             ),
         ] = None,
+        keep_workspace: Annotated[
+            bool,
+            typer.Option(
+                "--keep-workspace",
+                help=(
+                    "L1 only: retain host l1-work/ under the run dir after cleanup "
+                    "(default: delete; debug only — never required for Hub upload)."
+                ),
+            ),
+        ] = False,
     ) -> None:
         """Run one member or a full Database suite (Application-layer task_id axis)."""
         import asyncio
@@ -177,6 +187,7 @@ def register(app: typer.Typer) -> None:
                         plan.task_ids[0],
                         overrides=overrides or None,
                         profiles_path=profiles,
+                        keep_workspace=keep_workspace,
                     )
                 )
                 summary = {
@@ -264,6 +275,7 @@ def register(app: typer.Typer) -> None:
                     profiles_path=profiles,
                     resume=resume_id is not None,
                     on_progress=_progress,
+                    keep_workspace=keep_workspace,
                 )
             )
             final_status = (

--- a/src/bora/registry/results_archive.py
+++ b/src/bora/registry/results_archive.py
@@ -17,9 +17,21 @@ from pathlib import Path
 
 MEDIA_TYPE = "application/vnd.bora.attempt-result.v1.tar+gzip"
 
+# Host sandbox residual under the Attempt run dir — never Hub-facing.
+_L1_WORK_ROOT = "l1-work"
+
+
+def _is_l1_work_rel(rel: str) -> bool:
+    """True when *rel* is ``l1-work`` or under it (posix, relative to run_dir)."""
+    return rel == _L1_WORK_ROOT or rel.startswith(f"{_L1_WORK_ROOT}/")
+
 
 def build_attempt_archive(run_dir: Path, *, run_id: str) -> tuple[bytes, str, int]:
-    """Pack ``run_dir`` as ``.bora/runs/<run_id>/…``; return bytes, blob_digest, size."""
+    """Pack ``run_dir`` as ``.bora/runs/<run_id>/…``; return bytes, blob_digest, size.
+
+    Excludes ``l1-work/**`` even if residual files remain on disk (e.g.
+    ``--keep-workspace`` or a failed host cleanup) so Registry blobs stay curated.
+    """
     root = run_dir.expanduser().resolve(strict=True)
     if not root.is_dir():
         msg = f"run directory not found: {root}"
@@ -31,6 +43,8 @@ def build_attempt_archive(run_dir: Path, *, run_id: str) -> tuple[bytes, str, in
         if not path.is_file():
             continue
         rel = path.relative_to(root).as_posix()
+        if _is_l1_work_rel(rel):
+            continue
         members.append((f"{prefix}/{rel}", path))
 
     return _pack_tree(members)
@@ -99,7 +113,10 @@ def _pack_tree(members: list[tuple[str, Path]]) -> tuple[bytes, str, int]:
 
 
 def build_suite_archive(suite_dir: Path, *, suite_run_id: str) -> tuple[bytes, str, int]:
-    """Pack ``suite_dir`` as ``.bora/suite-runs/<suite_run_id>/…``."""
+    """Pack ``suite_dir`` as ``.bora/suite-runs/<suite_run_id>/…``.
+
+    Defense in depth: skip any nested ``l1-work/**`` path segments.
+    """
     root = suite_dir.expanduser().resolve(strict=True)
     if not root.is_dir():
         msg = f"suite directory not found: {root}"
@@ -111,6 +128,8 @@ def build_suite_archive(suite_dir: Path, *, suite_run_id: str) -> tuple[bytes, s
         if not path.is_file():
             continue
         rel = path.relative_to(root).as_posix()
+        if _L1_WORK_ROOT in Path(rel).parts:
+            continue
         members.append((f"{prefix}/{rel}", path))
 
     return _pack_tree(members)

--- a/tests/application/test_l1_work_cleanup.py
+++ b/tests/application/test_l1_work_cleanup.py
@@ -1,0 +1,56 @@
+"""L1 host residual: default drop l1-work; --keep-workspace retains (issue #76)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bora.application.run_l1 import drop_l1_work
+
+
+def _seed_l1_work(run_dir: Path) -> Path:
+    work = run_dir / "l1-work"
+    (work / "workspace").mkdir(parents=True)
+    (work / "package_view" / "vendor").mkdir(parents=True)
+    (work / "workspace" / "out.txt").write_text("agent writable\n", encoding="utf-8")
+    (work / "package_view" / "vendor" / "big.bin").write_bytes(b"\x00" * 64)
+    # Hub-facing evidence sibling (must never be deleted by drop_l1_work).
+    (run_dir / "result.json").write_text('{"status":"PASS"}\n', encoding="utf-8")
+    (run_dir / "agent").mkdir()
+    (run_dir / "agent" / "summary.json").write_text("{}\n", encoding="utf-8")
+    return work
+
+
+def test_drop_l1_work_default_removes_tree(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run_a"
+    run_dir.mkdir()
+    work = _seed_l1_work(run_dir)
+
+    drop_l1_work(run_dir, keep_workspace=False)
+
+    assert not work.exists()
+    assert (run_dir / "result.json").is_file()
+    assert (run_dir / "agent" / "summary.json").is_file()
+
+
+def test_drop_l1_work_keep_workspace_retains_tree(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run_b"
+    run_dir.mkdir()
+    work = _seed_l1_work(run_dir)
+
+    drop_l1_work(run_dir, keep_workspace=True)
+
+    assert work.is_dir()
+    assert (work / "workspace" / "out.txt").is_file()
+    assert (work / "package_view" / "vendor" / "big.bin").is_file()
+    assert (run_dir / "result.json").is_file()
+
+
+def test_drop_l1_work_noop_when_missing(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run_c"
+    run_dir.mkdir()
+    (run_dir / "result.json").write_text("{}\n", encoding="utf-8")
+
+    drop_l1_work(run_dir, keep_workspace=False)
+
+    assert not (run_dir / "l1-work").exists()
+    assert (run_dir / "result.json").is_file()

--- a/tests/application/test_suite_cancel_progress.py
+++ b/tests/application/test_suite_cancel_progress.py
@@ -26,7 +26,7 @@ async def test_cancel_stops_new_units() -> None:
     plan.task_ids = ["alpha", "beta", "gamma"]
     calls: list[str] = []
 
-    async def runner(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+    async def runner(root, task_id, *, overrides=None, profiles_path=None, **kwargs):  # noqa: ANN001
         calls.append(task_id)
         if task_id == "alpha":
             # After first unit starts, request cancel so remaining are not run.
@@ -76,7 +76,7 @@ async def test_resume_retries_cancelled_placeholders() -> None:
     plan.task_ids = ["alpha", "beta", "gamma"]
     first_calls: list[str] = []
 
-    async def runner1(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+    async def runner1(root, task_id, *, overrides=None, profiles_path=None, **kwargs):  # noqa: ANN001
         first_calls.append(task_id)
         if task_id == "alpha":
             request_suite_cancel(plan.database_root, plan.suite_run_id)
@@ -109,7 +109,7 @@ async def test_resume_retries_cancelled_placeholders() -> None:
     plan2.task_ids = ["alpha", "beta", "gamma"]
     second_calls: list[str] = []
 
-    async def runner2(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+    async def runner2(root, task_id, *, overrides=None, profiles_path=None, **kwargs):  # noqa: ANN001
         second_calls.append(task_id)
         run_id = f"sha256_dead_run_{task_id}_2"
         abs_run = Path(root) / ".bora" / "runs" / run_id
@@ -147,7 +147,7 @@ async def test_progress_callback_events() -> None:
     plan = plan_suite_run(SUITE, task_id="alpha", n_attempts=2, max_concurrent_tasks=1)
     events: list[str] = []
 
-    async def runner(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+    async def runner(root, task_id, *, overrides=None, profiles_path=None, **kwargs):  # noqa: ANN001
         result = SimpleNamespace(status="PASS", score=1.0, evidence_path=None, logs=None)
         return 0, result, {"digest": "sha256:x"}
 

--- a/tests/application/test_suite_config_fingerprint.py
+++ b/tests/application/test_suite_config_fingerprint.py
@@ -182,7 +182,7 @@ async def test_suite_summary_includes_homogeneous_config() -> None:
     plan = plan_suite_run(SUITE, max_concurrent_tasks=2)
     plan.task_ids = ["alpha", "beta"]
 
-    async def stub(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+    async def stub(root, task_id, *, overrides=None, profiles_path=None, **kwargs):  # noqa: ANN001
         result = SimpleNamespace(status="PASS", score=1.0, evidence_path=None, logs=None)
         return 0, result, {"digest": f"sha256:{task_id}"}
 

--- a/tests/application/test_suite_metrics.py
+++ b/tests/application/test_suite_metrics.py
@@ -91,7 +91,7 @@ async def test_suite_summary_includes_metrics() -> None:
     plan = plan_suite_run(SUITE, max_concurrent_tasks=2)
     plan.task_ids = ["alpha", "beta", "gamma"]
 
-    async def runner(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+    async def runner(root, task_id, *, overrides=None, profiles_path=None, **kwargs):  # noqa: ANN001
         result = SimpleNamespace(
             status="PASS",
             score=1.0,

--- a/tests/application/test_suite_n_attempts.py
+++ b/tests/application/test_suite_n_attempts.py
@@ -46,7 +46,7 @@ async def test_always_k_produces_k_attempts() -> None:
     plan = plan_suite_run(SUITE, task_id="alpha", n_attempts=3, max_concurrent_tasks=1)
     calls: list[str] = []
 
-    async def runner(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+    async def runner(root, task_id, *, overrides=None, profiles_path=None, **kwargs):  # noqa: ANN001
         calls.append(task_id)
         run_id = f"sha256_dead_run_{task_id}_{len(calls)}"
         abs_run = Path(root) / ".bora" / "runs" / run_id
@@ -93,7 +93,7 @@ async def test_parallel_does_not_change_k() -> None:
     )
     reset_inflight_metrics()
 
-    async def slow(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+    async def slow(root, task_id, *, overrides=None, profiles_path=None, **kwargs):  # noqa: ANN001
         await asyncio.sleep(0.08)
         result = SimpleNamespace(status="PASS", score=1.0, evidence_path=None, logs=None)
         return 0, result, {"digest": "sha256:x"}
@@ -110,7 +110,7 @@ async def test_resume_skips_completed_and_appends() -> None:
     plan = plan_suite_run(SUITE, task_id="alpha", n_attempts=2, max_concurrent_tasks=1)
     call_n = {"n": 0}
 
-    async def runner(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+    async def runner(root, task_id, *, overrides=None, profiles_path=None, **kwargs):  # noqa: ANN001
         call_n["n"] += 1
         i = call_n["n"]
         run_id = f"sha256_dead_run_alpha_{i}"
@@ -156,7 +156,7 @@ async def test_resume_other_tasks_preserved() -> None:
     plan = plan_suite_run(SUITE, n_attempts=1, max_concurrent_tasks=2)
     plan.task_ids = ["alpha", "beta"]
 
-    async def runner(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+    async def runner(root, task_id, *, overrides=None, profiles_path=None, **kwargs):  # noqa: ANN001
         run_id = f"sha256_dead_run_{task_id}"
         abs_run = Path(root) / ".bora" / "runs" / run_id
         abs_run.mkdir(parents=True, exist_ok=True)
@@ -179,7 +179,7 @@ async def test_resume_other_tasks_preserved() -> None:
     )
     call_tasks: list[str] = []
 
-    async def runner2(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+    async def runner2(root, task_id, *, overrides=None, profiles_path=None, **kwargs):  # noqa: ANN001
         call_tasks.append(task_id)
         run_id = f"sha256_dead_run_{task_id}_extra"
         abs_run = Path(root) / ".bora" / "runs" / run_id

--- a/tests/application/test_suite_run.py
+++ b/tests/application/test_suite_run.py
@@ -55,7 +55,7 @@ async def test_concurrency_cap_with_stub_runner() -> None:
     plan.task_ids = ["alpha", "beta", "gamma"]
     reset_inflight_metrics()
 
-    async def slow_run(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+    async def slow_run(root, task_id, *, overrides=None, profiles_path=None, **kwargs):  # noqa: ANN001
         await asyncio.sleep(0.15)
         run_id = f"sha256_dead_run_{task_id}"
         abs_run = Path(root) / ".bora" / "runs" / run_id
@@ -91,7 +91,7 @@ async def test_fail_continues_others() -> None:
     plan = plan_suite_run(SUITE, max_concurrent_tasks=2)
     plan.task_ids = ["alpha", "beta", "delta-fail"]
 
-    async def mixed(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+    async def mixed(root, task_id, *, overrides=None, profiles_path=None, **kwargs):  # noqa: ANN001
         await asyncio.sleep(0.05)
         if task_id == "delta-fail":
             result = SimpleNamespace(status="FAIL", score=0.0, evidence_path="x", logs="x")
@@ -111,7 +111,7 @@ async def test_error_exit_code() -> None:
     plan = plan_suite_run(SUITE, max_concurrent_tasks=1)
     plan.task_ids = ["alpha", "beta"]
 
-    async def one_error(root, task_id, *, overrides=None, profiles_path=None):  # noqa: ANN001
+    async def one_error(root, task_id, *, overrides=None, profiles_path=None, **kwargs):  # noqa: ANN001
         if task_id == "beta":
             result = SimpleNamespace(status="ERROR", score=None, evidence_path=None, logs=None)
             return 2, result, {"digest": None}

--- a/tests/registry/test_results_archive_l1_work.py
+++ b/tests/registry/test_results_archive_l1_work.py
@@ -1,0 +1,59 @@
+"""Attempt/suite result archives exclude l1-work residual (issue #76)."""
+
+from __future__ import annotations
+
+import gzip
+import io
+import tarfile
+from pathlib import Path
+
+from bora.registry.results_archive import build_attempt_archive, build_suite_archive
+
+
+def _arcnames(archive: bytes) -> set[str]:
+    with (
+        gzip.GzipFile(fileobj=io.BytesIO(archive), mode="rb") as gz,
+        tarfile.open(fileobj=gz, mode="r:") as tar,
+    ):
+        return {m.name for m in tar.getmembers() if m.isfile()}
+
+
+def test_build_attempt_archive_excludes_l1_work(tmp_path: Path) -> None:
+    run_id = "run_test76"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir()
+    (run_dir / "result.json").write_text('{"status":"PASS"}\n', encoding="utf-8")
+    (run_dir / "lock.json").write_text("{}\n", encoding="utf-8")
+    (run_dir / "agent").mkdir()
+    (run_dir / "agent" / "trajectory.jsonl").write_text("{}\n", encoding="utf-8")
+    work = run_dir / "l1-work"
+    (work / "workspace").mkdir(parents=True)
+    (work / "workspace" / "scratch.txt").write_text("do not upload\n", encoding="utf-8")
+    (work / "package_view").mkdir()
+    (work / "package_view" / "vendor.bin").write_bytes(b"x" * 32)
+
+    archive, digest, size = build_attempt_archive(run_dir, run_id=run_id)
+    assert size == len(archive)
+    assert digest.startswith("sha256:")
+
+    names = _arcnames(archive)
+    prefix = f".bora/runs/{run_id}"
+    assert f"{prefix}/result.json" in names
+    assert f"{prefix}/lock.json" in names
+    assert f"{prefix}/agent/trajectory.jsonl" in names
+    assert not any("l1-work" in n for n in names)
+
+
+def test_build_suite_archive_excludes_nested_l1_work(tmp_path: Path) -> None:
+    suite_id = "suite_test76"
+    suite_dir = tmp_path / suite_id
+    suite_dir.mkdir()
+    (suite_dir / "summary.json").write_text("{}\n", encoding="utf-8")
+    nested = suite_dir / "nested" / "l1-work" / "workspace"
+    nested.mkdir(parents=True)
+    (nested / "leak.txt").write_text("nope\n", encoding="utf-8")
+
+    archive, _, _ = build_suite_archive(suite_dir, suite_run_id=suite_id)
+    names = _arcnames(archive)
+    assert f".bora/suite-runs/{suite_id}/summary.json" in names
+    assert not any("l1-work" in n for n in names)


### PR DESCRIPTION
## Summary

Closes #76.

- Keep L1 work root at `.bora/runs/<run_id>/l1-work/` (layout unchanged).
- **Default:** after Attempt cleanup (success and failure paths that already clean Docker), delete host `l1-work/`; Hub-facing evidence stays.
- **Opt-in:** `bora run --keep-workspace` retains `l1-work/` for local debug only (not required for Hub).
- **Defense in depth:** `build_attempt_archive` / suite pack never include `l1-work/**`, even if residual remains on disk.
- Docs/skills note curated evidence policy; suite runner stubs accept the new kwargs.

## Evidence

Local CI (path-filtered):

- `python-core`: ruff format/check, pyright, pytest (CI ignore set) — **386 passed**
- `python-registry`: `pytest tests/registry` — **48 passed**

Real `examples/journeys` (uploaded public to operator hub):

| Task | Status | Notes |
| --- | --- | --- |
| `env-postgres-min` | PASS | l0 |
| `multiagent-env-min` | PASS | l0, real agents |
| `tau2-dialog-min` | PASS | l0, real agents |
| `terminal-jsonl-agg` | PASS | **l1** / full_l1; default run left **no** `l1-work`; `--keep-workspace` retained disk tree while archive still excluded it |

## Test plan

- [x] Unit: `drop_l1_work` default vs keep
- [x] Unit: attempt/suite archive excludes `l1-work`
- [x] Local python-core + python-registry CI
- [x] Real journeys + hub upload
- [ ] GitHub Actions on this PR
- [ ] Reviewer: confirm Hub Attempt tabs still open without Workspace tab