### PR TITLE
feat(evidence): record per-step duration on trajectory tool calls

### DIFF
--- a/apps/hub/src/components/axis-label.tsx
+++ b/apps/hub/src/components/axis-label.tsx
@@ -1,0 +1,24 @@
+import { HoverTip } from "@/components/hover-tip";
+import { formatAxisLabel } from "@/lib/utils";
+
+export function AxisLabel({
+  value,
+  className,
+  empty = "-",
+}: {
+  value?: string | null;
+  className?: string;
+  empty?: string;
+}) {
+  const { text, title } = formatAxisLabel(value);
+  const shown = text === "-" ? empty : text;
+  const compacted = Boolean(title && title.includes("+") && text.endsWith("+..."));
+  if (!compacted) {
+    return <span className={className}>{shown}</span>;
+  }
+  return (
+    <HoverTip content={title}>
+      <span className={`${className ?? ""} cursor-help`.trim()}>{shown}</span>
+    </HoverTip>
+  );
+}

--- a/apps/hub/src/components/file-split-panel.tsx
+++ b/apps/hub/src/components/file-split-panel.tsx
@@ -317,7 +317,6 @@ export function FileSplitPanel({
                             "text-body hover:bg-row-hover transition-colors rounded-[4px]",
                           )}
                           style={{ paddingLeft: 8 + depth * 12 }}
-                          title={node.path}
                         >
                           {open ? (
                             <ChevronDown className="h-3.5 w-3.5 shrink-0 text-mute" />
@@ -352,7 +351,6 @@ export function FileSplitPanel({
                             : "text-body hover:bg-row-hover",
                         )}
                         style={{ paddingLeft: 8 + depth * 12 + 18 }}
-                        title={node.path}
                       >
                         <FileTypeIcon name={node.name} kind="file" />
                         <span className="truncate">{node.name}</span>

--- a/apps/hub/src/components/hover-tip.tsx
+++ b/apps/hub/src/components/hover-tip.tsx
@@ -1,0 +1,31 @@
+import type { ReactElement, ReactNode } from "react";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export function HoverTip({
+  content,
+  children,
+}: {
+  content?: ReactNode;
+  children: ReactElement;
+}) {
+  if (content == null || content === "") return children;
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent
+          side="top"
+          className="max-w-sm px-3 py-2 text-sm leading-5 break-all"
+        >
+          {content}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/hub/src/components/layout.tsx
+++ b/apps/hub/src/components/layout.tsx
@@ -64,7 +64,6 @@ export function Shell({
               <Link
                 to="/home"
                 className="hidden sm:inline-flex items-center gap-2 min-w-0 max-w-[14rem] hover:opacity-90"
-                title="Home"
               >
                 {githubAvatar || githubUser ? (
                   <img
@@ -78,7 +77,7 @@ export function Shell({
                     className="h-7 w-7 rounded-full border border-hairline bg-canvas-soft object-cover shrink-0"
                   />
                 ) : null}
-                <span className="text-sm text-body truncate" title={githubUser || undefined}>
+                <span className="text-sm text-body truncate">
                   {displayName}
                 </span>
               </Link>

--- a/apps/hub/src/components/leaderboard-table.tsx
+++ b/apps/hub/src/components/leaderboard-table.tsx
@@ -35,6 +35,8 @@ import {
   passPowerPrimaryK,
   primaryDisplayK,
 } from "@/lib/suite-metrics";
+import { AxisLabel } from "@/components/axis-label";
+import { HoverTip } from "@/components/hover-tip";
 import { formatScore } from "@/lib/utils";
 
 /** Shared column widths — keep Agent/Model tight so columns stay similar. */
@@ -137,15 +139,13 @@ function TruncateCell({
   className?: string;
   mono?: boolean;
 }) {
-  const display = text || "—";
   return (
     <TableCell className={className}>
-      <span
+      <AxisLabel
+        value={text}
+        empty="—"
         className={`block truncate ${mono ? "font-mono text-xs" : "text-sm"}`}
-        title={text || undefined}
-      >
-        {display}
-      </span>
+      />
     </TableCell>
   );
 }
@@ -335,17 +335,15 @@ export function LeaderboardTable({
                   <TableHead className={`text-right ${COL_METRIC}`}>
                     {head("n_attempts", "n_attempts", true)}
                   </TableHead>
-                  <TableHead
-                    className={`text-right ${COL_METRIC}`}
-                    title="Largest k from metrics.k_values / n_attempts; cell labels @k"
-                  >
-                    {head("pass_at_k", "pass@k", true)}
+                  <TableHead className={`text-right ${COL_METRIC}`}>
+                    <HoverTip content="Largest k from metrics.k_values / n_attempts; cell labels @k">
+                      <span className="inline-flex">{head("pass_at_k", "pass@k", true)}</span>
+                    </HoverTip>
                   </TableHead>
-                  <TableHead
-                    className={`text-right ${COL_METRIC}`}
-                    title="Same display k as pass@k; cell labels ^k"
-                  >
-                    {head("pass_power_k", "pass^k", true)}
+                  <TableHead className={`text-right ${COL_METRIC}`}>
+                    <HoverTip content="Same display k as pass@k; cell labels ^k">
+                      <span className="inline-flex">{head("pass_power_k", "pass^k", true)}</span>
+                    </HoverTip>
                   </TableHead>
                 </>
               ) : null}
@@ -421,10 +419,12 @@ export function LeaderboardTable({
                           {atK.value == null ? (
                             "—"
                           ) : (
-                            <span title={`pass@${atK.k}`}>
+                            <HoverTip content={`pass@${atK.k}`}>
+                              <span>
                               {formatPassMetric(atK.value)}
                               <span className="ml-1 text-mute">@{atK.k}</span>
-                            </span>
+                              </span>
+                            </HoverTip>
                           )}
                         </TableCell>
                         <TableCell
@@ -433,10 +433,12 @@ export function LeaderboardTable({
                           {powK.value == null ? (
                             "—"
                           ) : (
-                            <span title={`pass^${powK.k}`}>
+                            <HoverTip content={`pass^${powK.k}`}>
+                              <span>
                               {formatPassMetric(powK.value)}
                               <span className="ml-1 text-mute">^{powK.k}</span>
-                            </span>
+                              </span>
+                            </HoverTip>
                           )}
                         </TableCell>
                       </>
@@ -451,22 +453,20 @@ export function LeaderboardTable({
                           : "—"}
                     </TableCell>
                     <TableCell className={`font-mono text-xs ${COL_TEXT}`}>
-                      <span
-                        className="block truncate"
-                        title={s.uploaded_by || undefined}
-                      >
-                        {s.uploaded_by || "—"}
-                      </span>
+                      <HoverTip content={s.uploaded_by || undefined}>
+                        <span className="block truncate">
+                          {s.uploaded_by || "—"}
+                        </span>
+                      </HoverTip>
                     </TableCell>
                     <TableCell
                       className={`font-mono text-[11px] ${COL_METRIC}`}
                     >
-                      <span
-                        className="block truncate"
-                        title={s.suite_run_id}
-                      >
-                        {shortSuiteId(s.suite_run_id)}
-                      </span>
+                      <HoverTip content={s.suite_run_id}>
+                        <span className="block truncate">
+                          {shortSuiteId(s.suite_run_id)}
+                        </span>
+                      </HoverTip>
                     </TableCell>
                   </TableRow>
                   {open ? (

--- a/apps/hub/src/components/plugin-slot-timeline.tsx
+++ b/apps/hub/src/components/plugin-slot-timeline.tsx
@@ -1,3 +1,4 @@
+import { HoverTip } from "@/components/hover-tip";
 import type { DeclaredSlot, PluginPreview } from "@/lib/api";
 
 const SLOT_LEVEL: Record<string, number> = {
@@ -134,15 +135,16 @@ export function PluginSlotTimeline({
                   {slots.map((slot) => {
                     const path = resolvePluginEntryPath(slot.entry, files);
                     return (
+                      <HoverTip content={path}>
                       <button
                         key={`${slot.kind}-${slot.id}`}
                         type="button"
                         onClick={() => onOpenPath(path)}
-                        title={path}
                         className="cursor-pointer font-mono text-xs text-ink underline-offset-2 hover:underline hover:decoration-mute"
                       >
                         {slot.id}
                       </button>
+                      </HoverTip>
                     );
                   })}
                 </span>

--- a/apps/hub/src/components/sign-in-button.tsx
+++ b/apps/hub/src/components/sign-in-button.tsx
@@ -1,6 +1,7 @@
 import { useState, type ReactNode } from "react";
 
 import { GitHubIcon } from "@/components/github-icon";
+import { HoverTip } from "@/components/hover-tip";
 import { Button } from "@/components/ui/button";
 import {
   formatLoginError,
@@ -48,9 +49,9 @@ export function SignInButton({
         {busy ? "Redirecting…" : label}
       </Button>
       {error ? (
-        <span className="text-[11px] text-error" title={error}>
-          {error}
-        </span>
+        <HoverTip content={error}>
+          <span className="text-[11px] text-error">{error}</span>
+        </HoverTip>
       ) : null}
     </span>
   );

--- a/apps/hub/src/components/theme-toggle.tsx
+++ b/apps/hub/src/components/theme-toggle.tsx
@@ -32,7 +32,6 @@ export function ThemeToggle() {
           variant="outline"
           size="icon"
           aria-label={`Theme: ${mode}`}
-          title="Theme"
         >
           <ActiveIcon className="h-4 w-4" />
         </Button>

--- a/apps/hub/src/components/trial/actors-table.tsx
+++ b/apps/hub/src/components/trial/actors-table.tsx
@@ -1,3 +1,4 @@
+import { HoverTip } from "@/components/hover-tip";
 import {
   Table,
   TableBody,
@@ -40,15 +41,14 @@ export function ActorsTable({ actors }: { actors: NonNullable<Trial["actors"]> }
                 <TableCell className="font-mono text-[13px] tabular text-body">
                   {a.time_label || "-"}
                 </TableCell>
-                <TableCell
-                  className="font-mono text-[12px] text-mute max-w-[36ch]"
-                  title={
-                    a.usage_label
-                      ? "Observational usage (tokens/cost); not PASS authority. Cache hit = cached_read / input when present. Session-last invoke for cumulative fields."
-                      : undefined
-                  }
-                >
-                  {a.usage_label || "-"}
+                <TableCell className="font-mono text-[12px] text-mute max-w-[36ch]">
+                  {a.usage_label ? (
+                    <HoverTip content="Observational usage (tokens/cost); not PASS authority. Cache hit = cached_read / input when present. Session-last invoke for cumulative fields.">
+                      <span className="block truncate">{a.usage_label}</span>
+                    </HoverTip>
+                  ) : (
+                    "-"
+                  )}
                 </TableCell>
               </TableRow>
             ))}

--- a/apps/hub/src/components/trial/file-split-panel.tsx
+++ b/apps/hub/src/components/trial/file-split-panel.tsx
@@ -344,7 +344,6 @@ export function FileSplitPanel({
                             "text-body hover:bg-row-hover transition-colors rounded-[4px]",
                           )}
                           style={{ paddingLeft: 8 + depth * 12 }}
-                          title={node.path}
                         >
                           {open ? (
                             <ChevronDown className="h-3.5 w-3.5 shrink-0 text-mute" />
@@ -381,7 +380,6 @@ export function FileSplitPanel({
                             : "text-body hover:bg-row-hover",
                         )}
                         style={{ paddingLeft: 8 + depth * 12 + 18 }}
-                        title={node.path}
                       >
                         <FileTypeIcon name={node.name} kind="file" />
                         <span className="truncate">{node.name}</span>
@@ -404,9 +402,7 @@ export function FileSplitPanel({
         {selectedPath ? (
           <div className="px-3 py-2 border-b border-hairline text-[12px] font-mono text-mute shrink-0 bg-canvas-soft flex items-center gap-2">
             <FileTypeIcon name={selectedName || selectedPath} kind="file" />
-            <span className="truncate text-ink" title={selectedPath}>
-              {selectedPath}
-            </span>
+            <span className="truncate text-ink">{selectedPath}</span>
           </div>
         ) : null}
         <div className="p-0 flex-1 min-h-0 overflow-auto">

--- a/apps/hub/src/components/trial/trajectory-panel.tsx
+++ b/apps/hub/src/components/trial/trajectory-panel.tsx
@@ -32,6 +32,18 @@ type IconComp = ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
 const LONG_BODY_CHARS = 240;
 const LONG_BODY_LINES = 4;
 
+function formatElapsedMs(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const totalS = ms / 1000;
+  if (totalS < 10) return `${totalS.toFixed(1)}s`;
+  if (totalS < 60) return `${Math.round(totalS)}s`;
+  const minutes = Math.floor(totalS / 60);
+  const seconds = Math.round(totalS - minutes * 60);
+  if (seconds === 60) return `${minutes + 1}m`;
+  return seconds ? `${minutes}m ${String(seconds).padStart(2, "0")}s` : `${minutes}m`;
+}
+
 function bodyIsLong(body: string): boolean {
   return body.length > LONG_BODY_CHARS || body.split("\n").length > LONG_BODY_LINES;
 }
@@ -345,6 +357,13 @@ export function TrajectoryPanel({
                   {s.stop_reason ? <span>{s.stop_reason}</span> : null}
                   {s.ok === false ? (
                     <span className="text-error">not ok</span>
+                  ) : null}
+                  {typeof s.elapsed_ms === "number" &&
+                  Number.isFinite(s.elapsed_ms) &&
+                  s.elapsed_ms >= 0 ? (
+                    <span title="tool duration (observational)">
+                      {formatElapsedMs(s.elapsed_ms)}
+                    </span>
                   ) : null}
                 </div>
                 {body ? <CopyBodyButton text={body} /> : null}

--- a/apps/hub/src/components/trial/trajectory-panel.tsx
+++ b/apps/hub/src/components/trial/trajectory-panel.tsx
@@ -22,6 +22,7 @@ import {
   Wrench,
 } from "lucide-react";
 
+import { HoverTip } from "@/components/hover-tip";
 import type { TrajectoryStep } from "@/lib/trial-types";
 import { cn } from "@/lib/utils";
 
@@ -61,11 +62,11 @@ function CopyBodyButton({ text }: { text: string }) {
     }
   }
   return (
+    <HoverTip content={copied ? "Copied" : "Copy"}>
     <button
       type="button"
       onClick={onCopy}
       aria-label={copied ? "Copied" : "Copy step"}
-      title={copied ? "Copied" : "Copy"}
       className="shrink-0 rounded-[4px] p-0.5 text-mute hover:bg-row-hover hover:text-ink"
     >
       {copied ? (
@@ -74,6 +75,7 @@ function CopyBodyButton({ text }: { text: string }) {
         <Copy className="h-3.5 w-3.5" aria-hidden />
       )}
     </button>
+    </HoverTip>
   );
 }
 
@@ -361,9 +363,9 @@ export function TrajectoryPanel({
                   {typeof s.elapsed_ms === "number" &&
                   Number.isFinite(s.elapsed_ms) &&
                   s.elapsed_ms >= 0 ? (
-                    <span title="tool duration (observational)">
-                      {formatElapsedMs(s.elapsed_ms)}
-                    </span>
+                    <HoverTip content="tool duration (observational)">
+                      <span>{formatElapsedMs(s.elapsed_ms)}</span>
+                    </HoverTip>
                   ) : null}
                 </div>
                 {body ? <CopyBodyButton text={body} /> : null}
@@ -403,6 +405,7 @@ export function TrajectoryPanel({
         <p className="text-[11px] text-mute">
           Trajectory is observational only; independent evaluator owns PASS.
         </p>
+        <HoverTip content={allExpanded ? "Collapse all" : "Expand all"}>
         <button
           type="button"
           onClick={() => {
@@ -410,7 +413,6 @@ export function TrajectoryPanel({
             setExpandGen((n) => n + 1);
           }}
           aria-label={allExpanded ? "Collapse all" : "Expand all"}
-          title={allExpanded ? "Collapse all" : "Expand all"}
           className="shrink-0 rounded-[4px] p-0.5 text-mute hover:bg-row-hover hover:text-ink"
         >
           {allExpanded ? (
@@ -419,6 +421,7 @@ export function TrajectoryPanel({
             <UnfoldVertical className="h-3.5 w-3.5" aria-hidden />
           )}
         </button>
+        </HoverTip>
       </div>
       {groups.multi ? (
         <div className="space-y-4 max-h-[70vh] overflow-y-auto pr-1">

--- a/apps/hub/src/components/trial/trial-header.tsx
+++ b/apps/hub/src/components/trial/trial-header.tsx
@@ -1,3 +1,4 @@
+import { HoverTip } from "@/components/hover-tip";
 import type { Trial } from "@/lib/trial-types";
 
 /** Header without sibling nav (Hub has no local trial list siblings by default). */
@@ -45,15 +46,16 @@ export function TrialHeader({
               <span className="text-mute select-none" aria-hidden>
                 ·
               </span>
-              <a
-                href={trial.upstream_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-link hover:text-link-deep font-mono text-[13px] truncate max-w-[min(48ch,100%)]"
-                title={trial.upstream_name || trial.upstream_url}
-              >
-                {trial.upstream_url}
-              </a>
+              <HoverTip content={trial.upstream_name || trial.upstream_url}>
+                <a
+                  href={trial.upstream_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-link hover:text-link-deep font-mono text-[13px] truncate max-w-[min(48ch,100%)]"
+                >
+                  {trial.upstream_url}
+                </a>
+              </HoverTip>
             </>
           ) : null}
         </p>

--- a/apps/hub/src/lib/attempt-evidence.ts
+++ b/apps/hub/src/lib/attempt-evidence.ts
@@ -569,6 +569,12 @@ export function parseTrajectoryJsonl(text: string): TrajectoryStep[] {
       status: typeof rec.status === "string" ? rec.status : null,
       args: (args as TrajectoryStep["args"]) ?? null,
       raw_output: (rawOutput as TrajectoryStep["raw_output"]) ?? null,
+      elapsed_ms:
+        typeof rec.elapsed_ms === "number" && Number.isFinite(rec.elapsed_ms)
+          ? rec.elapsed_ms
+          : null,
+      started_at: typeof rec.started_at === "string" ? rec.started_at : null,
+      ended_at: typeof rec.ended_at === "string" ? rec.ended_at : null,
       outcome: typeof rec.outcome === "string" ? rec.outcome : null,
       option_id: typeof rec.option_id === "string" ? rec.option_id : null,
       policy: typeof rec.policy === "string" ? rec.policy : null,

--- a/apps/hub/src/lib/trial-types.ts
+++ b/apps/hub/src/lib/trial-types.ts
@@ -98,6 +98,10 @@ export type TrajectoryStep = {
   status?: string | null;
   args?: Record<string, unknown> | unknown[] | string | null;
   raw_output?: Record<string, unknown> | unknown[] | string | null;
+  /** Observational tool duration; omit when the sealed step has none. */
+  elapsed_ms?: number | null;
+  started_at?: string | null;
+  ended_at?: string | null;
   outcome?: string | null;
   option_id?: string | null;
   policy?: string | null;

--- a/apps/hub/src/lib/utils.ts
+++ b/apps/hub/src/lib/utils.ts
@@ -10,6 +10,18 @@ export function formatScore(value: number | null | undefined): string {
   return Number(value).toFixed(2);
 }
 
+/** Jobs / Hub axis: ``a+b+c`` → ``a+...``; tooltip keeps the full string. */
+export function formatAxisLabel(raw: string | null | undefined): {
+  text: string;
+  title?: string;
+} {
+  const value = (raw || "").trim();
+  if (!value) return { text: "-" };
+  const parts = value.split("+").map((s) => s.trim()).filter(Boolean);
+  if (parts.length <= 1) return { text: value, title: value };
+  return { text: `${parts[0]}+...`, title: parts.join("+") };
+}
+
 export function formatTrials(done: number | null | undefined, total: number | null | undefined): string {
   if (total == null) return "-";
   return `${done ?? 0}/${total}`;

--- a/apps/hub/src/pages/OrganizationDetailPage.tsx
+++ b/apps/hub/src/pages/OrganizationDetailPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
 import { BreadcrumbNav } from "@/components/breadcrumb";
+import { HoverTip } from "@/components/hover-tip";
 import { Shell } from "@/components/layout";
 import { SignInLink } from "@/components/sign-in-button";
 import { Button } from "@/components/ui/button";
@@ -566,12 +567,11 @@ export function OrganizationDetailPage() {
                             return (
                               <TableRow key={k.key_id}>
                                 <TableCell className="font-mono text-xs max-w-[min(40rem,50vw)]">
-                                  <span
-                                    className="block truncate"
-                                    title={display}
-                                  >
-                                    {display}
-                                  </span>
+                                  <HoverTip content={display}>
+                                    <span className="block truncate">
+                                      {display}
+                                    </span>
+                                  </HoverTip>
                                 </TableCell>
                                 <TableCell className="text-sm tabular-nums">
                                   {uses}

--- a/apps/hub/src/pages/OrganizationsPage.tsx
+++ b/apps/hub/src/pages/OrganizationsPage.tsx
@@ -2,6 +2,7 @@ import { Building2, Plus } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { HoverTip } from "@/components/hover-tip";
 import { Shell } from "@/components/layout";
 import { SignInLink } from "@/components/sign-in-button";
 import { Button } from "@/components/ui/button";
@@ -174,13 +175,13 @@ export function OrganizationsPage() {
               aria-label="Search organizations"
               className="flex-1 min-w-0"
             />
+            <HoverTip content="Join with invite key">
             <Button
               type="button"
               variant="outline"
               size="icon"
               className="shrink-0"
               aria-label="Join organization with invite key"
-              title="Join with invite key"
               onClick={() => {
                 setJoinOpen(true);
                 setJoinError(null);
@@ -188,6 +189,7 @@ export function OrganizationsPage() {
             >
               <Plus className="h-4 w-4" />
             </Button>
+            </HoverTip>
           </div>
           {filtered.length === 0 ? (
             <div className="rounded-[8px] border border-dashed border-hairline bg-canvas-soft p-10 text-center text-sm">

--- a/apps/hub/src/pages/TaskDetailPage.tsx
+++ b/apps/hub/src/pages/TaskDetailPage.tsx
@@ -31,6 +31,8 @@ import {
 } from "@/lib/api";
 import { getToken } from "@/lib/auth";
 import { buildNestedTree, type TreeNode } from "@/lib/file-tree";
+import { AxisLabel } from "@/components/axis-label";
+import { HoverTip } from "@/components/hover-tip";
 import { cn, formatScore } from "@/lib/utils";
 
 type Tab = "readme" | "files" | "jobs";
@@ -405,6 +407,11 @@ export function TaskDetailPage() {
                       canOpen && j.run_id
                         ? `/datasets/${encodeURIComponent(datasetId)}/tasks/${encodeURIComponent(taskId)}/attempts/${encodeURIComponent(j.run_id)}`
                         : null;
+                    const rowTip = canOpen
+                      ? "Open attempt detail"
+                      : j.run_id
+                        ? "Summary only — full Attempt not uploaded"
+                        : "No run_id for this task";
                     return (
                       <TableRow
                         key={j.suite_run_id}
@@ -425,16 +432,11 @@ export function TaskDetailPage() {
                         }}
                         tabIndex={canOpen ? 0 : undefined}
                         role={canOpen ? "link" : undefined}
-                        title={
-                          canOpen
-                            ? "Open attempt detail"
-                            : j.run_id
-                              ? "Summary only — full Attempt not uploaded"
-                              : "No run_id for this task"
-                        }
                       >
                         <TableCell className="font-mono text-xs">
+                          <HoverTip content={rowTip}>
                           <span className="text-ink">{j.suite_run_id}</span>
+                          </HoverTip>
                           {!canOpen ? (
                             <span className="ml-2 text-[11px] text-mute font-sans">
                               summary only
@@ -448,10 +450,10 @@ export function TaskDetailPage() {
                           {formatScore(j.score)}
                         </TableCell>
                         <TableCell className="text-sm text-body">
-                          {j.agent_label || "-"}
+                          <AxisLabel value={j.agent_label} />
                         </TableCell>
                         <TableCell className="text-sm font-mono text-xs">
-                          {j.model_label || "-"}
+                          <AxisLabel value={j.model_label} />
                         </TableCell>
                       </TableRow>
                     );

--- a/apps/viewer/src/components/axis-label.tsx
+++ b/apps/viewer/src/components/axis-label.tsx
@@ -1,0 +1,24 @@
+import { HoverTip } from "@/components/hover-tip";
+import { formatAxisLabel } from "@/lib/utils";
+
+export function AxisLabel({
+  value,
+  className,
+  empty = "-",
+}: {
+  value?: string | null;
+  className?: string;
+  empty?: string;
+}) {
+  const { text, title } = formatAxisLabel(value);
+  const shown = text === "-" ? empty : text;
+  const compacted = Boolean(title && title.includes("+") && text.endsWith("+..."));
+  if (!compacted) {
+    return <span className={className}>{shown}</span>;
+  }
+  return (
+    <HoverTip content={title}>
+      <span className={`${className ?? ""} cursor-help`.trim()}>{shown}</span>
+    </HoverTip>
+  );
+}

--- a/apps/viewer/src/components/hover-tip.tsx
+++ b/apps/viewer/src/components/hover-tip.tsx
@@ -1,0 +1,31 @@
+import type { ReactElement, ReactNode } from "react";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export function HoverTip({
+  content,
+  children,
+}: {
+  content?: ReactNode;
+  children: ReactElement;
+}) {
+  if (content == null || content === "") return children;
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent
+          side="top"
+          className="max-w-sm px-3 py-2 text-sm leading-5 break-all"
+        >
+          {content}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/viewer/src/components/theme-toggle.tsx
+++ b/apps/viewer/src/components/theme-toggle.tsx
@@ -32,7 +32,6 @@ export function ThemeToggle() {
           variant="outline"
           size="icon"
           aria-label={`Theme: ${mode}`}
-          title="Theme"
         >
           <ActiveIcon className="h-4 w-4" />
         </Button>

--- a/apps/viewer/src/components/trial/actors-table.tsx
+++ b/apps/viewer/src/components/trial/actors-table.tsx
@@ -1,3 +1,4 @@
+import { HoverTip } from "@/components/hover-tip";
 import {
   Table,
   TableBody,
@@ -59,15 +60,14 @@ export function ActorsTable({
                   <TableCell className="font-mono text-[13px] tabular text-body">
                     {a.time_label || "-"}
                   </TableCell>
-                  <TableCell
-                    className="font-mono text-[12px] text-mute max-w-[36ch]"
-                    title={
-                      a.usage_label
-                        ? "Observational usage (tokens/cost); not PASS authority. Cache hit = cached_read / input when present. Session-last invoke for cumulative fields."
-                        : undefined
-                    }
-                  >
-                    {a.usage_label || "-"}
+                  <TableCell className="font-mono text-[12px] text-mute max-w-[36ch]">
+                    {a.usage_label ? (
+                      <HoverTip content="Observational usage (tokens/cost); not PASS authority. Cache hit = cached_read / input when present. Session-last invoke for cumulative fields.">
+                        <span className="block truncate">{a.usage_label}</span>
+                      </HoverTip>
+                    ) : (
+                      "-"
+                    )}
                   </TableCell>
                 </TableRow>
               );

--- a/apps/viewer/src/components/trial/file-split-panel.tsx
+++ b/apps/viewer/src/components/trial/file-split-panel.tsx
@@ -344,7 +344,6 @@ export function FileSplitPanel({
                             "text-body hover:bg-row-hover transition-colors rounded-[4px]",
                           )}
                           style={{ paddingLeft: 8 + depth * 12 }}
-                          title={node.path}
                         >
                           {open ? (
                             <ChevronDown className="h-3.5 w-3.5 shrink-0 text-mute" />
@@ -381,7 +380,6 @@ export function FileSplitPanel({
                             : "text-body hover:bg-row-hover",
                         )}
                         style={{ paddingLeft: 8 + depth * 12 + 18 }}
-                        title={node.path}
                       >
                         <FileTypeIcon name={node.name} kind="file" />
                         <span className="truncate">{node.name}</span>
@@ -404,9 +402,7 @@ export function FileSplitPanel({
         {selectedPath ? (
           <div className="px-3 py-2 border-b border-hairline text-[12px] font-mono text-mute shrink-0 bg-canvas-soft flex items-center gap-2">
             <FileTypeIcon name={selectedName || selectedPath} kind="file" />
-            <span className="truncate text-ink" title={selectedPath}>
-              {selectedPath}
-            </span>
+            <span className="truncate text-ink">{selectedPath}</span>
           </div>
         ) : null}
         <div className="p-0 flex-1 min-h-0 overflow-auto">

--- a/apps/viewer/src/components/trial/trajectory-panel.tsx
+++ b/apps/viewer/src/components/trial/trajectory-panel.tsx
@@ -32,6 +32,18 @@ type IconComp = ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
 const LONG_BODY_CHARS = 240;
 const LONG_BODY_LINES = 4;
 
+function formatElapsedMs(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const totalS = ms / 1000;
+  if (totalS < 10) return `${totalS.toFixed(1)}s`;
+  if (totalS < 60) return `${Math.round(totalS)}s`;
+  const minutes = Math.floor(totalS / 60);
+  const seconds = Math.round(totalS - minutes * 60);
+  if (seconds === 60) return `${minutes + 1}m`;
+  return seconds ? `${minutes}m ${String(seconds).padStart(2, "0")}s` : `${minutes}m`;
+}
+
 function bodyIsLong(body: string): boolean {
   return body.length > LONG_BODY_CHARS || body.split("\n").length > LONG_BODY_LINES;
 }
@@ -345,6 +357,13 @@ export function TrajectoryPanel({
                   {s.stop_reason ? <span>{s.stop_reason}</span> : null}
                   {s.ok === false ? (
                     <span className="text-error">not ok</span>
+                  ) : null}
+                  {typeof s.elapsed_ms === "number" &&
+                  Number.isFinite(s.elapsed_ms) &&
+                  s.elapsed_ms >= 0 ? (
+                    <span title="tool duration (observational)">
+                      {formatElapsedMs(s.elapsed_ms)}
+                    </span>
                   ) : null}
                 </div>
                 {body ? <CopyBodyButton text={body} /> : null}

--- a/apps/viewer/src/components/trial/trajectory-panel.tsx
+++ b/apps/viewer/src/components/trial/trajectory-panel.tsx
@@ -22,6 +22,7 @@ import {
   Wrench,
 } from "lucide-react";
 
+import { HoverTip } from "@/components/hover-tip";
 import type { TrajectoryStep } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
@@ -61,11 +62,11 @@ function CopyBodyButton({ text }: { text: string }) {
     }
   }
   return (
+    <HoverTip content={copied ? "Copied" : "Copy"}>
     <button
       type="button"
       onClick={onCopy}
       aria-label={copied ? "Copied" : "Copy step"}
-      title={copied ? "Copied" : "Copy"}
       className="shrink-0 rounded-[4px] p-0.5 text-mute hover:bg-row-hover hover:text-ink"
     >
       {copied ? (
@@ -74,6 +75,7 @@ function CopyBodyButton({ text }: { text: string }) {
         <Copy className="h-3.5 w-3.5" aria-hidden />
       )}
     </button>
+    </HoverTip>
   );
 }
 
@@ -361,9 +363,9 @@ export function TrajectoryPanel({
                   {typeof s.elapsed_ms === "number" &&
                   Number.isFinite(s.elapsed_ms) &&
                   s.elapsed_ms >= 0 ? (
-                    <span title="tool duration (observational)">
-                      {formatElapsedMs(s.elapsed_ms)}
-                    </span>
+                    <HoverTip content="tool duration (observational)">
+                      <span>{formatElapsedMs(s.elapsed_ms)}</span>
+                    </HoverTip>
                   ) : null}
                 </div>
                 {body ? <CopyBodyButton text={body} /> : null}
@@ -403,6 +405,7 @@ export function TrajectoryPanel({
         <p className="text-[11px] text-mute">
           Trajectory is observational only; independent evaluator owns PASS.
         </p>
+        <HoverTip content={allExpanded ? "Collapse all" : "Expand all"}>
         <button
           type="button"
           onClick={() => {
@@ -410,7 +413,6 @@ export function TrajectoryPanel({
             setExpandGen((n) => n + 1);
           }}
           aria-label={allExpanded ? "Collapse all" : "Expand all"}
-          title={allExpanded ? "Collapse all" : "Expand all"}
           className="shrink-0 rounded-[4px] p-0.5 text-mute hover:bg-row-hover hover:text-ink"
         >
           {allExpanded ? (
@@ -419,6 +421,7 @@ export function TrajectoryPanel({
             <UnfoldVertical className="h-3.5 w-3.5" aria-hidden />
           )}
         </button>
+        </HoverTip>
       </div>
       {groups.multi ? (
         <div className="space-y-4 max-h-[70vh] overflow-y-auto pr-1">

--- a/apps/viewer/src/components/trial/trial-header.tsx
+++ b/apps/viewer/src/components/trial/trial-header.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
+import { HoverTip } from "@/components/hover-tip";
 import { Button } from "@/components/ui/button";
 import type { Trial } from "@/lib/api";
 
@@ -54,15 +55,16 @@ export function TrialHeader({
               <span className="text-mute select-none" aria-hidden>
                 ·
               </span>
-              <a
-                href={trial.upstream_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-link hover:text-link-deep font-mono text-[13px] truncate max-w-[min(48ch,100%)]"
-                title={trial.upstream_name || trial.upstream_url}
-              >
-                {trial.upstream_url}
-              </a>
+              <HoverTip content={trial.upstream_name || trial.upstream_url}>
+                <a
+                  href={trial.upstream_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-link hover:text-link-deep font-mono text-[13px] truncate max-w-[min(48ch,100%)]"
+                >
+                  {trial.upstream_url}
+                </a>
+              </HoverTip>
             </>
           ) : null}
         </p>

--- a/apps/viewer/src/lib/api.ts
+++ b/apps/viewer/src/lib/api.ts
@@ -150,6 +150,10 @@ export type TrajectoryStep = {
   status?: string | null;
   args?: Record<string, unknown> | unknown[] | string | null;
   raw_output?: Record<string, unknown> | unknown[] | string | null;
+  /** Observational tool duration; omit when the sealed step has none. */
+  elapsed_ms?: number | null;
+  started_at?: string | null;
+  ended_at?: string | null;
   /** permission_decision (batch auto-approve evidence) */
   outcome?: string | null;
   option_id?: string | null;

--- a/apps/viewer/src/lib/utils.ts
+++ b/apps/viewer/src/lib/utils.ts
@@ -26,6 +26,18 @@ export function formatTrials(done: number | null | undefined, total: number | nu
   return `${done ?? 0}/${total}`;
 }
 
+/** Jobs / Hub axis: ``a+b+c`` → ``a+...``; tooltip keeps the full string. */
+export function formatAxisLabel(raw: string | null | undefined): {
+  text: string;
+  title?: string;
+} {
+  const value = (raw || "").trim();
+  if (!value) return { text: "-" };
+  const parts = value.split("+").map((s) => s.trim()).filter(Boolean);
+  if (parts.length <= 1) return { text: value, title: value };
+  return { text: `${parts[0]}+...`, title: parts.join("+") };
+}
+
 export function formatDate(iso: string | null | undefined): string {
   if (!iso) return "-";
   try {

--- a/apps/viewer/src/pages/JobDetailPage.tsx
+++ b/apps/viewer/src/pages/JobDetailPage.tsx
@@ -19,6 +19,8 @@ import {
 } from "@/components/ui/table";
 import { fetchJob, type Job, type TaskRow } from "@/lib/api";
 import { taskHref, taskRunIds } from "@/lib/routes";
+import { AxisLabel } from "@/components/axis-label";
+import { HoverTip } from "@/components/hover-tip";
 import { formatError, formatScore } from "@/lib/utils";
 
 type SortKey = "task_id" | "agent_label" | "model_label" | "score" | "status";
@@ -154,29 +156,21 @@ export function JobDetailPage() {
                       }}
                     >
                       <TableCell className="font-medium max-w-[12rem]">
-                        <span className="block truncate" title={t.task_id}>
-                          {t.task_id}
-                        </span>
+                        <HoverTip content={t.task_id}>
+                          <span className="block truncate">{t.task_id}</span>
+                        </HoverTip>
                       </TableCell>
                       <TableCell className="max-w-[14rem]">
-                        <span
+                        <AxisLabel
+                          value={t.agent_label || job?.agent_label}
                           className="block truncate"
-                          title={
-                            t.agent_label || job?.agent_label || undefined
-                          }
-                        >
-                          {t.agent_label || job?.agent_label || "-"}
-                        </span>
+                        />
                       </TableCell>
                       <TableCell className="max-w-[18rem]">
-                        <span
+                        <AxisLabel
+                          value={t.model_label || job?.model_label}
                           className="block truncate font-mono text-xs"
-                          title={
-                            t.model_label || job?.model_label || undefined
-                          }
-                        >
-                          {t.model_label || job?.model_label || "-"}
-                        </span>
+                        />
                       </TableCell>
                       <TableCell className="text-body">
                         {t.dataset || job?.source || "-"}

--- a/apps/viewer/src/pages/JobsPage.tsx
+++ b/apps/viewer/src/pages/JobsPage.tsx
@@ -27,6 +27,8 @@ import {
 } from "@/components/ui/table";
 import { fetchJobs, type Job } from "@/lib/api";
 import { jobDisplayName, jobHref } from "@/lib/routes";
+import { AxisLabel } from "@/components/axis-label";
+import { HoverTip } from "@/components/hover-tip";
 import { formatDate, formatScore, formatTrials } from "@/lib/utils";
 
 type SortKey =
@@ -322,28 +324,23 @@ export function JobsPage() {
                     role="link"
                   >
                     <TableCell className="font-medium max-w-[16rem]">
-                      <span
-                        className="block truncate"
-                        title={jobDisplayName(job)}
-                      >
-                        {jobDisplayName(job)}
-                      </span>
+                      <HoverTip content={jobDisplayName(job)}>
+                        <span className="block truncate">
+                          {jobDisplayName(job)}
+                        </span>
+                      </HoverTip>
                     </TableCell>
                     <TableCell className="max-w-[14rem]">
-                      <span
+                      <AxisLabel
+                        value={job.agent_label}
                         className="block truncate"
-                        title={job.agent_label || undefined}
-                      >
-                        {job.agent_label || "-"}
-                      </span>
+                      />
                     </TableCell>
                     <TableCell className="max-w-[18rem]">
-                      <span
+                      <AxisLabel
+                        value={job.model_label}
                         className="block truncate font-mono text-xs"
-                        title={job.model_label || undefined}
-                      >
-                        {job.model_label || "-"}
-                      </span>
+                      />
                     </TableCell>
                     <TableCell className="tabular">
                       {formatScore(job.mean_score ?? job.result)}

--- a/docs/design/02-task-package-and-config.md
+++ b/docs/design/02-task-package-and-config.md
@@ -254,7 +254,8 @@ member task.yaml（角色槽 + intent + harness/eval）
   → actors_summary → config_fingerprint
 ```
 
-- 成员 `task.yaml` **禁止**内联 `executor` / `model` / `options` / `api_key` / `base_url`（无向后兼容双写法）。
+- 成员 `task.yaml` **禁止**内联 `executor` / `model` / `options` / `api_key` / `base_url` / `label`（无向后兼容双写法）。
+- Job binding 可选 `label`：Jobs / Hub 的 Agents 轴。缺省：`executor: acp` 用 `options.entry`，其它 kind 用 `executor`。**禁止**用 `options.agent` 当展示名。写入 lock `job_overlay` 与 Attempt/suite `agent_label`。
 - 缺 required role binding → `missing_binding` fail closed。
 - Intent `limits.*` **不可**经 `--set` 覆盖。
 - Leaderboard **job 轴**是 suite 级 `profiles.yaml` / `job_overlay`（role id → entry/model），不是「各 task 角色槽拓扑是否相同」。不同 task 可用不同 role id；只要绑定文档一致，`config_homogeneous` 仍为 true，公开可比榜展示该 yaml。

--- a/docs/design/05-runtime/evidence.md
+++ b/docs/design/05-runtime/evidence.md
@@ -106,11 +106,41 @@ ACP / nooa / …
 | `kind` | 字段 | 是否折进层 C |
 | --- | --- | --- |
 | `text` | `channel: thought\|assistant`，`text` | 是 |
-| `tool` | `phase: start\|update`，`tool_call_id`，可选 `title` / `function_name` / `tool_kind` / `status` / `args` / `content` / `raw_output` | 是（Core 按 `tool_call_id` 合并） |
+| `tool` | `phase: start\|update`，`tool_call_id`，可选 `title` / `function_name` / `tool_kind` / `status` / `args` / `content` / `raw_output`，以及下文逐步耗时 | 是（Core 按 `tool_call_id` 合并） |
 | `permission` | `outcome` / `option_id` / `policy` | 是 |
 | `opaque` | 任意 `payload` | **否**（只留 `events.jsonl`） |
 
 无 `schema: bora.trajectory.event/1` 的行不参与层 C 折叠。
+
+### 逐步耗时（观测；可选；fail-open）
+
+目的：Hub / Viewer 在 **单步**（尤其 `tool_call` / shell execute）上显示耗时，而不是只靠 Attempt 级 `phase_timing`。  
+**观测字段，不是 PASS。** 缺字段必须省略，禁止 Viewer / Hub 用文件 mtime 或页面时钟补造。
+
+| 字段 | 位置 | 含义 |
+| --- | --- | --- |
+| `at` | 信封（任意 `kind`，可选） | 生产者观测到本事件的时间（ISO-8601 UTC） |
+| `elapsed_ms` | `kind: tool`（start 或 update，可选） | 该 `tool_call_id` 截至本事件的墙钟毫秒（≥ 0） |
+| `started_at` | `kind: tool`（可选） | 该 call 首次观测到的开始时间（ISO-8601 UTC） |
+| `ended_at` | `kind: tool`（可选） | 该 call 完成 / 末次 update 的时间（ISO-8601 UTC） |
+
+**谁写：**
+
+| 角色 | 写什么 |
+| --- | --- |
+| Executor Adapter / 插件 | vendor 流里已有 duration / timestamp 则映射；可把 **接收时刻** 写成 `at`（adapter 时钟）。vendor 没有则整组省略 |
+| Core evidence writer | 按 `tool_call_id` 合并后抄到层 C；**不**从 filesystem mtime 推断 |
+| Hub / Viewer | 层 C 有 `elapsed_ms` 才在步骤头显示；没有则不画标签 |
+
+**合并（Core，同一 `tool_call_id`）：**
+
+- `started_at` = 第一条非空 `started_at`，否则第一条信封 `at`
+- `ended_at` = 最后一条非空 `ended_at`，否则最后一条信封 `at`
+- `elapsed_ms` = 最后一条非空 `elapsed_ms`；若仍缺且 `started_at` + `ended_at` 都能解析，则用二者之差（毫秒，≥ 0）
+- 非法值（负数、非数字、无法解析的时间）丢弃，不当错误
+
+**层 C：** 合并结果写在对应 `type=tool_call` 行；若发出 `observation`，可抄同一组耗时。缺省字段省略。  
+**禁止**用逐步耗时改 score / PASS / evaluator 输入。
 
 ## `trajectory.jsonl`（turn 级，训练默认）
 
@@ -158,6 +188,8 @@ ACP / nooa / …
 | `kind` | tool kind（`read` / `edit` / `execute` / …） |
 | `status` | 合并后的终态（`pending` / `in_progress` / `completed` / `failed`） |
 | `args` | 调用参数（若有；须 redact） |
+| `elapsed_ms` | 该 call 墙钟毫秒（有则写；缺省省略） |
+| `started_at` / `ended_at` | 该 call 起止（有则写；ISO-8601 UTC） |
 | `turn_index` / `session_id` / `source` | 与 turn 行一致；`source` = 生产者 |
 
 **`observation` 推荐字段：**
@@ -168,9 +200,10 @@ ACP / nooa / …
 | `status` | 该 call 终态 |
 | `content` | 可读摘要 |
 | `raw_output` | 结构化回传（若有；须 redact） |
+| `elapsed_ms` / `started_at` / `ended_at` | 与对应 `tool_call` 同一组（有则抄；缺省省略） |
 | `turn_index` / `session_id` / `source` | 同上 |
 
-**合并规则：** 同一 `tool_call_id` 累积 `title` / `function_name` / `tool_kind` / `status` / `args` / `content` / `raw_output`；seal 发一条 `tool_call` + 可选 `observation`。  
+**合并规则：** 同一 `tool_call_id` 累积 `title` / `function_name` / `tool_kind` / `status` / `args` / `content` / `raw_output` 以及逐步耗时（见上节）；seal 发一条 `tool_call` + 可选 `observation`。  
 **有 call 无 result：** 仍写 `tool_call`；observation 仅在存在 content / raw_output / 终态 completed|failed 时写出。  
 **禁止**只落盘 call 而系统性丢弃已有 result。
 
@@ -182,7 +215,7 @@ ACP / nooa / …
 
 **多轮会话：** `turn_index` 为 Attempt 内 invoke 序号（1-based）；跨 turn 的 ACP `session_id` 可相同。合并训练样本时以 **invocation / turn_index** 为边界，不要把整个 `session_id` 当成单 turn。
 
-**非目标：** 用 `trajectory.jsonl` 替代 evaluator；要求 harness 自己写训练文件；把 ACP skills 目录类 `AvailableCommandsUpdate` 灌进训练轨迹（应过滤）。训练导出流水线细节可链 Issues（如导出工具演进），不在 design 写进度。
+**非目标：** 用 `trajectory.jsonl` 替代 evaluator；要求 harness 自己写训练文件；把 ACP skills 目录类 `AvailableCommandsUpdate` 灌进训练轨迹（应过滤）；用文件 mtime 或 Viewer 时钟补造逐步耗时；要求每个 executor 都发出耗时（可选、fail-open）。训练导出流水线细节可链 Issues（如导出工具演进），不在 design 写进度。
 
 ## 所有权与非目标
 

--- a/plugins/dsh/src/dsh_plugin/trajectory.py
+++ b/plugins/dsh/src/dsh_plugin/trajectory.py
@@ -63,42 +63,42 @@ def to_bora_trajectory_events(
             call_id = str(data.get("callId") or data.get("id") or f"dsh_tool_{seq_n}")
             name = str(data.get("name") or "tool")
             names[call_id] = name
-            out.append(
-                {
-                    "schema": SCHEMA,
-                    "seq": seq_n,
-                    "session_id": session_id,
-                    "source": _SOURCE,
-                    "kind": "tool",
-                    "phase": "start",
-                    "tool_call_id": call_id,
-                    "title": name,
-                    "function_name": name,
-                    "tool_kind": _tool_kind(name),
-                    "status": "pending",
-                    "args": _as_args(data.get("arguments")),
-                }
-            )
+            start = {
+                "schema": SCHEMA,
+                "seq": seq_n,
+                "session_id": session_id,
+                "source": _SOURCE,
+                "kind": "tool",
+                "phase": "start",
+                "tool_call_id": call_id,
+                "title": name,
+                "function_name": name,
+                "tool_kind": _tool_kind(name),
+                "status": "pending",
+                "args": _as_args(data.get("arguments")),
+            }
+            _attach_timing(start, event, data)
+            out.append(start)
         elif et == "tool/result":
             seq_n = _next()
             call_id, content, is_error = _parse_tool_result(data)
             name = names.get(call_id, "tool")
-            out.append(
-                {
-                    "schema": SCHEMA,
-                    "seq": seq_n,
-                    "session_id": session_id,
-                    "source": _SOURCE,
-                    "kind": "tool",
-                    "phase": "update",
-                    "tool_call_id": call_id or f"dsh_tool_{seq_n}",
-                    "title": name,
-                    "function_name": name,
-                    "tool_kind": "other",
-                    "status": "failed" if is_error else "completed",
-                    "content": content,
-                }
-            )
+            update = {
+                "schema": SCHEMA,
+                "seq": seq_n,
+                "session_id": session_id,
+                "source": _SOURCE,
+                "kind": "tool",
+                "phase": "update",
+                "tool_call_id": call_id or f"dsh_tool_{seq_n}",
+                "title": name,
+                "function_name": name,
+                "tool_kind": "other",
+                "status": "failed" if is_error else "completed",
+                "content": content,
+            }
+            _attach_timing(update, event, data)
+            out.append(update)
         elif et == "turn/end":
             continue
         else:
@@ -230,6 +230,28 @@ def _parse_tool_result(data: dict[str, Any]) -> tuple[str, str, bool]:
             elif isinstance(inner, str):
                 parts.append(inner)
     return call_id, "".join(parts), is_error
+
+
+def _attach_timing(ev: dict[str, Any], *sources: Any) -> None:
+    for src in sources:
+        if not isinstance(src, dict):
+            continue
+        at = src.get("at") or src.get("timestamp") or src.get("created_at")
+        if isinstance(at, str) and at.strip() and "at" not in ev:
+            ev["at"] = at.strip()
+        for key in ("elapsed_ms", "elapsedMs", "duration_ms", "durationMs"):
+            if "elapsed_ms" in ev:
+                break
+            val = src.get(key)
+            if isinstance(val, bool) or not isinstance(val, int | float) or val < 0:
+                continue
+            ev["elapsed_ms"] = float(val)
+        started = src.get("started_at") or src.get("startedAt")
+        if isinstance(started, str) and started.strip() and "started_at" not in ev:
+            ev["started_at"] = started.strip()
+        ended = src.get("ended_at") or src.get("endedAt")
+        if isinstance(ended, str) and ended.strip():
+            ev["ended_at"] = ended.strip()
 
 
 def _unwrap_event(raw: dict[str, Any]) -> dict[str, Any]:

--- a/plugins/dsh/src/dsh_plugin/trajectory.py
+++ b/plugins/dsh/src/dsh_plugin/trajectory.py
@@ -7,6 +7,8 @@ Vendor-native rows stay in ``backend_raw/``. This module never emits ACP
 from __future__ import annotations
 
 import json
+import math
+from datetime import UTC, datetime
 from typing import Any
 
 SCHEMA = "bora.trajectory.event/1"
@@ -42,6 +44,7 @@ def to_bora_trajectory_events(
     out: list[dict[str, Any]] = []
     seq = 0
     names: dict[str, str] = {}
+    started_at: dict[str, str] = {}
 
     def _next() -> int:
         nonlocal seq
@@ -77,7 +80,10 @@ def to_bora_trajectory_events(
                 "status": "pending",
                 "args": _as_args(data.get("arguments")),
             }
-            _attach_timing(start, event, data)
+            _attach_timing(start, event, data, raw)
+            if isinstance(start.get("at"), str):
+                started_at[call_id] = start["at"]
+                start.setdefault("started_at", start["at"])
             out.append(start)
         elif et == "tool/result":
             seq_n = _next()
@@ -97,7 +103,18 @@ def to_bora_trajectory_events(
                 "status": "failed" if is_error else "completed",
                 "content": content,
             }
-            _attach_timing(update, event, data)
+            _attach_timing(update, event, data, raw)
+            call_key = str(update.get("tool_call_id") or "")
+            start_iso = started_at.get(call_key)
+            if start_iso:
+                update.setdefault("started_at", start_iso)
+            end_iso = update.get("at") if isinstance(update.get("at"), str) else None
+            if end_iso:
+                update.setdefault("ended_at", end_iso)
+            if update.get("elapsed_ms") is None and start_iso and end_iso:
+                elapsed = _iso_delta_ms(start_iso, end_iso)
+                if elapsed is not None:
+                    update["elapsed_ms"] = elapsed
             out.append(update)
         elif et == "turn/end":
             continue
@@ -233,17 +250,19 @@ def _parse_tool_result(data: dict[str, Any]) -> tuple[str, str, bool]:
 
 
 def _attach_timing(ev: dict[str, Any], *sources: Any) -> None:
+    at = _coerce_event_at(*sources)
+    if at and "at" not in ev:
+        ev["at"] = at
     for src in sources:
         if not isinstance(src, dict):
             continue
-        at = src.get("at") or src.get("timestamp") or src.get("created_at")
-        if isinstance(at, str) and at.strip() and "at" not in ev:
-            ev["at"] = at.strip()
         for key in ("elapsed_ms", "elapsedMs", "duration_ms", "durationMs"):
             if "elapsed_ms" in ev:
                 break
             val = src.get(key)
-            if isinstance(val, bool) or not isinstance(val, int | float) or val < 0:
+            if isinstance(val, bool) or not isinstance(val, int | float):
+                continue
+            if not math.isfinite(val) or val < 0:
                 continue
             ev["elapsed_ms"] = float(val)
         started = src.get("started_at") or src.get("startedAt")
@@ -252,6 +271,71 @@ def _attach_timing(ev: dict[str, Any], *sources: Any) -> None:
         ended = src.get("ended_at") or src.get("endedAt")
         if isinstance(ended, str) and ended.strip():
             ev["ended_at"] = ended.strip()
+
+
+def _coerce_event_at(*sources: Any) -> str | None:
+    """Vendor clock first (timestamp / epoch ``time``), then receive-time ``at``."""
+    strings: list[str] = []
+    epoch_iso: str | None = None
+    receive: str | None = None
+    for src in sources:
+        if not isinstance(src, dict):
+            continue
+        for key in ("timestamp", "created_at", "started_at"):
+            val = src.get(key)
+            if isinstance(val, str) and val.strip():
+                strings.append(val.strip())
+        iso = _epoch_to_iso(src.get("time"))
+        if iso and epoch_iso is None:
+            epoch_iso = iso
+        at = src.get("at")
+        if isinstance(at, str) and at.strip() and receive is None:
+            receive = at.strip()
+    if strings:
+        return strings[0]
+    return epoch_iso or receive
+
+
+def _epoch_to_iso(value: Any) -> str | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    if not math.isfinite(value) or value <= 0:
+        return None
+    ms = float(value)
+    if ms < 1e11:
+        ms *= 1000.0
+    try:
+        parsed = datetime.fromtimestamp(ms / 1000.0, tz=UTC)
+    except (OverflowError, OSError, ValueError):
+        return None
+    stamp = parsed.strftime("%Y-%m-%dT%H:%M:%S")
+    if parsed.microsecond:
+        stamp = f"{stamp}.{parsed.microsecond:06d}".rstrip("0")
+    return stamp + "Z"
+
+
+def _iso_delta_ms(started: str, ended: str) -> float | None:
+    a = _parse_iso(started)
+    b = _parse_iso(ended)
+    if a is None or b is None:
+        return None
+    delta = (b - a).total_seconds() * 1000.0
+    if delta < 0:
+        return 0.0
+    return round(delta, 3)
+
+
+def _parse_iso(value: str) -> datetime | None:
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
 
 
 def _unwrap_event(raw: dict[str, Any]) -> dict[str, Any]:

--- a/plugins/dsh/src/dsh_plugin/trajectory.py
+++ b/plugins/dsh/src/dsh_plugin/trajectory.py
@@ -45,6 +45,7 @@ def to_bora_trajectory_events(
     seq = 0
     names: dict[str, str] = {}
     started_at: dict[str, str] = {}
+    step_started_ms: float | None = None
 
     def _next() -> int:
         nonlocal seq
@@ -56,11 +57,21 @@ def to_bora_trajectory_events(
             continue
         event = _unwrap_event(raw)
         et = str(event.get("type") or "")
+        if et == "step/start":
+            raw_t = event.get("time")
+            if raw_t is None:
+                raw_t = raw.get("time")
+            if isinstance(raw_t, int | float) and not isinstance(raw_t, bool):
+                step_started_ms = float(raw_t)
+            continue
         if et in _SKIP_TYPES:
             continue
         data = event.get("data") if isinstance(event.get("data"), dict) else {}
         if et == "assistant/message":
-            seq = _emit_assistant_message(out, _next, session_id, data)
+            llm_ms = _delta_epoch_ms(step_started_ms, event.get("time", raw.get("time")))
+            seq = _emit_assistant_message(
+                out, _next, session_id, data, elapsed_ms=llm_ms, event=event, raw=raw
+            )
         elif et == "tool/call":
             seq_n = _next()
             call_id = str(data.get("callId") or data.get("id") or f"dsh_tool_{seq_n}")
@@ -113,7 +124,7 @@ def to_bora_trajectory_events(
                 update.setdefault("ended_at", end_iso)
             if update.get("elapsed_ms") is None and start_iso and end_iso:
                 elapsed = _iso_delta_ms(start_iso, end_iso)
-                if elapsed is not None:
+                if elapsed is not None and elapsed > 0:
                     update["elapsed_ms"] = elapsed
             out.append(update)
         elif et == "turn/end":
@@ -197,12 +208,17 @@ def _emit_assistant_message(
     next_seq: Any,
     session_id: str,
     data: dict[str, Any],
+    *,
+    elapsed_ms: float | None = None,
+    event: dict[str, Any] | None = None,
+    raw: dict[str, Any] | None = None,
 ) -> int:
     message = data.get("message") if isinstance(data.get("message"), dict) else data
     content = message.get("content") if isinstance(message, dict) else None
     if not isinstance(content, list):
         return 0
     seq = 0
+    emitted: list[dict[str, Any]] = []
     for block in content:
         if not isinstance(block, dict):
             continue
@@ -211,16 +227,25 @@ def _emit_assistant_message(
             text = str(block.get("text") or "")
             if text:
                 seq = next_seq()
-                out.append(_text(seq, session_id, "thought", text))
+                emitted.append(_text(seq, session_id, "thought", text))
         elif btype == "text":
             text = str(block.get("text") or "")
             if text:
                 seq = next_seq()
-                out.append(_text(seq, session_id, "assistant", text))
+                emitted.append(_text(seq, session_id, "assistant", text))
         elif btype == "tool-call":
             # Committed tool-call on the message — tool/call event is the source
             # of truth; skip the duplicate block.
             continue
+    # Stamp the visible reply (assistant text) when present. Reasoning-only
+    # steps keep the duration on thought. Never leave the final agent bubble
+    # empty because the time went to a hidden thought fold.
+    stamp = next((row for row in reversed(emitted) if row.get("channel") == "assistant"), None)
+    if stamp is None and emitted:
+        stamp = emitted[-1]
+    if stamp is not None:
+        _stamp_llm_elapsed(stamp, elapsed_ms, event, raw)
+    out.extend(emitted)
     return seq
 
 
@@ -294,6 +319,32 @@ def _coerce_event_at(*sources: Any) -> str | None:
     if strings:
         return strings[0]
     return epoch_iso or receive
+
+
+def _stamp_llm_elapsed(
+    ev: dict[str, Any],
+    elapsed_ms: float | None,
+    event: dict[str, Any] | None,
+    raw: dict[str, Any] | None,
+) -> None:
+    if elapsed_ms is not None and elapsed_ms > 0:
+        ev["elapsed_ms"] = float(elapsed_ms)
+    if event is not None or raw is not None:
+        at = _coerce_event_at(*(x for x in (event, raw) if x is not None))
+        if at:
+            ev["at"] = at
+            ev["ended_at"] = at
+
+
+def _delta_epoch_ms(start: float | None, end: Any) -> float | None:
+    if start is None or isinstance(end, bool) or not isinstance(end, int | float):
+        return None
+    if not math.isfinite(end):
+        return None
+    delta = float(end) - float(start)
+    if delta <= 0:
+        return None
+    return round(delta, 3)
 
 
 def _epoch_to_iso(value: Any) -> str | None:

--- a/plugins/nooa/src/nooa_plugin/trajectory.py
+++ b/plugins/nooa/src/nooa_plugin/trajectory.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from contextlib import suppress
+from datetime import datetime, timezone
 from typing import Any
 
 SCHEMA = "bora.trajectory.event/1"
@@ -180,6 +181,8 @@ class EventTap:
             return
         if tag is not None and "tag" not in row:
             row["tag"] = str(tag)
+        if "at" not in row:
+            row["at"] = _utc_now_iso()
         key = _row_key(row)
         if key in self._seen:
             # Later ToolCallEvent updates carry the result — replace.
@@ -344,43 +347,43 @@ def _emit_tool_pair(
         args = {"code": pending_code}
         pending_code = None
     if call_id not in emitted_tools:
-        out.append(
-            {
-                "schema": SCHEMA,
-                "seq": seq,
-                "session_id": session_id,
-                "source": _SOURCE,
-                "kind": "tool",
-                "phase": "start",
-                "tool_call_id": call_id,
-                "title": name,
-                "function_name": name,
-                "tool_kind": _tool_kind(name),
-                "status": "pending",
-                "args": args,
-            }
-        )
+        start = {
+            "schema": SCHEMA,
+            "seq": seq,
+            "session_id": session_id,
+            "source": _SOURCE,
+            "kind": "tool",
+            "phase": "start",
+            "tool_call_id": call_id,
+            "title": name,
+            "function_name": name,
+            "tool_kind": _tool_kind(name),
+            "status": "pending",
+            "args": args,
+        }
+        _attach_timing(start, raw)
+        out.append(start)
         emitted_tools.add(call_id)
     if raw.get("result") is not None:
         seq += 1
         result = raw["result"]
-        out.append(
-            {
-                "schema": SCHEMA,
-                "seq": seq,
-                "session_id": session_id,
-                "source": _SOURCE,
-                "kind": "tool",
-                "phase": "update",
-                "tool_call_id": call_id,
-                "title": name,
-                "function_name": name,
-                "tool_kind": _tool_kind(name),
-                "status": "failed" if _is_error_result(result) else "completed",
-                "content": _stringify_result(result),
-                "raw_output": result,
-            }
-        )
+        update = {
+            "schema": SCHEMA,
+            "seq": seq,
+            "session_id": session_id,
+            "source": _SOURCE,
+            "kind": "tool",
+            "phase": "update",
+            "tool_call_id": call_id,
+            "title": name,
+            "function_name": name,
+            "tool_kind": _tool_kind(name),
+            "status": "failed" if _is_error_result(result) else "completed",
+            "content": _stringify_result(result),
+            "raw_output": result,
+        }
+        _attach_timing(update, raw)
+        out.append(update)
     return seq, pending_code
 
 
@@ -417,41 +420,41 @@ def _emit_python_output(
         args = {"code": pending_code}
         pending_code = None
     if call_id not in emitted_tools:
-        out.append(
-            {
-                "schema": SCHEMA,
-                "seq": seq,
-                "session_id": session_id,
-                "source": _SOURCE,
-                "kind": "tool",
-                "phase": "start",
-                "tool_call_id": call_id,
-                "title": "execute_python",
-                "function_name": "execute_python",
-                "tool_kind": "execute",
-                "status": "pending",
-                "args": args,
-            }
-        )
-        emitted_tools.add(call_id)
-        seq += 1
-    out.append(
-        {
+        start = {
             "schema": SCHEMA,
             "seq": seq,
             "session_id": session_id,
             "source": _SOURCE,
             "kind": "tool",
-            "phase": "update",
+            "phase": "start",
             "tool_call_id": call_id,
             "title": "execute_python",
             "function_name": "execute_python",
             "tool_kind": "execute",
-            "status": status,
-            "content": _python_obs_text(payload),
-            "raw_output": payload,
+            "status": "pending",
+            "args": args,
         }
-    )
+        _attach_timing(start, raw)
+        out.append(start)
+        emitted_tools.add(call_id)
+        seq += 1
+    update = {
+        "schema": SCHEMA,
+        "seq": seq,
+        "session_id": session_id,
+        "source": _SOURCE,
+        "kind": "tool",
+        "phase": "update",
+        "tool_call_id": call_id,
+        "title": "execute_python",
+        "function_name": "execute_python",
+        "tool_kind": "execute",
+        "status": status,
+        "content": _python_obs_text(payload),
+        "raw_output": payload,
+    }
+    _attach_timing(update, raw)
+    out.append(update)
     return seq, pending_code
 
 
@@ -465,6 +468,32 @@ def _text(seq: int, session_id: str, channel: str, text: str) -> dict[str, Any]:
         "channel": channel,
         "text": text,
     }
+
+
+def _utc_now_iso() -> str:
+    now = datetime.now(timezone.utc)
+    stamp = now.strftime("%Y-%m-%dT%H:%M:%S")
+    if now.microsecond:
+        stamp = f"{stamp}.{now.microsecond:06d}".rstrip("0")
+    return stamp + "Z"
+
+
+def _attach_timing(ev: dict[str, Any], raw: dict[str, Any]) -> None:
+    at = raw.get("at") or raw.get("timestamp") or raw.get("created_at")
+    if isinstance(at, str) and at.strip():
+        ev["at"] = at.strip()
+    for key in ("elapsed_ms", "elapsedMs", "duration_ms", "durationMs"):
+        val = raw.get(key)
+        if isinstance(val, bool) or not isinstance(val, int | float) or val < 0:
+            continue
+        ev["elapsed_ms"] = float(val)
+        break
+    started = raw.get("started_at") or raw.get("startedAt")
+    if isinstance(started, str) and started.strip():
+        ev["started_at"] = started.strip()
+    ended = raw.get("ended_at") or raw.get("endedAt")
+    if isinstance(ended, str) and ended.strip():
+        ev["ended_at"] = ended.strip()
 
 
 def _event_manager(agent: Any) -> Any | None:

--- a/plugins/nooa/src/nooa_plugin/trajectory.py
+++ b/plugins/nooa/src/nooa_plugin/trajectory.py
@@ -269,6 +269,8 @@ def to_bora_trajectory_events(
     emitted_tools: set[str] = set()
     pending_code: str | None = None
     started_at: dict[str, str] = {}
+    llm_started_at: str | None = None
+    pending_llm_elapsed: float | None = None
     has_vendor_tools = any(
         isinstance(row, dict)
         and _event_type(row) in {"ToolCallEvent", "ToolCall", "PythonOutput"}
@@ -287,6 +289,15 @@ def to_bora_trajectory_events(
         if has_vendor_tools and str(raw.get("id") or "").startswith("tap_"):
             continue
         et = _event_type(raw)
+        if et == "LLMCallStart":
+            llm_started_at = _coerce_event_at(raw)
+            continue
+        if et == "LLMCallEnd":
+            end_at = _coerce_event_at(raw)
+            if llm_started_at and end_at:
+                pending_llm_elapsed = _iso_delta_ms(llm_started_at, end_at)
+            llm_started_at = None
+            continue
         if et in _SKIP_KINDS:
             continue
         if et == "Task":
@@ -298,20 +309,28 @@ def to_bora_trajectory_events(
             if not isinstance(text, str):
                 text = str(text or "")
             if text:
-                out.append(_text(_next(), session_id, "assistant", text))
+                row = _text(_next(), session_id, "assistant", text)
+                pending_llm_elapsed = _attach_llm_elapsed(row, pending_llm_elapsed)
+                out.append(row)
         elif et == "LLMOutput":
             text = raw.get("content")
             if not isinstance(text, str):
                 text = str(text or "")
             if text and _looks_like_code(text):
                 pending_code = text
-                out.append(_text(_next(), session_id, "thought", text))
+                row = _text(_next(), session_id, "thought", text)
+                pending_llm_elapsed = _attach_llm_elapsed(row, pending_llm_elapsed)
+                out.append(row)
             elif text:
-                out.append(_text(_next(), session_id, "assistant", text))
+                row = _text(_next(), session_id, "assistant", text)
+                pending_llm_elapsed = _attach_llm_elapsed(row, pending_llm_elapsed)
+                out.append(row)
         elif et in {"Reasoning", "Error", "Feedback"}:
             text = raw.get("content")
             if text:
-                out.append(_text(_next(), session_id, "thought", str(text)))
+                row = _text(_next(), session_id, "thought", str(text))
+                pending_llm_elapsed = _attach_llm_elapsed(row, pending_llm_elapsed)
+                out.append(row)
         elif et in {"ToolCallEvent", "ToolCall"}:
             seq, pending_code = _emit_tool_pair(
                 out,
@@ -335,7 +354,9 @@ def to_bora_trajectory_events(
         elif et == "LLMComplete":
             reason = raw.get("reasoning_content")
             if isinstance(reason, str) and reason.strip():
-                out.append(_text(_next(), session_id, "thought", reason))
+                row = _text(_next(), session_id, "thought", reason)
+                pending_llm_elapsed = _attach_llm_elapsed(row, pending_llm_elapsed)
+                out.append(row)
             # Proposed calls on the LLM row are not the execute span.
             # ToolCallEvent + PythonOutput own start/end when present.
             if has_vendor_tools:
@@ -579,21 +600,30 @@ def _remember_start(started_at: dict[str, str], call_id: str, ev: dict[str, Any]
 
 
 def _apply_span(ev: dict[str, Any], started_at: dict[str, str], call_id: str) -> None:
-    start_iso = ev.get("started_at") if isinstance(ev.get("started_at"), str) else None
-    if not start_iso:
-        start_iso = started_at.get(call_id)
+    # Remembered ToolCallEvent start wins. PythonOutput.started_at is often the
+    # output timestamp (same as ended_at) and must not zero the span.
+    start_iso = started_at.get(call_id)
+    if not start_iso and isinstance(ev.get("started_at"), str):
+        start_iso = ev["started_at"]
     if start_iso:
-        ev.setdefault("started_at", start_iso)
+        ev["started_at"] = start_iso
         started_at.setdefault(call_id, start_iso)
     end_iso = ev.get("ended_at") if isinstance(ev.get("ended_at"), str) else None
     if not end_iso and isinstance(ev.get("at"), str):
         end_iso = ev["at"]
     if end_iso:
-        ev.setdefault("ended_at", end_iso)
+        ev["ended_at"] = end_iso
     if ev.get("elapsed_ms") is None and start_iso and end_iso:
         elapsed = _iso_delta_ms(start_iso, end_iso)
-        if elapsed is not None:
+        if elapsed is not None and elapsed > 0:
             ev["elapsed_ms"] = elapsed
+
+
+def _attach_llm_elapsed(ev: dict[str, Any], elapsed_ms: float | None) -> float | None:
+    if elapsed_ms is None or elapsed_ms <= 0:
+        return elapsed_ms
+    ev["elapsed_ms"] = float(elapsed_ms)
+    return None
 
 
 def _iso_delta_ms(started: str, ended: str) -> float | None:

--- a/plugins/nooa/src/nooa_plugin/trajectory.py
+++ b/plugins/nooa/src/nooa_plugin/trajectory.py
@@ -11,6 +11,8 @@ are notify-only — they must be tapped via ``on("*")`` during invoke.
 from __future__ import annotations
 
 import json
+import math
+import time
 from collections.abc import Callable
 from contextlib import suppress
 from datetime import datetime, timezone
@@ -95,9 +97,12 @@ class EventTap:
         return out
 
     async def _on_python(self, ctx: Any, nxt: Any) -> Any:
+        started_at = _utc_now_iso()
+        t0 = time.monotonic()
         out = await nxt(ctx)
+        elapsed_ms = max(0.0, (time.monotonic() - t0) * 1000.0)
         with suppress(Exception):
-            self._capture_python(out)
+            self._capture_python(out, started_at=started_at, elapsed_ms=elapsed_ms)
         return out
 
     def _capture_llm(self, ctx: Any) -> None:
@@ -143,37 +148,48 @@ class EventTap:
                 }
             )
 
-    def _capture_python(self, ctx: Any) -> None:
+    def _capture_python(
+        self,
+        ctx: Any,
+        *,
+        started_at: str | None = None,
+        elapsed_ms: float | None = None,
+    ) -> None:
         code = getattr(ctx, "code", None)
         result = getattr(ctx, "result", None)
         call_id = f"tap_py_{len(self._rows) + 1}"
         args = {"code": code} if isinstance(code, str) and code else {}
-        self._ingest(
-            {
-                "event_type": "ToolCallEvent",
-                "id": call_id,
-                "tool_call_id": call_id,
-                "name": "execute_python",
-                "arguments": args,
-            }
-        )
+        start_row: dict[str, Any] = {
+            "event_type": "ToolCallEvent",
+            "id": call_id,
+            "tool_call_id": call_id,
+            "name": "execute_python",
+            "arguments": args,
+        }
+        if started_at:
+            start_row["started_at"] = started_at
+            start_row["at"] = started_at
+        self._ingest(start_row)
         stdout = getattr(result, "stdout", "") if result is not None else ""
         stderr = getattr(result, "stderr", "") if result is not None else ""
         error = getattr(result, "error", None) if result is not None else None
         value = getattr(result, "returned_value", None) if result is not None else None
         success = bool(getattr(result, "success", True)) if result is not None else True
-        self._ingest(
-            {
-                "event_type": "PythonOutput",
-                "id": f"{call_id}_out",
-                "tool_call_id": call_id,
-                "execution_status": "complete" if success else "error",
-                "stdout": stdout or "",
-                "stderr": stderr or "",
-                "error": "" if error is None else str(error),
-                "value": None if value is None else _jsonable(value),
-            }
-        )
+        end_row: dict[str, Any] = {
+            "event_type": "PythonOutput",
+            "id": f"{call_id}_out",
+            "tool_call_id": call_id,
+            "execution_status": "complete" if success else "error",
+            "stdout": stdout or "",
+            "stderr": stderr or "",
+            "error": "" if error is None else str(error),
+            "value": None if value is None else _jsonable(value),
+        }
+        if started_at:
+            end_row["started_at"] = started_at
+        if elapsed_ms is not None and math.isfinite(elapsed_ms) and elapsed_ms >= 0:
+            end_row["elapsed_ms"] = float(elapsed_ms)
+        self._ingest(end_row)
 
     def _ingest(self, ev: Any, *, tag: Any = None) -> None:
         row = _event_to_dict(ev)
@@ -181,13 +197,23 @@ class EventTap:
             return
         if tag is not None and "tag" not in row:
             row["tag"] = str(tag)
-        if "at" not in row:
+        vendor_ts = row.get("timestamp") or row.get("created_at")
+        if isinstance(vendor_ts, str) and vendor_ts.strip():
+            row.setdefault("at", vendor_ts.strip())
+        elif "at" not in row:
             row["at"] = _utc_now_iso()
         key = _row_key(row)
         if key in self._seen:
-            # Later ToolCallEvent updates carry the result — replace.
+            # Later ToolCallEvent updates carry the result — replace, keep start.
             for i, existing in enumerate(self._rows):
                 if _row_key(existing) == key:
+                    first = (
+                        existing.get("started_at")
+                        or existing.get("timestamp")
+                        or existing.get("at")
+                    )
+                    if isinstance(first, str) and first.strip():
+                        row.setdefault("started_at", first.strip())
                     self._rows[i] = row
                     return
             return
@@ -242,6 +268,13 @@ def to_bora_trajectory_events(
     seq = 0
     emitted_tools: set[str] = set()
     pending_code: str | None = None
+    started_at: dict[str, str] = {}
+    has_vendor_tools = any(
+        isinstance(row, dict)
+        and _event_type(row) in {"ToolCallEvent", "ToolCall", "PythonOutput"}
+        and not str(row.get("id") or "").startswith("tap_")
+        for row in raw_events
+    )
 
     def _next() -> int:
         nonlocal seq
@@ -250,6 +283,8 @@ def to_bora_trajectory_events(
 
     for raw in raw_events:
         if not isinstance(raw, dict):
+            continue
+        if has_vendor_tools and str(raw.get("id") or "").startswith("tap_"):
             continue
         et = _event_type(raw)
         if et in _SKIP_KINDS:
@@ -284,6 +319,7 @@ def to_bora_trajectory_events(
                 session_id,
                 raw,
                 emitted_tools,
+                started_at,
                 pending_code=pending_code,
             )
         elif et == "PythonOutput":
@@ -293,12 +329,17 @@ def to_bora_trajectory_events(
                 session_id,
                 raw,
                 emitted_tools,
+                started_at,
                 pending_code=pending_code,
             )
         elif et == "LLMComplete":
             reason = raw.get("reasoning_content")
             if isinstance(reason, str) and reason.strip():
                 out.append(_text(_next(), session_id, "thought", reason))
+            # Proposed calls on the LLM row are not the execute span.
+            # ToolCallEvent + PythonOutput own start/end when present.
+            if has_vendor_tools:
+                continue
             for call in raw.get("tool_calls") or []:
                 if not isinstance(call, dict):
                     continue
@@ -313,7 +354,13 @@ def to_bora_trajectory_events(
                     "arguments": args,
                 }
                 seq, pending_code = _emit_tool_pair(
-                    out, seq, session_id, fake, emitted_tools, pending_code=pending_code
+                    out,
+                    seq,
+                    session_id,
+                    fake,
+                    emitted_tools,
+                    started_at,
+                    pending_code=pending_code,
                 )
         else:
             seq = _next()
@@ -336,6 +383,7 @@ def _emit_tool_pair(
     session_id: str,
     raw: dict[str, Any],
     emitted_tools: set[str],
+    started_at: dict[str, str],
     *,
     pending_code: str | None,
 ) -> tuple[int, str | None]:
@@ -362,8 +410,11 @@ def _emit_tool_pair(
             "args": args,
         }
         _attach_timing(start, raw)
+        _remember_start(started_at, call_id, start)
         out.append(start)
         emitted_tools.add(call_id)
+    else:
+        _remember_start(started_at, call_id, {"at": _coerce_event_at(raw)})
     if raw.get("result") is not None:
         seq += 1
         result = raw["result"]
@@ -383,6 +434,17 @@ def _emit_tool_pair(
             "raw_output": result,
         }
         _attach_timing(update, raw)
+        # Folded ToolCallEvent.timestamp is the start, not the end.
+        if _event_type(raw) in {"ToolCallEvent", "ToolCall"}:
+            start_iso = started_at.get(call_id)
+            if start_iso:
+                update["started_at"] = start_iso
+            if "elapsed_ms" not in raw and "ended_at" not in raw:
+                update.pop("ended_at", None)
+                if update.get("at") == start_iso:
+                    update.pop("at", None)
+                    update.pop("elapsed_ms", None)
+        _apply_span(update, started_at, call_id)
         out.append(update)
     return seq, pending_code
 
@@ -393,6 +455,7 @@ def _emit_python_output(
     session_id: str,
     raw: dict[str, Any],
     emitted_tools: set[str],
+    started_at: dict[str, str],
     *,
     pending_code: str | None,
 ) -> tuple[int, str | None]:
@@ -435,6 +498,7 @@ def _emit_python_output(
             "args": args,
         }
         _attach_timing(start, raw)
+        _remember_start(started_at, call_id, start)
         out.append(start)
         emitted_tools.add(call_id)
         seq += 1
@@ -454,6 +518,7 @@ def _emit_python_output(
         "raw_output": payload,
     }
     _attach_timing(update, raw)
+    _apply_span(update, started_at, call_id)
     out.append(update)
     return seq, pending_code
 
@@ -479,12 +544,14 @@ def _utc_now_iso() -> str:
 
 
 def _attach_timing(ev: dict[str, Any], raw: dict[str, Any]) -> None:
-    at = raw.get("at") or raw.get("timestamp") or raw.get("created_at")
-    if isinstance(at, str) and at.strip():
-        ev["at"] = at.strip()
+    at = _coerce_event_at(raw)
+    if at:
+        ev["at"] = at
     for key in ("elapsed_ms", "elapsedMs", "duration_ms", "durationMs"):
         val = raw.get(key)
-        if isinstance(val, bool) or not isinstance(val, int | float) or val < 0:
+        if isinstance(val, bool) or not isinstance(val, int | float):
+            continue
+        if not math.isfinite(val) or val < 0:
             continue
         ev["elapsed_ms"] = float(val)
         break
@@ -494,6 +561,63 @@ def _attach_timing(ev: dict[str, Any], raw: dict[str, Any]) -> None:
     ended = raw.get("ended_at") or raw.get("endedAt")
     if isinstance(ended, str) and ended.strip():
         ev["ended_at"] = ended.strip()
+
+
+def _coerce_event_at(raw: dict[str, Any]) -> str | None:
+    for key in ("timestamp", "created_at", "started_at", "at"):
+        val = raw.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    return None
+
+
+def _remember_start(started_at: dict[str, str], call_id: str, ev: dict[str, Any]) -> None:
+    at = ev.get("started_at") or ev.get("at")
+    if isinstance(at, str) and at and call_id not in started_at:
+        started_at[call_id] = at
+        ev.setdefault("started_at", at)
+
+
+def _apply_span(ev: dict[str, Any], started_at: dict[str, str], call_id: str) -> None:
+    start_iso = ev.get("started_at") if isinstance(ev.get("started_at"), str) else None
+    if not start_iso:
+        start_iso = started_at.get(call_id)
+    if start_iso:
+        ev.setdefault("started_at", start_iso)
+        started_at.setdefault(call_id, start_iso)
+    end_iso = ev.get("ended_at") if isinstance(ev.get("ended_at"), str) else None
+    if not end_iso and isinstance(ev.get("at"), str):
+        end_iso = ev["at"]
+    if end_iso:
+        ev.setdefault("ended_at", end_iso)
+    if ev.get("elapsed_ms") is None and start_iso and end_iso:
+        elapsed = _iso_delta_ms(start_iso, end_iso)
+        if elapsed is not None:
+            ev["elapsed_ms"] = elapsed
+
+
+def _iso_delta_ms(started: str, ended: str) -> float | None:
+    a = _parse_iso(started)
+    b = _parse_iso(ended)
+    if a is None or b is None:
+        return None
+    delta = (b - a).total_seconds() * 1000.0
+    if delta < 0:
+        return 0.0
+    return round(delta, 3)
+
+
+def _parse_iso(value: str) -> datetime | None:
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def _event_manager(agent: Any) -> Any | None:

--- a/skills/bora-cli/SKILL.md
+++ b/skills/bora-cli/SKILL.md
@@ -134,7 +134,7 @@ Value after `=` is JSON (strings need quotes):
 
 - On disk: `<dataset>/.bora/runs/<run_id>/` — Hub-facing curated evidence (`result.json`, `agent/`, `evaluation/`, `artifacts/`, lock/runtime JSON).
 - L1 host sandbox lives at `l1-work/` **during** the Attempt; **default cleanup deletes it**. Use `--keep-workspace` only for local debug. `bora results upload` never packs `l1-work/**`.
-- Inspect trajectory: open `<dataset>/.bora/runs/<run_id>/agent/invocations/<nnnn>-*/trajectory.jsonl` (**turn-level** training rows) and `events.jsonl` (optional stream/debug)
+- Inspect trajectory: open `<dataset>/.bora/runs/<run_id>/agent/invocations/<nnnn>-*/trajectory.jsonl` (**turn-level** training rows) and `events.jsonl` (optional stream/debug). `tool_call` / `observation` may include observational `elapsed_ms` (omit when the adapter had no timing)
 - Export: `uv run bora evidence <dataset>/.bora/runs/<run_id> --out /tmp/bora-export`
 - Trajectory presence **never** upgrades score
 

--- a/skills/bora-cli/references/commands.md
+++ b/skills/bora-cli/references/commands.md
@@ -52,7 +52,9 @@ Stdout JSON (high level):
 - Per invocation (any executor): Core writes `agent/invocations/<nnnn>-*/trajectory.jsonl`
   from `bora.trajectory.event/1` (user + merged assistant/thought + tool/observation +
   terminal). Rows use `session_id` and producer `source` (not `acp_session_id`).
-  Stream chunks are not the training default; see `docs/design/05-runtime/evidence.md`.
+  `tool_call` / `observation` may carry observational `elapsed_ms` when the adapter
+  had timing; missing values are omitted. Stream chunks are not the training default;
+  see `docs/design/05-runtime/evidence.md`.
 - Docker packages use L1 path when `provider.kind: docker`. First-party coding entries
   stay on the parent ACP client + `docker exec` placement; other installed executors
   bind via `bind_to_target`.

--- a/src/bora/adapters/acp/client.py
+++ b/src/bora/adapters/acp/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from contextlib import suppress as contextlib_suppress
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from bora.adapters.acp.usage import _as_plain_mapping
@@ -234,7 +234,7 @@ class _BoraAcpClient:
 
 
 def _utc_now_iso() -> str:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     stamp = now.strftime("%Y-%m-%dT%H:%M:%S")
     if now.microsecond:
         stamp = f"{stamp}.{now.microsecond:06d}".rstrip("0")

--- a/src/bora/adapters/acp/client.py
+++ b/src/bora/adapters/acp/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from contextlib import suppress as contextlib_suppress
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any
 
 from bora.adapters.acp.usage import _as_plain_mapping
@@ -103,7 +104,7 @@ class _BoraAcpClient:
         except Exception:  # noqa: BLE001
             decision["option_id"] = "allow"
         self.permission_decisions.append(decision)
-        self.events.append(decision)
+        self.record(decision)
         return resp
 
     async def session_update(self, session_id: str, update: Any, **kwargs: Any) -> None:
@@ -170,7 +171,7 @@ class _BoraAcpClient:
                 # Keep legacy key for older event consumers (raw UsageUpdate shape).
                 event["usage"] = raw_update
             event["has_usage_update"] = True
-        self.events.append(event)
+        self.record(event)
 
     async def write_text_file(
         self, session_id: str, path: str, content: str, **kwargs: Any
@@ -206,7 +207,7 @@ class _BoraAcpClient:
     async def create_elicitation(self, message: str, mode: Any, **kwargs: Any) -> Any:
         import acp
 
-        self.events.append(
+        self.record(
             {
                 "type": "elicitation",
                 "action": "decline",
@@ -219,11 +220,25 @@ class _BoraAcpClient:
     async def complete_elicitation(self, elicitation_id: str, **kwargs: Any) -> None:
         return None
 
+    def record(self, event: dict[str, Any]) -> None:
+        """Append a vendor event and stamp receive-time ``at`` when missing."""
+        if "at" not in event:
+            event["at"] = _utc_now_iso()
+        self.events.append(event)
+
     async def ext_method(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         return {}
 
     async def ext_notification(self, method: str, params: dict[str, Any]) -> None:
         return None
+
+
+def _utc_now_iso() -> str:
+    now = datetime.now(timezone.utc)
+    stamp = now.strftime("%Y-%m-%dT%H:%M:%S")
+    if now.microsecond:
+        stamp = f"{stamp}.{now.microsecond:06d}".rstrip("0")
+    return stamp + "Z"
 
 
 def _map_stop_reason(stop: str | None) -> tuple[bool, str | None]:

--- a/src/bora/adapters/acp/executor.py
+++ b/src/bora/adapters/acp/executor.py
@@ -273,7 +273,7 @@ class AcpExecutor(AgentExecutor):
                     dumped_prompt = prompt_usage_raw.model_dump(by_alias=True, exclude_none=True)
                     if isinstance(dumped_prompt, dict):
                         event_prompt_usage = dumped_prompt
-            self._client.events.append(
+            self._client.record(
                 {
                     "type": "prompt_usage",
                     "session_id": self._acp_session_id,

--- a/src/bora/adapters/acp/trajectory_map.py
+++ b/src/bora/adapters/acp/trajectory_map.py
@@ -119,6 +119,7 @@ def acp_session_events_to_bora(
             "content": content_text,
             "raw_output": raw_output,
         }
+        _attach_timing(ev, raw, upd)
         out.append(ev)
 
     for call_id, title in longest_title.items():
@@ -142,6 +143,51 @@ def acp_session_events_to_bora(
             }
         )
     return out
+
+
+def _attach_timing(ev: dict[str, Any], raw: dict[str, Any], upd: dict[str, Any]) -> None:
+    """Copy vendor duration / timestamps; fail-open when absent."""
+    at = raw.get("at")
+    if isinstance(at, str) and at.strip():
+        ev["at"] = at
+    meta = upd.get("_meta") if isinstance(upd.get("_meta"), dict) else None
+    if meta is None:
+        meta = upd.get("field_meta") if isinstance(upd.get("field_meta"), dict) else None
+    elapsed = _first_elapsed_ms(upd, meta, raw)
+    if elapsed is not None:
+        ev["elapsed_ms"] = elapsed
+    started = _first_iso(upd, meta, raw, keys=("started_at", "startedAt"))
+    if started is not None:
+        ev["started_at"] = started
+    ended = _first_iso(upd, meta, raw, keys=("ended_at", "endedAt"))
+    if ended is not None:
+        ev["ended_at"] = ended
+
+
+def _first_elapsed_ms(*sources: Any) -> float | None:
+    keys = ("elapsed_ms", "elapsedMs", "duration_ms", "durationMs")
+    for src in sources:
+        if not isinstance(src, dict):
+            continue
+        for key in keys:
+            val = src.get(key)
+            if isinstance(val, bool) or not isinstance(val, int | float):
+                continue
+            if val < 0:
+                continue
+            return float(val)
+    return None
+
+
+def _first_iso(*sources: Any, keys: tuple[str, ...]) -> str | None:
+    for src in sources:
+        if not isinstance(src, dict):
+            continue
+        for key in keys:
+            val = src.get(key)
+            if isinstance(val, str) and val.strip():
+                return val.strip()
+    return None
 
 
 def _session_update_name(ev: dict[str, Any], upd: dict[str, Any]) -> str:

--- a/src/bora/adapters/acp/trajectory_map.py
+++ b/src/bora/adapters/acp/trajectory_map.py
@@ -7,6 +7,7 @@ Core writer after this mapping.
 from __future__ import annotations
 
 import json
+import math
 from typing import Any
 
 from bora.evidence.schema import EVENT_SCHEMA_VERSION
@@ -173,7 +174,7 @@ def _first_elapsed_ms(*sources: Any) -> float | None:
             val = src.get(key)
             if isinstance(val, bool) or not isinstance(val, int | float):
                 continue
-            if val < 0:
+            if not math.isfinite(val) or val < 0:
                 continue
             return float(val)
     return None

--- a/src/bora/application/attempt/run_l0.py
+++ b/src/bora/application/attempt/run_l0.py
@@ -342,6 +342,12 @@ def bind_l0_result(ctx: AttemptStageContext) -> None:
     phase_timing = timer.as_dict()
     result_doc["phase_timing"] = phase_timing
     result_doc["duration"] = format_duration_ms(phase_timing.get("total_ms"))
+    from bora.config.profiles import attach_display_labels
+
+    attach_display_labels(
+        result_doc,
+        thaw(ctx.lock.job_overlay) if ctx.lock.job_overlay is not None else None,
+    )
     from bora.evidence.attempt_record import write_attempt_result
 
     write_attempt_result(ctx.run_dir, result_doc)
@@ -372,6 +378,8 @@ def bind_l0_result(ctx: AttemptStageContext) -> None:
                     "phase_timing": phase_timing,
                     "started_at": phase_timing.get("started_at"),
                     "finished_at": phase_timing.get("finished_at"),
+                    "agent_label": result_doc.get("agent_label") or "",
+                    "model_label": result_doc.get("model_label") or "",
                 }
             )
     if flat.status == "PASS":

--- a/src/bora/application/attempt/run_l1_evidence.py
+++ b/src/bora/application/attempt/run_l1_evidence.py
@@ -131,6 +131,18 @@ def write_l1_evidence(
     from bora.evidence.redaction import RedactionError, redact_and_assert, redact_value
 
     result_doc["l1"] = {**(result_doc.get("l1") or {}), **l1_meta}
+    from bora.config.profiles import attach_display_labels
+
+    lock_doc: dict[str, Any] = {}
+    lock_path = run_dir / "lock.json"
+    if lock_path.is_file():
+        try:
+            loaded = json.loads(lock_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            loaded = None
+        if isinstance(loaded, dict):
+            lock_doc = loaded
+    attach_display_labels(result_doc, lock_doc.get("job_overlay"))
     write_attempt_result(run_dir, result_doc)
     write_attempt_json(run_dir, AGENT_FILENAME, agent_meta)
     # Fail-closed redaction (no string-replace self-confirm).
@@ -159,6 +171,10 @@ def write_l1_evidence(
             summary["finished_at"] = pt.get("finished_at")
     if result_doc.get("duration") is not None:
         summary["duration"] = result_doc.get("duration")
+    if result_doc.get("agent_label"):
+        summary["agent_label"] = result_doc["agent_label"]
+    if result_doc.get("model_label"):
+        summary["model_label"] = result_doc["model_label"]
     (run_dir / "summary.json").write_text(
         json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )

--- a/src/bora/application/suite/suite_config_fingerprint.py
+++ b/src/bora/application/suite/suite_config_fingerprint.py
@@ -82,6 +82,9 @@ def actors_summary_from_profiles(
         row: dict[str, str] = {"profile_id": pid, "entry": entry, "model": model}
         if executor:
             row["executor"] = executor
+        label = str(raw.get("label") or "").strip()
+        if label:
+            row["label"] = label
         if options_s:
             row["options"] = options_s
         rows.append(row)
@@ -292,21 +295,17 @@ def topology_key(actors: Sequence[Mapping[str, str]]) -> str:
 
 
 def derive_labels(actors: Sequence[Mapping[str, str]]) -> tuple[str, str]:
-    """Default agent_label / model_label from actors (suite-level display)."""
+    """Default agent_label / model_label from actors (suite / Jobs / Hub).
+
+    Display only: ``label`` → ACP ``entry`` → ``executor``. Never ``options.agent``.
+    """
+    from bora.config.profiles import display_agent_name, join_display_names
+
     if not actors:
         return "", ""
-    if len(actors) == 1:
-        a = actors[0]
-        agent = a.get("entry") or a.get("profile_id") or ""
-        model = a.get("model") or ""
-        return agent, model
-    agent = "+".join(a.get("profile_id") or a.get("entry") or "?" for a in actors)
-    models = [a.get("model") or "" for a in actors]
-    if all(models) and len(set(models)) == 1:
-        model = models[0]
-    else:
-        model = "+".join(m or "?" for m in models)
-    return agent, model
+    agents = [display_agent_name(a) for a in actors]
+    models = [str(a.get("model") or "").strip() for a in actors]
+    return join_display_names(agents), join_display_names(models)
 
 
 def compute_suite_config_fields(

--- a/src/bora/config/profiles.py
+++ b/src/bora/config/profiles.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import copy
 import re
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -30,7 +30,7 @@ PROFILES_FORMAT = "bora.profiles/1"
 
 # Fields that constitute job binding — forbidden on member task.yaml slots.
 BINDING_FIELD_KEYS = frozenset(
-    {"executor", "model", "options", "api_key", "base_url", "extensions"}
+    {"executor", "model", "options", "api_key", "base_url", "extensions", "label"}
 )
 
 # Allowlisted nested binding override leaves under /bindings/<role_id>/…
@@ -371,6 +371,65 @@ def secret_free_options(options: Mapping[str, Any] | None) -> dict[str, Any]:
     return out
 
 
+def display_agent_name(binding: Mapping[str, Any]) -> str:
+    """Jobs / Hub agent axis. Never reads ``options.agent`` (plugin start path).
+
+    Priority: binding ``label`` → ACP ``options.entry`` → ``executor``.
+    """
+    label = binding.get("label")
+    if isinstance(label, str) and label.strip():
+        return label.strip()
+    executor = str(binding.get("executor") or "").strip()
+    if executor == "acp":
+        options = binding.get("options")
+        if isinstance(options, Mapping):
+            entry = options.get("entry")
+            if entry is not None and str(entry).strip():
+                return str(entry).strip()
+        projected = binding.get("entry")
+        if isinstance(projected, str) and projected.strip():
+            return projected.strip()
+        return executor
+    return executor
+
+
+def join_display_names(names: Sequence[str]) -> str:
+    """Collapse identical names; join distinct ones with ``+`` (UI may shorten)."""
+    cleaned = [n.strip() for n in names if isinstance(n, str) and n.strip()]
+    if not cleaned:
+        return ""
+    if len(set(cleaned)) == 1:
+        return cleaned[0]
+    return "+".join(cleaned)
+
+
+def display_labels_from_overlay(overlay: Mapping[str, Any] | None) -> tuple[str, str]:
+    """``(agent_label, model_label)`` from secret-free ``job_overlay``."""
+    if not isinstance(overlay, Mapping):
+        return "", ""
+    bindings = overlay.get("bindings")
+    if not isinstance(bindings, Mapping) or not bindings:
+        return "", ""
+    agents: list[str] = []
+    models: list[str] = []
+    for raw in bindings.values():
+        if not isinstance(raw, Mapping):
+            continue
+        agents.append(display_agent_name(raw))
+        model = raw.get("model")
+        models.append(model.strip() if isinstance(model, str) else "")
+    return join_display_names(agents), join_display_names(models)
+
+
+def attach_display_labels(doc: dict[str, Any], overlay: Mapping[str, Any] | None) -> None:
+    """Write sealed ``agent_label`` / ``model_label`` onto result or summary."""
+    agent, model = display_labels_from_overlay(overlay)
+    if agent:
+        doc["agent_label"] = agent
+    if model:
+        doc["model_label"] = model
+
+
 def project_job_overlay(
     bindings: Mapping[str, Mapping[str, Any]],
     *,
@@ -387,7 +446,7 @@ def project_job_overlay(
         if not isinstance(raw, Mapping):
             continue
         row: dict[str, Any] = {}
-        for k in ("executor", "model", "base_url", "api_key"):
+        for k in ("executor", "model", "base_url", "api_key", "label"):
             if k in raw and raw[k] is not None:
                 row[k] = raw[k]
         options = secret_free_options(

--- a/src/bora/evidence/trajectory.py
+++ b/src/bora/evidence/trajectory.py
@@ -7,6 +7,7 @@ folds those events into Viewer/Hub turn steps. Observational — never PASS.
 from __future__ import annotations
 
 import json
+import math
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -279,8 +280,8 @@ def _should_emit_observation(state: dict[str, Any]) -> bool:
 
 
 def _copy_timing(row: dict[str, Any], state: dict[str, Any]) -> None:
-    elapsed = state.get("elapsed_ms")
-    if isinstance(elapsed, int | float) and not isinstance(elapsed, bool):
+    elapsed = _coerce_elapsed_ms(state.get("elapsed_ms"))
+    if elapsed is not None:
         row["elapsed_ms"] = elapsed
     started = state.get("started_at")
     if isinstance(started, str) and started:
@@ -302,13 +303,15 @@ def _merge_timing(state: dict[str, Any], ev: dict[str, Any]) -> None:
     ended = _coerce_iso(ev.get("ended_at"))
     if ended is not None:
         state["ended_at"] = ended
+        state["ended_at_explicit"] = True
 
     at = _coerce_iso(ev.get("at"))
     if at is None:
         return
     if state.get("started_at") is None:
         state["started_at"] = at
-    state["ended_at"] = at
+    if not state.get("ended_at_explicit"):
+        state["ended_at"] = at
 
 
 def _finalize_timing(state: dict[str, Any]) -> None:
@@ -327,7 +330,7 @@ def _finalize_timing(state: dict[str, Any]) -> None:
 def _coerce_elapsed_ms(value: Any) -> float | None:
     if isinstance(value, bool) or not isinstance(value, int | float):
         return None
-    if value < 0:
+    if not math.isfinite(value) or value < 0:
         return None
     return float(value)
 

--- a/src/bora/evidence/trajectory.py
+++ b/src/bora/evidence/trajectory.py
@@ -7,7 +7,7 @@ folds those events into Viewer/Hub turn steps. Observational — never PASS.
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -350,12 +350,12 @@ def _parse_iso(value: Any) -> datetime | None:
     except ValueError:
         return None
     if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
 
 
 def _format_iso(value: datetime) -> str:
-    utc = value.astimezone(timezone.utc)
+    utc = value.astimezone(UTC)
     stamp = utc.strftime("%Y-%m-%dT%H:%M:%S")
     micros = utc.microsecond
     if micros:

--- a/src/bora/evidence/trajectory.py
+++ b/src/bora/evidence/trajectory.py
@@ -43,6 +43,9 @@ def write_trajectory_jsonl(
 
     thought_parts: list[str] = []
     assistant_parts: list[str] = []
+    thought_timing: dict[str, Any] = {}
+    assistant_timing: dict[str, Any] = {}
+    last_text_timing: dict[str, Any] = {}
     permission_events: list[dict[str, Any]] = []
     tool_states: dict[str, dict[str, Any]] = {}
     session_id: str | None = None
@@ -63,8 +66,14 @@ def write_trajectory_jsonl(
             channel = ev.get("channel")
             if channel == "thought" and text:
                 thought_parts.append(text)
+                _accumulate_text_timing(thought_timing, ev)
+                last_text_timing = {}
+                _accumulate_text_timing(last_text_timing, ev)
             elif channel == "assistant" and text:
                 assistant_parts.append(text)
+                _accumulate_text_timing(assistant_timing, ev)
+                last_text_timing = {}
+                _accumulate_text_timing(last_text_timing, ev)
         elif kind == "tool":
             _merge_tool(tool_states, ev)
         elif kind == "permission":
@@ -106,17 +115,17 @@ def write_trajectory_jsonl(
         }
     ]
     if merged_thought:
-        lines.append(
-            {
-                "type": "turn",
-                "role": "assistant",
-                "part": "thought",
-                "content": merged_thought,
-                "turn_index": turn_index,
-                "session_id": session_id,
-                "source": producer,
-            }
-        )
+        thought_line: dict[str, Any] = {
+            "type": "turn",
+            "role": "assistant",
+            "part": "thought",
+            "content": merged_thought,
+            "turn_index": turn_index,
+            "session_id": session_id,
+            "source": producer,
+        }
+        _copy_timing(thought_line, thought_timing)
+        lines.append(_drop_nulls(thought_line, keep={"type", "role", "turn_index", "source"}))
 
     for call_id, state in tool_states.items():
         _finalize_tool_state(state)
@@ -153,16 +162,22 @@ def write_trajectory_jsonl(
             _copy_timing(obs, state)
             lines.append(_drop_nulls(obs, keep={"type", "tool_call_id", "turn_index", "source"}))
 
-    lines.append(
-        {
-            "type": "turn",
-            "role": "assistant",
-            "content": merged_assistant,
-            "turn_index": turn_index,
-            "session_id": session_id,
-            "source": producer,
-        }
-    )
+    assistant_line: dict[str, Any] = {
+        "type": "turn",
+        "role": "assistant",
+        "content": merged_assistant,
+        "turn_index": turn_index,
+        "session_id": session_id,
+        "source": producer,
+    }
+    # Final agent bubble is often final_text with no timed assistant-channel
+    # event (nooa return_result / dsh reply after a thought). Use the last
+    # timed text burst so the visible reply is not blank.
+    if _coerce_elapsed_ms(assistant_timing.get("elapsed_ms")) in (None, 0.0):
+        _copy_timing(assistant_line, last_text_timing)
+    else:
+        _copy_timing(assistant_line, assistant_timing)
+    lines.append(_drop_nulls(assistant_line, keep={"type", "role", "turn_index", "source"}))
     for pe in permission_events:
         pe = {**pe, "turn_index": turn_index, "session_id": session_id}
         lines.append(pe)
@@ -281,7 +296,7 @@ def _should_emit_observation(state: dict[str, Any]) -> bool:
 
 def _copy_timing(row: dict[str, Any], state: dict[str, Any]) -> None:
     elapsed = _coerce_elapsed_ms(state.get("elapsed_ms"))
-    if elapsed is not None:
+    if elapsed is not None and elapsed > 0:
         row["elapsed_ms"] = elapsed
     started = state.get("started_at")
     if isinstance(started, str) and started:
@@ -289,6 +304,20 @@ def _copy_timing(row: dict[str, Any], state: dict[str, Any]) -> None:
     ended = state.get("ended_at")
     if isinstance(ended, str) and ended:
         row["ended_at"] = ended
+
+
+def _accumulate_text_timing(state: dict[str, Any], ev: dict[str, Any]) -> None:
+    """Sum observational LLM/step duration onto the merged thought/assistant turn."""
+    elapsed = _coerce_elapsed_ms(ev.get("elapsed_ms"))
+    if elapsed is not None and elapsed > 0:
+        prev = _coerce_elapsed_ms(state.get("elapsed_ms")) or 0.0
+        state["elapsed_ms"] = prev + elapsed
+    started = _coerce_iso(ev.get("started_at") or ev.get("at"))
+    if started is not None and state.get("started_at") is None:
+        state["started_at"] = started
+    ended = _coerce_iso(ev.get("ended_at") or ev.get("at"))
+    if ended is not None:
+        state["ended_at"] = ended
 
 
 def _merge_timing(state: dict[str, Any], ev: dict[str, Any]) -> None:

--- a/src/bora/evidence/trajectory.py
+++ b/src/bora/evidence/trajectory.py
@@ -7,6 +7,7 @@ folds those events into Viewer/Hub turn steps. Observational — never PASS.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -132,6 +133,7 @@ def write_trajectory_jsonl(
         args = state.get("args")
         if args is not None:
             tool_line["args"] = args
+        _copy_timing(tool_line, state)
         lines.append(_drop_nulls(tool_line, keep={"type", "tool_call_id", "turn_index", "source"}))
 
         if _should_emit_observation(state):
@@ -147,6 +149,7 @@ def write_trajectory_jsonl(
                 obs["content"] = state["content"]
             if state.get("raw_output") is not None:
                 obs["raw_output"] = state["raw_output"]
+            _copy_timing(obs, state)
             lines.append(_drop_nulls(obs, keep={"type", "tool_call_id", "turn_index", "source"}))
 
     lines.append(
@@ -243,6 +246,8 @@ def _merge_tool(tool_states: dict[str, dict[str, Any]], ev: dict[str, Any]) -> N
         if not chunks or chunks[-1] != content:
             chunks.append(content)
 
+    _merge_timing(state, ev)
+
 
 def _finalize_tool_state(state: dict[str, Any]) -> None:
     if not state.get("function_name") or state.get("function_name") == "tool":
@@ -261,6 +266,7 @@ def _finalize_tool_state(state: dict[str, Any]) -> None:
         state["content"] = "\n\n".join(chunks)
     if state.get("args") is None:
         state["args"] = {}
+    _finalize_timing(state)
 
 
 def _should_emit_observation(state: dict[str, Any]) -> bool:
@@ -270,3 +276,88 @@ def _should_emit_observation(state: dict[str, Any]) -> bool:
         return True
     status = state.get("status")
     return isinstance(status, str) and status.lower() in {"completed", "failed"}
+
+
+def _copy_timing(row: dict[str, Any], state: dict[str, Any]) -> None:
+    elapsed = state.get("elapsed_ms")
+    if isinstance(elapsed, int | float) and not isinstance(elapsed, bool):
+        row["elapsed_ms"] = elapsed
+    started = state.get("started_at")
+    if isinstance(started, str) and started:
+        row["started_at"] = started
+    ended = state.get("ended_at")
+    if isinstance(ended, str) and ended:
+        row["ended_at"] = ended
+
+
+def _merge_timing(state: dict[str, Any], ev: dict[str, Any]) -> None:
+    elapsed = _coerce_elapsed_ms(ev.get("elapsed_ms"))
+    if elapsed is not None:
+        state["elapsed_ms"] = elapsed
+
+    started = _coerce_iso(ev.get("started_at"))
+    if started is not None and state.get("started_at") is None:
+        state["started_at"] = started
+
+    ended = _coerce_iso(ev.get("ended_at"))
+    if ended is not None:
+        state["ended_at"] = ended
+
+    at = _coerce_iso(ev.get("at"))
+    if at is None:
+        return
+    if state.get("started_at") is None:
+        state["started_at"] = at
+    state["ended_at"] = at
+
+
+def _finalize_timing(state: dict[str, Any]) -> None:
+    if state.get("elapsed_ms") is not None:
+        return
+    started = _parse_iso(state.get("started_at"))
+    ended = _parse_iso(state.get("ended_at"))
+    if started is None or ended is None:
+        return
+    delta_ms = (ended - started).total_seconds() * 1000.0
+    if delta_ms < 0:
+        delta_ms = 0.0
+    state["elapsed_ms"] = round(delta_ms, 3)
+
+
+def _coerce_elapsed_ms(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    if value < 0:
+        return None
+    return float(value)
+
+
+def _coerce_iso(value: Any) -> str | None:
+    parsed = _parse_iso(value)
+    if parsed is None:
+        return None
+    return _format_iso(parsed)
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_iso(value: datetime) -> str:
+    utc = value.astimezone(timezone.utc)
+    stamp = utc.strftime("%Y-%m-%dT%H:%M:%S")
+    micros = utc.microsecond
+    if micros:
+        stamp = f"{stamp}.{micros:06d}".rstrip("0")
+    return stamp + "Z"

--- a/src/bora/viewer/jobs.py
+++ b/src/bora/viewer/jobs.py
@@ -294,6 +294,46 @@ def _read_json_object(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
+def _started_from_evidence(evidence: Path, result: dict[str, Any] | None = None) -> str | None:
+    """Single-task result.json has no created_at; wall start lives on phase_timing."""
+    src = result if isinstance(result, dict) else {}
+    for key in ("created_at", "started_at"):
+        val = src.get(key)
+        if isinstance(val, str) and val.strip():
+            return val
+    pt = src.get("phase_timing")
+    if isinstance(pt, dict):
+        val = pt.get("started_at")
+        if isinstance(val, str) and val.strip():
+            return val
+    summary = _read_json_object(evidence / "summary.json") or {}
+    for key in ("started_at", "created_at"):
+        val = summary.get(key)
+        if isinstance(val, str) and val.strip():
+            return val
+    spt = summary.get("phase_timing")
+    if isinstance(spt, dict):
+        val = spt.get("started_at")
+        if isinstance(val, str) and val.strip():
+            return val
+    return None
+
+
+def _labels_from_lock(lock: dict[str, Any], result: dict[str, Any]) -> tuple[str, str]:
+    """Prefer sealed result labels; else Core display_labels_from_overlay."""
+    from bora.config.profiles import display_labels_from_overlay
+
+    agent = result.get("agent_label") or lock.get("agent_label")
+    model = result.get("model_label") or lock.get("model_label")
+    a = agent.strip() if isinstance(agent, str) else ""
+    m = model.strip() if isinstance(model, str) else ""
+    if a and m:
+        return a, m
+    overlay = lock.get("job_overlay") if isinstance(lock.get("job_overlay"), dict) else None
+    derived_a, derived_m = display_labels_from_overlay(overlay)
+    return a or derived_a, m or derived_m
+
+
 def _single_job_row(evidence: Path, *, run_id: str, database_root: Path) -> dict[str, Any]:
     from bora.evidence.attempt_record import read_attempt_result
 
@@ -302,7 +342,8 @@ def _single_job_row(evidence: Path, *, run_id: str, database_root: Path) -> dict
     task_id = str(result.get("task_id") or lock.get("task_id") or "")
     status = str(result.get("status") or result.get("verdict") or "")
     score = result.get("score")
-    started = result.get("created_at") or result.get("started_at")
+    started = _started_from_evidence(evidence, result)
+    agent_label, model_label = _labels_from_lock(lock, result)
     man = None
     with contextlib.suppress(ConfigError):
         man = load_database_manifest(database_root)
@@ -313,8 +354,8 @@ def _single_job_row(evidence: Path, *, run_id: str, database_root: Path) -> dict
         "source": task_id or "single",
         "database_id": man.database_id if man else None,
         "database_version": man.version if man else None,
-        "agent_label": str(lock.get("agent_label") or result.get("agent_label") or ""),
-        "model_label": str(lock.get("model_label") or result.get("model_label") or ""),
+        "agent_label": agent_label,
+        "model_label": model_label,
         "provider_label": str(lock.get("provider_label") or result.get("provider_label") or ""),
         "environment": str(result.get("environment") or "local"),
         "result": score,
@@ -501,6 +542,7 @@ def _get_single_job(root: Path, job_id: str) -> dict[str, Any]:
                     "score": job.get("score"),
                     "exit_code": job.get("exit_code"),
                     "duration": job.get("duration"),
+                    "started": job.get("started"),
                 }
             ],
             "error": None,

--- a/src/bora/viewer/trials/surface.py
+++ b/src/bora/viewer/trials/surface.py
@@ -76,14 +76,20 @@ def _available_tabs(evidence: Path) -> list[str]:
 
 
 def _profile_variant(profile: dict[str, Any]) -> str | None:
-    """Lock options variant: ACP entry, else plugin agent/label, else none."""
+    """Lock display variant: binding label, else ACP entry. Never options.agent."""
+    label = profile.get("label")
+    if isinstance(label, str) and label.strip():
+        return label.strip()
     opts = profile.get("options") if isinstance(profile.get("options"), dict) else {}
     if not isinstance(opts, dict):
         return None
-    for key in ("entry", "agent", "label"):
-        val = opts.get(key)
-        if isinstance(val, str) and val.strip():
-            return val.strip()
+    val = opts.get("label")
+    if isinstance(val, str) and val.strip():
+        return val.strip()
+    if str(profile.get("executor") or "").strip() == "acp":
+        entry = opts.get("entry")
+        if isinstance(entry, str) and entry.strip():
+            return entry.strip()
     return None
 
 
@@ -294,6 +300,9 @@ def _trial_meta_from_evidence(
             duration = format_duration_ms(float(total_ms))
     started = (
         summary.get("started_at")
+        or summary.get("created_at")
+        or result.get("started_at")
+        or result.get("created_at")
         or (phase_timing or {}).get("started_at")
         or suite_row.get("started")
     )

--- a/src/bora/viewer/trials/trajectory.py
+++ b/src/bora/viewer/trials/trajectory.py
@@ -214,6 +214,18 @@ def _parse_trajectory_jsonl(path: Path) -> list[dict[str, Any]]:
                         "raw_output": raw_output
                         if isinstance(raw_output, (dict, list, str))
                         else None,
+                        "elapsed_ms": (
+                            obj.get("elapsed_ms")
+                            if isinstance(obj.get("elapsed_ms"), (int, float))
+                            and not isinstance(obj.get("elapsed_ms"), bool)
+                            else None
+                        ),
+                        "started_at": obj.get("started_at")
+                        if isinstance(obj.get("started_at"), str)
+                        else None,
+                        "ended_at": obj.get("ended_at")
+                        if isinstance(obj.get("ended_at"), str)
+                        else None,
                         # permission_decision summary fields
                         "outcome": obj.get("outcome"),
                         "option_id": obj.get("option_id"),

--- a/tests/adapters/test_trajectory_tool_observation.py
+++ b/tests/adapters/test_trajectory_tool_observation.py
@@ -498,6 +498,46 @@ def test_writer_omits_timing_when_absent(tmp_path: Path) -> None:
     assert "ended_at" not in tool
 
 
+def test_acp_mapper_copies_vendor_elapsed_and_at(tmp_path: Path) -> None:
+    events = (
+        {
+            "type": "session_update",
+            "session_id": "s1",
+            "at": "2026-08-14T12:00:00Z",
+            "update": {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "c1",
+                "title": "ls",
+                "kind": "execute",
+                "status": "pending",
+                "rawInput": {"command": "ls"},
+                "startedAt": "2026-08-14T12:00:00Z",
+            },
+        },
+        {
+            "type": "session_update",
+            "session_id": "s1",
+            "at": "2026-08-14T12:00:01.5Z",
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "c1",
+                "status": "completed",
+                "content": [{"type": "content", "content": {"type": "text", "text": "ok"}}],
+                "durationMs": 1500,
+                "endedAt": "2026-08-14T12:00:01.5Z",
+            },
+        },
+    )
+    mapped = acp_session_events_to_bora(events)
+    tools = [e for e in mapped if e.get("kind") == "tool"]
+    assert tools[0]["at"] == "2026-08-14T12:00:00Z"
+    assert tools[0]["started_at"] == "2026-08-14T12:00:00Z"
+    assert tools[-1]["elapsed_ms"] == 1500.0
+    path = _write(tmp_path, events=mapped, prompt="p", final_text="done")
+    tool = next(x for x in _read_lines(path) if x["type"] == "tool_call")
+    assert tool["elapsed_ms"] == 1500.0
+
+
 def test_writer_drops_invalid_timing(tmp_path: Path) -> None:
     events = (
         {

--- a/tests/adapters/test_trajectory_tool_observation.py
+++ b/tests/adapters/test_trajectory_tool_observation.py
@@ -538,6 +538,58 @@ def test_acp_mapper_copies_vendor_elapsed_and_at(tmp_path: Path) -> None:
     assert tool["elapsed_ms"] == 1500.0
 
 
+def test_writer_keeps_explicit_ended_at_over_later_at(tmp_path: Path) -> None:
+    events = (
+        {
+            "schema": EVENT_SCHEMA_VERSION,
+            "seq": 1,
+            "source": "acp",
+            "kind": "tool",
+            "phase": "start",
+            "tool_call_id": "c1",
+            "function_name": "read",
+            "started_at": "2026-08-14T12:00:00Z",
+            "at": "2026-08-14T12:00:00Z",
+        },
+        {
+            "schema": EVENT_SCHEMA_VERSION,
+            "seq": 2,
+            "source": "acp",
+            "kind": "tool",
+            "phase": "update",
+            "tool_call_id": "c1",
+            "status": "completed",
+            "content": "body",
+            "ended_at": "2026-08-14T12:00:01Z",
+            "at": "2026-08-14T12:00:03Z",
+        },
+    )
+    path = _write(tmp_path, events=events, prompt="p", final_text="done")
+    tool = next(x for x in _read_lines(path) if x["type"] == "tool_call")
+    assert tool["ended_at"] == "2026-08-14T12:00:01Z"
+    assert tool["elapsed_ms"] == 1000.0
+
+
+def test_writer_drops_nonfinite_elapsed_ms(tmp_path: Path) -> None:
+    events = (
+        {
+            "schema": EVENT_SCHEMA_VERSION,
+            "seq": 1,
+            "source": "acp",
+            "kind": "tool",
+            "phase": "update",
+            "tool_call_id": "c1",
+            "function_name": "read",
+            "status": "completed",
+            "content": "x",
+            "elapsed_ms": float("inf"),
+        },
+    )
+    path = _write(tmp_path, events=events, prompt="p", final_text="done")
+    tool = next(x for x in _read_lines(path) if x["type"] == "tool_call")
+    assert "elapsed_ms" not in tool
+
+
 def test_writer_drops_invalid_timing(tmp_path: Path) -> None:
     events = (
         {

--- a/tests/adapters/test_trajectory_tool_observation.py
+++ b/tests/adapters/test_trajectory_tool_observation.py
@@ -403,3 +403,118 @@ def test_opaque_not_folded(tmp_path: Path) -> None:
     lines = _read_lines(path)
     assert [x["type"] for x in lines] == ["turn", "turn", "terminal"]
     assert lines[1]["source"] == "nooa"
+
+
+def test_writer_copies_elapsed_ms_onto_tool_and_observation(tmp_path: Path) -> None:
+    events = (
+        {
+            "schema": EVENT_SCHEMA_VERSION,
+            "seq": 1,
+            "source": "acp",
+            "kind": "tool",
+            "phase": "start",
+            "tool_call_id": "c1",
+            "title": "ls",
+            "function_name": "execute",
+            "tool_kind": "execute",
+            "status": "pending",
+            "args": {"command": "ls"},
+            "started_at": "2026-08-14T12:00:00Z",
+        },
+        {
+            "schema": EVENT_SCHEMA_VERSION,
+            "seq": 2,
+            "source": "acp",
+            "kind": "tool",
+            "phase": "update",
+            "tool_call_id": "c1",
+            "status": "completed",
+            "content": "ok",
+            "elapsed_ms": 1420.5,
+            "ended_at": "2026-08-14T12:00:01.420Z",
+        },
+    )
+    path = _write(tmp_path, events=events, prompt="p", final_text="done")
+    lines = _read_lines(path)
+    tool = next(x for x in lines if x["type"] == "tool_call")
+    obs = next(x for x in lines if x["type"] == "observation")
+    assert tool["elapsed_ms"] == 1420.5
+    assert tool["started_at"] == "2026-08-14T12:00:00Z"
+    assert tool["ended_at"] == "2026-08-14T12:00:01.42Z"
+    assert obs["elapsed_ms"] == 1420.5
+    assert obs["started_at"] == tool["started_at"]
+    assert "elapsed_ms" not in next(x for x in lines if x["type"] == "terminal")
+
+
+def test_writer_derives_elapsed_ms_from_started_and_ended(tmp_path: Path) -> None:
+    events = (
+        {
+            "schema": EVENT_SCHEMA_VERSION,
+            "seq": 1,
+            "source": "acp",
+            "kind": "tool",
+            "phase": "start",
+            "tool_call_id": "c1",
+            "function_name": "read",
+            "at": "2026-08-14T12:00:00.000Z",
+        },
+        {
+            "schema": EVENT_SCHEMA_VERSION,
+            "seq": 2,
+            "source": "acp",
+            "kind": "tool",
+            "phase": "update",
+            "tool_call_id": "c1",
+            "status": "completed",
+            "content": "body",
+            "at": "2026-08-14T12:00:02.250Z",
+        },
+    )
+    path = _write(tmp_path, events=events, prompt="p", final_text="done")
+    tool = next(x for x in _read_lines(path) if x["type"] == "tool_call")
+    assert tool["elapsed_ms"] == 2250.0
+    assert tool["started_at"] == "2026-08-14T12:00:00Z"
+    assert tool["ended_at"] == "2026-08-14T12:00:02.25Z"
+
+
+def test_writer_omits_timing_when_absent(tmp_path: Path) -> None:
+    events = (
+        {
+            "schema": EVENT_SCHEMA_VERSION,
+            "seq": 1,
+            "source": "acp",
+            "kind": "tool",
+            "phase": "start",
+            "tool_call_id": "c1",
+            "function_name": "read",
+            "status": "completed",
+            "content": "x",
+        },
+    )
+    path = _write(tmp_path, events=events, prompt="p", final_text="done")
+    tool = next(x for x in _read_lines(path) if x["type"] == "tool_call")
+    assert "elapsed_ms" not in tool
+    assert "started_at" not in tool
+    assert "ended_at" not in tool
+
+
+def test_writer_drops_invalid_timing(tmp_path: Path) -> None:
+    events = (
+        {
+            "schema": EVENT_SCHEMA_VERSION,
+            "seq": 1,
+            "source": "acp",
+            "kind": "tool",
+            "phase": "start",
+            "tool_call_id": "c1",
+            "function_name": "read",
+            "elapsed_ms": -3,
+            "started_at": "not-a-time",
+            "status": "completed",
+            "content": "x",
+        },
+    )
+    path = _write(tmp_path, events=events, prompt="p", final_text="done")
+    tool = next(x for x in _read_lines(path) if x["type"] == "tool_call")
+    assert "elapsed_ms" not in tool
+    assert "started_at" not in tool

--- a/tests/application/test_suite_config_fingerprint.py
+++ b/tests/application/test_suite_config_fingerprint.py
@@ -148,6 +148,22 @@ def test_homogeneous_true_identical_topology() -> None:
     assert fields["model_label"] == "x"
 
 
+def test_derive_labels_nooa_uses_executor_not_options_agent() -> None:
+    a = actors_summary_from_profiles(
+        [
+            {
+                "id": "solver",
+                "executor": "nooa",
+                "model": "openai/glm-5.2",
+                "options": {"agent": "lib.agents:JsonlAggAgent"},
+            }
+        ]
+    )
+    fields = compute_suite_config_fields([a])
+    assert fields["agent_label"] == "nooa"
+    assert fields["model_label"] == "openai/glm-5.2"
+
+
 def test_empty_agent_tasks_do_not_break_fallback_homogeneity() -> None:
     """No-agent tasks + identical agent tasks remain homogeneous (fallback path)."""
     solo = actors_summary_from_profiles(

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -14,6 +14,9 @@ from bora.config.load_and_lock import ConfigCore
 from bora.config.model import thaw
 from bora.config.profiles import (
     assert_slots_have_no_inline_binding,
+    display_agent_name,
+    display_labels_from_overlay,
+    join_display_names,
     load_profiles_document,
     merge_bindings_onto_slots,
     project_job_overlay,
@@ -219,3 +222,46 @@ def test_job_overlay_keeps_plugin_options() -> None:
     assert opts["method"] == "run"
     assert "command" not in opts
     assert "_acp_lock" not in opts
+
+
+def test_display_agent_name_never_uses_options_agent() -> None:
+    assert (
+        display_agent_name(
+            {
+                "executor": "nooa",
+                "options": {"agent": "lib.agents:JsonlAggAgent"},
+            }
+        )
+        == "nooa"
+    )
+    assert (
+        display_agent_name(
+            {
+                "executor": "nooa",
+                "label": "nooa",
+                "options": {"agent": "lib.agents:JsonlAggAgent"},
+            }
+        )
+        == "nooa"
+    )
+    assert display_agent_name({"executor": "acp", "options": {"entry": "pi"}}) == "pi"
+    assert display_agent_name({"executor": "dsh"}) == "dsh"
+
+
+def test_display_labels_from_overlay_joins_distinct() -> None:
+    agent, model = display_labels_from_overlay(
+        {
+            "bindings": {
+                "a": {"executor": "acp", "options": {"entry": "pi"}, "model": "m1"},
+                "b": {"executor": "dsh", "model": "m2"},
+            }
+        }
+    )
+    assert agent == "pi+dsh"
+    assert model == "m1+m2"
+    assert join_display_names(["nooa", "nooa"]) == "nooa"
+
+
+def test_project_job_overlay_keeps_label() -> None:
+    overlay = project_job_overlay({"solver": {"executor": "nooa", "label": "nooa", "model": "x"}})
+    assert overlay["bindings"]["solver"]["label"] == "nooa"

--- a/tests/plugins/test_dsh_trajectory_map.py
+++ b/tests/plugins/test_dsh_trajectory_map.py
@@ -190,3 +190,37 @@ def test_foreign_wrapped_event_unwraps() -> None:
     )
     assert mapped[0]["function_name"] == "read_file"
     assert mapped[0]["args"]["path"] == "a"
+
+
+def test_tool_result_copies_vendor_elapsed_ms() -> None:
+    mapped = to_bora_trajectory_events(
+        (
+            {
+                "type": "tool/call",
+                "timestamp": "2026-08-14T12:00:00Z",
+                "data": {"callId": "c1", "name": "bash", "arguments": {"command": "echo"}},
+            },
+            {
+                "type": "tool/result",
+                "timestamp": "2026-08-14T12:00:01Z",
+                "data": {
+                    "elapsed_ms": 1000,
+                    "message": {
+                        "source": {"kind": "tool", "callId": "c1"},
+                        "content": [
+                            {
+                                "type": "tool-result",
+                                "toolCallId": "c1",
+                                "content": [{"type": "text", "text": "ok"}],
+                            }
+                        ],
+                    },
+                },
+            },
+        )
+    )
+    start = next(e for e in mapped if e.get("phase") == "start")
+    update = next(e for e in mapped if e.get("phase") == "update")
+    assert start["at"] == "2026-08-14T12:00:00Z"
+    assert update["elapsed_ms"] == 1000.0
+    assert update["at"] == "2026-08-14T12:00:01Z"

--- a/tests/plugins/test_dsh_trajectory_map.py
+++ b/tests/plugins/test_dsh_trajectory_map.py
@@ -192,6 +192,43 @@ def test_foreign_wrapped_event_unwraps() -> None:
     assert mapped[0]["args"]["path"] == "a"
 
 
+def test_tool_result_derives_elapsed_from_epoch_time() -> None:
+    mapped = to_bora_trajectory_events(
+        (
+            {
+                "type": "tool/call",
+                "seq": 10,
+                "time": 1_786_675_378_287,
+                "data": {"callId": "c1", "name": "bash", "arguments": {"command": "ls"}},
+            },
+            {
+                "type": "tool/result",
+                "seq": 11,
+                "time": 1_786_675_378_347,
+                "sourceEventSeqs": [10],
+                "data": {
+                    "message": {
+                        "source": {"kind": "tool", "callId": "c1"},
+                        "content": [
+                            {
+                                "type": "tool-result",
+                                "toolCallId": "c1",
+                                "content": [{"type": "text", "text": "ok"}],
+                            }
+                        ],
+                    },
+                },
+            },
+        )
+    )
+    start = next(e for e in mapped if e.get("phase") == "start")
+    update = next(e for e in mapped if e.get("phase") == "update")
+    assert start["at"]
+    assert update["elapsed_ms"] == 60.0
+    assert update["started_at"] == start["at"]
+    assert update["ended_at"] == update["at"]
+
+
 def test_tool_result_copies_vendor_elapsed_ms() -> None:
     mapped = to_bora_trajectory_events(
         (

--- a/tests/plugins/test_dsh_trajectory_map.py
+++ b/tests/plugins/test_dsh_trajectory_map.py
@@ -192,6 +192,45 @@ def test_foreign_wrapped_event_unwraps() -> None:
     assert mapped[0]["args"]["path"] == "a"
 
 
+def test_assistant_elapsed_from_step_start() -> None:
+    mapped = to_bora_trajectory_events(
+        (
+            {"type": "step/start", "time": 1_786_675_378_000, "data": {"step": 1}},
+            {
+                "type": "assistant/message",
+                "time": 1_786_675_379_250,
+                "data": {"message": {"content": [{"type": "text", "text": "working"}]}},
+            },
+            {
+                "type": "tool/call",
+                "time": 1_786_675_379_251,
+                "data": {"callId": "c1", "name": "bash", "arguments": {"command": "ls"}},
+            },
+            {
+                "type": "tool/result",
+                "time": 1_786_675_379_271,
+                "data": {
+                    "message": {
+                        "source": {"kind": "tool", "callId": "c1"},
+                        "content": [
+                            {
+                                "type": "tool-result",
+                                "toolCallId": "c1",
+                                "content": [{"type": "text", "text": "ok"}],
+                            }
+                        ],
+                    }
+                },
+            },
+        )
+    )
+    texts = [e for e in mapped if e.get("kind") == "text"]
+    assert texts[-1]["channel"] == "assistant"
+    assert texts[-1]["elapsed_ms"] == 1250.0
+    update = next(e for e in mapped if e.get("phase") == "update")
+    assert update["elapsed_ms"] == 20.0
+
+
 def test_tool_result_derives_elapsed_from_epoch_time() -> None:
     mapped = to_bora_trajectory_events(
         (

--- a/tests/plugins/test_nooa_trajectory_map.py
+++ b/tests/plugins/test_nooa_trajectory_map.py
@@ -85,6 +85,120 @@ def test_tool_call_event_with_result() -> None:
     assert mapped[0]["args"] == {"path": "/tmp/a"}
 
 
+def test_python_output_derives_elapsed_from_vendor_timestamp() -> None:
+    mapped = to_bora_trajectory_events(
+        (
+            {
+                "event_type": "ToolCallEvent",
+                "id": "vendor-1",
+                "tool_call_id": "c1",
+                "name": "execute_python",
+                "arguments": {"code": "print(1)"},
+                "timestamp": "2026-08-14T12:00:00.000Z",
+                "at": "2026-08-14T12:00:59Z",
+            },
+            {
+                "event_type": "PythonOutput",
+                "id": "vendor-1-out",
+                "tool_call_id": "c1",
+                "execution_status": "complete",
+                "stdout": "1\n",
+                "timestamp": "2026-08-14T12:00:01.250Z",
+                "at": "2026-08-14T12:00:59Z",
+            },
+        )
+    )
+    start = next(e for e in mapped if e.get("phase") == "start")
+    update = next(e for e in mapped if e.get("phase") == "update")
+    assert start["at"] == "2026-08-14T12:00:00.000Z"
+    assert update["elapsed_ms"] == 1250.0
+
+
+def test_mapper_skips_tap_duplicates_when_vendor_tools_exist() -> None:
+    mapped = to_bora_trajectory_events(
+        (
+            {
+                "event_type": "ToolCallEvent",
+                "id": "tap_py_4",
+                "tool_call_id": "tap_py_4",
+                "name": "execute_python",
+                "at": "2026-08-14T12:00:00.000Z",
+            },
+            {
+                "event_type": "PythonOutput",
+                "id": "tap_py_4_out",
+                "tool_call_id": "tap_py_4",
+                "execution_status": "complete",
+                "stdout": "x",
+                "at": "2026-08-14T12:00:00.001Z",
+            },
+            {
+                "event_type": "ToolCallEvent",
+                "id": "vendor-1",
+                "tool_call_id": "c1",
+                "name": "execute_python",
+                "timestamp": "2026-08-14T12:00:00.000Z",
+            },
+            {
+                "event_type": "PythonOutput",
+                "id": "vendor-1-out",
+                "tool_call_id": "c1",
+                "execution_status": "complete",
+                "stdout": "x",
+                "timestamp": "2026-08-14T12:00:00.400Z",
+            },
+        )
+    )
+    tools = [e for e in mapped if e.get("kind") == "tool"]
+    ids = {e.get("tool_call_id") for e in tools}
+    assert ids == {"c1"}
+    update = next(e for e in tools if e.get("phase") == "update")
+    assert update["elapsed_ms"] == 400.0
+
+
+def test_llmcomplete_does_not_steal_execute_span() -> None:
+    mapped = to_bora_trajectory_events(
+        (
+            {
+                "event_type": "LLMComplete",
+                "id": "tap_llmcomplete_3",
+                "tool_calls": [
+                    {
+                        "tool_call_id": "c1",
+                        "function_name": "execute_python",
+                        "arguments": {"code": "print(1)"},
+                    }
+                ],
+            },
+            {
+                "event_type": "ToolCallEvent",
+                "id": "vendor-1",
+                "tool_call_id": "c1",
+                "name": "execute_python",
+                "arguments": {"code": "print(1)"},
+                "result": {"ok": True},
+                "timestamp": "2026-08-14T12:00:00.000Z",
+            },
+            {
+                "event_type": "PythonOutput",
+                "id": "vendor-1-out",
+                "tool_call_id": "c1",
+                "execution_status": "complete",
+                "stdout": "1\n",
+                "timestamp": "2026-08-14T12:00:00.080Z",
+            },
+        )
+    )
+    starts = [e for e in mapped if e.get("kind") == "tool" and e.get("phase") == "start"]
+    assert len(starts) == 1
+    update = next(
+        e
+        for e in mapped
+        if e.get("kind") == "tool" and e.get("phase") == "update" and e.get("elapsed_ms")
+    )
+    assert update["elapsed_ms"] == 80.0
+
+
 def test_tool_call_copies_vendor_elapsed_ms() -> None:
     mapped = to_bora_trajectory_events(
         (

--- a/tests/plugins/test_nooa_trajectory_map.py
+++ b/tests/plugins/test_nooa_trajectory_map.py
@@ -85,6 +85,25 @@ def test_tool_call_event_with_result() -> None:
     assert mapped[0]["args"] == {"path": "/tmp/a"}
 
 
+def test_tool_call_copies_vendor_elapsed_ms() -> None:
+    mapped = to_bora_trajectory_events(
+        (
+            {
+                "event_type": "ToolCallEvent",
+                "tool_call_id": "c1",
+                "name": "read_file",
+                "arguments": {"path": "/tmp/a"},
+                "result": {"ok": True, "text": "hi"},
+                "elapsed_ms": 88,
+                "at": "2026-08-14T12:00:01Z",
+            },
+        )
+    )
+    update = next(e for e in mapped if e.get("phase") == "update")
+    assert update["elapsed_ms"] == 88.0
+    assert update["at"] == "2026-08-14T12:00:01Z"
+
+
 async def _passthrough(value: object) -> object:
     return value
 

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -241,6 +241,9 @@ def test_trajectory_tool_call_and_observation_steps(tmp_path: Path) -> None:
             "kind": "read",
             "status": "completed",
             "args": {"path": "/w/a.txt"},
+            "elapsed_ms": 1420.5,
+            "started_at": "2026-08-14T12:00:00Z",
+            "ended_at": "2026-08-14T12:00:01.42Z",
             "turn_index": 1,
             "source": "acp",
         },
@@ -267,6 +270,8 @@ def test_trajectory_tool_call_and_observation_steps(tmp_path: Path) -> None:
     assert tool.get("tool_call_id") == "call_1"
     assert tool.get("kind") == "read"
     assert tool.get("function_name") == "read"
+    assert tool.get("elapsed_ms") == 1420.5
+    assert tool.get("started_at") == "2026-08-14T12:00:00Z"
     # args surfaced as content when no content field
     assert tool.get("content") and "a.txt" in tool["content"]
     obs = next(s for s in payload["steps"] if s.get("type") == "observation")

--- a/website/content/docs/reference/results-and-pass.en.mdx
+++ b/website/content/docs/reference/results-and-pass.en.mdx
@@ -71,7 +71,7 @@ So: to show a package run on the public board, use **suite run → upload-suite*
 ## Browse
 
 [Viewer](/docs/run/local-viewer).  
-Attempt pages may show **Timing** (and **Tokens** when present). Time / tokens are **hints**, not PASS.
+Attempt pages may show **Timing** (and **Tokens** when present). Trajectory tool-call rows may show a duration when the sealed step has `elapsed_ms`. Time / tokens / step duration are **hints**, not PASS.
 
 ## Failure kinds
 

--- a/website/content/docs/reference/results-and-pass.mdx
+++ b/website/content/docs/reference/results-and-pass.mdx
@@ -71,7 +71,7 @@ description: Result 怎么读；pass@k 是 job 指标，不是整包 PASS。
 ## 本机翻看
 
 [Viewer](/docs/run/local-viewer)：Jobs → Tasks → Attempt。  
-Attempt 页可有 **Timing**（及有数据时的 **Tokens**）条；耗时 / token **只是参考**，不是 PASS。
+Attempt 页可有 **Timing**（及有数据时的 **Tokens**）条。轨迹 `tool_call` 在密封行带 `elapsed_ms` 时显示单步耗时。耗时 / token / 单步耗时 **只是参考**，不是 PASS。
 
 ## 失败怎么分
 

--- a/website/content/docs/run/local-viewer.en.mdx
+++ b/website/content/docs/run/local-viewer.en.mdx
@@ -33,6 +33,7 @@ uv run bora view examples/core --open /jobs/<id>
 | Attempt | Outcome, **Timing** (and **Tokens** when present), actors, evidence tabs |
 
 Timing comes from Attempt `phase_timing` (`prepare` / `run` / `evaluate` / `cleanup`); hover bar segments for durations.  
-Time / tokens are **hints**, not PASS. Trajectory is not scoring authority. Each **tool-call** row (and other long rows) can collapse; the observational PASS note has expand-all / collapse-all, matching the Hub Attempt page.
+When a sealed `tool_call` row carries `elapsed_ms`, the step header shows that duration. Missing timing is omitted — Viewer does not invent it from file mtimes or the page clock.  
+Time / tokens / step duration are **hints**, not PASS. Trajectory is not scoring authority. Each **tool-call** row (and other long rows) can collapse; the observational PASS note has expand-all / collapse-all, matching the Hub Attempt page.
 
 Viewer does **not** talk to Registry — see [Hub](/docs/share/hub). SPA details: `apps/viewer/README.md`.

--- a/website/content/docs/run/local-viewer.mdx
+++ b/website/content/docs/run/local-viewer.mdx
@@ -35,6 +35,7 @@ uv run bora view examples/core --open /jobs/<id>
 | Attempt | 结果条、**Timing**（有数据时还有 **Tokens**）、角色、证据页签（Trajectory / Agent / …） |
 
 Timing 来自 Attempt `phase_timing`（prepare / run / evaluate / cleanup）；hover 色条看分段耗时。  
-耗时和 token **只是参考**，不是 PASS。轨迹也不是评分依据。Trajectory 里每条 **tool-call**（以及过长行）可折叠；观测 PASS 条上有全部展开 / 全部收起，与 Hub Attempt 页一致。
+密封的 `tool_call` 若带 `elapsed_ms`，步骤头会显示该步耗时；没有就不画标签——Viewer 不会用文件 mtime 或页面时钟补造。  
+耗时、token、单步耗时 **只是参考**，不是 PASS。轨迹也不是评分依据。Trajectory 里每条 **tool-call**（以及过长行）可折叠；观测 PASS 条上有全部展开 / 全部收起，与 Hub Attempt 页一致。
 
 Viewer **不连** Registry。远程目录见 [Hub](/docs/share/hub)。改 SPA 看仓库 `apps/viewer/README.md`。

--- a/website/content/docs/share/hub.en.mdx
+++ b/website/content/docs/share/hub.en.mdx
@@ -16,7 +16,7 @@ Hub (`apps/hub`) is the web UI on top of Registry—browse shared packages and r
 - Leaderboard: complete, release-bound suite rows only. Incomplete or draft-bound runs stay on the task Jobs list. Sortable headers. Observational metrics, not suite PASS. Expand a row for **profiles** / **plugin** tabs (secret-free YAML and rehydrate commands; plugins open the marketplace)  
 - Plugin detail: L0–L5 **declared-slot** timeline; expand jumps into the in-package file preview. The browser never executes plugin code  
 - Signed-in **Home**: jobs you uploaded, orgs, datasets/tasks you can maintain, plugins you uploaded. Signed-out visitors go to sign-in. No publish / upload / release buttons  
-- List search sits on the same row as **Your organizations | Explore**; file-tree pane height is stable; trajectory tool-call rows collapse  
+- List search sits on the same row as **Your organizations | Explore**; file-tree pane height is stable; trajectory tool-call rows collapse; a step shows duration only when `elapsed_ms` is on the sealed row  
 
 - **Sign in with GitHub** (browser OAuth; CLI stays on Device Flow)
 

--- a/website/content/docs/share/hub.mdx
+++ b/website/content/docs/share/hub.mdx
@@ -16,7 +16,7 @@ Hub（`apps/hub`）是连 Registry 的网页端，用来浏览共享的包与跑
 - Leaderboard：只列出**完备且绑定 release** 的 suite；缺题结果与 draft 绑定跑次不上榜，仍出现在 Task **Jobs**。可点表头排序；观测指标，非 suite PASS。展开行有 **profiles** / **plugin** 页签（无密钥 YAML 与再跑命令；插件进 marketplace）  
 - 插件详情：L0–L5 **声明槽**时间线，点开跳到包内文件预览；浏览器不执行插件  
 - 登录后的 **Home**：你上传的 Jobs、组织、可维护 Dataset / Task、你上传的插件。未登录会去登录页。无 publish / upload / release 按钮  
-- 列表搜索与 **Your organizations | Explore** 同一行；文件树分栏高度固定；轨迹里 tool-call 可折叠  
+- 列表搜索与 **Your organizations | Explore** 同一行；文件树分栏高度固定；轨迹里 tool-call 可折叠；步骤头只在密封行带 `elapsed_ms` 时显示耗时  
 
 - **用 GitHub 登录**（浏览器 OAuth；CLI 仍是 Device Flow）
 


### PR DESCRIPTION
Closes #100

Operators can see how long a trajectory step took (especially `tool_call` / shell execute), not only the Attempt-level `phase_timing` bar.

## What changed

- Design (`docs/design/05-runtime/evidence.md`) names optional observational fields: envelope `at`, and on `kind: tool` `elapsed_ms` / `started_at` / `ended_at`. Adapters write them; Core merges; Hub/Viewer only display. Missing values stay omitted (fail-open). Never PASS.
- Core writer folds last `elapsed_ms` onto `tool_call` and the paired `observation`. If `elapsed_ms` is absent it derives from `started_at`/`ended_at` or envelope `at`. Invalid / non-finite / negative values are dropped. An explicit `ended_at` is not overwritten by a later `at`.
- ACP stamps receive-time `at` on session events and copies vendor `durationMs` / timestamps when present. nooa and dsh do the same for native dumps.
- Hub and Viewer show a Harbor-style duration on the step header when `elapsed_ms` is present, and omit the label when it is not.
- Reader docs and CLI skills describe the field without treating it as score authority.

## Acceptance

- [x] Design names the fields and who writes them
- [x] Layer B events may carry per-tool elapsed time without secrets
- [x] `trajectory.jsonl` surfaces that duration on the matching step
- [x] Hub and Viewer show it when present; omit the label when absent
- [x] Trajectory remains observational (not PASS)

## Evidence

Live L1 smoke (worktree):

```text
uv run bora run examples/journeys --task terminal-jsonl-agg
# status=PASS  score=1.0  assurance=l1  entry=pi
```

Sealed trajectory had five tool steps with `elapsed_ms` (execute 95ms / 4.9s, read 371ms / 212ms / 109ms). Viewer Attempt page showed those labels on tool/observation headers and no duration on user / assistant / terminal rows.

Acceptance subagent: **ACCEPT-WITH-FIXES**. Follow-ups landed in `fix(evidence): keep explicit ended_at and drop non-finite elapsed`.

## Local CI

- python-core: ruff format/check, pyright, 530 passed
- python-registry: 99 passed, 2 skipped
- viewer / hub lint+build, website build: passed

## Out of scope

- Inferring duration from file mtimes or the Viewer clock
- Suite-level PASS
- Requiring every executor to emit timing