### PR TITLE
feat(plugin): expose DSH permission mode via profiles options

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -153,7 +153,7 @@ BORA/
 │   ├── store.py               # 一份 MetadataStore + 薄 Postgres 适配
 │   └── routes.py              # ROUTES 必须声明 access；skip_auth 仅 access=none
 ├── examples/                  # 见 examples/README.md
-│   ├── journeys/              # case-class：env / multiagent / tau2 / terminal（+ profiles.nooa / profiles.dsh）
+│   ├── journeys/              # case-class：env / multiagent / tau2 / terminal（+ profiles.nooa / profiles.dsh[.read-only]）
 │   ├── core/                  # config / harness / eval / agent / SDK
 │   ├── l1/                    # Provider L1 isolation probes
 │   └── slot-probe/            # multi-slot 插件 e2e（需 bora plugin install）

--- a/docs/design/11-extension-plugins.md
+++ b/docs/design/11-extension-plugins.md
@@ -153,5 +153,5 @@ L1：bake 安装 `nooa` + **in-container worker**；parent 把 model/base_url/�
 - 结构地图：[`ARCHITECTURE.md`](../../ARCHITECTURE.md)（plugins 树、emit map）  
 - Owner：[`09-owner-matrix-and-structure.md`](09-owner-matrix-and-structure.md)  
 - Runtime Agent：[`05-runtime/agent-service.md`](05-runtime/agent-service.md)  
-- 示例：`plugins/nooa`、`plugins/dsh`、`plugins/slot-probe`、`examples/journeys/profiles.nooa.yaml`、`examples/journeys/profiles.dsh.yaml`、`examples/slot-probe/`  
+- 示例：`plugins/nooa`、`plugins/dsh`（`options.permission` 为插件自有键，非新 slot）、`plugins/slot-probe`、`examples/journeys/profiles.nooa.yaml`、`examples/journeys/profiles.dsh.yaml`、`examples/journeys/profiles.dsh.read-only.yaml`、`examples/slot-probe/`  
 - 交付跟踪：GitHub Issues（Epic 插件系统）

--- a/examples/README.md
+++ b/examples/README.md
@@ -87,6 +87,9 @@ uv run bora plugin install plugins/dsh
 unset BORA_OFFLINE_AGENT
 uv run bora run examples/journeys --task terminal-jsonl-agg \
   --profiles examples/journeys/profiles.dsh.yaml
+# Optional DSH file-effect policy (omit permission to keep unrestricted local tools):
+# uv run bora run examples/journeys --task terminal-jsonl-agg \
+#   --profiles examples/journeys/profiles.dsh.read-only.yaml
 ```
 
 ## `slot-probe/` (`database_id: example/slot-probe`)

--- a/examples/journeys/profiles.dsh.read-only.yaml
+++ b/examples/journeys/profiles.dsh.read-only.yaml
@@ -1,0 +1,18 @@
+# Journeys profiles: dsh with DSH file-effect policy read-only.
+# Usage:
+#   uv run bora plugin install plugins/dsh
+#   uv run bora run examples/journeys --task terminal-jsonl-agg \
+#     --profiles examples/journeys/profiles.dsh.read-only.yaml
+#
+# Coding tasks that must write workspace files should omit permission
+# (or use workspace-write). This binding is for dialog-style jobs and
+# for checking that DSH bash/fs writes are denied.
+# Same harness as profiles.dsh.yaml — only the job binding changes.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: dsh
+    model: deepseek-v4-flash
+    api_key: deepseek_api_key
+    options:
+      permission: read-only

--- a/examples/journeys/profiles.dsh.read-only.yaml
+++ b/examples/journeys/profiles.dsh.read-only.yaml
@@ -5,8 +5,8 @@
 #     --profiles examples/journeys/profiles.dsh.read-only.yaml
 #
 # Coding tasks that must write workspace files should omit permission
-# (or use workspace-write). This binding is for dialog-style jobs and
-# for checking that DSH bash/fs writes are denied.
+# (or use workspace-write). This binding fences file-tool writes.
+# bash redirects still write on the bundled jsonrpc runtime.
 # Same harness as profiles.dsh.yaml — only the job binding changes.
 format: bora.profiles/1
 bindings:

--- a/examples/journeys/profiles.dsh.yaml
+++ b/examples/journeys/profiles.dsh.yaml
@@ -4,6 +4,8 @@
 #   # repo/.env should define deepseek_api_key (projected as DEEPSEEK_API_KEY)
 #   uv run bora run examples/journeys --task terminal-jsonl-agg \
 #     --profiles examples/journeys/profiles.dsh.yaml
+# File-effect policy: profiles.dsh.read-only.yaml, or
+#   --set '/bindings/solver/options/permission="read-only"'
 #
 # api_key = env locator name (never a secret value).
 # Same harness as ACP / nooa — only the job binding changes.

--- a/examples/journeys/tasks/terminal-jsonl-agg/README.md
+++ b/examples/journeys/tasks/terminal-jsonl-agg/README.md
@@ -36,6 +36,16 @@ uv run bora run examples/journeys --task terminal-jsonl-agg \
   --profiles examples/journeys/profiles.dsh.yaml
 ```
 
+This journey writes `aggregates.json`, so omit `options.permission` or use
+`workspace-write`. `read-only` is a DSH file-effect policy for jobs that
+must not write; it is not BORA isolation.
+
+```bash
+uv run bora run examples/journeys --task terminal-jsonl-agg \
+  --profiles examples/journeys/profiles.dsh.read-only.yaml
+# or: --set '/bindings/solver/options/permission="read-only"'
+```
+
 Needs locator `deepseek_api_key` in repo `.env`. L1 bake installs
 `deepseek-harness-sdk` in the Attempt image.
 

--- a/examples/journeys/tasks/terminal-jsonl-agg/README.md
+++ b/examples/journeys/tasks/terminal-jsonl-agg/README.md
@@ -37,8 +37,8 @@ uv run bora run examples/journeys --task terminal-jsonl-agg \
 ```
 
 This journey writes `aggregates.json`, so omit `options.permission` or use
-`workspace-write`. `read-only` is a DSH file-effect policy for jobs that
-must not write; it is not BORA isolation.
+`workspace-write`. `read-only` fences DSH file-tool writes only; bash can
+still write on the bundled jsonrpc runtime. It is not BORA isolation.
 
 ```bash
 uv run bora run examples/journeys --task terminal-jsonl-agg \

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -38,8 +38,25 @@ bindings:
     model: deepseek-v4-flash
     api_key: deepseek_api_key          # env locator
     options:
-      composition: slim
+      composition: slim               # omit permission → unrestricted local bash/fs
+      # permission: read-only         # or workspace-write | danger-full-access
 ```
+
+`options.permission` is plugin-owned (same pattern as `composition`). Allowed
+values: `read-only` | `workspace-write` | `danger-full-access`. Setting it
+loads the sandboxed composition (`dsh-bash-sandbox` / `dsh-fs-sandbox` +
+`dsh-sandbox-policy`) and passes `DSH_PERMISSION_MODE`. Omit it to keep today's
+slim / unrestricted local tools. Invalid values fail closed at materialize —
+no spawn.
+
+Batch approval is `never` in the sandboxed tree so an unattended `bora run`
+cannot hang on a permission prompt. This is a DSH file-effect policy, not
+BORA isolation. L1 Docker + landlock / Seatbelt may fail to start
+(`SANDBOX_UNAVAILABLE`); that fails closed. Do not claim `isolated` from this
+knob.
+
+Same harness; switch only via profiles or
+`--set '/bindings/<role>/options/permission="read-only"'`.
 
 ## Journeys smoke (L1, real API)
 
@@ -48,6 +65,9 @@ uv run bora plugin install plugins/dsh
 unset BORA_OFFLINE_AGENT
 uv run bora run examples/journeys --task terminal-jsonl-agg \
   --profiles examples/journeys/profiles.dsh.yaml
+# file-effect policy (writes via DSH bash/fs are denied):
+# uv run bora run examples/journeys --task terminal-jsonl-agg \
+#   --profiles examples/journeys/profiles.dsh.read-only.yaml
 ```
 
 ## Recognition ≠ Ready ≠ bind

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -44,10 +44,15 @@ bindings:
 
 `options.permission` is plugin-owned (same pattern as `composition`). Allowed
 values: `read-only` | `workspace-write` | `danger-full-access`. Setting it
-loads the sandboxed composition (`dsh-bash-sandbox` / `dsh-fs-sandbox` +
-`dsh-sandbox-policy`) and passes `DSH_PERMISSION_MODE`. Omit it to keep today's
+loads the sandboxed composition (`dsh-fs-sandbox` + `dsh-sandbox-policy` +
+`dsh-sandbox-local`) and passes `DSH_PERMISSION_MODE`. Omit it to keep today's
 slim / unrestricted local tools. Invalid values fail closed at materialize —
 no spawn.
+
+The bundled `dsh-jsonrpc-agent` (`deepseek-harness-sdk==0.1.0rc6`) ships
+`dsh-fs-sandbox` but **not** `dsh-bash-sandbox`. The sandboxed tree therefore
+keeps `dsh-bash-local`. File-tool writes are fenced; a bash redirect can still
+write. Do not claim bash confinement on this runtime.
 
 Batch approval is `never` in the sandboxed tree so an unattended `bora run`
 cannot hang on a permission prompt. This is a DSH file-effect policy, not

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -70,7 +70,7 @@ uv run bora plugin install plugins/dsh
 unset BORA_OFFLINE_AGENT
 uv run bora run examples/journeys --task terminal-jsonl-agg \
   --profiles examples/journeys/profiles.dsh.yaml
-# file-effect policy (writes via DSH bash/fs are denied):
+# file-effect policy (file-tool writes denied; bash can still write):
 # uv run bora run examples/journeys --task terminal-jsonl-agg \
 #   --profiles examples/journeys/profiles.dsh.read-only.yaml
 ```

--- a/plugins/dsh/compositions/sandboxed.cordis.yml
+++ b/plugins/dsh/compositions/sandboxed.cordis.yml
@@ -1,0 +1,86 @@
+# BORA-owned sandboxed composition for the bundled dsh-jsonrpc-agent runtime.
+# Same jsonrpc + llm + sessions as slim; bash/fs swap to the first-party sandbox
+# pair already inside the runtime bin (no extra npm). Isolation hard boundary is
+# still BORA mount/UID — this is a DSH file-effect policy, not isolated.
+# Batch approval is never: an unattended Attempt cannot answer prompts.
+
+- id: sdk-jsonrpc-server
+  name: '@deepseek-ai/dsh-sdk-jsonrpc-server'
+  config:
+    maxTokensAsSuccess: !!js "process.env.DSH_MAX_TOKENS_AS_SUCCESS === undefined ? true : JSON.parse(process.env.DSH_MAX_TOKENS_AS_SUCCESS)"
+
+- id: llm-deepseek
+  name: '@deepseek-ai/dsh-llm-deepseek'
+  config:
+    thinking: enabled
+    reasoningEffort: max
+
+- id: subprocess
+  name: '@deepseek-ai/dsh-subprocess-local'
+
+- id: sandbox
+  name: '@deepseek-ai/dsh-sandbox-local'
+
+- id: sandbox-policy
+  name: '@deepseek-ai/dsh-sandbox-policy'
+  config:
+    mode: !!js process.env.DSH_PERMISSION_MODE || 'read-only'
+    workspaceRoot: !!js process.env.DSH_CWD ?? process.cwd()
+
+- id: approval
+  name: '@deepseek-ai/dsh-user-approval'
+  config:
+    policy: never
+
+- id: bash
+  name: '@deepseek-ai/dsh-bash-sandbox'
+  config:
+    cwd: !!js process.env.DSH_CWD ?? process.cwd()
+    timeoutMs: 60000
+
+- id: agent-spine
+  name: '@deepseek-ai/dsh-agent-spine-demo'
+  config:
+    persona: !!js process.env.DSH_SYSTEM_PROMPT ?? 'You are a coding agent. Your working directory is the task workspace. Use bash and filesystem tools to complete the instruction. Write required output files, then reply briefly. Do not ask questions.'
+    workspaceContext: false
+    skills:
+      enabled: false
+    toolBash:
+      enableRunInBackground: false
+    toolJobs: false
+
+- id: sessions
+  name: '@deepseek-ai/dsh-session-persistence-jsonl'
+  config:
+    root: !!js process.env.DSH_SESSION_ROOT
+    compression: none
+
+- id: session-checkpoints
+  name: '@deepseek-ai/dsh-session-checkpoint-policy'
+
+- id: tool-todo
+  name: '@deepseek-ai/dsh-tool-todo'
+  config:
+    allowParallelInProgress: true
+
+- id: fs-sandbox
+  name: '@deepseek-ai/dsh-fs-sandbox'
+  config:
+    cwd: !!js process.env.DSH_CWD ?? process.cwd()
+
+- id: fs-observation-policy
+  name: '@deepseek-ai/dsh-fs-observation-policy'
+
+- id: tool-fs
+  name: '@deepseek-ai/dsh-tool-fs'
+
+- id: token-meter
+  name: '@deepseek-ai/dsh-token-meter'
+
+- id: compaction-basic
+  name: '@deepseek-ai/dsh-compaction-basic'
+  config:
+    thresholdRatio: 0.8
+    retainRatio: 0.16
+    maxTokens: 8192
+    compactionRetries: 1

--- a/plugins/dsh/compositions/sandboxed.cordis.yml
+++ b/plugins/dsh/compositions/sandboxed.cordis.yml
@@ -1,8 +1,10 @@
 # BORA-owned sandboxed composition for the bundled dsh-jsonrpc-agent runtime.
-# Same jsonrpc + llm + sessions as slim; bash/fs swap to the first-party sandbox
-# pair already inside the runtime bin (no extra npm). Isolation hard boundary is
-# still BORA mount/UID — this is a DSH file-effect policy, not isolated.
-# Batch approval is never: an unattended Attempt cannot answer prompts.
+# Same jsonrpc + llm + sessions as slim. File writes go through dsh-fs-sandbox
+# (in the 0.1.0rc6 jsonrpc bin). dsh-bash-sandbox is NOT compiled into that
+# bin — keep dsh-bash-local or the runtime fails to start. Isolation hard
+# boundary is still BORA mount/UID; this is a DSH file-effect policy, not
+# isolated. Batch approval is never: an unattended Attempt cannot answer
+# prompts.
 
 - id: sdk-jsonrpc-server
   name: '@deepseek-ai/dsh-sdk-jsonrpc-server'
@@ -33,7 +35,7 @@
     policy: never
 
 - id: bash
-  name: '@deepseek-ai/dsh-bash-sandbox'
+  name: '@deepseek-ai/dsh-bash-local'
   config:
     cwd: !!js process.env.DSH_CWD ?? process.cwd()
     timeoutMs: 60000

--- a/plugins/dsh/docker/Dockerfile.bake
+++ b/plugins/dsh/docker/Dockerfile.bake
@@ -8,11 +8,12 @@ FROM ${BASE_IMAGE}
 USER root
 COPY src/dsh_plugin /opt/dsh/dsh_plugin
 COPY worker/bora_executor_dsh.py /usr/local/bin/bora-executor-dsh
-COPY compositions/slim.cordis.yml /opt/dsh/compositions/slim.cordis.yml
+COPY compositions/ /opt/dsh/compositions/
 # Pin official wheels at image build. No invoke-time npm i / floating pip.
 RUN chmod 755 /usr/local/bin/bora-executor-dsh \
     && test -f /usr/local/bin/bora-executor-dsh \
     && test -f /opt/dsh/compositions/slim.cordis.yml \
+    && test -f /opt/dsh/compositions/sandboxed.cordis.yml \
     && python3 -m py_compile /usr/local/bin/bora-executor-dsh \
     && python3 -m pip install --no-cache-dir "deepseek-harness-sdk==0.1.0rc6"
 

--- a/plugins/dsh/src/dsh_plugin/container.py
+++ b/plugins/dsh/src/dsh_plugin/container.py
@@ -15,12 +15,15 @@ from dsh_plugin.factory import (
     DEFAULT_COMPOSITION,
     DEFAULT_MODEL,
     DEFAULT_PROVIDER,
+    container_cordis_path,
+    permission_child_env,
     resolve_api_key_value,
     resolve_base_url,
+    resolve_effective_composition,
+    resolve_permission,
 )
 
 WORKER_PATH = "/usr/local/bin/bora-executor-dsh"
-CORDIS_CONTAINER = "/opt/dsh/compositions/slim.cordis.yml"
 WORKDIR_CONTAINER = "/attempt/workspace"
 HOME_CONTAINER = "/attempt/home"
 
@@ -38,6 +41,7 @@ class DshContainerExecutor(AgentExecutor):
         model: str = DEFAULT_MODEL,
         provider: str = DEFAULT_PROVIDER,
         composition: str = DEFAULT_COMPOSITION,
+        permission: str | None = None,
         base_url: str | None = None,
         api_key_env: str | None = None,
         uid: int = 10001,
@@ -49,7 +53,11 @@ class DshContainerExecutor(AgentExecutor):
         self.container_id = container_id
         self.model = model or DEFAULT_MODEL
         self.provider = provider or DEFAULT_PROVIDER
-        self.composition = composition or DEFAULT_COMPOSITION
+        self.permission = resolve_permission(permission)
+        self.composition = resolve_effective_composition(
+            composition=composition, permission=self.permission
+        )
+        self.cordis_container = container_cordis_path(self.composition)
         self.base_url = (base_url or "").strip() or None
         self.api_key_env = (api_key_env or "").strip() or None
         self.uid = uid
@@ -71,7 +79,8 @@ class DshContainerExecutor(AgentExecutor):
         env: dict[str, str] = {
             "DSH_CWD": self.workdir_container,
             "DSH_SESSION_ROOT": f"{self.home_container.rstrip('/')}/dsh-sessions",
-            "DSH_CORDIS_CONFIG": CORDIS_CONTAINER,
+            "DSH_CORDIS_CONFIG": self.cordis_container,
+            **permission_child_env(self.permission),
         }
         key = resolve_api_key_value(self.api_key_env)
         if key:
@@ -97,9 +106,10 @@ class DshContainerExecutor(AgentExecutor):
             "model": self.model,
             "provider": self.provider,
             "composition": self.composition,
+            "permission": self.permission,
             "workdir": effective_workdir,
             "session_root": f"{self.home_container.rstrip('/')}/dsh-sessions",
-            "cordis": CORDIS_CONTAINER,
+            "cordis": self.cordis_container,
             "session_id": self.session_id,
         }
         env = self._child_env()

--- a/plugins/dsh/src/dsh_plugin/factory.py
+++ b/plugins/dsh/src/dsh_plugin/factory.py
@@ -24,6 +24,9 @@ from dsh_plugin.trajectory import extract_usage, to_bora_trajectory_events
 DEFAULT_MODEL = "deepseek-v4-flash"
 DEFAULT_PROVIDER = "deepseek-official"
 DEFAULT_COMPOSITION = "slim"
+SANDBOXED_COMPOSITION = "sandboxed"
+PERMISSION_ENV = "DSH_PERMISSION_MODE"
+PERMISSION_MODES = frozenset({"read-only", "workspace-write", "danger-full-access"})
 _CREDENTIAL_ENV_NAMES = ("DEEPSEEK_API_KEY", "deepseek_api_key")
 _BASE_URL_ENV_FALLBACKS = ("DEEPSEEK_BASE_URL", "deepseek_base_url")
 _OK_REASONS = frozenset({"completed", "max-tokens"})
@@ -45,13 +48,18 @@ def _plugin_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def resolve_composition_path(name: str | None) -> Path:
+def _composition_slug(name: str | None) -> str:
     slug = (name or DEFAULT_COMPOSITION).strip() or DEFAULT_COMPOSITION
     if "/" in slug or "\\" in slug or slug.startswith("."):
         raise ExtensionMaterializeError(
             f"dsh_composition_invalid:{slug}",
             kind="extension_materialize_failed",
         )
+    return slug
+
+
+def resolve_composition_path(name: str | None) -> Path:
+    slug = _composition_slug(name)
     path = _plugin_root() / "compositions" / f"{slug}.cordis.yml"
     if not path.is_file():
         raise ExtensionMaterializeError(
@@ -59,6 +67,43 @@ def resolve_composition_path(name: str | None) -> Path:
             kind="extension_materialize_failed",
         )
     return path
+
+
+def container_cordis_path(name: str | None) -> str:
+    return f"/opt/dsh/compositions/{_composition_slug(name)}.cordis.yml"
+
+
+def resolve_permission(raw: Any) -> str | None:
+    """Validate ``options.permission``. Omit / blank → None (keep slim)."""
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raise ExtensionMaterializeError(
+            f"dsh_permission_invalid:{raw!r}",
+            kind="extension_materialize_failed",
+        )
+    value = raw.strip()
+    if not value:
+        return None
+    if value not in PERMISSION_MODES:
+        raise ExtensionMaterializeError(
+            f"dsh_permission_invalid:{value}",
+            kind="extension_materialize_failed",
+        )
+    return value
+
+
+def resolve_effective_composition(*, composition: str | None, permission: str | None) -> str:
+    explicit = (composition or "").strip()
+    if permission and (not explicit or explicit == DEFAULT_COMPOSITION):
+        return SANDBOXED_COMPOSITION
+    return explicit or DEFAULT_COMPOSITION
+
+
+def permission_child_env(permission: str | None) -> dict[str, str]:
+    if not permission:
+        return {}
+    return {PERMISSION_ENV: permission}
 
 
 def resolve_api_key_value(locator: str | None) -> str | None:
@@ -139,8 +184,10 @@ class DshExecutorSPI:
         self.profile_id = profile_id
         self.model = (model or "").strip() or DEFAULT_MODEL
         self.provider = str(opts.get("provider") or DEFAULT_PROVIDER).strip() or DEFAULT_PROVIDER
-        self.composition = str(opts.get("composition") or DEFAULT_COMPOSITION).strip() or (
-            DEFAULT_COMPOSITION
+        self.permission = resolve_permission(opts.get("permission"))
+        self.composition = resolve_effective_composition(
+            composition=str(opts.get("composition") or "").strip() or None,
+            permission=self.permission,
         )
         self.base_url = base_url
         self.api_key_env = api_key
@@ -170,6 +217,7 @@ class DshExecutorSPI:
             model=self.model,
             provider=self.provider,
             composition=self.composition,
+            permission=self.permission,
             base_url=self.base_url if isinstance(self.base_url, str) else None,
             api_key_env=self.api_key_env if isinstance(self.api_key_env, str) else None,
             session_id=self._session_id,
@@ -275,6 +323,7 @@ class DshExecutorSPI:
                 "finish_reason": reason,
                 "session_root": result.session_root or self._session_root,
                 "composition": self.composition,
+                "permission": self.permission,
                 "execution_location": "host",
             },
         )
@@ -317,6 +366,7 @@ class DshExecutorSPI:
             env["DEEPSEEK_API_KEY"] = key
         if base:
             env["DEEPSEEK_BASE_URL"] = base
+        env.update(permission_child_env(self.permission))
         self._harness = DeepSeekHarness(
             provider=self.provider,
             model=self.model,

--- a/plugins/dsh/worker/bora_executor_dsh.py
+++ b/plugins/dsh/worker/bora_executor_dsh.py
@@ -157,9 +157,8 @@ def main() -> int:
 
     traj = _load_trajectory()
     raw_perm = req.get("permission")
-    permission = (
-        os.environ.get("DSH_PERMISSION_MODE")
-        or (str(raw_perm).strip() if isinstance(raw_perm, str) else "")
+    permission = os.environ.get("DSH_PERMISSION_MODE") or (
+        str(raw_perm).strip() if isinstance(raw_perm, str) else ""
     )
     child_env: dict[str, str] = {}
     if permission:

--- a/plugins/dsh/worker/bora_executor_dsh.py
+++ b/plugins/dsh/worker/bora_executor_dsh.py
@@ -14,6 +14,9 @@ DEEPSEEK_API_KEY / DEEPSEEK_BASE_URL arrive via projected env)::
       "session_id": "bora-solver-…"
     }
 
+``DSH_PERMISSION_MODE`` (when set) is forwarded into the child runtime so
+``sandboxed.cordis.yml`` can resolve ``sandbox-policy.mode``.
+
 Writes one AgentResult-shaped JSON object to stdout.
 """
 
@@ -153,6 +156,15 @@ def main() -> int:
         )
 
     traj = _load_trajectory()
+    raw_perm = req.get("permission")
+    permission = (
+        os.environ.get("DSH_PERMISSION_MODE")
+        or (str(raw_perm).strip() if isinstance(raw_perm, str) else "")
+    )
+    child_env: dict[str, str] = {}
+    if permission:
+        child_env["DSH_PERMISSION_MODE"] = permission
+        os.environ["DSH_PERMISSION_MODE"] = permission
     try:
         with DeepSeekHarness(
             provider=provider,
@@ -160,7 +172,7 @@ def main() -> int:
             cwd=workdir,
             session_root=session_root,
             cordis=cordis,
-            env={},
+            env=child_env,
         ) as harness:
             session = harness.start_session(session_id_s)
             result = session.run(prompt)
@@ -189,6 +201,10 @@ def main() -> int:
                     "session_id": result.session_id,
                     "finish_reason": reason,
                     "session_root": result.session_root or session_root,
+                    "composition": str(
+                        req.get("composition") or Path(cordis).name.removesuffix(".cordis.yml")
+                    ),
+                    "permission": permission or None,
                 },
             },
             code=0 if ok else 1,

--- a/skills/bora-cli/SKILL.md
+++ b/skills/bora-cli/SKILL.md
@@ -213,6 +213,7 @@ Must not PASS agent packages. Typed errors only.
 | L1 isolation contracts       | Provider tests: `uv run pytest tests/provider_l1/test_harness_isolation_contracts.py tests/provider_l1/test_filtered_mount.py -q`              |
 | nooa plugin (L1)             | `bora plugin install plugins/nooa` then `bora run examples/journeys --task terminal-jsonl-agg --profiles examples/journeys/profiles.nooa.yaml` |
 | dsh plugin (L1)              | `bora plugin install plugins/dsh` then `bora run examples/journeys --task terminal-jsonl-agg --profiles examples/journeys/profiles.dsh.yaml`   |
+| dsh file-effect policy       | same + `--profiles examples/journeys/profiles.dsh.read-only.yaml` or `--set '/bindings/solver/options/permission="read-only"'`                 |
 
 ## Detail
 

--- a/skills/bora-plugin/SKILL.md
+++ b/skills/bora-plugin/SKILL.md
@@ -110,7 +110,7 @@ Discover flags with `bora plugin --help`. Do not invent commands.
 | `docs/design/05-runtime/evidence.md` | Three-layer trajectory contract |
 | `src/bora/plugins/slots.py` / `protocol.py` | Slot ids and `ExecutorSPI` |
 | `plugins/nooa` | External executor + bake + neutral trajectory |
-| `plugins/dsh` | External DeepSeek Harness JSON-RPC executor + bake (not ACP) |
+| `plugins/dsh` | External DeepSeek Harness JSON-RPC executor + bake (not ACP); `options.permission` is plugin-owned |
 | `plugins/slot-probe` + `examples/slot-probe` | Multi-slot on-handler regression, not a business template |
 
 Siblings: orientation → `$bora-platform`; CLI → `$bora-cli`; Database/profiles → `$bora-config-package`; harness → `$bora-sdk-harness`.

--- a/skills/bora-plugin/references/authoring.md
+++ b/skills/bora-plugin/references/authoring.md
@@ -139,7 +139,10 @@ bindings:
 ```
 
 `--set /bindings/<role>/options/<key>=…` is allowed (ACP still rejects
-`command` / engine keys).
+`command` / engine keys). Plugin-owned keys stay opaque to Core — for
+example dsh `options.permission` (`read-only` / `workspace-write` /
+`danger-full-access`) selects a plugin composition and child env. Invalid
+values fail closed at materialize.
 
 ## Typed failures
 

--- a/tests/plugins/test_dsh_permission.py
+++ b/tests/plugins/test_dsh_permission.py
@@ -61,9 +61,7 @@ def test_permission_selects_sandboxed_unless_custom_composition() -> None:
         resolve_effective_composition(composition="sandboxed", permission="read-only")
         == SANDBOXED_COMPOSITION
     )
-    assert (
-        resolve_effective_composition(composition="custom", permission="read-only") == "custom"
-    )
+    assert resolve_effective_composition(composition="custom", permission="read-only") == "custom"
     assert resolve_effective_composition(composition=None, permission=None) == DEFAULT_COMPOSITION
     assert resolve_effective_composition(composition="slim", permission=None) == "slim"
 

--- a/tests/plugins/test_dsh_permission.py
+++ b/tests/plugins/test_dsh_permission.py
@@ -1,0 +1,176 @@
+"""dsh options.permission: composition swap, env, fail-closed (no live DSH)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bora.plugins.errors import ExtensionMaterializeError
+
+_DSH_SRC = Path(__file__).resolve().parents[2] / "plugins" / "dsh" / "src"
+if str(_DSH_SRC) not in sys.path:
+    sys.path.insert(0, str(_DSH_SRC))
+
+from dsh_plugin.container import DshContainerExecutor  # noqa: E402
+from dsh_plugin.factory import (  # noqa: E402
+    DEFAULT_COMPOSITION,
+    PERMISSION_ENV,
+    SANDBOXED_COMPOSITION,
+    DshExecutorSPI,
+    build_executor,
+    permission_child_env,
+    resolve_composition_path,
+    resolve_effective_composition,
+    resolve_permission,
+)
+
+
+def test_resolve_permission_omit_and_blank() -> None:
+    assert resolve_permission(None) is None
+    assert resolve_permission("") is None
+    assert resolve_permission("   ") is None
+
+
+@pytest.mark.parametrize("mode", ["read-only", "workspace-write", "danger-full-access"])
+def test_resolve_permission_allows_known_modes(mode: str) -> None:
+    assert resolve_permission(mode) == mode
+    assert resolve_permission(f"  {mode}  ") == mode
+
+
+def test_resolve_permission_rejects_unknown() -> None:
+    with pytest.raises(ExtensionMaterializeError, match="dsh_permission_invalid:ask"):
+        resolve_permission("ask")
+    with pytest.raises(ExtensionMaterializeError, match="dsh_permission_invalid"):
+        resolve_permission(1)
+
+
+def test_permission_selects_sandboxed_unless_custom_composition() -> None:
+    assert (
+        resolve_effective_composition(composition=None, permission="read-only")
+        == SANDBOXED_COMPOSITION
+    )
+    assert (
+        resolve_effective_composition(composition="slim", permission="workspace-write")
+        == SANDBOXED_COMPOSITION
+    )
+    assert (
+        resolve_effective_composition(composition="sandboxed", permission="read-only")
+        == SANDBOXED_COMPOSITION
+    )
+    assert (
+        resolve_effective_composition(composition="custom", permission="read-only") == "custom"
+    )
+    assert resolve_effective_composition(composition=None, permission=None) == DEFAULT_COMPOSITION
+    assert resolve_effective_composition(composition="slim", permission=None) == "slim"
+
+
+def test_sandboxed_composition_file_exists() -> None:
+    path = resolve_composition_path(SANDBOXED_COMPOSITION)
+    text = path.read_text(encoding="utf-8")
+    assert "dsh-bash-sandbox" in text
+    assert "dsh-fs-sandbox" in text
+    assert "dsh-sandbox-policy" in text
+    assert "DSH_PERMISSION_MODE" in text
+    assert "policy: never" in text
+    assert "dsh-bash-local" not in text
+    assert "dsh-fs-local" not in text
+
+
+def test_factory_permission_switches_composition_and_bind_env() -> None:
+    spi = build_executor(
+        options={"permission": "read-only"},
+        model="deepseek-v4-flash",
+        api_key="deepseek_api_key",
+        profile_id="solver",
+    )
+    assert spi.permission == "read-only"
+    assert spi.composition == SANDBOXED_COMPOSITION
+    bound = spi.bind_to_target(
+        SimpleNamespace(
+            container_id="cid123",
+            uid=10001,
+            gid=10001,
+            workdir="/attempt/workspace",
+            home="/attempt/home",
+        )
+    )
+    assert isinstance(bound, DshContainerExecutor)
+    assert bound.permission == "read-only"
+    assert bound.composition == SANDBOXED_COMPOSITION
+    assert bound.cordis_container == "/opt/dsh/compositions/sandboxed.cordis.yml"
+    env = bound._child_env()
+    assert env[PERMISSION_ENV] == "read-only"
+    assert env["DSH_CORDIS_CONFIG"] == bound.cordis_container
+
+
+def test_omitted_permission_keeps_slim() -> None:
+    spi = DshExecutorSPI(options={"composition": "slim"})
+    assert spi.permission is None
+    assert spi.composition == "slim"
+    bound = spi.bind_to_target(
+        SimpleNamespace(
+            container_id="cid123",
+            uid=10001,
+            gid=10001,
+            workdir="/attempt/workspace",
+            home="/attempt/home",
+        )
+    )
+    assert bound.permission is None
+    assert bound.composition == "slim"
+    assert bound.cordis_container == "/opt/dsh/compositions/slim.cordis.yml"
+    env = bound._child_env()
+    assert PERMISSION_ENV not in env
+
+
+def test_invalid_permission_raises_before_spawn() -> None:
+    with pytest.raises(ExtensionMaterializeError, match="dsh_permission_invalid:rwx"):
+        DshExecutorSPI(options={"permission": "rwx"})
+    with pytest.raises(ExtensionMaterializeError, match="dsh_permission_invalid:rwx"):
+        DshContainerExecutor(container_id="cid", permission="rwx")
+
+
+def test_host_invoke_forwards_permission_env(monkeypatch: object) -> None:
+    monkeypatch.delenv("BORA_OFFLINE_AGENT", raising=False)  # type: ignore[attr-defined]
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")  # type: ignore[attr-defined]
+    harness = MagicMock()
+    session = MagicMock()
+    session.run.return_value = SimpleNamespace(
+        events=[],
+        notifications=(),
+        final_response="ok",
+        finish_reason="completed",
+        session_id="s1",
+        session_root="/tmp/dsh",
+    )
+    harness.start_session.return_value = session
+
+    captured: dict[str, object] = {}
+
+    def _factory(**kwargs: object) -> MagicMock:
+        captured.update(kwargs)
+        return harness
+
+    fake_mod = MagicMock()
+    fake_mod.DeepSeekHarness = _factory
+    spi = DshExecutorSPI(options={"permission": "workspace-write"}, model="deepseek-v4-flash")
+    with patch.dict(sys.modules, {"deepseek_harness": fake_mod}):
+        result = spi.invoke("hello", timeout=5.0)
+    assert result.ok
+    env = captured.get("env")
+    assert isinstance(env, dict)
+    assert env[PERMISSION_ENV] == "workspace-write"
+    cordis = str(captured.get("cordis") or "")
+    assert cordis.endswith("sandboxed.cordis.yml")
+    assert result.metadata is not None
+    assert result.metadata.get("composition") == SANDBOXED_COMPOSITION
+    assert result.metadata.get("permission") == "workspace-write"
+
+
+def test_permission_child_env_empty_when_unset() -> None:
+    assert permission_child_env(None) == {}
+    assert permission_child_env("read-only") == {PERMISSION_ENV: "read-only"}

--- a/tests/plugins/test_dsh_permission.py
+++ b/tests/plugins/test_dsh_permission.py
@@ -69,13 +69,14 @@ def test_permission_selects_sandboxed_unless_custom_composition() -> None:
 def test_sandboxed_composition_file_exists() -> None:
     path = resolve_composition_path(SANDBOXED_COMPOSITION)
     text = path.read_text(encoding="utf-8")
-    assert "dsh-bash-sandbox" in text
     assert "dsh-fs-sandbox" in text
     assert "dsh-sandbox-policy" in text
     assert "DSH_PERMISSION_MODE" in text
     assert "policy: never" in text
-    assert "dsh-bash-local" not in text
-    assert "dsh-fs-local" not in text
+    assert "name: '@deepseek-ai/dsh-bash-local'" in text
+    assert "name: '@deepseek-ai/dsh-fs-sandbox'" in text
+    assert "name: '@deepseek-ai/dsh-bash-sandbox'" not in text
+    assert "name: '@deepseek-ai/dsh-fs-local'" not in text
 
 
 def test_factory_permission_switches_composition_and_bind_env() -> None:

--- a/website/content/docs/run/plugins.en.mdx
+++ b/website/content/docs/run/plugins.en.mdx
@@ -43,7 +43,14 @@ uv run bora run examples/journeys --task terminal-jsonl-agg \
 # DeepSeek Harness (not ACP):
 # uv run bora run examples/journeys --task terminal-jsonl-agg \
 #   --profiles examples/journeys/profiles.dsh.yaml
+# Optional DSH file-effect policy (plugin-owned options.permission):
+# uv run bora run examples/journeys --task terminal-jsonl-agg \
+#   --profiles examples/journeys/profiles.dsh.read-only.yaml
 ```
+
+`dsh` `options.permission` accepts `read-only`, `workspace-write`, or
+`danger-full-access`. Omit it to keep unrestricted local bash/fs. Invalid
+values fail closed. This is not a BORA isolation claim.
 
 `bora lock` writes the resolved extension graph into `extension_bindings` in the lock summary.
 

--- a/website/content/docs/run/plugins.en.mdx
+++ b/website/content/docs/run/plugins.en.mdx
@@ -50,7 +50,8 @@ uv run bora run examples/journeys --task terminal-jsonl-agg \
 
 `dsh` `options.permission` accepts `read-only`, `workspace-write`, or
 `danger-full-access`. Omit it to keep unrestricted local bash/fs. Invalid
-values fail closed. This is not a BORA isolation claim.
+values fail closed. On the bundled jsonrpc runtime, file-tool writes are
+fenced; bash stays local. This is not a BORA isolation claim.
 
 `bora lock` writes the resolved extension graph into `extension_bindings` in the lock summary.
 

--- a/website/content/docs/run/plugins.mdx
+++ b/website/content/docs/run/plugins.mdx
@@ -42,7 +42,14 @@ uv run bora run examples/journeys --task terminal-jsonl-agg \
 # DeepSeek Harness（非 ACP）：
 # uv run bora run examples/journeys --task terminal-jsonl-agg \
 #   --profiles examples/journeys/profiles.dsh.yaml
+# 可选 DSH 文件效果策略（插件自有 options.permission）：
+# uv run bora run examples/journeys --task terminal-jsonl-agg \
+#   --profiles examples/journeys/profiles.dsh.read-only.yaml
 ```
+
+`dsh` 的 `options.permission` 只接受 `read-only`、`workspace-write`、
+`danger-full-access`。省略则仍用不受限的本地 bash/fs。非法值 fail-closed。
+这不是 BORA isolation 声明。
 
 `bora lock` 会把解析后的扩展图写入摘要中的 `extension_bindings`。
 

--- a/website/content/docs/run/plugins.mdx
+++ b/website/content/docs/run/plugins.mdx
@@ -49,7 +49,7 @@ uv run bora run examples/journeys --task terminal-jsonl-agg \
 
 `dsh` 的 `options.permission` 只接受 `read-only`、`workspace-write`、
 `danger-full-access`。省略则仍用不受限的本地 bash/fs。非法值 fail-closed。
-这不是 BORA isolation 声明。
+随 jsonrpc 运行时：文件工具写入受围栏，bash 仍是本地。这不是 BORA isolation 声明。
 
 `bora lock` 会把解析后的扩展图写入摘要中的 `extension_bindings`。
 


### PR DESCRIPTION
## Summary

Let the external `dsh` plugin select DeepSeek Harness file-permission mode from job bindings, without new Core slots.

Dialog / tool-JSON jobs can set `read-only`. Coding jobs that must write keep today's slim tree (omit `permission`) or opt into `workspace-write`.

```yaml
bindings:
  solver:
    executor: dsh
    model: deepseek-v4-flash
    api_key: deepseek_api_key
    options:
      permission: read-only   # or workspace-write | danger-full-access
```

`--set '/bindings/<role>/options/permission="read-only"'` works the same way.

Closes #106.

## Mechanism

Plugin-owned `options.permission` (same pattern as `composition`). Not a new slot. Not ACP.

| Value | Effect |
| --- | --- |
| omitted / blank | slim composition, unrestricted local bash/fs (no behavior change) |
| `read-only` / `workspace-write` / `danger-full-access` | sandboxed composition + `DSH_PERMISSION_MODE` |
| anything else | typed `ExtensionMaterializeError` (`dsh_permission_invalid`); no spawn |

Sandboxed composition:

- loads `dsh-sandbox-local` + `dsh-sandbox-policy` + `dsh-fs-sandbox`
- keeps `dsh-bash-local` — **`dsh-bash-sandbox` is not compiled into `deepseek-harness-sdk==0.1.0rc6` `dsh-jsonrpc-agent`** (naming it fails to start)
- `dsh-user-approval` `policy: never` so an unattended Attempt cannot hang on prompts
- bake copies the whole `compositions/` directory

File-tool writes are fenced. A bash redirect can still write on this runtime. Isolation hard boundary remains BORA mount/UID. Do not claim `isolated` from this knob.

Host SPI and L1 `docker exec` both pass `DSH_PERMISSION_MODE`. L1 picks `/opt/dsh/compositions/sandboxed.cordis.yml` when permission is set.

## How to run

```bash
uv run bora plugin install plugins/dsh
unset BORA_OFFLINE_AGENT
# repo/.env locator: deepseek_api_key

# default slim (coding write path)
uv run bora run examples/journeys --task terminal-jsonl-agg \
  --profiles examples/journeys/profiles.dsh.yaml

# file-effect policy
uv run bora run examples/journeys --task terminal-jsonl-agg \
  --profiles examples/journeys/profiles.dsh.read-only.yaml
# or: --set '/bindings/solver/options/permission="read-only"'
```

## Local evidence (this branch)

| Run | Result |
| --- | --- |
| Host `DeepSeekHarness` + sandboxed + `read-only` | START_OK; write tool `[sandbox: file access denied under read-only mode]`; file not created; agent `DENIED`; no hang |
| Host same + `workspace-write` | `probe_write.txt` written (`hello`); completed |
| L1 `examples/journeys --task terminal-jsonl-agg` + `profiles.dsh.read-only.yaml` | **PASS** / 1.0, `assurance: l1`, `execution_location: attempt-container`, bake `dsh`, 1m 53s, no hang. Agent wrote `aggregates.json` via **bash** (documented hole). Lock has `options.permission: read-only`. |
| Earlier L1 run that named `dsh-bash-sandbox` | ERROR / `dsh_timeout` — runtime never started; fixed in the last commit |

Scoped journeys only. Does **not** claim `isolated` or `real-benchmark-verified`. Does **not** claim this wires tau2 / package tools into DSH.

## Test plan

- [x] Unit: `tests/plugins/test_dsh_permission.py` (omit / three modes / invalid materialize / composition swap / env)
- [x] `bora lock` writes `job_overlay.bindings.solver.options.permission` (locator only, no secret)
- [x] Local python-core equivalent (ruff / pyright / 535 pytest) and website build
- [x] Real L0 write-deny + write-allow probes
- [x] Real L1 journeys task with `read-only` (no hang)

## Docs

Plugin README, journeys READMEs, `profiles.dsh.read-only.yaml`, website plugins (zh/en), skills, Architecture, design/11. Reader-facing text has no GitHub issue numbers.

## Non-goals

- New Core slots or `acp_entries.json`
- Extra npm at invoke time
- A separate “no tools at all” dialog composition
- Fixing tau3 tool-bridge mismatch
- Claiming bash confinement or `isolated` from DSH sandbox alone