### PR TITLE
feat(plugin): external DeepSeek Harness executor (not ACP)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -153,12 +153,13 @@ BORA/
 │   ├── store.py               # 一份 MetadataStore + 薄 Postgres 适配
 │   └── routes.py              # ROUTES 必须声明 access；skip_auth 仅 access=none
 ├── examples/                  # 见 examples/README.md
-│   ├── journeys/              # case-class：env / multiagent / tau2 / terminal（+ profiles.nooa）
+│   ├── journeys/              # case-class：env / multiagent / tau2 / terminal（+ profiles.nooa / profiles.dsh）
 │   ├── core/                  # config / harness / eval / agent / SDK
 │   ├── l1/                    # Provider L1 isolation probes
 │   └── slot-probe/            # multi-slot 插件 e2e（需 bora plugin install）
 ├── plugins/                   # 外置 bora.plugin/1 示例（不进 Core contrib）
 │   ├── nooa/                  # executor provide + image_contribute Ready
+│   ├── dsh/                   # DeepSeek Harness JSON-RPC executor + bake
 │   └── slot-probe/            # multi 钩子可观测探针
 ├── tests/
 │   ├── acceptance/

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Agent benchmarks usually score the model and leave the **harness**—orchestrati
 - **Drop an existing harness into a shared boundary** — keep your workflow; the outer layer unifies config lock, isolation (host / Docker), visibility, and independent scoring for cross-framework reproduction
 - **Batch a full Dataset or a parameter matrix** — run every task in a suite, or campaign over allowlisted overrides such as seed / profile
 - **Aggregate suite scores and archive job results** — suite runs write observational `pass_rate` / `mean_score`; push them to the Registry when you need a shared results store
-- **Browse local suite runs in a Web UI** — `bora view` opens Jobs → Tasks → Attempt over `.bora/suite-runs/`; drill into a run for Trajectory, multi-role Time/Usage, and optional provenance links
-- **Share packages and results on Registry / Hub** — publish under an organization, invite members, share private results; browse remote jobs in the Hub when they are uploaded
+- **Browse local runs in a Web UI** — `bora view` opens Jobs → Tasks → Attempt for suite jobs and single-task Attempts in the opened Database; drill into a run for Trajectory, multi-role Time/Usage, and optional provenance links
+- **Share packages and results on Registry / Hub** — upload a Dataset draft then `bora release`, or publish a release directly; invite members; share private results. Public Leaderboard lists complete, release-bound suite runs; incomplete or draft-bound rows stay on Jobs
 - **Review and export trajectories** — each invoke lands on disk; `bora evidence` exports a sealed copy for failure analysis or training pipelines
 
 ---
@@ -70,6 +70,7 @@ uv run bora run examples/core -k 5 --max-concurrent-tasks 2
 
 # Local results console (build SPA once: cd apps/viewer && pnpm build)
 uv run bora view examples/core --no-browser
+# uv run bora view examples/core --dev --open /jobs/<id>
 
 # List executor kinds / ACP entries ready on this host
 uv run bora executors -v
@@ -77,6 +78,10 @@ uv run bora executors -v
 # Mechanism plugins
 # uv run bora plugin install plugins/nooa
 # uv run bora plugin list
+
+# Dataset draft → immutable release (Registry login + --org required)
+# uv run bora publish <dataset> --org <org> --draft
+# uv run bora release <org/dataset>
 ```
 
 ### Let a coding agent drive it

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ uv run bora executors -v
 
 # Mechanism plugins
 # uv run bora plugin install plugins/nooa
+# uv run bora plugin install plugins/dsh
 # uv run bora plugin list
 
 # Dataset draft → immutable release (Registry login + --org required)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -77,6 +77,7 @@ uv run bora executors -v
 
 # 机制插件
 # uv run bora plugin install plugins/nooa
+# uv run bora plugin install plugins/dsh
 # uv run bora plugin list
 
 # Dataset draft → 不可变 release（需 Registry 登录 + --org）

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,8 +23,8 @@
 - **把已有 harness 接到统一边界** — 保留你自己的 workflow，外层统一锁定配置、隔离（本机 / Docker）、可见性与独立打分，便于跨框架复现
 - **整份 Dataset 或参数矩阵批量跑** — 一次跑完套件内多个 task，或用 campaign 扫 seed / profile 等允许覆盖的参数
 - **Suite 聚合分与 job 结果归档** — suite 跑完写入观测用的 `pass_rate` / `mean_score`；需要共享时可以上传到 Registry
-- **本机浏览 suite 跑次** — `bora view` 打开 Jobs → Tasks → Attempt；可钻进 run 看 Trajectory、多角色 Time/Usage 与 provenance 外链
-- **用 Registry / Hub 共享包与结果** — 按组织发布 Dataset、邀请成员、分享私有结果；已上传的远程 Jobs 可在 Hub 里浏览
+- **本机浏览跑次** — `bora view` 打开 Jobs → Tasks → Attempt，覆盖 suite job 与单题 Attempt；可钻进 run 看 Trajectory、多角色 Time/Usage 与 provenance 外链
+- **用 Registry / Hub 共享包与结果** — 先上传 Dataset draft 再 `bora release`，或直接发 release；邀请成员、分享私有结果。公开 Leaderboard 只列完备且绑定 release 的 suite；缺题或 draft 绑定行只出现在 Jobs
 - **复盘与导出轨迹** — 每次 invoke 落盘证据；需要时 `bora evidence` 导出，供失败分析或训练管线
 
 ---
@@ -70,6 +70,7 @@ uv run bora run examples/core -k 5 --max-concurrent-tasks 2
 
 # 本机结果台（SPA 先构建一次：cd apps/viewer && pnpm build）
 uv run bora view examples/core --no-browser
+# uv run bora view examples/core --dev --open /jobs/<id>
 
 # 查看本机支持的 executor / ACP entry
 uv run bora executors -v
@@ -77,6 +78,10 @@ uv run bora executors -v
 # 机制插件
 # uv run bora plugin install plugins/nooa
 # uv run bora plugin list
+
+# Dataset draft → 不可变 release（需 Registry 登录 + --org）
+# uv run bora publish <dataset> --org <org> --draft
+# uv run bora release <org/dataset>
 ```
 
 ### 让 coding agent 帮你跑

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,8 +46,10 @@
 | [design/08-conversion-security-testing.md](design/08-conversion-security-testing.md)     | 转换、测试、安全边界                                                                   |
 | [design/09-owner-matrix-and-structure.md](design/09-owner-matrix-and-structure.md)       | Owner 矩阵、决策检查表、目标结构、相关资料                                             |
 | [design/10-examples-database-52.md](design/10-examples-database-52.md)                   | 设计意图下的示例对照（非进度）                                                         |
+| [design/11-extension-plugins.md](design/11-extension-plugins.md)                         | 扩展点 L0–L5、注册表、lock bindings、`bora.plugin/1`、Recognition ≠ Ready             |
+| [design/12-hub-dataset-and-leaderboard.md](design/12-hub-dataset-and-leaderboard.md)     | Dataset draft/release、dataset ACL、Leaderboard 完备性、个人主页                       |
 
-正文标题**不再**沿用 vault 总文档的 `## N.` / `### N.M.` 序号（避免跨文件序号断裂）；文件名前缀 `00`–`10` 仍作读序。Runtime 已按执行链拆分为 `05-runtime/*`。
+正文标题**不再**沿用 vault 总文档的 `## N.` / `### N.M.` 序号（避免跨文件序号断裂）；文件名前缀 `00`–`12` 仍作读序。Runtime 已按执行链拆分为 `05-runtime/*`。
 
 ## 与 vault 总设计的对齐
 

--- a/docs/design/11-extension-plugins.md
+++ b/docs/design/11-extension-plugins.md
@@ -153,5 +153,5 @@ L1：bake 安装 `nooa` + **in-container worker**；parent 把 model/base_url/�
 - 结构地图：[`ARCHITECTURE.md`](../../ARCHITECTURE.md)（plugins 树、emit map）  
 - Owner：[`09-owner-matrix-and-structure.md`](09-owner-matrix-and-structure.md)  
 - Runtime Agent：[`05-runtime/agent-service.md`](05-runtime/agent-service.md)  
-- 示例：`plugins/nooa`、`plugins/slot-probe`、`examples/journeys/profiles.nooa.yaml`、`examples/slot-probe/`  
+- 示例：`plugins/nooa`、`plugins/dsh`、`plugins/slot-probe`、`examples/journeys/profiles.nooa.yaml`、`examples/journeys/profiles.dsh.yaml`、`examples/slot-probe/`  
 - 交付跟踪：GitHub Issues（Epic 插件系统）

--- a/examples/README.md
+++ b/examples/README.md
@@ -74,6 +74,21 @@ Package agents under each task’s `lib/agents.py` are `nooa.Agent` subclasses
 (generation methods). L1 Ready bakes `nooa` + in-container worker and projects
 credentials — not parent host SPI success.
 
+### External dsh plugin (optional profiles)
+
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) path: official
+JSON-RPC SDK (`deepseek-harness-sdk`), not ACP. Same journeys harness; bind
+`executor: dsh` + `model` + locator `deepseek_api_key`. L1 bake installs the
+wheels in the Attempt image — host `--extra dsh` is only for L0 host SPI.
+
+```bash
+uv run bora plugin install plugins/dsh
+# repo/.env: deepseek_api_key (projected as DEEPSEEK_API_KEY)
+unset BORA_OFFLINE_AGENT
+uv run bora run examples/journeys --task terminal-jsonl-agg \
+  --profiles examples/journeys/profiles.dsh.yaml
+```
+
 ## `slot-probe/` (`database_id: example/slot-probe`)
 
 Multi-slot extension e2e (not a default public smoke). Requires:

--- a/examples/journeys/env.example
+++ b/examples/journeys/env.example
@@ -1,3 +1,5 @@
 # Copy to .env and fill locally. Never commit real keys.
 glm_coding_api_key=
 # ZAI_CODING_CN_API_KEY projected from locator when configured.
+# dsh plugin locator (runtime projects DEEPSEEK_API_KEY).
+deepseek_api_key=

--- a/examples/journeys/profiles.dsh.yaml
+++ b/examples/journeys/profiles.dsh.yaml
@@ -1,0 +1,17 @@
+# Journeys profiles bound to external dsh plugin (DeepSeek Harness JSON-RPC).
+# Usage:
+#   uv run bora plugin install plugins/dsh
+#   # repo/.env should define deepseek_api_key (projected as DEEPSEEK_API_KEY)
+#   uv run bora run examples/journeys --task terminal-jsonl-agg \
+#     --profiles examples/journeys/profiles.dsh.yaml
+#
+# api_key = env locator name (never a secret value).
+# Same harness as ACP / nooa — only the job binding changes.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: dsh
+    model: deepseek-v4-flash
+    api_key: deepseek_api_key
+    options:
+      composition: slim

--- a/examples/journeys/tasks/terminal-jsonl-agg/README.md
+++ b/examples/journeys/tasks/terminal-jsonl-agg/README.md
@@ -26,5 +26,18 @@ uv run bora run examples/journeys --task terminal-jsonl-agg \
 Requires `bora-attempt:l1` image with ACP entries baked in, host credentials for
 the chosen entry, and Docker.
 
+## dsh plugin (optional)
+
+Same harness; bind DeepSeek Harness via an alternate profiles file (not ACP):
+
+```bash
+uv run bora plugin install plugins/dsh
+uv run bora run examples/journeys --task terminal-jsonl-agg \
+  --profiles examples/journeys/profiles.dsh.yaml
+```
+
+Needs locator `deepseek_api_key` in repo `.env`. L1 bake installs
+`deepseek-harness-sdk` in the Attempt image.
+
 `BORA_L1_USE_SOLUTION=1` seeds `solution/*` into the Attempt workspace for L1
 isolation smoke only — **not** the real Agent acceptance path for this journey.

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -1,0 +1,61 @@
+# dsh — DeepSeek Harness executor plugin
+
+External `bora.plugin/1` package. **Not** first-party BORA core.
+
+Drives [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) over
+the official Python JSON-RPC SDK (`deepseek-harness-sdk` + bundled
+`dsh-jsonrpc-agent`). This is **not** ACP: DSH's shipped ACP wire is too thin
+for BORA evidence (no tools / reasoning / usage; model is not on
+`config_options`).
+
+```python
+from deepseek_harness import DeepSeekHarness
+
+with DeepSeekHarness(model="deepseek-v4-flash", cwd=workdir, session_root=attempt_dir) as h:
+    result = h.start_session(session_id).run(prompt)
+```
+
+Profile `model` is passed on `initialize`. `api_key` is an env locator
+(never a secret value). Sessions persist under the Attempt (`DSH_SESSION_ROOT`),
+not the task workspace.
+
+## Install
+
+```bash
+uv sync --extra dsh          # optional; L1 bake installs the wheels in-image
+uv run bora plugin install plugins/dsh
+```
+
+Install updates `$BORA_HOME/plugins` (default `~/.bora/plugins`) only — **never**
+edits `profiles.yaml` / `bora.yaml` / `task.yaml`.
+
+## Bind
+
+```yaml
+bindings:
+  solver:
+    executor: dsh
+    model: deepseek-v4-flash
+    api_key: deepseek_api_key          # env locator
+    options:
+      composition: slim
+```
+
+## Journeys smoke (L1, real API)
+
+```bash
+uv run bora plugin install plugins/dsh
+unset BORA_OFFLINE_AGENT
+uv run bora run examples/journeys --task terminal-jsonl-agg \
+  --profiles examples/journeys/profiles.dsh.yaml
+```
+
+## Recognition ≠ Ready ≠ bind
+
+- **install** → Recognition only (`plugin list` / executor visible)
+- **profiles `executor: dsh`** → bind (+ model / api_key locator)
+- **L1 Ready** → `image_contribute` bake installs the SDK wheels +
+  `bora-executor-dsh`; invoke is **docker exec** with projected `DEEPSEEK_API_KEY`
+
+Host SPI success is not L1 Ready. Offline (`BORA_OFFLINE_AGENT=1`) fail-closes
+without spawning the runtime.

--- a/plugins/dsh/compositions/slim.cordis.yml
+++ b/plugins/dsh/compositions/slim.cordis.yml
@@ -1,0 +1,71 @@
+# BORA-owned slim composition for the bundled dsh-jsonrpc-agent runtime.
+# Must include @deepseek-ai/dsh-sdk-jsonrpc-server. stdout is reserved for JSON-RPC.
+# Isolation hard boundary is BORA mount/UID; this tree uses local bash/fs (no
+# landlock helper, no approval ask). Do not add a console logger or web tools.
+
+- id: sdk-jsonrpc-server
+  name: '@deepseek-ai/dsh-sdk-jsonrpc-server'
+  config:
+    maxTokensAsSuccess: !!js "process.env.DSH_MAX_TOKENS_AS_SUCCESS === undefined ? true : JSON.parse(process.env.DSH_MAX_TOKENS_AS_SUCCESS)"
+
+- id: llm-deepseek
+  name: '@deepseek-ai/dsh-llm-deepseek'
+  config:
+    thinking: enabled
+    reasoningEffort: max
+
+- id: subprocess
+  name: '@deepseek-ai/dsh-subprocess-local'
+
+- id: bash
+  name: '@deepseek-ai/dsh-bash-local'
+  config:
+    cwd: !!js process.env.DSH_CWD ?? process.cwd()
+    timeoutMs: 60000
+
+- id: agent-spine
+  name: '@deepseek-ai/dsh-agent-spine-demo'
+  config:
+    persona: !!js process.env.DSH_SYSTEM_PROMPT ?? 'You are a coding agent. Your working directory is the task workspace. Use bash and filesystem tools to complete the instruction. Write required output files, then reply briefly. Do not ask questions.'
+    workspaceContext: false
+    skills:
+      enabled: false
+    toolBash:
+      enableRunInBackground: false
+    toolJobs: false
+
+- id: sessions
+  name: '@deepseek-ai/dsh-session-persistence-jsonl'
+  config:
+    root: !!js process.env.DSH_SESSION_ROOT
+    compression: none
+
+- id: session-checkpoints
+  name: '@deepseek-ai/dsh-session-checkpoint-policy'
+
+- id: tool-todo
+  name: '@deepseek-ai/dsh-tool-todo'
+  config:
+    allowParallelInProgress: true
+
+- id: fs-local
+  name: '@deepseek-ai/dsh-fs-local'
+  config:
+    cwd: !!js process.env.DSH_CWD ?? process.cwd()
+
+- id: fs-observation-policy
+  name: '@deepseek-ai/dsh-fs-observation-policy'
+
+- id: tool-fs
+  name: '@deepseek-ai/dsh-tool-fs'
+
+- id: token-meter
+  name: '@deepseek-ai/dsh-token-meter'
+
+- id: compaction-basic
+  name: '@deepseek-ai/dsh-compaction-basic'
+  config:
+    thresholdRatio: 0.8
+    retainRatio: 0.16
+    maxTokens: 8192
+    compactionRetries: 1

--- a/plugins/dsh/docker/Dockerfile.bake
+++ b/plugins/dsh/docker/Dockerfile.bake
@@ -1,0 +1,21 @@
+# Layer dsh in-container worker + DeepSeek Harness Python wheels onto a package Attempt image.
+# Build context = installed dsh plugin package root (path install cache).
+# Usage (host):
+#   docker build --build-arg BASE_IMAGE=<pkg-tag> -f docker/Dockerfile.bake -t <out> .
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+USER root
+COPY src/dsh_plugin /opt/dsh/dsh_plugin
+COPY worker/bora_executor_dsh.py /usr/local/bin/bora-executor-dsh
+COPY compositions/slim.cordis.yml /opt/dsh/compositions/slim.cordis.yml
+# Pin official wheels at image build. No invoke-time npm i / floating pip.
+RUN chmod 755 /usr/local/bin/bora-executor-dsh \
+    && test -f /usr/local/bin/bora-executor-dsh \
+    && test -f /opt/dsh/compositions/slim.cordis.yml \
+    && python3 -m py_compile /usr/local/bin/bora-executor-dsh \
+    && python3 -m pip install --no-cache-dir "deepseek-harness-sdk==0.1.0rc6"
+
+# Prefer non-root actor when base defines it.
+USER bora
+WORKDIR /attempt/workspace

--- a/plugins/dsh/plugin.yaml
+++ b/plugins/dsh/plugin.yaml
@@ -1,0 +1,15 @@
+format: bora.plugin/1
+plugin_id: dsh
+version: 0.1.0
+slots:
+  provide:
+    - id: executor
+      priority: 110
+      entry: "dsh_plugin.factory:build_executor"
+  "on":
+    - id: image_contribute
+      priority: 110
+      entry: "dsh_plugin.hooks:image_contribute"
+    - id: trajectory_collect
+      priority: 110
+      entry: "dsh_plugin.hooks:trajectory_collect"

--- a/plugins/dsh/src/dsh_plugin/__init__.py
+++ b/plugins/dsh/src/dsh_plugin/__init__.py
@@ -1,0 +1,10 @@
+"""dsh plugin package.
+
+Submodules that need BORA Core (factory, container) must be imported by
+name. Package import itself stays Core-free so the in-container worker can
+load ``dsh_plugin.trajectory``.
+"""
+
+PLUGIN_ID = "dsh"
+
+__all__ = ["PLUGIN_ID"]

--- a/plugins/dsh/src/dsh_plugin/container.py
+++ b/plugins/dsh/src/dsh_plugin/container.py
@@ -1,0 +1,253 @@
+"""L1 dsh executor: docker exec the baked in-container worker."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from bora.adapters.agent_container import wrap_docker_exec
+from bora.adapters.agent_contract import AgentExecutor, AgentResult
+from bora.adapters.provider_docker.cli_supervise import supervise_docker_cli
+from bora.provider.contract import TerminationPolicy
+from bora.provider.outcomes import ProcessTerminalKind
+from dsh_plugin import PLUGIN_ID
+from dsh_plugin.factory import (
+    DEFAULT_COMPOSITION,
+    DEFAULT_MODEL,
+    DEFAULT_PROVIDER,
+    resolve_api_key_value,
+    resolve_base_url,
+)
+
+WORKER_PATH = "/usr/local/bin/bora-executor-dsh"
+CORDIS_CONTAINER = "/opt/dsh/compositions/slim.cordis.yml"
+WORKDIR_CONTAINER = "/attempt/workspace"
+HOME_CONTAINER = "/attempt/home"
+
+
+class DshContainerExecutor(AgentExecutor):
+    """Invoke DeepSeekHarness inside the Attempt container via baked worker."""
+
+    kind = PLUGIN_ID
+    execution_location = "attempt-container"
+
+    def __init__(
+        self,
+        *,
+        container_id: str,
+        model: str = DEFAULT_MODEL,
+        provider: str = DEFAULT_PROVIDER,
+        composition: str = DEFAULT_COMPOSITION,
+        base_url: str | None = None,
+        api_key_env: str | None = None,
+        uid: int = 10001,
+        gid: int = 10001,
+        workdir_container: str = WORKDIR_CONTAINER,
+        home_container: str = HOME_CONTAINER,
+        session_id: str | None = None,
+    ) -> None:
+        self.container_id = container_id
+        self.model = model or DEFAULT_MODEL
+        self.provider = provider or DEFAULT_PROVIDER
+        self.composition = composition or DEFAULT_COMPOSITION
+        self.base_url = (base_url or "").strip() or None
+        self.api_key_env = (api_key_env or "").strip() or None
+        self.uid = uid
+        self.gid = gid
+        self.workdir_container = workdir_container
+        self.home_container = home_container
+        self.workdir = workdir_container
+        self.session_id = session_id
+        self._ready = False
+
+    def open(self, **kwargs: Any) -> None:
+        del kwargs
+        self._ready = True
+
+    def close(self) -> None:
+        self._ready = False
+
+    def _child_env(self) -> dict[str, str]:
+        env: dict[str, str] = {
+            "DSH_CWD": self.workdir_container,
+            "DSH_SESSION_ROOT": f"{self.home_container.rstrip('/')}/dsh-sessions",
+            "DSH_CORDIS_CONFIG": CORDIS_CONTAINER,
+        }
+        key = resolve_api_key_value(self.api_key_env)
+        if key:
+            env["DEEPSEEK_API_KEY"] = key
+        base = resolve_base_url(self.base_url)
+        if base:
+            env["DEEPSEEK_BASE_URL"] = base
+        return env
+
+    def invoke(
+        self,
+        prompt: str,
+        *,
+        timeout: float = 60.0,
+        workdir: str | None = None,
+        collect_dir: str | None = None,
+        redaction_sentinels: tuple[str, ...] | list[str] | None = None,
+    ) -> AgentResult:
+        del redaction_sentinels
+        effective_workdir = workdir or self.workdir_container
+        payload: dict[str, Any] = {
+            "prompt": prompt,
+            "model": self.model,
+            "provider": self.provider,
+            "composition": self.composition,
+            "workdir": effective_workdir,
+            "session_root": f"{self.home_container.rstrip('/')}/dsh-sessions",
+            "cordis": CORDIS_CONTAINER,
+            "session_id": self.session_id,
+        }
+        env = self._child_env()
+        env["DSH_CWD"] = effective_workdir
+        cmd = wrap_docker_exec(
+            container_id=self.container_id,
+            uid=self.uid,
+            gid=self.gid,
+            workdir=effective_workdir,
+            env=env,
+            argv=["python3", WORKER_PATH],
+        )
+        teardown_requested = {"value": False}
+
+        def _terminate() -> str | None:
+            teardown_requested["value"] = True
+            return None
+
+        def _is_alive() -> bool:
+            return teardown_requested["value"]
+
+        try:
+            outcome = supervise_docker_cli(
+                cmd,
+                timeout_seconds=max(1.0, float(timeout)),
+                stdin_bytes=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                termination=TerminationPolicy(terminate=_terminate, is_alive=_is_alive),
+            )
+        except FileNotFoundError as exc:
+            return AgentResult(
+                model=self.model,
+                text="",
+                structured=None,
+                ok=False,
+                error=f"dsh_container_exec:{exc}",
+                metadata={
+                    "plugin": PLUGIN_ID,
+                    "execution_location": self.execution_location,
+                },
+            )
+
+        if outcome.terminal == ProcessTerminalKind.TIMED_OUT:
+            return AgentResult(
+                model=self.model,
+                text="",
+                structured=None,
+                ok=False,
+                error="dsh_timeout",
+                metadata={
+                    "plugin": PLUGIN_ID,
+                    "execution_location": self.execution_location,
+                },
+            )
+        if outcome.terminal == ProcessTerminalKind.SPAWN_FAILED:
+            return AgentResult(
+                model=self.model,
+                text="",
+                structured=None,
+                ok=False,
+                error=f"dsh_container_exec:{(outcome.stderr_summary or '')[:200]}",
+                metadata={
+                    "plugin": PLUGIN_ID,
+                    "execution_location": self.execution_location,
+                },
+            )
+
+        stdout = (outcome.stdout_summary or "").strip()
+        stderr = (outcome.stderr_summary or "")[-2000:]
+        if not stdout:
+            return AgentResult(
+                model=self.model,
+                text="",
+                structured=None,
+                ok=False,
+                error="dsh_container_empty_stdout",
+                stderr=stderr,
+                metadata={
+                    "plugin": PLUGIN_ID,
+                    "execution_location": self.execution_location,
+                    "returncode": outcome.exit_code,
+                },
+            )
+        line = stdout.splitlines()[-1]
+        try:
+            doc = json.loads(line)
+        except json.JSONDecodeError:
+            return AgentResult(
+                model=self.model,
+                text=stdout[:2000],
+                structured=None,
+                ok=False,
+                error="dsh_container_bad_json",
+                stderr=stderr,
+                metadata={
+                    "plugin": PLUGIN_ID,
+                    "execution_location": self.execution_location,
+                },
+            )
+        if not isinstance(doc, dict):
+            return AgentResult(
+                model=self.model,
+                text=str(doc),
+                structured=None,
+                ok=False,
+                error="dsh_container_result_not_object",
+                metadata={
+                    "plugin": PLUGIN_ID,
+                    "execution_location": self.execution_location,
+                },
+            )
+        base_meta: dict[str, Any] = {}
+        raw_meta = doc.get("metadata")
+        if isinstance(raw_meta, dict):
+            base_meta = {str(k): v for k, v in raw_meta.items()}
+        structured = doc.get("structured") if isinstance(doc.get("structured"), dict) else None
+        raw_events = doc.get("events")
+        events: tuple[dict[str, Any], ...] = ()
+        if isinstance(raw_events, list):
+            events = tuple(e for e in raw_events if isinstance(e, dict))
+        raw_native = doc.get("native_events")
+        native: list[dict[str, Any]] = []
+        if isinstance(raw_native, list):
+            native = [e for e in raw_native if isinstance(e, dict)]
+        usage = doc.get("usage") if isinstance(doc.get("usage"), dict) else None
+        meta: dict[str, Any] = {
+            **base_meta,
+            "plugin": PLUGIN_ID,
+            "execution_location": self.execution_location,
+            "returncode": outcome.exit_code,
+            "native_event_count": len(native),
+        }
+        if collect_dir and native:
+            from pathlib import Path
+
+            root = Path(collect_dir)
+            root.mkdir(parents=True, exist_ok=True)
+            (root / "dsh_events.jsonl").write_text(
+                "\n".join(json.dumps(e, ensure_ascii=False, default=str) for e in native) + "\n",
+                encoding="utf-8",
+            )
+        return AgentResult(
+            model=str(doc.get("model") or self.model),
+            text=str(doc.get("text") or ""),
+            structured=structured,
+            ok=bool(doc.get("ok", False)),
+            error=str(doc["error"]) if doc.get("error") else None,
+            stderr=stderr,
+            events=events,
+            usage=usage,
+            metadata=meta,
+        )

--- a/plugins/dsh/src/dsh_plugin/factory.py
+++ b/plugins/dsh/src/dsh_plugin/factory.py
@@ -1,0 +1,335 @@
+"""dsh ExecutorSPI — official DeepSeek Harness JSON-RPC SDK (not ACP).
+
+Drive ``deepseek-harness-sdk`` / ``dsh-jsonrpc-agent``. Model is passed on
+``initialize``. Credentials arrive as projected env (locator name on the
+profile). Host SPI is Recognition / L0 only; L1 Ready uses bind_to_target.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import contextlib
+import json
+import os
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any
+
+from bora.adapters.agent_contract import AgentResult, parse_validated_text_structured
+from bora.plugins.errors import ExtensionMaterializeError
+from dsh_plugin import PLUGIN_ID
+from dsh_plugin.trajectory import extract_usage, to_bora_trajectory_events
+
+DEFAULT_MODEL = "deepseek-v4-flash"
+DEFAULT_PROVIDER = "deepseek-official"
+DEFAULT_COMPOSITION = "slim"
+_CREDENTIAL_ENV_NAMES = ("DEEPSEEK_API_KEY", "deepseek_api_key")
+_BASE_URL_ENV_FALLBACKS = ("DEEPSEEK_BASE_URL", "deepseek_base_url")
+_OK_REASONS = frozenset({"completed", "max-tokens"})
+
+
+def describe_dsh() -> dict[str, Any]:
+    return {
+        "execution_mode": "container-worker",
+        "tools": "native",
+        "structured_output": "validated-text",
+        "session": "reuse-process",
+        "stream": "native-events",
+        "credential_env_names": _CREDENTIAL_ENV_NAMES,
+        "binary": "dsh-jsonrpc-agent",
+    }
+
+
+def _plugin_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def resolve_composition_path(name: str | None) -> Path:
+    slug = (name or DEFAULT_COMPOSITION).strip() or DEFAULT_COMPOSITION
+    if "/" in slug or "\\" in slug or slug.startswith("."):
+        raise ExtensionMaterializeError(
+            f"dsh_composition_invalid:{slug}",
+            kind="extension_materialize_failed",
+        )
+    path = _plugin_root() / "compositions" / f"{slug}.cordis.yml"
+    if not path.is_file():
+        raise ExtensionMaterializeError(
+            f"dsh_composition_missing:{slug}",
+            kind="extension_materialize_failed",
+        )
+    return path
+
+
+def resolve_api_key_value(locator: str | None) -> str | None:
+    names: list[str] = []
+    if locator and str(locator).strip():
+        names.append(str(locator).strip())
+    for name in _CREDENTIAL_ENV_NAMES:
+        if name not in names:
+            names.append(name)
+    for name in names:
+        val = os.environ.get(name)
+        if val and str(val).strip():
+            return str(val).strip()
+    return None
+
+
+def resolve_base_url(explicit: str | None) -> str | None:
+    if explicit and str(explicit).strip():
+        return str(explicit).strip()
+    for key in _BASE_URL_ENV_FALLBACKS:
+        raw = os.environ.get(key)
+        if raw and str(raw).strip():
+            return str(raw).strip()
+    return None
+
+
+def _write_backend_raw(
+    collect_dir: str | None,
+    native: list[dict[str, Any]],
+    notifications: list[dict[str, Any]] | None = None,
+) -> None:
+    if not collect_dir:
+        return
+    root = Path(collect_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    rows = list(native)
+    if notifications:
+        rows.extend(notifications)
+    if not rows:
+        return
+    (root / "dsh_events.jsonl").write_text(
+        "\n".join(json.dumps(e, ensure_ascii=False, default=str) for e in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _offline() -> bool:
+    return os.environ.get("BORA_OFFLINE_AGENT") == "1"
+
+
+def _ok_from_reason(reason: str | None, text: str) -> bool:
+    if reason in {"error", "interrupted"}:
+        return False
+    if reason in _OK_REASONS:
+        return True
+    return bool(text)
+
+
+class DshExecutorSPI:
+    """Host SPI wrapping DeepSeekHarness. L1 uses DshContainerExecutor."""
+
+    kind = PLUGIN_ID
+
+    def __init__(
+        self,
+        *,
+        options: dict[str, Any] | None = None,
+        profile_id: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        plugin_id: str | None = None,
+        **_kwargs: Any,
+    ) -> None:
+        del plugin_id
+        opts = dict(options or {})
+        self.options = opts
+        self.profile_id = profile_id
+        self.model = (model or "").strip() or DEFAULT_MODEL
+        self.provider = str(opts.get("provider") or DEFAULT_PROVIDER).strip() or DEFAULT_PROVIDER
+        self.composition = str(opts.get("composition") or DEFAULT_COMPOSITION).strip() or (
+            DEFAULT_COMPOSITION
+        )
+        self.base_url = base_url
+        self.api_key_env = api_key
+        self.default_workdir = str(opts.get("_workdir")).strip() if opts.get("_workdir") else None
+        self._harness: Any = None
+        self._session: Any = None
+        self._session_id = f"bora-{self.profile_id or 'solver'}-{uuid.uuid4().hex[:12]}"
+        self._session_root: str | None = None
+        self._tmp_session: tempfile.TemporaryDirectory[str] | None = None
+        self._ready = False
+
+    @staticmethod
+    def describe() -> dict[str, Any]:
+        return describe_dsh()
+
+    def bind_to_target(self, placement: Any) -> Any:
+        from dsh_plugin.container import DshContainerExecutor
+
+        workdir = str(getattr(placement, "workdir", None) or "/attempt/workspace")
+        home = str(getattr(placement, "home", None) or "/attempt/home")
+        return DshContainerExecutor(
+            container_id=str(placement.container_id),
+            uid=int(placement.uid),
+            gid=int(placement.gid),
+            workdir_container=workdir,
+            home_container=home,
+            model=self.model,
+            provider=self.provider,
+            composition=self.composition,
+            base_url=self.base_url if isinstance(self.base_url, str) else None,
+            api_key_env=self.api_key_env if isinstance(self.api_key_env, str) else None,
+            session_id=self._session_id,
+        )
+
+    def open(self, **kwargs: Any) -> None:
+        del kwargs
+        if _offline():
+            raise ExtensionMaterializeError(
+                "offline_forced",
+                kind="extension_materialize_failed",
+            )
+        self._ready = True
+
+    def close(self) -> None:
+        harness = self._harness
+        self._harness = None
+        self._session = None
+        self._ready = False
+        if harness is not None:
+            with contextlib.suppress(Exception):
+                harness.close()
+        tmp = self._tmp_session
+        self._tmp_session = None
+        if tmp is not None:
+            tmp.cleanup()
+
+    def invoke(
+        self,
+        prompt: str,
+        *,
+        timeout: float = 60.0,
+        workdir: str | None = None,
+        collect_dir: str | None = None,
+        redaction_sentinels: tuple[str, ...] | list[str] | None = None,
+    ) -> AgentResult:
+        del redaction_sentinels
+        if _offline():
+            return AgentResult(
+                model=self.model,
+                text="",
+                structured=None,
+                ok=False,
+                error="offline_forced",
+                metadata={"plugin": PLUGIN_ID},
+            )
+        try:
+            self._ensure_started(workdir or self.default_workdir)
+        except ExtensionMaterializeError as exc:
+            return AgentResult(
+                model=self.model,
+                text="",
+                structured=None,
+                ok=False,
+                error=str(getattr(exc, "message", None) or exc),
+                metadata={"plugin": PLUGIN_ID},
+            )
+        assert self._session is not None
+        try:
+            result = self._run_session(prompt, timeout=timeout)
+        except TimeoutError:
+            self.close()
+            return AgentResult(
+                model=self.model,
+                text="",
+                structured=None,
+                ok=False,
+                error="dsh_timeout",
+                metadata={"plugin": PLUGIN_ID, "session_id": self._session_id},
+            )
+        except Exception as exc:  # noqa: BLE001
+            return AgentResult(
+                model=self.model,
+                text="",
+                structured=None,
+                ok=False,
+                error=f"{type(exc).__name__}:{exc}",
+                metadata={"plugin": PLUGIN_ID, "session_id": self._session_id},
+            )
+        native = [e for e in (result.events or []) if isinstance(e, dict)]
+        notes: list[dict[str, Any]] = []
+        for note in result.notifications or ():
+            payload = getattr(note, "payload", None)
+            method = getattr(note, "method", None)
+            if isinstance(payload, dict):
+                notes.append({"method": method, **payload})
+        _write_backend_raw(collect_dir, native, notes)
+        mapped = tuple(to_bora_trajectory_events(native, session_id=result.session_id))
+        text = str(result.final_response or "")
+        reason = result.finish_reason
+        ok = _ok_from_reason(reason, text)
+        return AgentResult(
+            model=self.model,
+            text=text,
+            structured=parse_validated_text_structured(text),
+            ok=ok,
+            error=None if ok else str(reason or "dsh_error"),
+            events=mapped,
+            usage=extract_usage(native),
+            metadata={
+                "plugin": PLUGIN_ID,
+                "session_id": result.session_id,
+                "finish_reason": reason,
+                "session_root": result.session_root or self._session_root,
+                "composition": self.composition,
+                "execution_location": "host",
+            },
+        )
+
+    def _run_session(self, prompt: str, *, timeout: float) -> Any:
+        assert self._session is not None
+        wait = max(1.0, float(timeout))
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            fut = pool.submit(self._session.run, prompt)
+            try:
+                return fut.result(timeout=wait)
+            except concurrent.futures.TimeoutError as exc:
+                raise TimeoutError("dsh_timeout") from exc
+
+    def _ensure_started(self, workdir: str | None) -> None:
+        if self._harness is not None:
+            return
+        try:
+            from deepseek_harness import DeepSeekHarness
+        except ImportError as exc:
+            raise ExtensionMaterializeError(
+                "dsh_package_missing: install deepseek-harness-sdk==0.1.0rc6 "
+                "(uv sync --extra dsh / pip install deepseek-harness-sdk==0.1.0rc6)",
+                kind="extension_materialize_failed",
+            ) from exc
+        key = resolve_api_key_value(self.api_key_env if isinstance(self.api_key_env, str) else None)
+        base = resolve_base_url(self.base_url if isinstance(self.base_url, str) else None)
+        if not key and not (base and ("127.0.0.1" in base or "localhost" in base)):
+            raise ExtensionMaterializeError(
+                f"dsh_missing_credential: env {self.api_key_env or 'DEEPSEEK_API_KEY'!r} unset",
+                kind="extension_materialize_failed",
+            )
+        cordis = resolve_composition_path(self.composition)
+        cwd = str(Path(workdir or Path.cwd()).expanduser().resolve(strict=False))
+        if self._session_root is None:
+            self._tmp_session = tempfile.TemporaryDirectory(prefix="bora-dsh-")
+            self._session_root = self._tmp_session.name
+        env: dict[str, str] = {}
+        if key:
+            env["DEEPSEEK_API_KEY"] = key
+        if base:
+            env["DEEPSEEK_BASE_URL"] = base
+        self._harness = DeepSeekHarness(
+            provider=self.provider,
+            model=self.model,
+            cwd=cwd,
+            session_root=self._session_root,
+            cordis=str(cordis),
+            env=env,
+        )
+        self._harness.start()
+        self._session = self._harness.start_session(self._session_id)
+        self._ready = True
+
+
+def build_executor(**kwargs: Any) -> DshExecutorSPI:
+    """plugin.yaml provide entry: factory(**kwargs) -> ExecutorSPI."""
+    return DshExecutorSPI(**kwargs)

--- a/plugins/dsh/src/dsh_plugin/hooks.py
+++ b/plugins/dsh/src/dsh_plugin/hooks.py
@@ -1,0 +1,38 @@
+"""Multi-slot on-handlers for dsh (image_contribute / trajectory_collect)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dsh_plugin import PLUGIN_ID
+
+
+async def image_contribute(ctx: Any, value: Any, nxt: Any) -> Any:
+    """Declare this plugin on the image_contribute chain (L1 Ready)."""
+    del ctx
+    base = list(value) if isinstance(value, list) else []
+    base.append({"plugin": PLUGIN_ID})
+    return await nxt(base)
+
+
+async def trajectory_collect(ctx: Any, value: Any, nxt: Any) -> Any:
+    """Map native DSH dumps. Do not claim already-mapped foreign events."""
+    del ctx
+    out = await nxt(value)
+    if not isinstance(out, dict):
+        return out
+    from dsh_plugin.trajectory import SCHEMA, to_bora_trajectory_events
+
+    events = out.get("events")
+    if not isinstance(events, (list, tuple)) or not events:
+        return out
+    if all(isinstance(e, dict) and e.get("schema") == SCHEMA for e in events):
+        if not any(e.get("source") == PLUGIN_ID for e in events if isinstance(e, dict)):
+            return out
+        meta = dict(out.get("metadata") or {})
+        meta.setdefault("trajectory_source", PLUGIN_ID)
+        return {**out, "metadata": meta}
+    mapped = to_bora_trajectory_events(tuple(e for e in events if isinstance(e, dict)))
+    meta = dict(out.get("metadata") or {})
+    meta.setdefault("trajectory_source", PLUGIN_ID)
+    return {**out, "events": tuple(mapped), "metadata": meta}

--- a/plugins/dsh/src/dsh_plugin/trajectory.py
+++ b/plugins/dsh/src/dsh_plugin/trajectory.py
@@ -1,0 +1,313 @@
+"""Map DeepSeek Harness session events to ``bora.trajectory.event/1``.
+
+Vendor-native rows stay in ``backend_raw/``. This module never emits ACP
+``session_update`` shapes. Importable in-image (no BORA Core).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+SCHEMA = "bora.trajectory.event/1"
+_SOURCE = "dsh"
+_OPAQUE_CLIP = 8_000
+
+# Streaming / bookkeeping — dump as vendor raw, do not fold token deltas.
+_SKIP_TYPES = frozenset(
+    {
+        "assistant/chunk",
+        "reasoning-chunks",
+        "text-chunks",
+        "tool-call-chunks",
+        "request/header",
+        "request/context",
+        "session/title",
+        "session",
+        "agent/inbox/spliced",
+        "turn/start",
+        "step/start",
+        "step/end",
+        "user/message",
+    }
+)
+
+
+def to_bora_trajectory_events(
+    raw_events: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+    *,
+    session_id: str = "dsh",
+) -> list[dict[str, Any]]:
+    """Committed DSH session events → Core-owned trajectory events."""
+    out: list[dict[str, Any]] = []
+    seq = 0
+    names: dict[str, str] = {}
+
+    def _next() -> int:
+        nonlocal seq
+        seq += 1
+        return seq
+
+    for raw in raw_events:
+        if not isinstance(raw, dict):
+            continue
+        event = _unwrap_event(raw)
+        et = str(event.get("type") or "")
+        if et in _SKIP_TYPES:
+            continue
+        data = event.get("data") if isinstance(event.get("data"), dict) else {}
+        if et == "assistant/message":
+            seq = _emit_assistant_message(out, _next, session_id, data)
+        elif et == "tool/call":
+            seq_n = _next()
+            call_id = str(data.get("callId") or data.get("id") or f"dsh_tool_{seq_n}")
+            name = str(data.get("name") or "tool")
+            names[call_id] = name
+            out.append(
+                {
+                    "schema": SCHEMA,
+                    "seq": seq_n,
+                    "session_id": session_id,
+                    "source": _SOURCE,
+                    "kind": "tool",
+                    "phase": "start",
+                    "tool_call_id": call_id,
+                    "title": name,
+                    "function_name": name,
+                    "tool_kind": _tool_kind(name),
+                    "status": "pending",
+                    "args": _as_args(data.get("arguments")),
+                }
+            )
+        elif et == "tool/result":
+            seq_n = _next()
+            call_id, content, is_error = _parse_tool_result(data)
+            name = names.get(call_id, "tool")
+            out.append(
+                {
+                    "schema": SCHEMA,
+                    "seq": seq_n,
+                    "session_id": session_id,
+                    "source": _SOURCE,
+                    "kind": "tool",
+                    "phase": "update",
+                    "tool_call_id": call_id or f"dsh_tool_{seq_n}",
+                    "title": name,
+                    "function_name": name,
+                    "tool_kind": "other",
+                    "status": "failed" if is_error else "completed",
+                    "content": content,
+                }
+            )
+        elif et == "turn/end":
+            continue
+        else:
+            seq_n = _next()
+            out.append(
+                {
+                    "schema": SCHEMA,
+                    "seq": seq_n,
+                    "session_id": session_id,
+                    "source": _SOURCE,
+                    "kind": "opaque",
+                    "payload": _clip(event),
+                }
+            )
+    return out
+
+
+def extract_usage(
+    raw_events: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+) -> dict[str, Any] | None:
+    """Sum per-step committed usage for one Session.run interval.
+
+    DSH emits usage on every ``assistant/message`` (and a matching
+    ``assistant/chunk``). Last-step numbers are the current request only
+    (cache grows, uncached input shrinks). Chunks are ignored so a
+    message+chunk pair is not double-counted. Not ACP UsageUpdate.
+    """
+    totals = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "reasoning_tokens": 0,
+    }
+    seen = False
+    for raw in raw_events:
+        if not isinstance(raw, dict):
+            continue
+        event = _unwrap_event(raw)
+        if event.get("type") != "assistant/message":
+            continue
+        data = event.get("data") if isinstance(event.get("data"), dict) else {}
+        usage = data.get("usage")
+        if not isinstance(usage, dict):
+            continue
+        part = _normalize_usage(usage)
+        if not part:
+            continue
+        seen = True
+        for key in totals:
+            val = part.get(key)
+            if isinstance(val, int):
+                totals[key] += val
+    if not seen:
+        return None
+    out = {k: v for k, v in totals.items() if v or k in {"input_tokens", "output_tokens"}}
+    out["total_tokens"] = totals["input_tokens"] + totals["output_tokens"]
+    return out
+
+
+def extract_finish_reason(
+    raw_events: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+) -> str | None:
+    for raw in reversed(list(raw_events)):
+        if not isinstance(raw, dict):
+            continue
+        event = _unwrap_event(raw)
+        if event.get("type") != "turn/end":
+            continue
+        data = event.get("data") if isinstance(event.get("data"), dict) else {}
+        reason = data.get("reason") if isinstance(data.get("reason"), dict) else {}
+        kind = reason.get("kind")
+        if isinstance(kind, str) and kind:
+            return kind
+    return None
+
+
+def _emit_assistant_message(
+    out: list[dict[str, Any]],
+    next_seq: Any,
+    session_id: str,
+    data: dict[str, Any],
+) -> int:
+    message = data.get("message") if isinstance(data.get("message"), dict) else data
+    content = message.get("content") if isinstance(message, dict) else None
+    if not isinstance(content, list):
+        return 0
+    seq = 0
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        btype = str(block.get("type") or "")
+        if btype == "reasoning":
+            text = str(block.get("text") or "")
+            if text:
+                seq = next_seq()
+                out.append(_text(seq, session_id, "thought", text))
+        elif btype == "text":
+            text = str(block.get("text") or "")
+            if text:
+                seq = next_seq()
+                out.append(_text(seq, session_id, "assistant", text))
+        elif btype == "tool-call":
+            # Committed tool-call on the message — tool/call event is the source
+            # of truth; skip the duplicate block.
+            continue
+    return seq
+
+
+def _parse_tool_result(data: dict[str, Any]) -> tuple[str, str, bool]:
+    message = data.get("message") if isinstance(data.get("message"), dict) else {}
+    source = message.get("source") if isinstance(message.get("source"), dict) else {}
+    call_id = str(source.get("callId") or "")
+    parts: list[str] = []
+    is_error = False
+    content = message.get("content")
+    if isinstance(content, list):
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            if not call_id:
+                call_id = str(item.get("toolCallId") or "")
+            if item.get("isError"):
+                is_error = True
+            inner = item.get("content")
+            if isinstance(inner, list):
+                for block in inner:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        parts.append(str(block.get("text") or ""))
+            elif isinstance(inner, str):
+                parts.append(inner)
+    return call_id, "".join(parts), is_error
+
+
+def _unwrap_event(raw: dict[str, Any]) -> dict[str, Any]:
+    inner = raw.get("event")
+    if isinstance(inner, dict) and ("type" in inner or "data" in inner):
+        return inner
+    return raw
+
+
+def _text(seq: int, session_id: str, channel: str, text: str) -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "seq": seq,
+        "session_id": session_id,
+        "source": _SOURCE,
+        "kind": "text",
+        "channel": channel,
+        "text": text,
+    }
+
+
+def _as_args(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return {str(k): v for k, v in value.items()}
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {"raw": value}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def _tool_kind(name: str) -> str:
+    lowered = name.lower()
+    if any(n in lowered for n in ("bash", "shell", "exec", "python")):
+        return "execute"
+    if any(n in lowered for n in ("read", "cat", "view")):
+        return "read"
+    if any(n in lowered for n in ("write", "edit", "str_replace")):
+        return "edit"
+    return "other"
+
+
+def _normalize_usage(raw: dict[str, Any]) -> dict[str, Any]:
+    def _int(keys: tuple[str, ...]) -> int | None:
+        for key in keys:
+            val = raw.get(key)
+            if isinstance(val, bool):
+                continue
+            if isinstance(val, (int, float)):
+                return int(val)
+        return None
+
+    out: dict[str, Any] = {}
+    inp = _int(("input_tokens", "inputTokens"))
+    outp = _int(("output_tokens", "outputTokens"))
+    cache = _int(("cache_read_tokens", "cacheReadTokens"))
+    reason = _int(("reasoning_tokens", "reasoningTokens"))
+    if inp is not None:
+        out["input_tokens"] = inp
+    if outp is not None:
+        out["output_tokens"] = outp
+    if inp is not None or outp is not None:
+        out["total_tokens"] = (inp or 0) + (outp or 0)
+    if cache is not None:
+        out["cache_read_tokens"] = cache
+    if reason is not None:
+        out["reasoning_tokens"] = reason
+    return out
+
+
+def _clip(raw: dict[str, Any]) -> dict[str, Any]:
+    try:
+        blob = json.dumps(raw, ensure_ascii=False, default=str)
+    except TypeError:
+        return {"repr": str(raw)[:_OPAQUE_CLIP]}
+    if len(blob) <= _OPAQUE_CLIP:
+        return raw
+    return {"clipped": True, "preview": blob[:_OPAQUE_CLIP]}

--- a/plugins/dsh/worker/bora_executor_dsh.py
+++ b/plugins/dsh/worker/bora_executor_dsh.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""In-container dsh worker — official DeepSeek Harness JSON-RPC SDK.
+
+Reads one JSON object from stdin (no secrets required in the payload;
+DEEPSEEK_API_KEY / DEEPSEEK_BASE_URL arrive via projected env)::
+
+    {
+      "prompt": "...",
+      "model": "deepseek-v4-flash",
+      "provider": "deepseek-official",
+      "workdir": "/attempt/workspace",
+      "session_root": "/attempt/home/dsh-sessions",
+      "cordis": "/opt/dsh/compositions/slim.cordis.yml",
+      "session_id": "bora-solver-…"
+    }
+
+Writes one AgentResult-shaped JSON object to stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+_PLUGIN_ROOT = Path("/opt/dsh")
+if _PLUGIN_ROOT.is_dir() and str(_PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_ROOT))
+
+_OK_REASONS = frozenset({"completed", "max-tokens"})
+
+
+def _load_trajectory() -> Any:
+    try:
+        from dsh_plugin import trajectory as traj
+    except ImportError:
+        import importlib.util
+
+        path = Path("/opt/dsh/dsh_plugin/trajectory.py")
+        if not path.is_file():
+            return None
+        spec = importlib.util.spec_from_file_location("dsh_plugin_trajectory", path)
+        if spec is None or spec.loader is None:
+            return None
+        traj = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(traj)
+    return traj
+
+
+def _ok_from_reason(reason: str | None, text: str) -> bool:
+    if reason in {"error", "interrupted"}:
+        return False
+    if reason in _OK_REASONS:
+        return True
+    return bool(text)
+
+
+def _parse_structured(text: str) -> dict[str, Any] | None:
+    trimmed = text.strip()
+    if not trimmed.startswith("{") or not trimmed.endswith("}"):
+        return None
+    try:
+        val = json.loads(trimmed)
+    except json.JSONDecodeError:
+        return None
+    return val if isinstance(val, dict) else None
+
+
+def _emit(doc: dict[str, Any], *, code: int) -> int:
+    print(json.dumps(doc, ensure_ascii=False, default=str))
+    return code
+
+
+def main() -> int:
+    try:
+        req = json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError as exc:
+        return _emit(
+            {"ok": False, "error": f"bad_request_json:{exc}", "model": "dsh", "text": ""},
+            code=2,
+        )
+    if not isinstance(req, dict):
+        return _emit(
+            {"ok": False, "error": "request_not_object", "model": "dsh", "text": ""},
+            code=2,
+        )
+
+    model = str(req.get("model") or os.environ.get("DSH_MODEL") or "deepseek-v4-flash")
+    provider = str(req.get("provider") or "deepseek-official")
+    prompt = str(req.get("prompt") or "")
+    workdir = str(req.get("workdir") or os.environ.get("DSH_CWD") or "/attempt/workspace")
+    session_root = str(
+        req.get("session_root")
+        or os.environ.get("DSH_SESSION_ROOT")
+        or "/attempt/home/dsh-sessions"
+    )
+    cordis = str(
+        req.get("cordis")
+        or os.environ.get("DSH_CORDIS_CONFIG")
+        or "/opt/dsh/compositions/slim.cordis.yml"
+    )
+    session_id = req.get("session_id")
+    session_id_s = (
+        str(session_id).strip() if isinstance(session_id, str) and session_id.strip() else None
+    )
+
+    if os.environ.get("BORA_OFFLINE_AGENT") == "1":
+        return _emit(
+            {
+                "ok": False,
+                "error": "offline_forced",
+                "model": model,
+                "text": "",
+                "metadata": {"plugin": "dsh"},
+            },
+            code=1,
+        )
+
+    alias = os.environ.get("deepseek_api_key")  # noqa: SIM112 — profile locator
+    if not os.environ.get("DEEPSEEK_API_KEY") and not alias:
+        return _emit(
+            {
+                "ok": False,
+                "error": "dsh_missing_credential",
+                "model": model,
+                "text": "",
+                "metadata": {"plugin": "dsh"},
+            },
+            code=2,
+        )
+
+    # Alias lowercase locator so the runtime sees the official name.
+    if not os.environ.get("DEEPSEEK_API_KEY") and alias:
+        os.environ["DEEPSEEK_API_KEY"] = alias
+
+    Path(session_root).mkdir(parents=True, exist_ok=True)
+    Path(workdir).mkdir(parents=True, exist_ok=True)
+
+    try:
+        from deepseek_harness import DeepSeekHarness
+    except ImportError as exc:
+        return _emit(
+            {
+                "ok": False,
+                "error": f"dsh_package_missing:{exc}",
+                "model": model,
+                "text": "",
+                "metadata": {"plugin": "dsh"},
+            },
+            code=2,
+        )
+
+    traj = _load_trajectory()
+    try:
+        with DeepSeekHarness(
+            provider=provider,
+            model=model,
+            cwd=workdir,
+            session_root=session_root,
+            cordis=cordis,
+            env={},
+        ) as harness:
+            session = harness.start_session(session_id_s)
+            result = session.run(prompt)
+        native = [e for e in (result.events or []) if isinstance(e, dict)]
+        mapped: list[dict[str, Any]] = []
+        usage = None
+        if traj is not None:
+            mapped = traj.to_bora_trajectory_events(native, session_id=result.session_id)
+            usage = traj.extract_usage(native)
+        text = str(result.final_response or "")
+        reason = result.finish_reason
+        ok = _ok_from_reason(reason, text)
+        return _emit(
+            {
+                "model": model,
+                "text": text,
+                "structured": _parse_structured(text),
+                "ok": ok,
+                "error": None if ok else str(reason or "dsh_error"),
+                "events": mapped,
+                "native_events": native,
+                "usage": usage,
+                "metadata": {
+                    "plugin": "dsh",
+                    "execution_location": "attempt-container",
+                    "session_id": result.session_id,
+                    "finish_reason": reason,
+                    "session_root": result.session_root or session_root,
+                },
+            },
+            code=0 if ok else 1,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _emit(
+            {
+                "model": model,
+                "text": "",
+                "structured": None,
+                "ok": False,
+                "error": f"{type(exc).__name__}:{exc}",
+                "metadata": {
+                    "plugin": "dsh",
+                    "execution_location": "attempt-container",
+                },
+            },
+            code=1,
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ nooa = [
     "nooa>=0.0.7",
     "socksio>=1.0.0",
 ]
+dsh = [
+    "deepseek-harness-sdk==0.1.0rc6",
+]
 
 [project.scripts]
 bora = "bora.cli.main:app"
@@ -79,7 +82,7 @@ asyncio_default_fixture_loop_scope = "function"
 
 [tool.pyright]
 include = ["src", "tests"]
-extraPaths = ["plugins/nooa/src"]
+extraPaths = ["plugins/nooa/src", "plugins/dsh/src"]
 pythonVersion = "3.12"
 typeCheckingMode = "standard"
 venvPath = "."

--- a/skills/bora-cli/SKILL.md
+++ b/skills/bora-cli/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: bora-cli
 description: >
-  Operate BORA public CLI (bora lock/run/plugin/executors/campaign/evidence/status/submit/cancel):
+  Operate BORA public CLI (bora lock/run/plugin/view/publish/release/executors/campaign/evidence/status/submit/cancel):
   install with uv, command flags, allowlisted --set pointers, exit codes, Result.logs
   trajectory locator, offline fail-closed (BORA_OFFLINE_AGENT), list supported executor
-  kinds and ACP entry readiness, plugin install/list/uninstall, and which example packages
-  to run. Use when the agent must lock a package, run an Attempt, list executor / entry
-  values, install a bora.plugin/1, export trajectory, upload suite results for Hub, interpret
-  PASS/FAIL/ERROR, debug CLI output, or choose a public smoke. Trigger phrases: "bora run",
-  "bora lock", "bora plugin", "bora executors", "upload-suite", "Hub Leaderboard",
-  "which executor", "ACP entry", "export trajectory", "Result.logs", "exit code",
-  "offline agent", "switch profile", "install nooa".
+  kinds and ACP entry readiness, plugin install/list/uninstall, dataset draft/release,
+  and which example packages to run. Use when the agent must lock a package, run an
+  Attempt, list executor / entry values, install a bora.plugin/1, open local Jobs,
+  export trajectory, upload suite results for Hub, interpret PASS/FAIL/ERROR, debug
+  CLI output, or choose a public smoke. Trigger phrases: "bora run", "bora lock",
+  "bora plugin", "bora view", "bora publish", "bora release", "bora executors",
+  "upload-suite", "Hub Leaderboard", "which executor", "ACP entry", "export trajectory",
+  "Result.logs", "exit code", "offline agent", "switch profile", "install nooa",
+  "draft slot".
   Do not invent flags not in production.
 ---
 
@@ -50,7 +52,9 @@ uv run bora --help
 | `bora results delete\|set-visibility … --kind attempt\|suite` | Owner delete (`--yes`) or flip visibility after upload                       |
 | `bora results share\|unshare …`                               | Grant / revoke private result access (owner only)                            |
 | `bora results export-profiles <suite_run_id> --out …`         | Rehydrate job binding as profiles.yaml (locators only)                       |
-| `bora publish … --org … [--replace]`                          | Package publish; replace same version is org-owner only                      |
+| `bora view <database> [--dev] [--open …]`                     | Local Jobs UI (no Registry). `--dev` starts Vite when possible; `--open` deep-links a job/task/run |
+| `bora publish … --org … [--draft] [--replace]`                | Package publish; `--draft` overwrites the draft slot; `--replace` is org-owner only |
+| `bora release <database_id>`                                  | Owner: promote the current dataset draft to an immutable version             |
 | `bora registry delete\|set-visibility <id@ver>`               | Org-owner package delete (`--yes`) / visibility flip                         |
 | `bora submit` / `bora status` / `bora cancel`                 | Durable Run **or suite job** (8-hex id; status/cancel may take `--database`) |
 
@@ -158,7 +162,7 @@ Value after `=` is JSON (strings need quotes):
 | What you did                                                                           | Registry                                        | Hub Leaderboard / Task Jobs                                    |
 | -------------------------------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------------------- |
 | `bora run … --task X` then `bora results upload … --run <run_id>`                      | Attempt row exists (`suite_run_id` often empty) | **Usually invisible** as a leaderboard / Jobs row              |
-| `bora run <database>` (omit `--task`) → `bora results upload-suite … --suite-run <id>` | Suite row + metrics + task_refs                 | **Visible** on Leaderboard; Tasks → Jobs list suite membership |
+| `bora run <database>` (omit `--task`) → `bora results upload-suite … --suite-run <id>` | Suite row + metrics + task_refs                 | **Leaderboard** only if **complete** and bound to a **release**; Task Jobs list every visible suite (including incomplete / draft-bound) |
 | `upload-suite … --with-attempts`                                                       | Also packs each attempt under task_refs         | Task Jobs can **deep-link** Attempt detail / trajectory        |
 
 **Do this when the goal is “show on Hub”:**
@@ -183,6 +187,7 @@ Also:
 
 - Hub must point at the **same** Registry URL as `~/.bora/credentials` (local dev often `http://127.0.0.1:8700` + Hub `VITE_REGISTRY_PROXY_TARGET`).
 - `bora results upload` remains valid for archiving a single Attempt / deep-link when you already know `run_id`; it is **not** a substitute for `upload-suite` for Leaderboard.
+- Public Leaderboard further requires a **complete** suite (every task on the bound version has a result; FAIL / ERROR still count) bound to a **release**. `bora publish --draft` then `bora release` (or a direct `bora publish` release) before expecting a board row. Draft-bound and incomplete suites stay on Jobs.
 - Suite metrics (`pass_rate`, pass@k, …) are **observational** — not suite-level PASS.
 
 ## Offline / fail-closed

--- a/skills/bora-cli/SKILL.md
+++ b/skills/bora-cli/SKILL.md
@@ -83,7 +83,7 @@ options:
 Do **not** hardcode a fixed list; inventory is authoritative. Do **not** use
 `executor: codex|pi|opencode|claude-code` (migrated to ACP entry).
 
-Installed plugins (e.g. `nooa`) appear as additional `executor:` values after
+Installed plugins (e.g. `nooa`, `dsh`) appear as additional `executor:` values after
 `bora plugin install` — still selected only via profiles / `--set` bindings.
 
 ### Plugin install (local cache only)
@@ -212,6 +212,7 @@ Must not PASS agent packages. Typed errors only.
 | L1 SDK session               | `uv run bora run examples/l1 --task sdk-session-single-actor`                                                                                  |
 | L1 isolation contracts       | Provider tests: `uv run pytest tests/provider_l1/test_harness_isolation_contracts.py tests/provider_l1/test_filtered_mount.py -q`              |
 | nooa plugin (L1)             | `bora plugin install plugins/nooa` then `bora run examples/journeys --task terminal-jsonl-agg --profiles examples/journeys/profiles.nooa.yaml` |
+| dsh plugin (L1)              | `bora plugin install plugins/dsh` then `bora run examples/journeys --task terminal-jsonl-agg --profiles examples/journeys/profiles.dsh.yaml`   |
 
 ## Detail
 

--- a/skills/bora-cli/references/commands.md
+++ b/skills/bora-cli/references/commands.md
@@ -109,17 +109,39 @@ Stdout JSON (high level):
   with `--with-attempts`, linked attempts also replace.
 - Registry stores full `metrics` blob (no strip). pass@k is **not**
   `config_fingerprint` / job identity.
-- Hub Leaderboard: lists **suite** rows; optional n_attempts / pass@k / pass^k when present;
-  default sort remains pass_rate → mean_score.
+- Hub Leaderboard: lists **complete, release-bound suite** rows (`board=1`); optional
+  n_attempts / pass@k / pass^k when present; default sort remains pass_rate → mean_score.
+  Incomplete or draft-bound suites stay on Task Jobs.
 
 ### Hub path checklist
 
 ```text
+bora publish <db> --org <org> --draft
+bora release <org/dataset>            # or bora publish … without --draft
 bora run <db> [--profiles …]          # omit --task → suite
   → .bora/suite-runs/<8-hex>/summary.json
 bora results upload-suite <db> --suite-run <8-hex> --public [--with-attempts]
-  → Hub: Dataset → Leaderboard row; Task → Jobs → optional Attempt deep-link
+  → Hub: Dataset → Leaderboard row (complete + release-bound);
+    Task → Jobs → optional Attempt deep-link (all visible suites)
 ```
+
+## `bora publish` / `bora release`
+
+- `bora publish <db> --org <org> --draft` overwrites the one draft slot for that
+  `database_id`. Reserved version name `draft` is not a release.
+- `bora release <database_id>` (owner) promotes the current draft to an immutable
+  `database_id@version`. `--version` overrides the draft `bora.yaml` version.
+- Direct `bora publish` without `--draft` still creates a release.
+- Plugin packages do **not** use the draft slot.
+- Unauthorized readers get 404 on draft; they never see whether a draft exists.
+
+## `bora view`
+
+- Local read-only Database UI. No Registry.
+- `--dev`: API only; starts `apps/viewer` Vite when possible, else prints the
+  two-process fallback. Advertise `:5173` only after Vite is listening.
+- `--open /jobs/<id>` (or a task/run path) deep-links after a local run.
+- Jobs list includes suite runs **and** single-task Attempts in the opened Database.
 
 ## Registry owner ops
 

--- a/skills/bora-config-package/SKILL.md
+++ b/skills/bora-config-package/SKILL.md
@@ -292,7 +292,7 @@ Upload (`bora results upload-suite`) **projects** these fields to the Registry; 
 
 | Goal | Correct path | Wrong expectation |
 | --- | --- | --- |
-| Dataset **Leaderboard** has a row | `bora run <db>` (**omit** `--task`) → `upload-suite --suite-run <id>` | Only `bora run --task` + `results upload` (attempt lands in DB; board often **missing**) |
+| Dataset **Leaderboard** has a row | Bind a **release** (`bora publish --draft` then `bora release`, or a direct `bora publish`) → `bora run <db>` (**omit** `--task`) → `upload-suite --suite-run <id>` of a **complete** suite | Only `bora run --task` + `results upload`; or a draft-bound / incomplete suite (attempt or Jobs may exist; **board** often missing) |
 | Task **Jobs** openable trajectory | `upload-suite --with-attempts` (or later upload the run_id attached under suite `task_refs`) | Attempt-only upload, no suite row |
 
 Fingerprint / binding display requires a **suite row already uploaded** (with `job_overlay` / `config_fingerprint`).

--- a/skills/bora-platform/SKILL.md
+++ b/skills/bora-platform/SKILL.md
@@ -49,7 +49,7 @@ Authoring / porting / scenario-homogeneous Datasets: load `$bora-config-package`
 5. **Skills only describe shipped surfaces** — never invent CLI flags or Core APIs.
 6. **Coding-agent Target:** `executor: acp` + `options.entry` — not private CLI `executor: codex|pi|…`.
 7. **Plugins:** fixed L0–L5 extension points + registry; `bora plugin install` never rewrites profiles; Recognition ≠ L1 Ready (`image_contribute` bake); no executor dual path.
-8. **Hub Leaderboard / Task Jobs need suite uploads** — `bora results upload` (single Attempt) is not enough for primary Hub surfaces; use suite run + `bora results upload-suite` (often `--with-attempts`). Detail: `$bora-cli` § Hub visibility.
+8. **Hub Leaderboard / Task Jobs need suite uploads** — `bora results upload` (single Attempt) is not enough for primary Hub surfaces; use suite run + `bora results upload-suite` (often `--with-attempts`). Public Leaderboard further requires a **complete**, **release-bound** suite; incomplete or draft-bound rows stay on Jobs. Detail: `$bora-cli` § Hub visibility.
 
 ## Evidence grades (honest)
 

--- a/skills/bora-plugin/SKILL.md
+++ b/skills/bora-plugin/SKILL.md
@@ -110,6 +110,7 @@ Discover flags with `bora plugin --help`. Do not invent commands.
 | `docs/design/05-runtime/evidence.md` | Three-layer trajectory contract |
 | `src/bora/plugins/slots.py` / `protocol.py` | Slot ids and `ExecutorSPI` |
 | `plugins/nooa` | External executor + bake + neutral trajectory |
+| `plugins/dsh` | External DeepSeek Harness JSON-RPC executor + bake (not ACP) |
 | `plugins/slot-probe` + `examples/slot-probe` | Multi-slot on-handler regression, not a business template |
 
 Siblings: orientation → `$bora-platform`; CLI → `$bora-cli`; Database/profiles → `$bora-config-package`; harness → `$bora-sdk-harness`.

--- a/skills/bora-plugin/references/authoring.md
+++ b/skills/bora-plugin/references/authoring.md
@@ -1,7 +1,8 @@
 # Author a `bora.plugin/1`
 
-Reference implementations: `plugins/nooa` (real executor), `plugins/slot-probe`
-(multi-slot probe — not a business template).
+Reference implementations: `plugins/nooa` (real executor), `plugins/dsh`
+(DeepSeek Harness JSON-RPC, not ACP), `plugins/slot-probe` (multi-slot probe —
+not a business template).
 
 - [Package layout](#package-layout)
 - [ExecutorSPI](#executorspi)

--- a/src/bora/cli/README.md
+++ b/src/bora/cli/README.md
@@ -236,6 +236,8 @@ uv run bora release my-org/dataset
 uv run bora publish path/to/db --org my-lab --public
 # Same database_id@version → 409 unless org owner passes --replace (rewrites blob/digests/visibility):
 # uv run bora publish path/to/db --org my-lab --replace
+# Public Leaderboard lists complete, release-bound suite uploads only.
+# Draft-bound / incomplete suites stay on Task Jobs.
 ```
 
 ### Lock / run by ref
@@ -301,6 +303,8 @@ After `bora run <database>` (full suite or Always-k), summary lives at
 `upload-suite` **recomputes** missing k maps locally from `attempts[]` or task
 `n`/`c` before POST. Registry stores the full `metrics` blob (no strip).
 pass@k is **not** a `config_fingerprint` / job-identity key.
+Public Leaderboard lists only **complete**, **release-bound** suites; incomplete
+or draft-bound rows stay on Task Jobs.
 
 ```bash
 uv run bora results upload-suite /path/to/database --suite-run <suite_run_id> \

--- a/tests/plugins/test_dsh_container_executor.py
+++ b/tests/plugins/test_dsh_container_executor.py
@@ -1,0 +1,130 @@
+"""dsh container SPI + host factory (no live DeepSeek runtime)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from bora.provider.outcomes import ProcessOutcome, ProcessTerminalKind
+from bora.runtime.identity import IdentityFactory
+
+_DSH_SRC = Path(__file__).resolve().parents[2] / "plugins" / "dsh" / "src"
+if str(_DSH_SRC) not in sys.path:
+    sys.path.insert(0, str(_DSH_SRC))
+
+from dsh_plugin.container import DshContainerExecutor  # noqa: E402
+from dsh_plugin.factory import DshExecutorSPI, build_executor, describe_dsh  # noqa: E402
+from dsh_plugin.hooks import image_contribute, trajectory_collect  # noqa: E402
+from dsh_plugin.trajectory import SCHEMA  # noqa: E402
+
+
+def test_describe_and_bind_to_target() -> None:
+    desc = describe_dsh()
+    assert desc["binary"] == "dsh-jsonrpc-agent"
+    assert "DEEPSEEK_API_KEY" in desc["credential_env_names"]
+    spi = build_executor(
+        options={"composition": "slim"},
+        model="deepseek-v4-flash",
+        api_key="deepseek_api_key",
+        profile_id="solver",
+    )
+    bound = spi.bind_to_target(
+        SimpleNamespace(
+            container_id="cid123",
+            uid=10001,
+            gid=10001,
+            workdir="/attempt/workspace",
+            home="/attempt/home",
+        )
+    )
+    assert isinstance(bound, DshContainerExecutor)
+    assert bound.execution_location == "attempt-container"
+    assert bound.model == "deepseek-v4-flash"
+
+
+def test_offline_invoke_does_not_start(monkeypatch: object) -> None:
+    monkeypatch.setenv("BORA_OFFLINE_AGENT", "1")  # type: ignore[attr-defined]
+    spi = DshExecutorSPI(model="deepseek-v4-flash", api_key="deepseek_api_key")
+    result = spi.invoke("ping")
+    assert result.ok is False
+    assert result.error == "offline_forced"
+
+
+def test_container_executor_parses_worker_stdout() -> None:
+    payload = {
+        "model": "deepseek-v4-flash",
+        "text": '{"status":"completed"}',
+        "structured": {"status": "completed"},
+        "ok": True,
+        "error": None,
+        "events": [
+            {
+                "schema": SCHEMA,
+                "seq": 1,
+                "session_id": "s",
+                "source": "dsh",
+                "kind": "text",
+                "channel": "assistant",
+                "text": "ok",
+            }
+        ],
+        "native_events": [{"type": "turn/end", "data": {"reason": {"kind": "completed"}}}],
+        "metadata": {"plugin": "dsh", "execution_location": "attempt-container"},
+    }
+
+    def fake_supervise(argv, **kwargs):  # noqa: ANN001, ANN003
+        del argv, kwargs
+        factory = IdentityFactory()
+        attempt = factory.new_attempt(factory.new_trial(factory.new_run(), "sha256:" + "d" * 64))
+        return ProcessOutcome(
+            attempt=attempt,
+            assurance="l0",
+            terminal=ProcessTerminalKind.EXITED,
+            exit_code=0,
+            signal=None,
+            stdout_summary=json.dumps(payload) + "\n",
+            stderr_summary="",
+            truncated=False,
+            pid=None,
+            pgid=None,
+            writer_stop_confirmed=True,
+            cleanup_ok=True,
+        )
+
+    ex = DshContainerExecutor(container_id="cid123", model="deepseek-v4-flash")
+    with patch("dsh_plugin.container.supervise_docker_cli", side_effect=fake_supervise):
+        result = ex.invoke("do it", timeout=5.0)
+    assert result.ok
+    assert result.metadata is not None
+    assert result.metadata.get("execution_location") == "attempt-container"
+    assert result.metadata.get("plugin") == "dsh"
+    assert result.events[0]["source"] == "dsh"
+
+
+async def test_image_contribute_declares_plugin() -> None:
+    async def nxt(value: object) -> object:
+        return value
+
+    out = await image_contribute(None, [], nxt)
+    assert out == [{"plugin": "dsh"}]
+
+
+async def test_trajectory_collect_maps_native() -> None:
+    async def nxt(value: object) -> object:
+        return value
+
+    native = {
+        "events": (
+            {
+                "type": "tool/call",
+                "data": {"callId": "c", "name": "bash", "arguments": '{"command":"ls"}'},
+            },
+        )
+    }
+    out = await trajectory_collect(None, native, nxt)
+    assert out["metadata"]["trajectory_source"] == "dsh"
+    assert out["events"][0]["schema"] == SCHEMA
+    assert out["events"][0]["source"] == "dsh"

--- a/tests/plugins/test_dsh_trajectory_map.py
+++ b/tests/plugins/test_dsh_trajectory_map.py
@@ -1,0 +1,192 @@
+"""dsh native dump → bora.trajectory.event/1 (no ACP masquerade)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from bora.evidence.trajectory import write_trajectory_jsonl
+
+_DSH_SRC = Path(__file__).resolve().parents[2] / "plugins" / "dsh" / "src"
+if str(_DSH_SRC) not in sys.path:
+    sys.path.insert(0, str(_DSH_SRC))
+
+from dsh_plugin.trajectory import (  # noqa: E402
+    SCHEMA,
+    extract_finish_reason,
+    extract_usage,
+    to_bora_trajectory_events,
+)
+
+
+def _read_lines(path: Path) -> list[dict]:
+    return [
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+
+
+def test_tool_call_and_result_map_to_layer_b(tmp_path: Path) -> None:
+    native = (
+        {
+            "type": "assistant/message",
+            "data": {
+                "message": {
+                    "content": [
+                        {"type": "reasoning", "text": "I will run bash."},
+                        {
+                            "type": "tool-call",
+                            "id": "call_1",
+                            "name": "bash",
+                            "arguments": '{"command": "echo hi"}',
+                        },
+                    ]
+                },
+                "usage": {
+                    "inputTokens": 10,
+                    "outputTokens": 4,
+                    "cacheReadTokens": 2,
+                    "reasoningTokens": 3,
+                },
+            },
+        },
+        {
+            "type": "tool/call",
+            "data": {
+                "callId": "call_1",
+                "name": "bash",
+                "arguments": '{"command": "echo hi"}',
+            },
+        },
+        {
+            "type": "tool/result",
+            "data": {
+                "message": {
+                    "source": {"kind": "tool", "callId": "call_1"},
+                    "content": [
+                        {
+                            "type": "tool-result",
+                            "toolCallId": "call_1",
+                            "content": [{"type": "text", "text": "hi\n"}],
+                            "isError": False,
+                        }
+                    ],
+                }
+            },
+        },
+        {
+            "type": "assistant/message",
+            "data": {"message": {"content": [{"type": "text", "text": "hi"}]}},
+        },
+        {"type": "turn/end", "data": {"reason": {"kind": "completed"}}},
+        {"type": "assistant/chunk", "data": {"chunk": {"type": "text", "text": "skip"}}},
+    )
+    mapped = to_bora_trajectory_events(native, session_id="bora-s")
+    assert all(e.get("schema") == SCHEMA for e in mapped)
+    assert all(e.get("source") == "dsh" for e in mapped)
+    assert all(e.get("session_id") == "bora-s" for e in mapped)
+    assert not any("sessionUpdate" in e or e.get("type") == "session_update" for e in mapped)
+    kinds = [e["kind"] for e in mapped]
+    assert kinds.count("tool") == 2
+    thought = next(e for e in mapped if e.get("channel") == "thought")
+    assert "bash" in thought["text"]
+    assistant = next(e for e in mapped if e.get("channel") == "assistant")
+    assert assistant["text"] == "hi"
+    start = next(e for e in mapped if e.get("kind") == "tool" and e.get("phase") == "start")
+    assert start["function_name"] == "bash"
+    assert start["tool_call_id"] == "call_1"
+    assert start["args"]["command"] == "echo hi"
+    update = next(e for e in mapped if e.get("kind") == "tool" and e.get("phase") == "update")
+    assert update["function_name"] == "bash"
+    assert "hi" in (update.get("content") or "")
+    assert extract_finish_reason(native) == "completed"
+    usage = extract_usage(native)
+    assert usage is not None
+    assert usage["input_tokens"] == 10
+    assert usage["output_tokens"] == 4
+    assert usage["cache_read_tokens"] == 2
+    assert usage["total_tokens"] == 14
+
+    path = write_trajectory_jsonl(
+        tmp_path / "inv",
+        prompt="echo hi",
+        events=mapped,
+        final_text="hi",
+        structured=None,
+        usage=usage,
+        ok=True,
+        error=None,
+        metadata={"executor_kind": "dsh", "plugin": "dsh"},
+    )
+    lines = _read_lines(path)
+    types = [x["type"] for x in lines]
+    assert "tool_call" in types
+    assert "observation" in types
+    tool = next(x for x in lines if x["type"] == "tool_call")
+    assert tool["source"] == "dsh"
+    assert "acp_session_id" not in tool
+
+
+def test_extract_usage_sums_committed_steps_not_last_or_chunks() -> None:
+    native = (
+        {
+            "type": "assistant/chunk",
+            "data": {
+                "chunk": {
+                    "type": "usage",
+                    "usage": {
+                        "inputTokens": 1914,
+                        "outputTokens": 81,
+                        "cacheReadTokens": 0,
+                        "reasoningTokens": 15,
+                    },
+                }
+            },
+        },
+        {
+            "type": "assistant/message",
+            "data": {
+                "usage": {
+                    "inputTokens": 1914,
+                    "outputTokens": 81,
+                    "cacheReadTokens": 0,
+                    "reasoningTokens": 15,
+                }
+            },
+        },
+        {
+            "type": "assistant/message",
+            "data": {
+                "usage": {
+                    "inputTokens": 238,
+                    "outputTokens": 196,
+                    "cacheReadTokens": 4096,
+                    "reasoningTokens": 0,
+                }
+            },
+        },
+    )
+    assert extract_usage(native) == {
+        "input_tokens": 2152,
+        "output_tokens": 277,
+        "cache_read_tokens": 4096,
+        "reasoning_tokens": 15,
+        "total_tokens": 2429,
+    }
+
+
+def test_foreign_wrapped_event_unwraps() -> None:
+    mapped = to_bora_trajectory_events(
+        (
+            {
+                "method": "session.event",
+                "sessionId": "s",
+                "event": {
+                    "type": "tool/call",
+                    "data": {"callId": "c2", "name": "read_file", "arguments": {"path": "a"}},
+                },
+            },
+        )
+    )
+    assert mapped[0]["function_name"] == "read_file"
+    assert mapped[0]["args"]["path"] == "a"

--- a/uv.lock
+++ b/uv.lock
@@ -192,6 +192,9 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
 ]
+dsh = [
+    { name = "deepseek-harness-sdk" },
+]
 nooa = [
     { name = "httpx", extra = ["socks"] },
     { name = "nooa" },
@@ -215,6 +218,7 @@ requires-dist = [
     { name = "agent-client-protocol", specifier = "==0.12.0" },
     { name = "bora-sdk", editable = "sdk/python" },
     { name = "boto3", marker = "extra == 'registry'", specifier = ">=1.35.0" },
+    { name = "deepseek-harness-sdk", marker = "extra == 'dsh'", specifier = "==0.1.0rc6" },
     { name = "httpx", extras = ["socks"], marker = "extra == 'nooa'", specifier = ">=0.28.1" },
     { name = "nooa", marker = "extra == 'nooa'", specifier = ">=0.0.7" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'registry'", specifier = ">=3.2.0" },
@@ -225,7 +229,7 @@ requires-dist = [
     { name = "socksio", marker = "extra == 'nooa'", specifier = ">=1.0.0" },
     { name = "typer", specifier = ">=0.16.0" },
 ]
-provides-extras = ["dev", "nooa", "registry"]
+provides-extras = ["dev", "dsh", "nooa", "registry"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -426,6 +430,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "deepseek-harness-runtime-bin"
+version = "0.1.0rc6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/19/548c84e9d02683612b6a3a23571d68480c657ef5f4aa1e3c656898ee1824/deepseek_harness_runtime_bin-0.1.0rc6-py3-none-macosx_14_0_arm64.whl", hash = "sha256:2bbd65edd52dfc340d74f88a890e8031a272a820e58406c2de1f5f5dee51bd9f", size = 52313658, upload-time = "2026-08-13T12:51:03.522Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/0b/d9128f0b3edc5ab5fc6d8746e669c924bd23fd017e645796b3b439dd0eb3/deepseek_harness_runtime_bin-0.1.0rc6-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:99d0ef334a4e3cb178d7b0302bbdd01c8dde6068ee5fe8b01e074541db5c7747", size = 56774186, upload-time = "2026-08-13T12:51:07.783Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/26/1c6bc9c26618ca5b2f155a428d4c0c5d5174b68077cccbc10a1629bb3611/deepseek_harness_runtime_bin-0.1.0rc6-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:d7261d3bdadfa8d10ab03fd06c6bbc66a182ae27d39892a0eb7c2ce9d63a5448", size = 57038106, upload-time = "2026-08-13T12:51:11.387Z" },
+]
+
+[[package]]
+name = "deepseek-harness-sdk"
+version = "0.1.0rc6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deepseek-harness-runtime-bin" },
+    { name = "pydantic" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/10/efd7ad88cd6140be4883d055abf9acd7fa8e5424a20de8a224d310e67f2f/deepseek_harness_sdk-0.1.0rc6-py3-none-any.whl", hash = "sha256:8a05421be4298196cf94383e0a3164b020f5f5977a8d30019cc5add64cb208eb", size = 12880, upload-time = "2026-08-13T12:52:09.047Z" },
 ]
 
 [[package]]

--- a/website/content/docs/index.en.mdx
+++ b/website/content/docs/index.en.mdx
@@ -18,5 +18,6 @@ Agent evaluation often focuses on model scores while orchestration, visibility, 
 | Connect coding agents via ACP      | [ACP profiles](/docs/agents/acp-profiles)                                                      |
 | Install a mechanism plugin         | [Mechanism plugins](/docs/run/plugins)                                                         |
 | Look up commands and config fields | [CLI reference](/docs/reference/cli) · [Config field reference](/docs/reference/config-fields) |
+| Browse local results / remote Hub  | [Local viewer](/docs/run/local-viewer) · [Hub](/docs/share/hub) · [Registry](/docs/share/registry) |
 
 Mechanism design lives under [`docs/design/`](https://github.com/ZJU-REAL/BORA/tree/main/docs/design). This site is organized by usage path.

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -20,5 +20,6 @@ icon: BookOpen
 | 接入 coding agent（ACP） | [ACP Profiles](/docs/agents/acp-profiles)                                           |
 | 安装机制插件             | [机制插件](/docs/run/plugins)                                                       |
 | 查阅命令与配置字段       | [CLI 参考](/docs/reference/cli) · [配置字段参考](/docs/reference/config-fields)     |
+| 浏览本机结果 / 远程 Hub  | [本地结果查看器](/docs/run/local-viewer) · [Hub](/docs/share/hub) · [Registry](/docs/share/registry) |
 
 机制设计详见仓库 [`docs/design/`](https://github.com/ZJU-REAL/BORA/tree/main/docs/design)。本站按使用路径组织文档。

--- a/website/content/docs/reference/results-and-pass.en.mdx
+++ b/website/content/docs/reference/results-and-pass.en.mdx
@@ -63,10 +63,10 @@ These are **observational aggregates**, not suite-level PASS.
 | Upload command | Artifact | Hub primary UI |
 | --- | --- | --- |
 | `bora results upload --run …` | Single Attempt | **Usually not** on Dataset Leaderboard / Task Jobs |
-| `bora results upload-suite --suite-run …` | Suite row + metrics / task_refs | **Leaderboard** row; Task Jobs under that suite |
+| `bora results upload-suite --suite-run …` | Suite row + metrics / task_refs | **Leaderboard** only when complete and release-bound; incomplete or draft-bound rows stay on Task Jobs |
 | `… --with-attempts` | Also packs attempt dirs | Jobs can open Attempt detail / trajectory |
 
-So: to show a package run on Hub, use **suite run → upload-suite**, not attempt-only upload. See [Suite](/docs/run/suite) and [Hub](/docs/share/hub).
+So: to show a package run on the public board, use **suite run → upload-suite** against a published release, not attempt-only upload. See [Suite](/docs/run/suite) and [Hub](/docs/share/hub).
 
 ## Browse
 

--- a/website/content/docs/reference/results-and-pass.mdx
+++ b/website/content/docs/reference/results-and-pass.mdx
@@ -63,10 +63,10 @@ description: Result 怎么读；pass@k 是 job 指标，不是整包 PASS。
 | 上传命令 | 产物 | Hub 主界面 |
 | --- | --- | --- |
 | `bora results upload --run …` | 单次 Attempt | **一般不进** Dataset Leaderboard / Task Jobs 主列表 |
-| `bora results upload-suite --suite-run …` | Suite 行 + metrics / task_refs | **Leaderboard** 一行；Task Jobs 挂在该 suite 下 |
+| `bora results upload-suite --suite-run …` | Suite 行 + metrics / task_refs | **完备且绑定 release** 才上 Leaderboard；缺题或 draft 绑定只出现在 Task Jobs |
 | `… --with-attempts` | 额外上传各 attempt 目录 | Jobs 可点进 Attempt 详情 / 轨迹 |
 
-因此：要给别人（或自己）在 Hub 上「扫一眼整包」，流程是 **suite run → upload-suite**，不是只 upload 单题。详见 [Suite](/docs/run/suite) 与 [Hub](/docs/share/hub)。
+因此：要给别人（或自己）在 Hub 上「扫一眼整包」，流程是 **suite run → upload-suite**，并且绑定已发布 release。不是只 upload 单题。详见 [Suite](/docs/run/suite) 与 [Hub](/docs/share/hub)。
 
 ## 本机翻看
 

--- a/website/content/docs/run/local-viewer.en.mdx
+++ b/website/content/docs/run/local-viewer.en.mdx
@@ -28,11 +28,11 @@ uv run bora view examples/core --open /jobs/<id>
 
 | Layer | Content |
 | --- | --- |
-| Jobs | Local suite runs **and** single-task Attempts (Kind: suite / single) |
-| Tasks | Per-task status / score |
+| Jobs | Local suite runs **and** single-task Attempts (Kind: suite / single). Kind / Source are filters; suite Source lists task ids only |
+| Tasks | Per-task status / score. A suite task with one Attempt opens that trial directly |
 | Attempt | Outcome, **Timing** (and **Tokens** when present), actors, evidence tabs |
 
 Timing comes from Attempt `phase_timing` (`prepare` / `run` / `evaluate` / `cleanup`); hover bar segments for durations.  
-Time / tokens are **hints**, not PASS. Trajectory is not scoring authority. Each **tool-call** row (and other long rows) can collapse, matching the Hub Attempt page.
+Time / tokens are **hints**, not PASS. Trajectory is not scoring authority. Each **tool-call** row (and other long rows) can collapse; the observational PASS note has expand-all / collapse-all, matching the Hub Attempt page.
 
 Viewer does **not** talk to Registry — see [Hub](/docs/share/hub). SPA details: `apps/viewer/README.md`.

--- a/website/content/docs/run/local-viewer.mdx
+++ b/website/content/docs/run/local-viewer.mdx
@@ -30,11 +30,11 @@ uv run bora view examples/core --open /jobs/<id>
 
 | 层 | 内容 |
 | --- | --- |
-| Jobs | 本地 suite 跑次 **和** 单题 Attempt（Kind：suite / single） |
-| Tasks | 每题状态 / 分数 |
+| Jobs | 本地 suite 跑次 **和** 单题 Attempt（Kind：suite / single）。Kind / Source 是过滤器；suite 的 Source 只列 task id |
+| Tasks | 每题状态 / 分数。suite 题且只有 1 次 Attempt 时，点进后直接打开该 trial |
 | Attempt | 结果条、**Timing**（有数据时还有 **Tokens**）、角色、证据页签（Trajectory / Agent / …） |
 
 Timing 来自 Attempt `phase_timing`（prepare / run / evaluate / cleanup）；hover 色条看分段耗时。  
-耗时和 token **只是参考**，不是 PASS。轨迹也不是评分依据。Trajectory 里每条 **tool-call**（以及过长行）可折叠，与 Hub Attempt 页一致。
+耗时和 token **只是参考**，不是 PASS。轨迹也不是评分依据。Trajectory 里每条 **tool-call**（以及过长行）可折叠；观测 PASS 条上有全部展开 / 全部收起，与 Hub Attempt 页一致。
 
 Viewer **不连** Registry。远程目录见 [Hub](/docs/share/hub)。改 SPA 看仓库 `apps/viewer/README.md`。

--- a/website/content/docs/run/plugins.en.mdx
+++ b/website/content/docs/run/plugins.en.mdx
@@ -10,6 +10,7 @@ package harness business loop.
 
 ```bash
 uv run bora plugin install plugins/nooa
+# or: uv run bora plugin install plugins/dsh
 uv run bora plugin list
 ```
 
@@ -39,6 +40,9 @@ Use an alternate profiles file at run time without changing Database ACP default
 ```bash
 uv run bora run examples/journeys --task terminal-jsonl-agg \
   --profiles examples/journeys/profiles.nooa.yaml
+# DeepSeek Harness (not ACP):
+# uv run bora run examples/journeys --task terminal-jsonl-agg \
+#   --profiles examples/journeys/profiles.dsh.yaml
 ```
 
 `bora lock` writes the resolved extension graph into `extension_bindings` in the lock summary.
@@ -52,7 +56,8 @@ uv run bora run examples/journeys --task terminal-jsonl-agg \
 | **L1 Ready** | `image_contribute` bake during prepare; execute in-container |
 
 A successful install does **not** imply the L1 isolated path is ready. Docker L1 tasks
-need a successful bake before the container worker runs (for example nooa’s in-container path).
+need a successful bake before the container worker runs (for example nooa or dsh
+in-container).
 
 ## Relation to ACP
 

--- a/website/content/docs/run/plugins.mdx
+++ b/website/content/docs/run/plugins.mdx
@@ -9,6 +9,7 @@ description: 安装 bora.plugin/1、绑定 executor、Recognition 与 L1 Ready �
 
 ```bash
 uv run bora plugin install plugins/nooa
+# 或：uv run bora plugin install plugins/dsh
 uv run bora plugin list
 ```
 
@@ -38,6 +39,9 @@ bindings:
 ```bash
 uv run bora run examples/journeys --task terminal-jsonl-agg \
   --profiles examples/journeys/profiles.nooa.yaml
+# DeepSeek Harness（非 ACP）：
+# uv run bora run examples/journeys --task terminal-jsonl-agg \
+#   --profiles examples/journeys/profiles.dsh.yaml
 ```
 
 `bora lock` 会把解析后的扩展图写入摘要中的 `extension_bindings`。
@@ -51,7 +55,7 @@ uv run bora run examples/journeys --task terminal-jsonl-agg \
 | **L1 Ready** | `image_contribute` 在 prepare 时 bake 进 Attempt 镜像；容器内执行 |
 
 有 install 成功 **不等于** L1 隔离路径已就绪。Docker L1 任务需 bake 成功后，才在
-容器内调用 worker（例如 nooa 的 in-container 路径）。
+容器内调用 worker（例如 nooa / dsh 的 in-container 路径）。
 
 ## 与 ACP 的关系
 

--- a/website/content/docs/run/suite.en.mdx
+++ b/website/content/docs/run/suite.en.mdx
@@ -87,4 +87,6 @@ uv run bora results upload-suite examples/journeys \
 
 **Common mistake:** only `bora run … --task X` then `bora results upload --run …` — the attempt may exist in Registry, but **Leaderboard usually still has no row**. Leaderboard needs a suite job + `upload-suite`.
 
+The public board has two more gates: the suite must be **complete** (every task on the bound version has a result; FAIL / ERROR still count) and bound to a **release**. Incomplete or draft-bound rows stay on Task **Jobs**. Upload a working tree with `bora publish --draft`, then an owner runs `bora release` — or `bora publish` a release directly.
+
 See [Results and PASS](/docs/reference/results-and-pass) and [Hub](/docs/share/hub).

--- a/website/content/docs/run/suite.mdx
+++ b/website/content/docs/run/suite.mdx
@@ -87,4 +87,6 @@ uv run bora results upload-suite examples/journeys \
 
 **常见误解：** 只跑 `bora run … --task X` 再 `bora results upload --run …`——attempt 可能已经进 Registry，但 **Leaderboard 通常仍没有一行**。要上榜必须先 suite 再 `upload-suite`。
 
+公开榜还有两道门：suite **完备**（绑定版本的每题都有一条 result；题上 FAIL / ERROR 也算），且绑定 **release**。缺题或绑定 draft 的行只出现在 Task **Jobs**。先 `bora publish --draft`、owner 再 `bora release`，或直接 `bora publish` 发 release。
+
 详情见 [结果与 PASS](/docs/reference/results-and-pass) 与 [Hub](/docs/share/hub)。

--- a/website/content/docs/share/hub.en.mdx
+++ b/website/content/docs/share/hub.en.mdx
@@ -61,8 +61,8 @@ Jobs rows with uploaded run artifacts open detail; others show **Not uploaded**.
 
 | You want | Upload | How |
 | --- | --- | --- |
-| A **Leaderboard** row | A **suite** result | `bora run <database>` **without** `--task` → `bora results upload-suite --suite-run <id>` |
-| Task **Jobs** with openable Attempt / trajectory | Suite + **attempt** evidence | `upload-suite --with-attempts` |
+| A **Leaderboard** row | A **complete**, **release-bound** suite | `bora publish --draft` then `bora release` (or a direct `bora publish`) → `bora run <database>` **without** `--task` → `upload-suite --suite-run <id>` |
+| Task **Jobs** with openable Attempt / trajectory | Suite + **attempt** evidence | `upload-suite --with-attempts`; incomplete / draft-bound suites stay here |
 | Archive one Attempt only | `bora results upload --run <run_id>` | May exist in Registry, but **usually not** on Leaderboard |
 
 ```bash

--- a/website/content/docs/share/hub.mdx
+++ b/website/content/docs/share/hub.mdx
@@ -61,8 +61,8 @@ Jobs 列表里，已有运行产物的行可以点进去看；没上传的会显
 
 | 你想看 | 需要上传 | 怎么跑 / 传 |
 | --- | --- | --- |
-| Dataset **Leaderboard** 一行 | **suite** 结果 | 省略 `--task` 的 `bora run` → `bora results upload-suite --suite-run <id>` |
-| Task **Jobs** 可点开 Attempt / 轨迹 | suite + **attempt 证据** | `upload-suite --with-attempts`（或等价挂上 task_refs 的 attempt） |
+| Dataset **Leaderboard** 一行 | **完备**且绑定 **release** 的 suite | 先 `bora publish --draft` 再 `bora release`（或直接 `bora publish`）→ 省略 `--task` 的 `bora run` → `upload-suite --suite-run <id>` |
+| Task **Jobs** 可点开 Attempt / 轨迹 | suite + **attempt 证据** | `upload-suite --with-attempts`（或等价挂上 task_refs 的 attempt）；缺题 / draft 绑定也只出现在这里 |
 | 只归档一次 Attempt | `bora results upload --run <run_id>` | 可以进 Registry，但 **通常不会**出现在 Leaderboard |
 
 ```bash
@@ -70,7 +70,7 @@ Jobs 列表里，已有运行产物的行可以点进去看；没上传的会显
 uv run bora run <database> --profiles <profiles.yaml>
 uv run bora results upload-suite <database> --suite-run <8-hex> --public --with-attempts
 
-# 不够：单题 attempt upload  alone → 榜上经常空白
+# 不够：单题 attempt upload 单独上传 → 榜上经常空白
 # uv run bora run <database> --task <id>
 # uv run bora results upload <database> --run <run_id>
 ```


### PR DESCRIPTION
## Summary

Add an external `bora.plugin/1` at `plugins/dsh` that drives [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) over the official Python JSON-RPC SDK (`deepseek-harness-sdk==0.1.0rc6` + bundled `dsh-jsonrpc-agent`). Same package harness; switch only via profiles.

This is **not** ACP. DSH's shipped ACP surface has no pin-able product entry, does not bind `model` on the session, and keeps tools / reasoning / usage off the wire. The plugin speaks the official SDK instead of cloning first-party `executor: acp`.

Refs #103.

<img width="1405" height="773" alt="image" src="https://github.com/user-attachments/assets/8200c1b1-7155-4aa6-a415-517d527cb185" />


## Mechanism

| Slot | Role |
| --- | --- |
| `provide(executor)` | `DeepSeekHarness.start()` / `Session.run()` / `close()`; model on `initialize` |
| `on: image_contribute` | Bake pins the SDK wheels + slim `cordis.yml` + in-container worker |
| `on: trajectory_collect` | Committed DSH events → `bora.trajectory.event/1`, `source: dsh` |

- L1: `bind_to_target` → `docker exec` `bora-executor-dsh`. Host SPI success is not L1 Ready.
- Credentials: profile `api_key` is a locator (`deepseek_api_key` → `DEEPSEEK_API_KEY`). No secrets in lock / evidence.
- Usage: **sum** of each committed `assistant/message.usage` in one `Session.run` (not last-step only; chunks not double-counted). `total_tokens` = summed input + output.
- Sessions persist under the Attempt (`DSH_SESSION_ROOT`), not workspace `./.sessions`.
- Offline (`BORA_OFFLINE_AGENT=1`) fail-closes without spawning the runtime.
- Slim composition uses local bash/fs; isolation hard boundary on L1 is BORA mount/UID.

No Core factory branch, no new slot, no `acp_entries.json` row, no official five-entry BOM change.

## How to run

```bash
uv run bora plugin install plugins/dsh
unset BORA_OFFLINE_AGENT
# repo/.env locator: deepseek_api_key

# L1 journeys (bake installs wheels in the Attempt image)
uv run bora run examples/journeys --task terminal-jsonl-agg \
  --profiles examples/journeys/profiles.dsh.yaml
```

Optional host extra (L0 host SPI only): `uv sync --extra dsh`.

## Local evidence (this branch)

| Run | Result |
| --- | --- |
| L1 `examples/journeys --task terminal-jsonl-agg` + `profiles.dsh.yaml` + `deepseek-v4-flash` | **PASS** / 1.0, `assurance: l1`, `execution_location: attempt-container`, bake `dsh` |
| L0 `examples/tau3-airline --task airline-00` + both roles `executor: dsh` + `deepseek-v4-flash` | **PASS** / 1.0, `assurance: l0`, 17 invocations |

Scoped journeys only. Does **not** claim `isolated` or `real-benchmark-verified`.

## Test plan

- [x] `bora plugin install` / `list` / `executors` Recognition
- [x] `bora lock` writes `extension_bindings` for `dsh`; locator only, no secret
- [x] Unit: `tests/plugins/test_dsh_*.py`
- [x] Local python-core equivalent (ruff / pyright / offline pytest) and website build
- [x] Real L1 journeys task + real L0 tau3 `airline-00`
- [x] Reviewer: fail-closed missing bake / unbound L1 (not re-run here)

## Docs

Reader pages (zh/en plugins), `examples/README.md`, skills, Architecture, and design/11 list `plugins/dsh` beside nooa. No GitHub issue numbers in reader-facing text.
