### PR TITLE
fix(runtime): keep venv python symlink when spawning L0 children

### DIFF
--- a/src/bora/adapters/provider_local.py
+++ b/src/bora/adapters/provider_local.py
@@ -79,7 +79,7 @@ class LocalProcessProvider:
         # Prefer plan.argv as full argv when argv[0] matches basename or path.
         if plan.argv:
             argv = list(plan.argv)
-            # Ensure argv[0] is the granted executable path.
+            # Granted path, not symlink target — see ExecutableGrant.resolve.
             argv[0] = str(exe)
 
         env = {str(k): str(v) for k, v in plan.env.items()}

--- a/src/bora/provider/contract.py
+++ b/src/bora/provider/contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -18,7 +19,17 @@ class ExecutableGrant:
     path: Path
 
     def resolve(self) -> Path:
-        exe = self.path.expanduser().resolve(strict=False)
+        """Return the granted path (absolute). Do not follow the final symlink.
+
+        A venv ``python3`` is a symlink onto a shared CPython. Following it
+        makes ``argv[0]`` the base interpreter, which ignores ``pyvenv.cfg``
+        and drops venv ``site-packages`` (L0 evaluator then cannot import
+        package-host deps such as ``tau2``).
+        """
+        exe = self.path.expanduser()
+        if not exe.is_absolute():
+            exe = Path.cwd() / exe
+        exe = Path(os.path.normpath(exe))
         if not exe.exists() or not exe.is_file():
             raise ProviderError(
                 ERROR_UNDECLARED_EXECUTABLE,

--- a/tests/provider/test_executable_grant.py
+++ b/tests/provider/test_executable_grant.py
@@ -1,0 +1,38 @@
+"""ExecutableGrant must keep venv python symlinks (not follow to base CPython)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from bora.provider.contract import ExecutableGrant
+from bora.provider.errors import ProviderError
+
+
+def test_resolve_keeps_symlink_to_real_python(tmp_path: Path) -> None:
+    target = Path(sys.executable).resolve()
+    link = tmp_path / "bin" / "python3"
+    link.parent.mkdir()
+    link.symlink_to(target)
+    granted = ExecutableGrant(path=link).resolve()
+    assert granted == link
+    assert granted.is_symlink()
+    assert granted.resolve() == target
+
+
+def test_resolve_relative_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = Path(sys.executable).resolve()
+    monkeypatch.chdir(tmp_path)
+    link = Path("python3")
+    link.symlink_to(target)
+    granted = ExecutableGrant(path=Path("python3")).resolve()
+    assert granted == tmp_path / "python3"
+    assert granted.is_symlink()
+
+
+def test_resolve_missing_raises(tmp_path: Path) -> None:
+    with pytest.raises(ProviderError) as ei:
+        ExecutableGrant(path=tmp_path / "missing").resolve()
+    assert ei.value.error_code == "undeclared_executable"

--- a/tests/provider/test_local_process_provider.py
+++ b/tests/provider/test_local_process_provider.py
@@ -91,11 +91,7 @@ async def test_spawn_via_venv_symlink_keeps_site_packages(tmp_path: Path) -> Non
     link.symlink_to(real)
 
     attempt = _attempt()
-    code = (
-        "import bora_venv_probe, sys; "
-        "print(bora_venv_probe.MARKER); "
-        "print(sys.prefix)"
-    )
+    code = "import bora_venv_probe, sys; print(bora_venv_probe.MARKER); print(sys.prefix)"
     plan = ProcessLaunchPlan(
         attempt=attempt,
         workspace=WorkspacePlan(attempt=attempt, base_dir=tmp_path, relative_workdir="ws"),

--- a/tests/provider/test_local_process_provider.py
+++ b/tests/provider/test_local_process_provider.py
@@ -69,6 +69,49 @@ async def test_outside_workdir(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_spawn_via_venv_symlink_keeps_site_packages(tmp_path: Path) -> None:
+    """argv[0] must stay the venv python symlink so pyvenv.cfg applies.
+
+    Following the symlink to the shared CPython drops venv site-packages
+    (L0 evaluator then cannot import host deps such as tau2).
+    """
+    real = Path(sys.executable).resolve()
+    venv = tmp_path / "venv"
+    bindir = venv / "bin"
+    py_ver = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    site = venv / "lib" / py_ver / "site-packages"
+    bindir.mkdir(parents=True)
+    site.mkdir(parents=True)
+    (venv / "pyvenv.cfg").write_text(
+        f"home = {real.parent}\ninclude-system-site-packages = false\n",
+        encoding="utf-8",
+    )
+    (site / "bora_venv_probe.py").write_text("MARKER = 'venv-site'\n", encoding="utf-8")
+    link = bindir / "python3"
+    link.symlink_to(real)
+
+    attempt = _attempt()
+    code = (
+        "import bora_venv_probe, sys; "
+        "print(bora_venv_probe.MARKER); "
+        "print(sys.prefix)"
+    )
+    plan = ProcessLaunchPlan(
+        attempt=attempt,
+        workspace=WorkspacePlan(attempt=attempt, base_dir=tmp_path, relative_workdir="ws"),
+        executable=ExecutableGrant(path=link),
+        argv=(str(link), "-c", code),
+        env={"PATH": "/usr/bin:/bin"},
+        timeout_seconds=10.0,
+    )
+    outcome = await LocalProcessProvider().execute(plan)
+    assert outcome.terminal == ProcessTerminalKind.EXITED
+    assert outcome.exit_code == 0
+    assert "venv-site" in outcome.stdout_summary
+    assert str(venv) in outcome.stdout_summary
+
+
+@pytest.mark.asyncio
 async def test_undeclared_executable(tmp_path: Path) -> None:
     attempt = _attempt()
     plan = ProcessLaunchPlan(


### PR DESCRIPTION
Closes #86

L0 evaluator was exec'd through `Path.resolve()` of `.venv/bin/python3`, which follows the symlink onto uv's shared CPython and drops `pyvenv.cfg` / venv site-packages. Harness survived via injected `PYTHONPATH`; evaluator env is only `PATH`, so `import tau2` failed after a completed harness.

`ExecutableGrant.resolve()` now keeps the granted path (absolute, no final-symlink follow). Local spawn uses that as `argv[0]`.

## Test plan

- [x] `pytest tests/provider/test_executable_grant.py tests/provider/test_local_process_provider.py tests/provider/test_local_execute_seam.py tests/acceptance/test_provider_l0_application.py`
- [x] `bora run examples/tau3-airline --task airline-00` → PASS 1.0 (evaluator no longer `No module named 'tau2'`)