### PR TITLE
fix(runtime): stop L1 Docker leftover proliferation

### DIFF
--- a/docs/design/05-runtime/evidence.md
+++ b/docs/design/05-runtime/evidence.md
@@ -62,7 +62,7 @@ L1 prepare 把 host work root 放在 **同一 run 目录**下：`.bora/runs/<run
 | 策略 | 行为 |
 | --- | --- |
 | **默认** | Attempt cleanup（含已有 Docker cleanup 的失败路径）后 **删除** `l1-work/`，只保留 Hub-facing 证据 |
-| **`--keep-workspace`** | 保留 `l1-work/` 供本地调试；**不**要求 Hub / CI 开启 |
+| **`--keep-workspace`** | 保留 host `l1-work/` 供本地调试；Docker volume / env 容器仍删除；**不**要求 Hub / CI 开启 |
 | **Upload pack** | `build_attempt_archive` **排除** `l1-work/**`（即使 residual 仍在磁盘），Registry blob 只含 curated evidence |
 
 Hub Attempt tabs 与本地 `bora view` 仍只解析 Trajectory / Agent / Verifier / Artifacts / Lock / Runtime 等既有相对路径；不新增 Workspace tab。

--- a/docs/design/05-runtime/provider-l1.md
+++ b/docs/design/05-runtime/provider-l1.md
@@ -23,14 +23,46 @@ Provider 负责代码运行位置和 OS 级限制：
 ## Docker L1 镜像来源（package 拥有 Dockerfile）
 
 1. `provider.kind: docker` 时，package 必须提供 **`environment/Dockerfile`**（或 `provider.dockerfile` 指向的 package 内路径）。
-2. Runtime prepare：**确保官方基座** `bora-attempt:l1`（仓库 `docker/attempt`）→ **`docker build -f <package Dockerfile>`** 得到 Attempt 用 image → digest 写入 evidence。
-3. 官方基座构建一次、多处 `FROM` 复用；上游基座由 package Dockerfile 自行 `FROM` 并安装**同一 pin 表**声明的入口（禁止 package 自选 floating 版本）。
+2. Runtime prepare：**确保官方基座** `bora-attempt:l1`（仓库 `docker/attempt`）→ **`docker build -f <package Dockerfile>`** 得到 Attempt 用 image → **`image_digest` 写入 evidence**。本地 tag 只是 `docker run` 别名，不是寻址身份；Agent 流量仍是 `session_id` → 已绑定 target 上的 `docker exec`。
+3. 官方基座构建一次、多处 `FROM` 复用；上游基座由 package Dockerfile 自行 `FROM` 并安装**同一 pin 表**声明的入口（禁止 package 自选 floating 版本）。官方基座自身的 `build_input_digest` 覆盖 `Dockerfile` + `install-executors.sh` + `acp-entries.lock.json`；**不**因本条改变 `bora-attempt:l1` 的 tag 名。
 4. **基座预装（设计契约）：** 最低 coding-agent 验收 entry 的 **engine + ACP 入口** bake-in：
    - Mode 1：`codex`+`codex-acp`、`claude`+`claude-agent-acp`、**`pi`+`pi-acp`**；
    - Mode 2：`opencode` 含 `acp` 子命令；
    - Mode 3：exact Grok pin 的 `grok agent stdio`。
 5. Agent **ACP entry 在容器内**执行（不依赖挂载宿主 Homebrew binary）；缺 engine/adapter 则 fail closed，**禁止**以 parent 冒充 L1 PASS，**禁止** invoke 时 `npm i` / `npx latest`。
 6. **Parent 侧**运行 BORA ACP client（typed JSON-RPC）；Attempt 镜像**不**安装 Python ACP SDK。L1 通过 `docker exec` 附着容器内 entry 的 stdio。
+
+### 本地 Attempt 镜像：content-addressed tag
+
+Attempt 用镜像的 cache key **只**覆盖会改变镜像层的输入，**不得**包含 `lock.digest`、`task_id` 或 `docker image inspect` 的 id：
+
+```text
+package Dockerfile
++ FROM 基座 digest（`FROM bora-attempt:l1` 时取官方 lock 的 image_digest）
++ 该 Dockerfile COPY/ADD 的文件树
++ platform
++ 每个已绑定外置插件：Dockerfile.bake + bake 上下文里 COPY/ADD 的文件
+```
+
+本地 tag：
+
+```text
+bora-pkg:{content_key[:12]}
+bora-pkg:{content_key[:12]}-{plugin}-{bake_input[:12]}   # 仅当 image_contribute bake
+```
+
+`content_key` / `bake_input` 是上述输入的 digest。同一组输入第二次 prepare **跳过** `buildx --load`，复用已有 tag 与 image id。只改 `parameters` / `agent_profiles` / bindings（Dockerfile 与 bake 输入不变）**不得**产生新 tag。
+
+Bake 后缀来自 bake **输入** digest，禁止用 inspect id。绑定外置 executor 但 contribute 链为空或缺少 `Dockerfile.bake` 仍 fail closed。workspace、`ctx.params`、gold **不**进入镜像。
+
+### Attempt 拥有的 volume 与 env 容器随 Attempt 死亡
+
+Provider / Environment 在成功、失败、取消路径上都必须拆掉本 Attempt 创建的磁盘与 env 容器：
+
+- L1 target 的 named volume（`bora-home-*`）记入 Runtime 私有 ledger；`stop`、prepare rollback 与 Provider `cleanup` 对其 `volume rm`（`docker rm -fv` 只清匿名卷，**不能**替代 named volume 删除）。
+- Environment Postgres 等 Attempt 级容器：`stop()` 使用 `docker rm -fv`；`EnvironmentManager.close()` 与 Provider `cleanup` 必须跑完所有终态路径（含 prepare 失败与 cancel）。
+- `--keep-workspace` **只**保留 host `l1-work/`；**不**保留 Docker volume，也**不**另设 retain flag。
+- **禁止**把 `docker volume prune` / `docker system prune` 做成产品行为；不得删除 `bora-attempt:l1`，不得删除 Hub / Registry compose 卷。
 
 ### 术语：`entry` vs 包名
 

--- a/skills/bora-cli/SKILL.md
+++ b/skills/bora-cli/SKILL.md
@@ -42,7 +42,7 @@ uv run bora --help
 | `bora run <package> --task <id>`                              | One foreground Attempt                                                       |
 | `bora run <package> [-k N] [--max-concurrent-tasks N]`        | Suite / Always-k job (`-k` = `--n-attempts`; CLI only)                       |
 | `bora run … --resume-suite <id> [--task id] -k N`             | Append Attempts into existing suite job; recompute pass@k / pass^k           |
-| `bora run … --keep-workspace`                                 | L1 only: retain host `l1-work/` after cleanup (default: delete)              |
+| `bora run … --keep-workspace`                                 | L1 only: retain host `l1-work/` after cleanup (default: delete; Docker volumes still go) |
 | `bora run ... --set '/bindings/solver/options/entry="pi"'`    | Job binding override (entry/model)                                           |
 | `bora campaign <package> --task <id> --matrix ...`            | Serial matrix (`/parameters/*` or `/bindings/<role>/…`); ≠ Always-k          |
 | `bora evidence <logs-path> --out <dir>`                       | Sealed trajectory export (no score change)                                   |
@@ -133,7 +133,7 @@ Value after `=` is JSON (strings need quotes):
 **Single Attempt** (`--task` and default `-k 1`, no resume): typical fields `status`, `score`, `assurance`, `agent_invocations`, `evidence_path`, **`logs`** (portable under Dataset root, e.g. `.bora/runs/<run_id>`).
 
 - On disk: `<dataset>/.bora/runs/<run_id>/` — Hub-facing curated evidence (`result.json`, `agent/`, `evaluation/`, `artifacts/`, lock/runtime JSON).
-- L1 host sandbox lives at `l1-work/` **during** the Attempt; **default cleanup deletes it**. Use `--keep-workspace` only for local debug. `bora results upload` never packs `l1-work/**`.
+- L1 host sandbox lives at `l1-work/` **during** the Attempt; **default cleanup deletes it**. Use `--keep-workspace` only for local debug (host tree only; Docker volumes still go). `bora results upload` never packs `l1-work/**`.
 - Inspect trajectory: open `<dataset>/.bora/runs/<run_id>/agent/invocations/<nnnn>-*/trajectory.jsonl` (**turn-level** training rows) and `events.jsonl` (optional stream/debug)
 - Export: `uv run bora evidence <dataset>/.bora/runs/<run_id> --out /tmp/bora-export`
 - Trajectory presence **never** upgrades score

--- a/skills/bora-cli/references/commands.md
+++ b/skills/bora-cli/references/commands.md
@@ -46,8 +46,9 @@ Stdout JSON (high level):
   metrics. Retrying an ERROR needs a **new** suite, not resume of that index.
 - **`--keep-workspace`** (L1 / `provider.kind: docker` only): retain host
   `.bora/runs/<run_id>/l1-work/` after cleanup for local debug. **Default off** —
-  Runtime deletes `l1-work` after container cleanup. Not required for Hub; upload
-  pack excludes `l1-work/**` even if residual remains.
+  Runtime deletes `l1-work` after container cleanup. Docker volumes and env
+  containers are still removed. Not required for Hub; upload pack excludes
+  `l1-work/**` even if residual remains.
 - Suite artifacts: `.bora/suite-runs/<id>/summary.json`, `progress.json`.
 - Per invocation (any executor): Core writes `agent/invocations/<nnnn>-*/trajectory.jsonl`
   from `bora.trajectory.event/1` (user + merged assistant/thought + tool/observation +

--- a/src/bora/adapters/environment_postgres.py
+++ b/src/bora/adapters/environment_postgres.py
@@ -116,8 +116,9 @@ class PostgresEnvironment:
         }
 
     def stop(self) -> None:
+        # -v drops anonymous Postgres data volumes; --rm does not on force-rm.
         subprocess.run(
-            ["docker", "rm", "-f", self.container_name],
+            ["docker", "rm", "-fv", self.container_name],
             check=False,
             capture_output=True,
         )

--- a/src/bora/adapters/provider_docker/__init__.py
+++ b/src/bora/adapters/provider_docker/__init__.py
@@ -10,6 +10,8 @@ from bora.adapters.provider_docker.images import (
     build_package_image,
     ensure_base_image,
     ensure_image_lock,
+    package_image_content_digest,
+    package_local_tag,
     sys_executable,
 )
 from bora.adapters.provider_docker.provider import DockerProvider
@@ -23,5 +25,7 @@ __all__ = [
     "build_package_image",
     "ensure_base_image",
     "ensure_image_lock",
+    "package_image_content_digest",
+    "package_local_tag",
     "sys_executable",
 ]

--- a/src/bora/adapters/provider_docker/images.py
+++ b/src/bora/adapters/provider_docker/images.py
@@ -3,12 +3,21 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import re
+import shlex
 import subprocess
 import sys
 from pathlib import Path
+from typing import Iterable
 
 from bora.adapters.provider_docker.errors import ProviderL1Error
 from bora.adapters.provider_docker.types import DockerImageLock
+
+_OFFICIAL_BASE_TAG = "bora-attempt:l1"
+_COPY_HEAD = re.compile(r"^(COPY|ADD)\s+", re.IGNORECASE)
+_SKIP_COPY_DIR_NAMES = frozenset({".bora", ".git", "__pycache__", "node_modules"})
+_INSPECT_DIGEST_FMT = "{{if .RepoDigests}}{{index .RepoDigests 0}}{{else}}{{.Id}}{{end}}"
 
 
 def ensure_image_lock(repo_root: Path | None = None) -> Path:
@@ -34,17 +43,197 @@ def ensure_base_image(repo_root: Path | None = None) -> DockerImageLock:
     return DockerImageLock.load(path)
 
 
+def dockerfile_logical_lines(text: str) -> list[str]:
+    """Join backslash-continued Dockerfile lines; drop comments and blanks."""
+    lines: list[str] = []
+    buf: list[str] = []
+    for raw in text.splitlines():
+        stripped = raw.rstrip()
+        if stripped.endswith("\\"):
+            buf.append(stripped[:-1].rstrip())
+            continue
+        buf.append(stripped)
+        joined = " ".join(part.strip() for part in buf if part.strip())
+        buf = []
+        if not joined or joined.startswith("#"):
+            continue
+        lines.append(joined)
+    if buf:
+        joined = " ".join(part.strip() for part in buf if part.strip())
+        if joined and not joined.startswith("#"):
+            lines.append(joined)
+    return lines
+
+
+def parse_dockerfile_from_image(text: str) -> str | None:
+    """Return the first FROM image ref (skip scratch and substitution)."""
+    for line in dockerfile_logical_lines(text):
+        if not line.upper().startswith("FROM "):
+            continue
+        tokens = [t for t in line.split()[1:] if not t.startswith("-")]
+        if not tokens:
+            return None
+        image = tokens[0]
+        if image.upper() == "SCRATCH" or image.startswith("$"):
+            return None
+        return image
+    return None
+
+
+def parse_dockerfile_copy_sources(text: str) -> list[str]:
+    """COPY/ADD source paths in build context. Skip ``--from`` multi-stage copies."""
+    sources: list[str] = []
+    for line in dockerfile_logical_lines(text):
+        if not _COPY_HEAD.match(line):
+            continue
+        rest = _COPY_HEAD.sub("", line).strip()
+        if re.search(r"--from=", rest, flags=re.IGNORECASE):
+            continue
+        if rest.startswith("["):
+            try:
+                arr = json.loads(rest)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(arr, list) and len(arr) >= 2:
+                sources.extend(str(item) for item in arr[:-1])
+            continue
+        try:
+            tokens = shlex.split(rest)
+        except ValueError:
+            continue
+        tokens = [t for t in tokens if not t.startswith("-")]
+        if len(tokens) >= 2:
+            sources.extend(tokens[:-1])
+    return sources
+
+
+def _is_skipped_copy_path(path: Path, root: Path) -> bool:
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        return True
+    if any(part in _SKIP_COPY_DIR_NAMES for part in rel.parts):
+        return True
+    return path.suffix == ".pyc" or path.name == ".DS_Store"
+
+
+def hash_copy_sources(context_root: Path, sources: Iterable[str], hasher: hashlib._Hash) -> None:
+    """Hash COPY/ADD sources under *context_root* in stable order."""
+    root = context_root.resolve()
+    seen: set[str] = set()
+    for src in sources:
+        rel = src.lstrip("./")
+        if not rel or rel.startswith("/"):
+            continue
+        if any(ch in rel for ch in "*?["):
+            matches = sorted(p for p in root.glob(rel) if p.exists())
+        else:
+            candidate = root / rel
+            matches = [candidate] if candidate.exists() else []
+        for path in matches:
+            try:
+                resolved = path.resolve()
+                resolved.relative_to(root)
+            except ValueError:
+                continue
+            files: list[Path]
+            if resolved.is_file():
+                files = [resolved]
+            elif resolved.is_dir():
+                files = sorted(p for p in resolved.rglob("*") if p.is_file())
+            else:
+                continue
+            for file_path in files:
+                if _is_skipped_copy_path(file_path, root):
+                    continue
+                key = str(file_path.relative_to(root)).replace("\\", "/")
+                if key in seen:
+                    continue
+                seen.add(key)
+                hasher.update(key.encode("utf-8"))
+                hasher.update(b"\0")
+                hasher.update(file_path.read_bytes())
+                hasher.update(b"\0")
+
+
+def package_image_content_digest(
+    *,
+    dockerfile: Path,
+    package_root: Path,
+    platform: str,
+    base_digest: str,
+) -> str:
+    """Hex digest of Dockerfile + FROM base digest + COPY set + platform."""
+    text = dockerfile.read_bytes()
+    hasher = hashlib.sha256()
+    hasher.update(b"dockerfile\0")
+    hasher.update(text)
+    hasher.update(b"\0base\0")
+    hasher.update(base_digest.encode("utf-8"))
+    hasher.update(b"\0platform\0")
+    hasher.update(platform.encode("utf-8"))
+    hasher.update(b"\0copy\0")
+    hash_copy_sources(
+        package_root,
+        parse_dockerfile_copy_sources(text.decode("utf-8")),
+        hasher,
+    )
+    return hasher.hexdigest()
+
+
+def official_base_digest(repo_root: Path | None = None) -> str:
+    """Official ``bora-attempt:l1`` digest from the lock (stable; not a fresh inspect)."""
+    lock = ensure_base_image(repo_root)
+    return lock.image_digest or lock.build_input_digest
+
+
+def resolve_from_base_digest(dockerfile_text: str, repo_root: Path | None = None) -> str:
+    """Base identity for the content key.
+
+    ``FROM bora-attempt:l1`` uses the official lock digest so a rebuilt base
+    invalidates package tags. Other FROM refs stay the Dockerfile text (already
+    hashed); do not inspect them — first-build inspect would change the key.
+    """
+    ref = parse_dockerfile_from_image(dockerfile_text)
+    if ref is None:
+        return ""
+    image = ref.rsplit("/", 1)[-1]
+    if image == _OFFICIAL_BASE_TAG or ref == _OFFICIAL_BASE_TAG:
+        return official_base_digest(repo_root)
+    return ref
+
+
+def package_local_tag(content_digest: str) -> str:
+    return f"bora-pkg:{content_digest[:12]}"
+
+
+def inspect_image_digest(tag: str) -> str | None:
+    """Evidence digest for an existing local tag, or None if missing."""
+    proc = subprocess.run(
+        ["docker", "image", "inspect", tag, "--format", _INSPECT_DIGEST_FMT],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        return None
+    digest = (proc.stdout or "").strip()
+    return digest or None
+
+
 def build_package_image(
     *,
     package_root: Path,
     dockerfile_rel: str = "environment/Dockerfile",
     platform: str = "linux/arm64",
-    tag: str,
+    tag: str | None = None,
     repo_root: Path | None = None,
 ) -> DockerImageLock:
     """Build Attempt image from package Dockerfile (context = package root).
 
-    Ensures official base is available first so ``FROM bora-attempt:l1`` resolves.
+    Cache key is Dockerfile + FROM base digest + COPY set + platform — not
+    ``lock.digest`` or ``task_id``. Existing ``bora-pkg:{content[:12]}`` tags
+    skip ``buildx --load``.
     """
     package_root = package_root.resolve()
     df = (package_root / dockerfile_rel).resolve()
@@ -62,6 +251,24 @@ def build_package_image(
         )
 
     ensure_base_image(repo_root)
+    text = df.read_text(encoding="utf-8")
+    base_digest = resolve_from_base_digest(text, repo_root)
+    content = package_image_content_digest(
+        dockerfile=df,
+        package_root=package_root,
+        platform=platform,
+        base_digest=base_digest,
+    )
+    tag = tag or package_local_tag(content)
+    existing = inspect_image_digest(tag)
+    if existing is not None:
+        return DockerImageLock(
+            kind="docker-package-attempt",
+            platform=platform,
+            image_tag=tag,
+            image_digest=existing,
+            build_input_digest=f"sha256:{content}",
+        )
 
     cmd = [
         "docker",
@@ -83,29 +290,15 @@ def build_package_image(
             f"package image build failed: {(proc.stderr or proc.stdout or '')[-2000:]}",
         )
 
-    dig = subprocess.run(
-        [
-            "docker",
-            "image",
-            "inspect",
-            tag,
-            "--format",
-            "{{if .RepoDigests}}{{index .RepoDigests 0}}{{else}}{{.Id}}{{end}}",
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    if dig.returncode != 0:
+    image_digest = inspect_image_digest(tag)
+    if not image_digest:
         raise ProviderL1Error("image_unresolved", "cannot inspect package image")
-    image_digest = (dig.stdout or "").strip()
-    build_input = hashlib.sha256(df.read_bytes()).hexdigest()
     return DockerImageLock(
         kind="docker-package-attempt",
         platform=platform,
         image_tag=tag,
         image_digest=image_digest,
-        build_input_digest=f"sha256:{build_input}",
+        build_input_digest=f"sha256:{content}",
     )
 
 

--- a/src/bora/adapters/provider_docker/images.py
+++ b/src/bora/adapters/provider_docker/images.py
@@ -8,8 +8,8 @@ import re
 import shlex
 import subprocess
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 from bora.adapters.provider_docker.errors import ProviderL1Error
 from bora.adapters.provider_docker.types import DockerImageLock

--- a/src/bora/adapters/provider_docker/multi_actor.py
+++ b/src/bora/adapters/provider_docker/multi_actor.py
@@ -51,7 +51,7 @@ class DockerMultiActorMixin:
 
         ledger = TargetLedger(topology=topology)
         net = network_mode or topology.network
-        created: list[str] = []
+        created: list[ExecutionTarget] = []
 
         try:
             if topology.mode == IsolationMode.SHARED_CONTAINER:
@@ -65,7 +65,7 @@ class DockerMultiActorMixin:
                     generation=1,
                     isolation_mode=IsolationMode.SHARED_CONTAINER,
                 )
-                created.append(target.container_id or "")
+                created.append(target)
                 ledger.targets[target.target_id] = target
                 shared_gid = _SHARED_GID_BASE
                 bindings: list[ActorPhysicalBinding] = []
@@ -101,7 +101,7 @@ class DockerMultiActorMixin:
                         generation=1,
                         isolation_mode=IsolationMode.CONTAINER_PER_GROUP,
                     )
-                    created.append(target.container_id or "")
+                    created.append(target)
                     ledger.targets[target.target_id] = target
                     shared_gid = _SHARED_GID_BASE + gidx
                     group_bindings: list[ActorPhysicalBinding] = []
@@ -135,7 +135,7 @@ class DockerMultiActorMixin:
                     )
 
             runtime.target_ledger = ledger
-            runtime.agent_container_ids = [c for c in created if c]
+            runtime.agent_container_ids = [t.container_id for t in created if t.container_id]
             for cid in runtime.agent_container_ids:
                 runtime.register_writer(f"agent_target:{cid[:12]}")
             # Public mount inventory (no host paths / docker ids).
@@ -144,14 +144,9 @@ class DockerMultiActorMixin:
             )
             return ledger
         except Exception:
-            # Partial prepare: reverse cleanup before Harness start.
-            for cid in reversed(created):
-                if cid:
-                    subprocess.run(
-                        ["docker", "rm", "-f", cid],
-                        check=False,
-                        capture_output=True,
-                    )
+            # Partial prepare: drop containers and Attempt-owned volumes.
+            for target in reversed(created):
+                self._rm_target(target)
             raise
 
     def stop_agent_targets(self, runtime: DockerRuntime) -> None:
@@ -166,7 +161,7 @@ class DockerMultiActorMixin:
                 self._rm_target_volumes(target)
                 continue
             kill = subprocess.run(
-                ["docker", "rm", "-f", cid],
+                ["docker", "rm", "-fv", cid],
                 check=False,
                 capture_output=True,
             )
@@ -184,6 +179,20 @@ class DockerMultiActorMixin:
             target.container_id = None
             self._rm_target_volumes(target)
         runtime.agent_container_ids.clear()
+
+    @classmethod
+    def _rm_target(cls, target: ExecutionTarget) -> None:
+        cid = target.container_id
+        if cid:
+            subprocess.run(
+                ["docker", "rm", "-fv", cid],
+                check=False,
+                capture_output=True,
+            )
+            target.container_id = None
+        cls._rm_target_volumes(target)
+        if target.state != "cleaned":
+            target.state = "dead"
 
     @staticmethod
     def _rm_target_volumes(target: ExecutionTarget) -> None:
@@ -207,14 +216,8 @@ class DockerMultiActorMixin:
         t = runtime.target_ledger.targets.get(target_id)
         if t is None:
             return
-        if t.container_id:
-            subprocess.run(
-                ["docker", "rm", "-f", t.container_id],
-                check=False,
-                capture_output=True,
-            )
+        self._rm_target(t)
         t.state = "dead"
-        t.container_id = None
 
     def _start_long_lived_target(
         self,

--- a/src/bora/adapters/provider_docker/provider.py
+++ b/src/bora/adapters/provider_docker/provider.py
@@ -173,7 +173,7 @@ class DockerProvider(DockerMultiActorMixin):
 
         def _rm_force() -> str | None:
             subprocess.run(
-                ["docker", "rm", "-f", name], check=False, capture_output=True, text=True
+                ["docker", "rm", "-fv", name], check=False, capture_output=True, text=True
             )
             return "docker_rm_force"
 

--- a/src/bora/application/attempt/run_command_environment.py
+++ b/src/bora/application/attempt/run_command_environment.py
@@ -7,6 +7,7 @@ interpret free-form command dict rows.
 
 from __future__ import annotations
 
+import contextlib
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -15,6 +16,8 @@ from typing import Any
 from bora.config.model import thaw
 from bora.evaluation.result_binding import FlatResult, bind_result
 from bora.evidence.store import AttemptEvidenceStore
+
+ENV_CONTAINER_MARKER = "env_container_name.txt"
 
 
 def split_sql_statements(sql_text: str) -> list[str]:
@@ -89,6 +92,7 @@ def prepare_postgresql_environment(
         # Resource-type handoff only: container locator for package Tools.
         # No Benchmark/task/domain branch; package may ship environment/seed.sql.
         container = rid.split(":", 1)[-1] if ":" in rid else rid
+        (run_dir / ENV_CONTAINER_MARKER).write_text(f"{container}\n", encoding="utf-8")
         seed_file = package_root / "environment" / "seed.sql"
         seed_applied = False
         if seed_file.is_file():
@@ -222,8 +226,6 @@ def prepare_postgresql_environment(
 
         write_attempt_result(run_dir, summary)
         if env_manager is not None:
-            import contextlib
-
             with contextlib.suppress(Exception):
                 env_manager.close()
         return (
@@ -233,3 +235,53 @@ def prepare_postgresql_environment(
             (2, flat, {"environment": env_meta, "assurance": "l0"}),
         )
     return env_manager, evidence_store, env_meta, None
+
+
+def teardown_attempt_environment(ctx: Any) -> None:
+    """Stop env resources on every terminal path (success, failure, cancel).
+
+    ``--keep-workspace`` does not retain Docker volumes or env containers.
+    """
+    if getattr(ctx, "env_manager", None) is not None:
+        with contextlib.suppress(Exception):
+            from bora.application.attempt.extension_hooks import hook_env_teardown
+
+            attempt = getattr(ctx, "attempt", None)
+            td_ctx = SimpleNamespace(
+                attempt_id=str(
+                    (ctx.agent_meta or {}).get("attempt_id")
+                    or (attempt.value if attempt is not None else "")
+                ),
+                package_root=ctx.package_root,
+                workdir=ctx.package_root,
+                run_dir=ctx.run_dir,
+                env_manager=ctx.env_manager,
+                resource_id=(ctx.agent_meta.get("environment") or {}).get("resource_id"),
+            )
+            hook_env_teardown(
+                ctx.lock,
+                ctx.agent_meta.get("environment") or {"phase": "teardown"},
+                ctx=td_ctx,
+            )
+        with contextlib.suppress(Exception):
+            ctx.env_manager.close()
+        ctx.env_manager = None
+    marker = ctx.run_dir / ENV_CONTAINER_MARKER
+    if marker.is_file():
+        try:
+            from bora.adapters.environment_postgres import PostgresEnvironment
+
+            name = marker.read_text(encoding="utf-8").strip()
+            if name:
+                PostgresEnvironment(container_name=name).stop()
+        except Exception:
+            pass
+        with contextlib.suppress(OSError):
+            marker.unlink()
+    for handoff in (
+        ctx.package_root / ".bora_env_result.json",
+        ctx.run_dir / "env_manager.json",
+    ):
+        if handoff.exists():
+            with contextlib.suppress(OSError):
+                handoff.unlink()

--- a/src/bora/application/attempt/run_l0.py
+++ b/src/bora/application/attempt/run_l0.py
@@ -395,56 +395,19 @@ def bind_l0_result(ctx: AttemptStageContext) -> None:
 
 
 def cleanup_l0(ctx: AttemptStageContext) -> None:
-    from bora.application.attempt.extension_hooks import hook_cleanup, hook_env_teardown
+    from bora.application.attempt.extension_hooks import hook_cleanup
 
     timer = _timer(ctx)
-    attempt = ctx.attempt
     with timer.phase("cleanup"):
         if ctx.agent_server is not None:
             with contextlib.suppress(Exception):
                 ctx.agent_server.stop()
             ctx.agent_server = None
-        if ctx.env_manager is not None:
-            with contextlib.suppress(Exception):
-                from types import SimpleNamespace
+        from bora.application.attempt.run_command_environment import (
+            teardown_attempt_environment,
+        )
 
-                td_ctx = SimpleNamespace(
-                    attempt_id=str(
-                        ctx.agent_meta.get("attempt_id")
-                        or (attempt.value if attempt is not None else "")
-                    ),
-                    package_root=ctx.package_root,
-                    workdir=ctx.package_root,
-                    run_dir=ctx.run_dir,
-                    env_manager=ctx.env_manager,
-                    resource_id=(ctx.agent_meta.get("environment") or {}).get("resource_id"),
-                )
-                hook_env_teardown(
-                    ctx.lock,
-                    ctx.agent_meta.get("environment") or {"phase": "teardown"},
-                    ctx=td_ctx,
-                )
-            with contextlib.suppress(Exception):
-                ctx.env_manager.close()
-            ctx.env_manager = None
-        marker = ctx.run_dir / "env_container_name.txt"
-        if marker.is_file():
-            try:
-                from bora.adapters.environment_postgres import PostgresEnvironment
-
-                name = marker.read_text(encoding="utf-8").strip()
-                PostgresEnvironment(container_name=name).stop()
-            except Exception:
-                pass
-            with contextlib.suppress(OSError):
-                marker.unlink()
-        for handoff in (
-            ctx.package_root / ".bora_env_result.json",
-            ctx.run_dir / "env_manager.json",
-        ):
-            if handoff.exists():
-                with contextlib.suppress(OSError):
-                    handoff.unlink()
+        teardown_attempt_environment(ctx)
         hook_cleanup(ctx.lock)
         for leftover in (
             ctx.package_root / ".bora_agent_result.json",

--- a/src/bora/application/attempt/run_l1_evaluator.py
+++ b/src/bora/application/attempt/run_l1_evaluator.py
@@ -71,7 +71,7 @@ def run_clean_evaluator_container(
     try:
         proc = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=90)
     except subprocess.TimeoutExpired:
-        subprocess.run(["docker", "rm", "-f", name], check=False, capture_output=True)
+        subprocess.run(["docker", "rm", "-fv", name], check=False, capture_output=True)
         return (
             {"status": "ERROR", "score": None, "metrics": {"error": "timeout"}},
             {"ok": False, "writer_stop_confirmed": True, "package_mounted": False},

--- a/src/bora/application/attempt/run_l1_phases.py
+++ b/src/bora/application/attempt/run_l1_phases.py
@@ -492,6 +492,11 @@ def bind_l1_result(ctx: AttemptStageContext) -> None:
 
 
 def cleanup_l1(ctx: AttemptStageContext) -> None:
+    from bora.application.attempt.run_command_environment import (
+        teardown_attempt_environment,
+    )
+
+    teardown_attempt_environment(ctx)
     _l1_host_cleanup(
         ctx.docker,
         ctx.runtime,

--- a/src/bora/application/attempt/run_l1_prepare.py
+++ b/src/bora/application/attempt/run_l1_prepare.py
@@ -39,14 +39,12 @@ def prepare_l1_runtime(
     dockerfile_rel = str(provider.get("dockerfile") or "environment/Dockerfile")
     platform = str(provider.get("platform") or "linux/arm64")
     # Official base (FROM bora-attempt:l1) then package Dockerfile → Attempt image.
+    # Tag is content-addressed (Dockerfile + FROM digest + COPY set); not lock.digest.
     ensure_base_image(Path.cwd())
-    short = lock.digest.replace("sha256:", "")[:12]
-    tag = f"bora-pkg:{lock.task_id}-{short}"
     pkg_image = build_package_image(
         package_root=package_root,
         dockerfile_rel=dockerfile_rel,
         platform=platform,
-        tag=tag,
         repo_root=Path.cwd(),
     )
     # Lifecycle prepare + image_contribute consume (fail closed).

--- a/src/bora/application/plugin_ops/image_contribute_bake.py
+++ b/src/bora/application/plugin_ops/image_contribute_bake.py
@@ -16,6 +16,11 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from bora.adapters.provider_docker.images import (
+    hash_copy_sources,
+    inspect_image_digest,
+    parse_dockerfile_copy_sources,
+)
 from bora.adapters.provider_docker.types import DockerImageLock
 from bora.config.model import LockedTaskConfig, thaw
 from bora.plugins.bootstrap import ensure_bootstrapped
@@ -118,6 +123,38 @@ def _find_installed_plugin_root(plugin_id: str) -> Path | None:
     return None
 
 
+def bake_layer_content_digest(
+    *,
+    plugin_id: str,
+    plugin_root: Path,
+    dockerfile: Path,
+    base_content_digest: str,
+) -> str:
+    """Hex digest of bake inputs — not ``docker image inspect`` id."""
+    hasher = hashlib.sha256()
+    hasher.update(b"plugin\0")
+    hasher.update(plugin_id.encode("utf-8"))
+    hasher.update(b"\0bake\0")
+    hasher.update(dockerfile.read_bytes())
+    hasher.update(b"\0base\0")
+    hasher.update(base_content_digest.encode("utf-8"))
+    hasher.update(b"\0copy\0")
+    hash_copy_sources(
+        plugin_root,
+        parse_dockerfile_copy_sources(dockerfile.read_text(encoding="utf-8")),
+        hasher,
+    )
+    return hasher.hexdigest()
+
+
+def _base_content_digest(base_image: DockerImageLock) -> str:
+    return base_image.build_input_digest or base_image.image_tag
+
+
+def baked_image_tag(base_image: DockerImageLock, plugin_id: str, bake_digest: str) -> str:
+    return f"{base_image.image_tag}-{plugin_id}-{bake_digest[:12]}"
+
+
 def bake_plugin_layer(
     *,
     base_image: DockerImageLock,
@@ -132,6 +169,21 @@ def bake_plugin_layer(
         raise ImageContributeError(
             f"{plugin_id} bake Dockerfile missing: {dockerfile}",
             kind="plugin_not_ready",
+        )
+    bake_digest = bake_layer_content_digest(
+        plugin_id=plugin_id,
+        plugin_root=plugin_root,
+        dockerfile=dockerfile,
+        base_content_digest=_base_content_digest(base_image),
+    )
+    existing = inspect_image_digest(out_tag)
+    if existing is not None:
+        return DockerImageLock(
+            kind="docker-package-attempt",
+            platform=platform,
+            image_tag=out_tag,
+            image_digest=existing,
+            build_input_digest=f"sha256:{bake_digest}",
         )
 
     cmd = [
@@ -156,33 +208,17 @@ def bake_plugin_layer(
             kind="image_contribute_unsatisfied",
         )
 
-    dig = subprocess.run(
-        [
-            "docker",
-            "image",
-            "inspect",
-            out_tag,
-            "--format",
-            "{{if .RepoDigests}}{{index .RepoDigests 0}}{{else}}{{.Id}}{{end}}",
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    if dig.returncode != 0:
+    image_digest = inspect_image_digest(out_tag)
+    if not image_digest:
         raise ImageContributeError(
             f"cannot inspect baked {plugin_id} image", kind="image_unresolved"
         )
-    image_digest = (dig.stdout or "").strip()
-    build_input = hashlib.sha256(
-        plugin_id.encode() + dockerfile.read_bytes() + base_image.image_digest.encode()
-    ).hexdigest()
     return DockerImageLock(
         kind="docker-package-attempt",
         platform=platform,
         image_tag=out_tag,
         image_digest=image_digest,
-        build_input_digest=f"sha256:{build_input}",
+        build_input_digest=f"sha256:{bake_digest}",
     )
 
 
@@ -231,8 +267,13 @@ def apply_image_contribute_bake(
                 f"{plugin_id} bound/declared but docker/Dockerfile.bake missing",
                 kind="plugin_not_ready",
             )
-        short = hashlib.sha256(f"{current.image_digest}:{plugin_id}".encode()).hexdigest()[:12]
-        out_tag = f"{base_image.image_tag}-{plugin_id}-{short}"
+        bake_digest = bake_layer_content_digest(
+            plugin_id=plugin_id,
+            plugin_root=plugin_root,
+            dockerfile=dockerfile,
+            base_content_digest=_base_content_digest(current),
+        )
+        out_tag = baked_image_tag(current, plugin_id, bake_digest)
         current = bake_plugin_layer(
             base_image=current,
             platform=platform,

--- a/src/bora/cli/README.md
+++ b/src/bora/cli/README.md
@@ -81,7 +81,7 @@ Credentials file `~/.bora/credentials` (mode `0600`):
 | --- | --- |
 | `bora tasks` | List member task ids in a Database |
 | `bora lock` | Lock config (no Agent) |
-| `bora run` | Run one member or a full suite (Always-k via `-k` / `--n-attempts`; L1 `--keep-workspace` keeps `l1-work/`) |
+| `bora run` | Run one member or a full suite (Always-k via `-k` / `--n-attempts`; L1 `--keep-workspace` keeps host `l1-work/`, not Docker volumes) |
 | `bora campaign` | Serial parameter-matrix campaign (matrix axis ≠ k-attempt) |
 | `bora executors` | Host executor / ACP entry inventory |
 | `bora plugin install\|list\|uninstall` | Local `bora.plugin/1` cache (`$BORA_HOME/plugins`); never rewrites profiles |

--- a/src/bora/cli/cmd_campaign_run.py
+++ b/src/bora/cli/cmd_campaign_run.py
@@ -142,7 +142,8 @@ def register(app: typer.Typer) -> None:
                 "--keep-workspace",
                 help=(
                     "L1 only: retain host l1-work/ under the run dir after cleanup "
-                    "(default: delete; debug only — never required for Hub upload)."
+                    "(default: delete; debug only — never required for Hub upload). "
+                    "Docker volumes and env containers are still removed."
                 ),
             ),
         ] = False,

--- a/src/bora/environment/manager.py
+++ b/src/bora/environment/manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import atexit
 import contextlib
 from dataclasses import dataclass, field
 from typing import Any
@@ -22,6 +23,7 @@ class EnvironmentManager:
     _resources: dict[str, Any] = field(default_factory=dict)
     _actions: int = 0
     closed: bool = False
+    _atexit_registered: bool = False
 
     def _effect(self, decision: dict[str, Any]) -> None:
         if self.evidence_store is None:
@@ -56,6 +58,9 @@ class EnvironmentManager:
         env.start(timeout=90.0)
         rid = f"{kind}:{env.container_name}"
         self._resources[rid] = env
+        if not self._atexit_registered:
+            atexit.register(self.close)
+            self._atexit_registered = True
         self._effect({"decision": "allow", "op": "open", "kind": kind, "resource_id": rid})
         return {"ok": True, "resource_id": rid, "kind": kind}
 
@@ -142,6 +147,10 @@ class EnvironmentManager:
         if self.closed:
             return
         self.closed = True
+        if self._atexit_registered:
+            with contextlib.suppress(Exception):
+                atexit.unregister(self.close)
+            self._atexit_registered = False
         for env in list(self._resources.values()):
             with contextlib.suppress(Exception):
                 env.stop()

--- a/tests/adapters/test_attempt_volume_cleanup.py
+++ b/tests/adapters/test_attempt_volume_cleanup.py
@@ -1,0 +1,216 @@
+"""Attempt-owned Docker volumes and env containers die with the Attempt."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from bora.adapters.environment_postgres import PostgresEnvironment
+from bora.adapters.provider_docker.multi_actor import DockerMultiActorMixin
+from bora.adapters.provider_docker.provider import DockerProvider
+from bora.adapters.provider_docker.types import DockerImageLock, DockerRuntime
+from bora.application.attempt.run_command_environment import (
+    ENV_CONTAINER_MARKER,
+    teardown_attempt_environment,
+)
+from bora.environment.manager import EnvironmentManager
+from bora.provider.targets import (
+    ExecutionTarget,
+    IsolationMode,
+    LogicalActor,
+    LogicalGroup,
+    LogicalIsolationTopology,
+    TargetLedger,
+)
+from bora.runtime.identity import IdentityFactory
+
+
+def _attempt():
+    factory = IdentityFactory()
+    run = factory.new_run()
+    trial = factory.new_trial(run, "sha256:" + "c" * 64)
+    return factory.new_attempt(trial)
+
+
+def _topology() -> LogicalIsolationTopology:
+    return LogicalIsolationTopology(
+        mode=IsolationMode.SHARED_CONTAINER,
+        groups=(LogicalGroup(group_id="g", actor_ids=("solver",)),),
+        actors=(LogicalActor(actor_id="solver", group_id="g", profiles=("solver",)),),
+    )
+
+
+def _target(*, cid: str = "cid1", volume: str = "bora-home-abc") -> ExecutionTarget:
+    return ExecutionTarget(
+        target_id="t1",
+        group_id="g",
+        generation=1,
+        container_id=cid,
+        container_name="bora-agt-x",
+        workspace_volume=volume,
+        state="ready",
+        image_digest="sha256:img",
+        image_tag="bora-pkg:deadbeefcaf0",
+    )
+
+
+class _Proc:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_postgres_stop_removes_anonymous_volumes() -> None:
+    cmds: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> _Proc:
+        cmds.append(list(cmd))
+        return _Proc()
+
+    env = PostgresEnvironment(container_name="bora-env-deadbeef")
+    with patch("bora.adapters.environment_postgres.subprocess.run", side_effect=fake_run):
+        env.stop()
+    assert ["docker", "rm", "-fv", "bora-env-deadbeef"] in cmds
+    assert env.ready is False
+
+
+def test_stop_agent_targets_drops_named_home_volume() -> None:
+    cmds: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> _Proc:
+        cmds.append(list(cmd))
+        return _Proc(returncode=0 if cmd[1] != "inspect" else 1)
+
+    attempt = _attempt()
+    runtime = DockerRuntime(
+        attempt=attempt,
+        image_lock=DockerImageLock(
+            kind="t",
+            platform="linux/arm64",
+            image_tag="bora-pkg:x",
+            image_digest="sha256:img",
+            build_input_digest="sha256:d",
+        ),
+        target_ledger=TargetLedger(topology=_topology()),
+    )
+    target = _target()
+    runtime.target_ledger.targets[target.target_id] = target  # type: ignore[union-attr]
+    runtime.agent_container_ids = ["cid1"]
+
+    with patch("bora.adapters.provider_docker.multi_actor.subprocess.run", side_effect=fake_run):
+        DockerProvider().stop_agent_targets(runtime)
+
+    assert ["docker", "rm", "-fv", "cid1"] in cmds
+    assert ["docker", "volume", "rm", "-f", "bora-home-abc"] in cmds
+    assert target.workspace_volume is None
+    assert runtime.agent_container_ids == []
+
+
+def test_prepare_rollback_removes_container_and_volume() -> None:
+    cmds: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> _Proc:
+        cmds.append(list(cmd))
+        return _Proc()
+
+    attempt = _attempt()
+    runtime = DockerRuntime(
+        attempt=attempt,
+        image_lock=DockerImageLock(
+            kind="t",
+            platform="linux/arm64",
+            image_tag="bora-pkg:x",
+            image_digest="sha256:img",
+            build_input_digest="sha256:d",
+        ),
+        workdir_host=Path("/tmp/l1-work"),
+    )
+    started = _target()
+    provider = DockerProvider()
+
+    def fail_bootstrap(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("bootstrap-boom")
+
+    with (
+        patch.object(provider, "_start_long_lived_target", return_value=started),
+        patch.object(provider, "_bootstrap_actor_fs", side_effect=fail_bootstrap),
+        patch(
+            "bora.adapters.provider_docker.multi_actor.subprocess.run",
+            side_effect=fake_run,
+        ),
+    ):
+        try:
+            provider.prepare_agent_targets(runtime, _topology(), cred_root=Path("/tmp/creds"))
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("expected bootstrap failure")
+
+    assert ["docker", "rm", "-fv", "cid1"] in cmds
+    assert ["docker", "volume", "rm", "-f", "bora-home-abc"] in cmds
+    assert started.workspace_volume is None
+
+
+def test_teardown_closes_manager_and_marker_even_if_keep_workspace(
+    tmp_path: Path,
+) -> None:
+    stopped: list[str] = []
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / ENV_CONTAINER_MARKER).write_text("bora-env-abc123\n", encoding="utf-8")
+
+    class FakeEnv:
+        def stop(self) -> None:
+            stopped.append("manager")
+
+    mgr = EnvironmentManager(attempt_id="a")
+    mgr._resources["postgresql:bora-env-live"] = FakeEnv()
+    ctx = SimpleNamespace(
+        env_manager=mgr,
+        agent_meta={"environment": {"resource_id": "postgresql:bora-env-live"}},
+        package_root=pkg,
+        run_dir=run_dir,
+        attempt=None,
+        lock=SimpleNamespace(),
+        keep_workspace=True,
+    )
+
+    def fake_stop(self: PostgresEnvironment) -> None:
+        stopped.append(self.container_name)
+
+    with (
+        patch(
+            "bora.application.attempt.extension_hooks.hook_env_teardown",
+            return_value=None,
+        ),
+        patch.object(PostgresEnvironment, "stop", fake_stop),
+    ):
+        teardown_attempt_environment(ctx)
+
+    assert ctx.env_manager is None
+    assert mgr.closed is True
+    assert "manager" in stopped
+    assert "bora-env-abc123" in stopped
+    assert not (run_dir / ENV_CONTAINER_MARKER).exists()
+
+
+def test_rm_target_never_prunes_unrelated_volumes() -> None:
+    cmds: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> _Proc:
+        cmds.append(list(cmd))
+        return _Proc()
+
+    target = _target(volume="bora-home-only")
+    with patch("bora.adapters.provider_docker.multi_actor.subprocess.run", side_effect=fake_run):
+        DockerMultiActorMixin._rm_target(target)
+
+    volume_rms = [c for c in cmds if c[:3] == ["docker", "volume", "rm"]]
+    assert volume_rms == [["docker", "volume", "rm", "-f", "bora-home-only"]]
+    assert not any("prune" in c for c in cmds)
+    assert not any("bora-attempt:l1" in c for c in cmds)
+    assert not any("registry" in " ".join(c) for c in cmds)

--- a/tests/adapters/test_package_image_cache.py
+++ b/tests/adapters/test_package_image_cache.py
@@ -1,0 +1,171 @@
+"""Package Attempt image cache key: content, not lock.digest / task_id."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from bora.adapters.provider_docker.images import (
+    build_package_image,
+    package_image_content_digest,
+    package_local_tag,
+    parse_dockerfile_copy_sources,
+    parse_dockerfile_from_image,
+)
+from bora.adapters.provider_docker.types import DockerImageLock
+
+
+def _write_pkg(root: Path, dockerfile: str, files: dict[str, str] | None = None) -> Path:
+    df = root / "environment" / "Dockerfile"
+    df.parent.mkdir(parents=True, exist_ok=True)
+    df.write_text(dockerfile, encoding="utf-8")
+    for rel, body in (files or {}).items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    return df
+
+
+def test_parse_from_and_copy_skips_from_stage() -> None:
+    text = "\n".join(
+        [
+            "FROM bora-attempt:l1",
+            "COPY environment/tool.sh /usr/local/bin/tool",
+            "COPY --from=builder /opt/x /opt/x",
+            'COPY ["src/a.py", "src/b.py", "/app/"]',
+        ]
+    )
+    assert parse_dockerfile_from_image(text) == "bora-attempt:l1"
+    assert parse_dockerfile_copy_sources(text) == [
+        "environment/tool.sh",
+        "src/a.py",
+        "src/b.py",
+    ]
+
+
+def test_content_digest_stable_and_ignores_unrelated_files(tmp_path: Path) -> None:
+    df = _write_pkg(
+        tmp_path,
+        "FROM bora-attempt:l1\nCOPY environment/tool.sh /bin/tool\n",
+        {"environment/tool.sh": "echo ok\n"},
+    )
+    first = package_image_content_digest(
+        dockerfile=df,
+        package_root=tmp_path,
+        platform="linux/arm64",
+        base_digest="sha256:base",
+    )
+    (tmp_path / "task.yaml").write_text("id: other\n", encoding="utf-8")
+    (tmp_path / "profiles.yaml").write_text("x: 1\n", encoding="utf-8")
+    second = package_image_content_digest(
+        dockerfile=df,
+        package_root=tmp_path,
+        platform="linux/arm64",
+        base_digest="sha256:base",
+    )
+    assert first == second
+    assert package_local_tag(first) == f"bora-pkg:{first[:12]}"
+    assert "task" not in package_local_tag(first)
+
+
+def test_content_digest_changes_with_dockerfile_copy_or_base(tmp_path: Path) -> None:
+    df = _write_pkg(
+        tmp_path,
+        "FROM bora-attempt:l1\nCOPY environment/tool.sh /bin/tool\n",
+        {"environment/tool.sh": "echo a\n"},
+    )
+    kwargs: dict[str, Any] = {
+        "dockerfile": df,
+        "package_root": tmp_path,
+        "platform": "linux/arm64",
+        "base_digest": "sha256:base",
+    }
+    original = package_image_content_digest(**kwargs)
+    (tmp_path / "environment" / "tool.sh").write_text("echo b\n", encoding="utf-8")
+    assert package_image_content_digest(**kwargs) != original
+    df.write_text("FROM bora-attempt:l1\nRUN true\n", encoding="utf-8")
+    (tmp_path / "environment" / "tool.sh").write_text("echo a\n", encoding="utf-8")
+    assert package_image_content_digest(**kwargs) != original
+    df.write_text(
+        "FROM bora-attempt:l1\nCOPY environment/tool.sh /bin/tool\n",
+        encoding="utf-8",
+    )
+    assert (
+        package_image_content_digest(
+            dockerfile=df,
+            package_root=tmp_path,
+            platform="linux/arm64",
+            base_digest="sha256:other",
+        )
+        != original
+    )
+
+
+def test_build_skips_buildx_when_tag_exists(tmp_path: Path) -> None:
+    _write_pkg(tmp_path, "FROM bora-attempt:l1\n")
+    base = DockerImageLock(
+        kind="docker-attempt",
+        platform="linux/arm64",
+        image_tag="bora-attempt:l1",
+        image_digest="sha256:official",
+        build_input_digest="sha256:official-in",
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> object:
+        calls.append(list(cmd))
+        if cmd[:3] == ["docker", "image", "inspect"]:
+            return type("P", (), {"returncode": 0, "stdout": "sha256:cached\n", "stderr": ""})()
+        raise AssertionError(f"unexpected docker command: {cmd}")
+
+    with (
+        patch(
+            "bora.adapters.provider_docker.images.ensure_base_image",
+            return_value=base,
+        ),
+        patch("bora.adapters.provider_docker.images.subprocess.run", side_effect=fake_run),
+    ):
+        lock = build_package_image(package_root=tmp_path, platform="linux/arm64")
+
+    assert lock.image_digest == "sha256:cached"
+    assert lock.image_tag.startswith("bora-pkg:")
+    assert "task" not in lock.image_tag
+    assert all("buildx" not in cmd for cmd in calls)
+    assert lock.build_input_digest.startswith("sha256:")
+
+
+def test_build_runs_buildx_on_cache_miss(tmp_path: Path) -> None:
+    _write_pkg(tmp_path, "FROM bora-attempt:l1\n")
+    base = DockerImageLock(
+        kind="docker-attempt",
+        platform="linux/arm64",
+        image_tag="bora-attempt:l1",
+        image_digest="sha256:official",
+        build_input_digest="sha256:official-in",
+    )
+    seen_buildx = False
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> object:
+        nonlocal seen_buildx
+        if cmd[:3] == ["docker", "image", "inspect"]:
+            if seen_buildx:
+                return type("P", (), {"returncode": 0, "stdout": "sha256:new\n", "stderr": ""})()
+            return type("P", (), {"returncode": 1, "stdout": "", "stderr": "missing"})()
+        if cmd[:2] == ["docker", "buildx"]:
+            seen_buildx = True
+            return type("P", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        raise AssertionError(f"unexpected docker command: {cmd}")
+
+    with (
+        patch(
+            "bora.adapters.provider_docker.images.ensure_base_image",
+            return_value=base,
+        ),
+        patch("bora.adapters.provider_docker.images.subprocess.run", side_effect=fake_run),
+    ):
+        lock = build_package_image(package_root=tmp_path, platform="linux/arm64")
+
+    assert seen_buildx is True
+    assert lock.image_digest == "sha256:new"
+    assert lock.image_tag.startswith("bora-pkg:")

--- a/tests/application/test_attempt_identity.py
+++ b/tests/application/test_attempt_identity.py
@@ -116,7 +116,12 @@ def test_prepare_l1_runtime_uses_passed_attempt(
             )
 
     monkeypatch.setattr(prep, "ensure_base_image", lambda _cwd: None)
-    monkeypatch.setattr(prep, "build_package_image", lambda **_kw: image)
+
+    def _fake_build(**kw: object) -> DockerImageLock:
+        seen["build_kw"] = kw
+        return image
+
+    monkeypatch.setattr(prep, "build_package_image", _fake_build)
     monkeypatch.setattr(prep, "ensure_image_lock", lambda _cwd: tmp_path / "lock.json")
     monkeypatch.setattr(prep, "DockerProvider", FakeDocker)
     monkeypatch.setattr(hooks, "hook_prepare", lambda *_a, **_k: None)
@@ -136,6 +141,11 @@ def test_prepare_l1_runtime_uses_passed_attempt(
     assert seen["attempt"] is attempt
     assert runtime.attempt is attempt
     assert meta["attempt_id"] == attempt.value
+    build_kw = seen["build_kw"]
+    assert isinstance(build_kw, dict)
+    assert "tag" not in build_kw
+    assert lock.digest not in str(build_kw)
+    assert lock.task_id not in str(build_kw)
 
 
 def test_l1_prepare_source_has_no_identity_factory() -> None:

--- a/tests/plugins/test_image_contribute_bake.py
+++ b/tests/plugins/test_image_contribute_bake.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import patch
@@ -12,6 +13,9 @@ from bora.adapters.provider_docker.types import DockerImageLock
 from bora.application.plugin_ops.image_contribute_bake import (
     ImageContributeError,
     apply_image_contribute_bake,
+    bake_layer_content_digest,
+    bake_plugin_layer,
+    baked_image_tag,
     bound_executor_ids,
 )
 from bora.config.model import LockedTaskConfig
@@ -87,3 +91,137 @@ def test_apply_fail_closed_when_not_installed() -> None:
     ):
         apply_image_contribute_bake(lock=lock, base_image=_base(), platform="linux/arm64")
     assert ei.value.kind == "plugin_not_ready"
+
+
+def _plugin_root(tmp_path: Path, bake: str, files: dict[str, str] | None = None) -> Path:
+    root = tmp_path / "plugin"
+    df = root / "docker" / "Dockerfile.bake"
+    df.parent.mkdir(parents=True, exist_ok=True)
+    df.write_text(bake, encoding="utf-8")
+    for rel, body in (files or {}).items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    return root
+
+
+def test_bake_suffix_from_inputs_not_inspect_id(tmp_path: Path) -> None:
+    root = _plugin_root(
+        tmp_path,
+        "FROM ${BASE_IMAGE}\nCOPY worker/x.py /opt/x.py\n",
+        {"worker/x.py": "print(1)\n"},
+    )
+    df = root / "docker" / "Dockerfile.bake"
+    first = bake_layer_content_digest(
+        plugin_id="nooa",
+        plugin_root=root,
+        dockerfile=df,
+        base_content_digest="sha256:d",
+    )
+    second = bake_layer_content_digest(
+        plugin_id="nooa",
+        plugin_root=root,
+        dockerfile=df,
+        base_content_digest="sha256:d",
+    )
+    assert first == second
+    tag = baked_image_tag(_base(), "nooa", first)
+    assert tag.startswith("bora-pkg:x-nooa-")
+    assert "abc" not in tag
+    other_base = bake_layer_content_digest(
+        plugin_id="nooa",
+        plugin_root=root,
+        dockerfile=df,
+        base_content_digest="sha256:other",
+    )
+    assert other_base != first
+    (root / "worker" / "x.py").write_text("print(2)\n", encoding="utf-8")
+    assert (
+        bake_layer_content_digest(
+            plugin_id="nooa",
+            plugin_root=root,
+            dockerfile=df,
+            base_content_digest="sha256:d",
+        )
+        != first
+    )
+
+
+def test_apply_fail_closed_when_bake_file_missing(tmp_path: Path) -> None:
+    empty = tmp_path / "installed"
+    empty.mkdir()
+    lock = _lock_with_profiles([{"id": "s", "executor": "nooa"}])
+    with (
+        patch(
+            "bora.application.plugin_ops.image_contribute_bake.collect_declares_for_lock",
+            return_value=[{"plugin": "nooa"}],
+        ),
+        patch(
+            "bora.application.plugin_ops.image_contribute_bake._find_installed_plugin_root",
+            return_value=empty,
+        ),
+        pytest.raises(ImageContributeError) as ei,
+    ):
+        apply_image_contribute_bake(lock=lock, base_image=_base(), platform="linux/arm64")
+    assert ei.value.kind == "plugin_not_ready"
+
+
+def test_apply_reuses_baked_tag_without_inspect_suffix(tmp_path: Path) -> None:
+    root = _plugin_root(
+        tmp_path,
+        "FROM ${BASE_IMAGE}\nCOPY worker/x.py /opt/x.py\n",
+        {"worker/x.py": "print(1)\n"},
+    )
+    lock = _lock_with_profiles([{"id": "s", "executor": "nooa"}])
+    baked = DockerImageLock(
+        kind="docker-package-attempt",
+        platform="linux/arm64",
+        image_tag="bora-pkg:x-nooa-deadbeefcaf0",
+        image_digest="sha256:baked",
+        build_input_digest="sha256:bake",
+    )
+    with (
+        patch(
+            "bora.application.plugin_ops.image_contribute_bake.collect_declares_for_lock",
+            return_value=[{"plugin": "nooa"}],
+        ),
+        patch(
+            "bora.application.plugin_ops.image_contribute_bake._find_installed_plugin_root",
+            return_value=root,
+        ),
+        patch(
+            "bora.application.plugin_ops.image_contribute_bake.bake_plugin_layer",
+            return_value=baked,
+        ) as bake_layer,
+    ):
+        out, meta = apply_image_contribute_bake(
+            lock=lock, base_image=_base(), platform="linux/arm64"
+        )
+    assert out.image_tag == baked.image_tag
+    assert meta["status"] == "baked"
+    out_tag = bake_layer.call_args.kwargs["out_tag"]
+    assert out_tag.startswith("bora-pkg:x-nooa-")
+    assert "abc" not in out_tag
+    assert _base().image_digest not in out_tag
+
+
+def test_bake_plugin_layer_skips_buildx_when_tag_exists(tmp_path: Path) -> None:
+    root = _plugin_root(
+        tmp_path,
+        "FROM ${BASE_IMAGE}\nCOPY worker/x.py /opt/x.py\n",
+        {"worker/x.py": "print(1)\n"},
+    )
+    with patch(
+        "bora.application.plugin_ops.image_contribute_bake.inspect_image_digest",
+        return_value="sha256:cached-bake",
+    ):
+        out = bake_plugin_layer(
+            base_image=_base(),
+            platform="linux/arm64",
+            out_tag="bora-pkg:x-nooa-abc123abc123",
+            plugin_id="nooa",
+            plugin_root=root,
+        )
+    assert out.image_digest == "sha256:cached-bake"
+    assert out.image_tag == "bora-pkg:x-nooa-abc123abc123"
+    assert out.build_input_digest.startswith("sha256:")

--- a/website/content/docs/agents/l1-docker.en.mdx
+++ b/website/content/docs/agents/l1-docker.en.mdx
@@ -21,4 +21,8 @@ provider:
 
 The official Attempt base installs engines + ACP entries at **build** time. Task images should `FROM` that base — no runtime `npm i`.
 
+Local Attempt images are addressed by the Dockerfile, base digest, and COPY'd files. Changing only `parameters` or profiles does not create a new tag; a second prepare with the same inputs reuses the image. Evidence still records `image_digest`.
+
+When the Attempt ends (success, failure, or cancel), BORA removes that Attempt's `bora-home-*` volumes and env containers. `--keep-workspace` keeps host `l1-work/` only — not Docker volumes.
+
 Examples: [`examples/l1`](https://github.com/ZJU-REAL/BORA/tree/main/examples/l1). Visibility: [Docker and visibility](/docs/author/docker-and-visibility).

--- a/website/content/docs/agents/l1-docker.mdx
+++ b/website/content/docs/agents/l1-docker.mdx
@@ -21,4 +21,8 @@ provider:
 
 官方 Attempt 基座在**构建期**安装常见 engine + ACP 入口。题目镜像应基于基座，不要在 `bora run` 时临时 `npm i`。
 
+本地 Attempt 镜像按 Dockerfile、基座 digest 和 COPY 进去的文件寻址；只改 `parameters` / profiles 不会再打一个 tag。第二次相同输入会复用已有镜像。evidence 仍记录 `image_digest`。
+
+Attempt 结束（成功、失败或取消）后会拆掉该次创建的 `bora-home-*` volume 和 env 容器。`--keep-workspace` 只留 host 上的 `l1-work/`，不留 Docker volume。
+
 探针与示例：[`examples/l1`](https://github.com/ZJU-REAL/BORA/tree/main/examples/l1)。可见性目录见 [Docker 与可见性](/docs/author/docker-and-visibility)。

--- a/website/content/docs/reference/cli.en.mdx
+++ b/website/content/docs/reference/cli.en.mdx
@@ -39,7 +39,7 @@ Path = Dataset root. Destructive commands require `--yes`; overwrite same identi
 | `--max-concurrent-tasks N` | Max concurrent units; **speeds wall time only** |
 | `--n-attempts` / `-k N` | Always-k: N independent Attempts per task (default 1); **CLI/job only** |
 | `--resume-suite <suite_run_id>` | Resume job: skip finished units, append Attempts, recompute pass@k / pass^k |
-| `--keep-workspace` | L1 only: keep host `l1-work/` after cleanup (default: delete; uploads never pack it) |
+| `--keep-workspace` | L1 only: keep host `l1-work/` after cleanup (default: delete; uploads never pack it). Docker volumes are still removed |
 | `--set` / `--profiles` | Overrides / alternate job binding |
 
 ## `status` / `cancel`

--- a/website/content/docs/reference/cli.mdx
+++ b/website/content/docs/reference/cli.mdx
@@ -39,7 +39,7 @@ uv run bora results upload|upload-suite|share|unshare|set-visibility|delete …
 | `--max-concurrent-tasks N` | 并行 unit 上限；**只加速**，不改 k / PASS |
 | `--n-attempts` / `-k N` | Always-k：每题 N 次独立 Attempt（默认 1）；**CLI/job only** |
 | `--resume-suite <suite_run_id>` | 并进已有 job：跳过已完成 unit，追加 Attempt，重算 pass@k / pass^k |
-| `--keep-workspace` | 仅 L1：清理后保留 host `l1-work/`（默认删除；上传不打包） |
+| `--keep-workspace` | 仅 L1：清理后保留 host `l1-work/`（默认删除；上传不打包）。Docker volume 仍删除 |
 | `--set` / `--profiles` | 见下；与 job binding 相关 |
 
 ## `status` / `cancel`


### PR DESCRIPTION
Closes #101

Stop L1 Docker leftovers from piling up: package image tags were keyed on `lock.digest` / `task_id` / inspect ids, and Attempt-owned volumes / env containers were not always removed.

## Images

- Cache key is the package Dockerfile, official `FROM` digest, COPY/ADD tree, and platform — not the lock digest or task id.
- Local tag is `bora-pkg:{content[:12]}` (`-{plugin}-{bake_input[:12]}` after `image_contribute` bake).
- Second prepare with the same inputs skips `buildx --load`.
- Changing only `parameters` / profiles does not create a new tag.
- Bake suffix comes from bake inputs, not `docker image inspect`.
- Evidence / `public_view` still record `image_digest`. `bora-attempt:l1` is unchanged.

## Volumes

- Env stop, L1 target stop, and prepare rollback use `docker rm -fv` plus ledger `volume rm` for `bora-home-*`.
- `EnvironmentManager.close()` and Provider cleanup run on success, failure, and cancel (plus `atexit` for parent exit).
- `--keep-workspace` still keeps host `l1-work/` only. No `--keep-volumes`.
- No `docker volume prune` / `system prune`. Hub/registry compose volumes are never touched.

## Verification

- Unit/adapter tests for cache hit/miss, lock-only no retag, bake fail-closed, and volume teardown.
- Local `python-core` equivalent: ruff, pyright, 537 passed.
- Website build passed.
- Live L1: `examples/l1 --task sdk-session-single-actor` (ACP `pi`) **PASS** / `assurance:l1` twice, same image id `bora-pkg:62b19788e699` (`326ccaa9a08c`) after binding-only changes. `--keep-workspace` kept host `l1-work/` and still dropped Docker volumes. No leftover `bora-home-*` / env containers from those Attempts.

## Non-goals (unchanged)

- No registry push/pull of Attempt images.
- No isolation / ACP / `session_id` rewrite.
- No second CLI retain flag.
- No host-wide prune product feature.
- No evidence-grade upgrade.