### PR TITLE
feat(evidence): emit ReAct-ordered thought/tool steps in trajectory.jsonl

### DIFF
--- a/apps/hub/src/components/trial/trajectory-panel.tsx
+++ b/apps/hub/src/components/trial/trajectory-panel.tsx
@@ -247,9 +247,14 @@ export function TrajectoryPanel({
             kind: s.kind,
             functionName: s.function_name,
           });
+          const toolArgsEmpty =
+            s.args == null ||
+            (typeof s.args === "object" &&
+              !Array.isArray(s.args) &&
+              Object.keys(s.args).length === 0);
           let body: string | null =
             s.content ||
-            (isToolCall && s.args != null
+            (isToolCall && !toolArgsEmpty
               ? typeof s.args === "string"
                 ? s.args
                 : JSON.stringify(s.args, null, 2)

--- a/apps/viewer/src/components/trial/trajectory-panel.tsx
+++ b/apps/viewer/src/components/trial/trajectory-panel.tsx
@@ -247,9 +247,14 @@ export function TrajectoryPanel({
             kind: s.kind,
             functionName: s.function_name,
           });
+          const toolArgsEmpty =
+            s.args == null ||
+            (typeof s.args === "object" &&
+              !Array.isArray(s.args) &&
+              Object.keys(s.args).length === 0);
           let body: string | null =
             s.content ||
-            (isToolCall && s.args != null
+            (isToolCall && !toolArgsEmpty
               ? typeof s.args === "string"
                 ? s.args
                 : JSON.stringify(s.args, null, 2)

--- a/docs/design/05-runtime/evidence.md
+++ b/docs/design/05-runtime/evidence.md
@@ -105,7 +105,7 @@ ACP / nooa / …
 
 | `kind` | 字段 | 是否折进层 C |
 | --- | --- | --- |
-| `text` | `channel: thought\|assistant`，`text` | 是 |
+| `text` | `channel: thought\|assistant`，`text`，以及下文逐步耗时（按 burst 抄到层 C） | 是 |
 | `tool` | `phase: start\|update`，`tool_call_id`，可选 `title` / `function_name` / `tool_kind` / `status` / `args` / `content` / `raw_output`，以及下文逐步耗时 | 是（Core 按 `tool_call_id` 合并） |
 | `permission` | `outcome` / `option_id` / `policy` | 是 |
 | `opaque` | 任意 `payload` | **否**（只留 `events.jsonl`） |
@@ -114,22 +114,23 @@ ACP / nooa / …
 
 ### 逐步耗时（观测；可选；fail-open）
 
-目的：Hub / Viewer 在 **单步**（尤其 `tool_call` / shell execute）上显示耗时，而不是只靠 Attempt 级 `phase_timing`。  
+目的：Hub / Viewer 在 **单步**（thought / `tool_call` / 最终 assistant）上显示耗时，而不是只靠 Attempt 级 `phase_timing`。  
 **观测字段，不是 PASS。** 缺字段必须省略，禁止 Viewer / Hub 用文件 mtime 或页面时钟补造。
 
 | 字段 | 位置 | 含义 |
 | --- | --- | --- |
 | `at` | 信封（任意 `kind`，可选） | 生产者观测到本事件的时间（ISO-8601 UTC） |
 | `elapsed_ms` | `kind: tool`（start 或 update，可选） | 该 `tool_call_id` 截至本事件的墙钟毫秒（≥ 0） |
-| `started_at` | `kind: tool`（可选） | 该 call 首次观测到的开始时间（ISO-8601 UTC） |
-| `ended_at` | `kind: tool`（可选） | 该 call 完成 / 末次 update 的时间（ISO-8601 UTC） |
+| `elapsed_ms` | `kind: text`（thought / assistant，可选） | 该次文本 burst（一次 LLM 回复）的墙钟毫秒（≥ 0） |
+| `started_at` | `kind: tool` 或 `kind: text`（可选） | 该 call / burst 首次观测到的开始时间（ISO-8601 UTC） |
+| `ended_at` | `kind: tool` 或 `kind: text`（可选） | 该 call / burst 完成时间（ISO-8601 UTC） |
 
 **谁写：**
 
 | 角色 | 写什么 |
 | --- | --- |
 | Executor Adapter / 插件 | vendor 流里已有 duration / timestamp 则映射；可把 **接收时刻** 写成 `at`（adapter 时钟）。vendor 没有则整组省略 |
-| Core evidence writer | 按 `tool_call_id` 合并后抄到层 C；**不**从 filesystem mtime 推断 |
+| Core evidence writer | 按 `tool_call_id` 合并 tool 耗时；把 **同一 burst** 的 text 耗时抄到对应 thought / assistant 行；**不**从 filesystem mtime 推断 |
 | Hub / Viewer | 层 C 有 `elapsed_ms` 才在步骤头显示；没有则不画标签 |
 
 **合并（Core，同一 `tool_call_id`）：**
@@ -139,7 +140,13 @@ ACP / nooa / …
 - `elapsed_ms` = 最后一条非空 `elapsed_ms`；若仍缺且 `started_at` + `ended_at` 都能解析，则用二者之差（毫秒，≥ 0）
 - 非法值（负数、非数字、无法解析的时间）丢弃，不当错误
 
-**层 C：** 合并结果写在对应 `type=tool_call` 行；若发出 `observation`，可抄同一组耗时。缺省字段省略。  
+**合并（Core，同一 thought / assistant burst）：**
+
+- 连续、中间无 tool 的同 channel `kind: text` 算一次 burst；burst 内可累加 `elapsed_ms`
+- 该 burst 的耗时只写在 **对应那一行**；禁止堆到本 invoke 第一条 thought，也禁止把 thought 耗时抄到最终 assistant
+- 缺字段省略
+
+**层 C：** tool 合并结果写在对应 `type=tool_call` 行；若发出 `observation`，可抄同一组耗时。thought / 最终 assistant 各带本 burst 耗时。缺省字段省略。  
 **禁止**用逐步耗时改 score / PASS / evaluator 输入。
 
 ## `trajectory.jsonl`（turn 级，训练默认）
@@ -157,15 +164,25 @@ ACP / nooa / …
 **推荐行类型（JSONL，一行一对象）：**
 
 1. `type=turn` · `role=user` · `content=<完整 prompt>` · `turn_index` · 可选 `session_id` · `source`（生产者）
-2. `type=turn` · `role=assistant` · `part=thought` · `content=<合并后的 thought>`（有则写）
-3. **`type=tool_call`** · action 侧（有则写；见下）
-4. **`type=observation`** · 该 call 的环境回传 / tool result（有则写；与 call 成对）
-5. `type=turn` · `role=assistant` · `content=<合并后的最终 assistant 文本>`
-6. `type=permission_decision` · batch auto-approve 等（有则写；evidence 决策摘要）
-7. `type=terminal` · `ok` / `error` · `structured` / `usage` / `stop_reason` / executor 元数据摘要
+2. **ReAct 循环（可重复，按层 B 顺序）：**
+   - `type=turn` · `role=assistant` · `part=thought` · `content=<该次 burst 的 thought>`（有则写；**一次 burst 一行**）
+   - **`type=tool_call`** · action 侧（有则写；见下）
+   - **`type=observation`** · 该 call 的环境回传 / tool result（有则写；与 call 成对）
+3. `type=turn` · `role=assistant` · `content=<最终 assistant 文本>`（本 invoke 终稿；后无 tool）
+4. `type=permission_decision` · batch auto-approve 等（有则写；evidence 决策摘要）
+5. `type=terminal` · `ok` / `error` · `structured` / `usage` / `stop_reason` / executor 元数据摘要
 
-行序建议：user → thought →（按首次出现顺序的 tool_call + observation 对）→ assistant 终稿 → permission → terminal。  
-无 tool 的 invoke **不写** 3–4。
+**行序（契约）：**
+
+```text
+user → (thought? → tool_call → observation)* → assistant (final) → permission* → terminal
+```
+
+层 C **只由 Core evidence writer** 写出（不在 adapter / 插件里拼行）。Core 按层 B 输入顺序（`seq`）行走：thought 出现就冲刷该 burst；某个 `tool_call_id` 完成、或下一条非 tool 事件开始时，写出该 call 的 `tool_call` + 可选 `observation`。
+
+**禁止**按 type 分桶（先拼全部 thought，再倒全部 tool）。无兼容路径：旧的「一条胖 thought + 全部 tool + 一条终稿」不再写出。
+
+无 tool 的 invoke **不写** tool_call / observation；连续、中间无 tool 的 thought 仍可合成一条。
 
 `source` 是机制/插件 id，**不是**恒为 `acp`。会话字段名是 `session_id`，不是 `acp_session_id`。
 
@@ -203,9 +220,10 @@ ACP / nooa / …
 | `elapsed_ms` / `started_at` / `ended_at` | 与对应 `tool_call` 同一组（有则抄；缺省省略） |
 | `turn_index` / `session_id` / `source` | 同上 |
 
-**合并规则：** 同一 `tool_call_id` 累积 `title` / `function_name` / `tool_kind` / `status` / `args` / `content` / `raw_output` 以及逐步耗时（见上节）；seal 发一条 `tool_call` + 可选 `observation`。  
+**合并规则：** 同一 `tool_call_id` 累积 `title` / `function_name` / `tool_kind` / `status` / `args` / `content` / `raw_output` 以及逐步耗时（见上节）；在该 id 完成或下一条非 tool 事件开始时发一条 `tool_call` + 可选 `observation`。连续不同 id 的 tool 事件可并行缓冲，直到下一条非 tool。  
 **有 call 无 result：** 仍写 `tool_call`；observation 仅在存在 content / raw_output / 终态 completed|failed 时写出。  
-**禁止**只落盘 call 而系统性丢弃已有 result。
+**禁止**只落盘 call 而系统性丢弃已有 result。  
+**禁止**把跨 tool 的 thought 拼成一条，或把本 burst 以外的 `elapsed_ms` 抄到可见行。
 
 **Redaction：** `args` / `content` / `raw_output` 与既有轨迹 redact 同一路径（pattern + sentinels）；禁止 host secret / token 进入 `trajectory.jsonl`。
 

--- a/plugins/nooa/src/nooa_plugin/trajectory.py
+++ b/plugins/nooa/src/nooa_plugin/trajectory.py
@@ -271,6 +271,8 @@ def to_bora_trajectory_events(
     started_at: dict[str, str] = {}
     llm_started_at: str | None = None
     pending_llm_elapsed: float | None = None
+    last_llm_elapsed: float | None = None
+    last_return: dict[str, Any] | None = None
     has_vendor_tools = any(
         isinstance(row, dict)
         and _event_type(row) in {"ToolCallEvent", "ToolCall", "PythonOutput"}
@@ -296,6 +298,8 @@ def to_bora_trajectory_events(
             end_at = _coerce_event_at(raw)
             if llm_started_at and end_at:
                 pending_llm_elapsed = _iso_delta_ms(llm_started_at, end_at)
+                if pending_llm_elapsed and pending_llm_elapsed > 0:
+                    last_llm_elapsed = pending_llm_elapsed
             llm_started_at = None
             continue
         if et in _SKIP_KINDS:
@@ -341,6 +345,9 @@ def to_bora_trajectory_events(
                 started_at,
                 pending_code=pending_code,
             )
+            name = str(raw.get("name") or raw.get("tool") or "")
+            if name == "return_result":
+                last_return = raw
         elif et == "PythonOutput":
             seq, pending_code = _emit_python_output(
                 out,
@@ -383,6 +390,8 @@ def to_bora_trajectory_events(
                     started_at,
                     pending_code=pending_code,
                 )
+                if name == "return_result":
+                    last_return = fake
         else:
             seq = _next()
             out.append(
@@ -395,6 +404,16 @@ def to_bora_trajectory_events(
                     "payload": _clip(raw),
                 }
             )
+    has_assistant = any(ev.get("channel") == "assistant" for ev in out)
+    if last_return is not None and last_llm_elapsed and last_llm_elapsed > 0 and not has_assistant:
+        payload = last_return.get("arguments")
+        if payload is None:
+            payload = last_return.get("result")
+        text = _stringify_result(payload) if payload is not None else ""
+        if text:
+            row = _text(_next(), session_id, "assistant", text)
+            row["elapsed_ms"] = float(last_llm_elapsed)
+            out.append(row)
     return out
 
 

--- a/skills/bora-cli/references/commands.md
+++ b/skills/bora-cli/references/commands.md
@@ -50,11 +50,12 @@ Stdout JSON (high level):
   pack excludes `l1-work/**` even if residual remains.
 - Suite artifacts: `.bora/suite-runs/<id>/summary.json`, `progress.json`.
 - Per invocation (any executor): Core writes `agent/invocations/<nnnn>-*/trajectory.jsonl`
-  from `bora.trajectory.event/1` (user + merged assistant/thought + tool/observation +
-  terminal). Rows use `session_id` and producer `source` (not `acp_session_id`).
-  `tool_call` / `observation` may carry observational `elapsed_ms` when the adapter
-  had timing; missing values are omitted. Stream chunks are not the training default;
-  see `docs/design/05-runtime/evidence.md`.
+  from `bora.trajectory.event/1` in ReAct file order (user → thought/tool/observation
+  bursts → final assistant → terminal). Rows use `session_id` and producer `source`
+  (not `acp_session_id`). Thought / `tool_call` / `observation` / final assistant may
+  carry observational `elapsed_ms` when the adapter had timing; missing values are
+  omitted. Stream chunks are not the training default; see
+  `docs/design/05-runtime/evidence.md`.
 - Docker packages use L1 path when `provider.kind: docker`. First-party coding entries
   stay on the parent ACP client + `docker exec` placement; other installed executors
   bind via `bind_to_target`.

--- a/skills/bora-plugin/references/authoring.md
+++ b/skills/bora-plugin/references/authoring.md
@@ -78,7 +78,7 @@ credential_env_names, binary
 Layer B: each `AgentResult.events` row has `schema: bora.trajectory.event/1`,
 `source` = this plugin id, `session_id` (never `acp_session_id`).
 Layer C: only Core `bora.evidence.trajectory.write_trajectory_jsonl` writes
-`trajectory.jsonl`.
+`trajectory.jsonl` (ReAct seq order; do not emit layer-C rows yourself).
 
 `on: trajectory_collect`:
 

--- a/src/bora/adapters/acp/trajectory_map.py
+++ b/src/bora/adapters/acp/trajectory_map.py
@@ -48,17 +48,17 @@ def acp_session_events_to_bora(
 
         if raw.get("channel") in {"thought", "assistant"} and isinstance(raw.get("text"), str):
             seq += 1
-            out.append(
-                {
-                    "schema": EVENT_SCHEMA_VERSION,
-                    "seq": seq,
-                    "session_id": sid,
-                    "source": _SOURCE,
-                    "kind": "text",
-                    "channel": raw["channel"],
-                    "text": raw["text"],
-                }
-            )
+            text_ev: dict[str, Any] = {
+                "schema": EVENT_SCHEMA_VERSION,
+                "seq": seq,
+                "session_id": sid,
+                "source": _SOURCE,
+                "kind": "text",
+                "channel": raw["channel"],
+                "text": raw["text"],
+            }
+            _attach_timing(text_ev, raw, {})
+            out.append(text_ev)
             # A session_update may also carry a tool payload; fall through.
 
         raw_upd = raw.get("update")
@@ -123,26 +123,26 @@ def acp_session_events_to_bora(
         _attach_timing(ev, raw, upd)
         out.append(ev)
 
-    for call_id, title in longest_title.items():
-        if call_id in had_raw_input:
+    # Pi streams the command in title, not rawInput. Fill args on the
+    # existing tool events so Core does not see a late extra update.
+    for ev in out:
+        if ev.get("kind") != "tool":
+            continue
+        call_id = ev.get("tool_call_id")
+        if not isinstance(call_id, str) or call_id in had_raw_input:
             continue
         kind_l = (tool_kind_by_id.get(call_id) or "").lower()
         if kind_l not in {"execute", "other", ""}:
             continue
-        seq += 1
-        out.append(
-            {
-                "schema": EVENT_SCHEMA_VERSION,
-                "seq": seq,
-                "session_id": out[-1].get("session_id") if out else None,
-                "source": _SOURCE,
-                "kind": "tool",
-                "phase": "update",
-                "tool_call_id": call_id,
-                "title": title,
-                "args": {"command": title},
-            }
-        )
+        title = longest_title.get(call_id)
+        if not isinstance(title, str) or not title.strip():
+            continue
+        args = ev.get("args")
+        if args not in (None, {}):
+            continue
+        ev["args"] = {"command": title}
+        if not ev.get("title"):
+            ev["title"] = title
     return out
 
 

--- a/src/bora/evidence/trajectory.py
+++ b/src/bora/evidence/trajectory.py
@@ -91,6 +91,7 @@ def write_trajectory_jsonl(
         thought_timing.clear()
         if not content:
             return
+        _finalize_timing(timing)
         row: dict[str, Any] = {
             "type": "turn",
             "role": "assistant",
@@ -110,6 +111,7 @@ def write_trajectory_jsonl(
         assistant_timing.clear()
         if not content:
             return
+        _finalize_timing(timing)
         row: dict[str, Any] = {
             "type": "turn",
             "role": "assistant",
@@ -179,6 +181,7 @@ def write_trajectory_jsonl(
         "session_id": session_id,
         "source": producer,
     }
+    _finalize_timing(assistant_timing)
     _copy_timing(assistant_line, assistant_timing)
     lines.append(_drop_nulls(assistant_line, keep={"type", "role", "turn_index", "source"}))
     for pe in permission_events:

--- a/src/bora/evidence/trajectory.py
+++ b/src/bora/evidence/trajectory.py
@@ -35,8 +35,8 @@ def write_trajectory_jsonl(
     Consumes only events with ``schema == bora.trajectory.event/1``. Other
     rows are ignored (vendor raw belongs in ``backend_raw/`` / ``events.jsonl``).
 
-    Row order: user → thought → tool_call/observation* → assistant →
-    permission* → terminal.
+    Row order: user → (thought? → tool_call → observation)* →
+    assistant (final) → permission* → terminal.
     """
     inv_dir.mkdir(parents=True, exist_ok=True)
     path = inv_dir / "trajectory.jsonl"
@@ -45,7 +45,6 @@ def write_trajectory_jsonl(
     assistant_parts: list[str] = []
     thought_timing: dict[str, Any] = {}
     assistant_timing: dict[str, Any] = {}
-    last_text_timing: dict[str, Any] = {}
     permission_events: list[dict[str, Any]] = []
     tool_states: dict[str, dict[str, Any]] = {}
     session_id: str | None = None
@@ -60,36 +59,6 @@ def write_trajectory_jsonl(
         src = ev.get("source")
         if isinstance(src, str) and src:
             producer = src
-        kind = ev.get("kind")
-        if kind == "text":
-            text = ev.get("text") if isinstance(ev.get("text"), str) else ""
-            channel = ev.get("channel")
-            if channel == "thought" and text:
-                thought_parts.append(text)
-                _accumulate_text_timing(thought_timing, ev)
-                last_text_timing = {}
-                _accumulate_text_timing(last_text_timing, ev)
-            elif channel == "assistant" and text:
-                assistant_parts.append(text)
-                _accumulate_text_timing(assistant_timing, ev)
-                last_text_timing = {}
-                _accumulate_text_timing(last_text_timing, ev)
-        elif kind == "tool":
-            _merge_tool(tool_states, ev)
-        elif kind == "permission":
-            permission_events.append(
-                {
-                    "type": "permission_decision",
-                    "outcome": ev.get("outcome"),
-                    "option_id": ev.get("option_id"),
-                    "policy": ev.get("policy"),
-                    "source": producer or "bora",
-                }
-            )
-        # kind == opaque: events.jsonl only
-
-    merged_thought = "".join(thought_parts)
-    merged_assistant = final_text if final_text else "".join(assistant_parts)
 
     turn_index = 1
     if isinstance(metadata, dict):
@@ -114,54 +83,94 @@ def write_trajectory_jsonl(
             "source": "bora",
         }
     ]
-    if merged_thought:
-        thought_line: dict[str, Any] = {
+
+    def flush_thought() -> None:
+        content = "".join(thought_parts)
+        thought_parts.clear()
+        timing = dict(thought_timing)
+        thought_timing.clear()
+        if not content:
+            return
+        row: dict[str, Any] = {
             "type": "turn",
             "role": "assistant",
             "part": "thought",
-            "content": merged_thought,
+            "content": content,
             "turn_index": turn_index,
             "session_id": session_id,
             "source": producer,
         }
-        _copy_timing(thought_line, thought_timing)
-        lines.append(_drop_nulls(thought_line, keep={"type", "role", "turn_index", "source"}))
+        _copy_timing(row, timing)
+        lines.append(_drop_nulls(row, keep={"type", "role", "turn_index", "source"}))
 
-    for call_id, state in tool_states.items():
-        _finalize_tool_state(state)
-        tool_line: dict[str, Any] = {
-            "type": "tool_call",
-            "tool_call_id": call_id,
-            "title": state.get("title"),
-            "function_name": state.get("function_name") or "tool",
-            "kind": state.get("tool_kind"),
-            "status": state.get("status"),
+    def flush_assistant_burst() -> None:
+        content = "".join(assistant_parts)
+        assistant_parts.clear()
+        timing = dict(assistant_timing)
+        assistant_timing.clear()
+        if not content:
+            return
+        row: dict[str, Any] = {
+            "type": "turn",
+            "role": "assistant",
+            "content": content,
             "turn_index": turn_index,
             "session_id": session_id,
             "source": producer,
         }
-        args = state.get("args")
-        if args is not None:
-            tool_line["args"] = args
-        _copy_timing(tool_line, state)
-        lines.append(_drop_nulls(tool_line, keep={"type", "tool_call_id", "turn_index", "source"}))
+        _copy_timing(row, timing)
+        lines.append(_drop_nulls(row, keep={"type", "role", "turn_index", "source"}))
 
-        if _should_emit_observation(state):
-            obs: dict[str, Any] = {
-                "type": "observation",
-                "tool_call_id": call_id,
-                "status": state.get("status"),
-                "turn_index": turn_index,
-                "session_id": session_id,
-                "source": producer,
-            }
-            if state.get("content") is not None:
-                obs["content"] = state["content"]
-            if state.get("raw_output") is not None:
-                obs["raw_output"] = state["raw_output"]
-            _copy_timing(obs, state)
-            lines.append(_drop_nulls(obs, keep={"type", "tool_call_id", "turn_index", "source"}))
+    def flush_tools() -> None:
+        for call_id, state in tool_states.items():
+            _emit_tool_rows(
+                lines,
+                call_id=call_id,
+                state=state,
+                turn_index=turn_index,
+                session_id=session_id,
+                producer=producer,
+            )
+        tool_states.clear()
 
+    for ev in events:
+        if not isinstance(ev, dict) or ev.get("schema") != EVENT_SCHEMA_VERSION:
+            continue
+        kind = ev.get("kind")
+        if kind == "text":
+            text = ev.get("text") if isinstance(ev.get("text"), str) else ""
+            channel = ev.get("channel")
+            if channel == "thought" and text:
+                flush_assistant_burst()
+                flush_tools()
+                thought_parts.append(text)
+                _accumulate_text_timing(thought_timing, ev)
+            elif channel == "assistant" and text:
+                flush_thought()
+                flush_tools()
+                assistant_parts.append(text)
+                _accumulate_text_timing(assistant_timing, ev)
+        elif kind == "tool":
+            flush_thought()
+            flush_assistant_burst()
+            _merge_tool(tool_states, ev)
+        elif kind == "permission":
+            flush_thought()
+            flush_tools()
+            permission_events.append(
+                {
+                    "type": "permission_decision",
+                    "outcome": ev.get("outcome"),
+                    "option_id": ev.get("option_id"),
+                    "policy": ev.get("policy"),
+                    "source": producer,
+                }
+            )
+        # kind == opaque: events.jsonl only
+
+    flush_thought()
+    flush_tools()
+    merged_assistant = final_text if final_text else "".join(assistant_parts)
     assistant_line: dict[str, Any] = {
         "type": "turn",
         "role": "assistant",
@@ -170,13 +179,7 @@ def write_trajectory_jsonl(
         "session_id": session_id,
         "source": producer,
     }
-    # Final agent bubble is often final_text with no timed assistant-channel
-    # event (nooa return_result / dsh reply after a thought). Use the last
-    # timed text burst so the visible reply is not blank.
-    if _coerce_elapsed_ms(assistant_timing.get("elapsed_ms")) in (None, 0.0):
-        _copy_timing(assistant_line, last_text_timing)
-    else:
-        _copy_timing(assistant_line, assistant_timing)
+    _copy_timing(assistant_line, assistant_timing)
     lines.append(_drop_nulls(assistant_line, keep={"type", "role", "turn_index", "source"}))
     for pe in permission_events:
         pe = {**pe, "turn_index": turn_index, "session_id": session_id}
@@ -211,6 +214,50 @@ def write_trajectory_jsonl(
         encoding="utf-8",
     )
     return path
+
+
+def _emit_tool_rows(
+    lines: list[dict[str, Any]],
+    *,
+    call_id: str,
+    state: dict[str, Any],
+    turn_index: int,
+    session_id: str | None,
+    producer: str,
+) -> None:
+    _finalize_tool_state(state)
+    tool_line: dict[str, Any] = {
+        "type": "tool_call",
+        "tool_call_id": call_id,
+        "title": state.get("title"),
+        "function_name": state.get("function_name") or "tool",
+        "kind": state.get("tool_kind"),
+        "status": state.get("status"),
+        "turn_index": turn_index,
+        "session_id": session_id,
+        "source": producer,
+    }
+    args = state.get("args")
+    if args is not None:
+        tool_line["args"] = args
+    _copy_timing(tool_line, state)
+    lines.append(_drop_nulls(tool_line, keep={"type", "tool_call_id", "turn_index", "source"}))
+    if not _should_emit_observation(state):
+        return
+    obs: dict[str, Any] = {
+        "type": "observation",
+        "tool_call_id": call_id,
+        "status": state.get("status"),
+        "turn_index": turn_index,
+        "session_id": session_id,
+        "source": producer,
+    }
+    if state.get("content") is not None:
+        obs["content"] = state["content"]
+    if state.get("raw_output") is not None:
+        obs["raw_output"] = state["raw_output"]
+    _copy_timing(obs, state)
+    lines.append(_drop_nulls(obs, keep={"type", "tool_call_id", "turn_index", "source"}))
 
 
 def _drop_nulls(row: dict[str, Any], *, keep: set[str]) -> dict[str, Any]:
@@ -307,7 +354,7 @@ def _copy_timing(row: dict[str, Any], state: dict[str, Any]) -> None:
 
 
 def _accumulate_text_timing(state: dict[str, Any], ev: dict[str, Any]) -> None:
-    """Sum observational LLM/step duration onto the merged thought/assistant turn."""
+    """Sum observational LLM/step duration onto the current thought/assistant burst."""
     elapsed = _coerce_elapsed_ms(ev.get("elapsed_ms"))
     if elapsed is not None and elapsed > 0:
         prev = _coerce_elapsed_ms(state.get("elapsed_ms")) or 0.0

--- a/tests/adapters/test_trajectory_tool_observation.py
+++ b/tests/adapters/test_trajectory_tool_observation.py
@@ -590,6 +590,168 @@ def test_writer_drops_nonfinite_elapsed_ms(tmp_path: Path) -> None:
     assert "elapsed_ms" not in tool
 
 
+def _text(
+    *,
+    seq: int,
+    channel: str,
+    text: str,
+    elapsed_ms: float | None = None,
+    source: str = "acp",
+) -> dict[str, Any]:
+    ev: dict[str, Any] = {
+        "schema": EVENT_SCHEMA_VERSION,
+        "seq": seq,
+        "source": source,
+        "kind": "text",
+        "channel": channel,
+        "text": text,
+    }
+    if elapsed_ms is not None:
+        ev["elapsed_ms"] = elapsed_ms
+    return ev
+
+
+def _tool(
+    *,
+    seq: int,
+    call_id: str,
+    phase: str,
+    status: str = "completed",
+    content: str | None = None,
+    elapsed_ms: float | None = None,
+    function_name: str = "read",
+    source: str = "acp",
+) -> dict[str, Any]:
+    ev: dict[str, Any] = {
+        "schema": EVENT_SCHEMA_VERSION,
+        "seq": seq,
+        "source": source,
+        "kind": "tool",
+        "phase": phase,
+        "tool_call_id": call_id,
+        "function_name": function_name,
+        "status": status,
+    }
+    if content is not None:
+        ev["content"] = content
+    if elapsed_ms is not None:
+        ev["elapsed_ms"] = elapsed_ms
+    return ev
+
+
+def test_writer_interleaves_thought_and_tool_in_seq_order(tmp_path: Path) -> None:
+    events = (
+        _text(seq=1, channel="thought", text="thought A", elapsed_ms=8000),
+        _tool(seq=2, call_id="t1", phase="start", status="pending"),
+        _tool(seq=3, call_id="t1", phase="update", content="a-out", elapsed_ms=12),
+        _text(seq=4, channel="thought", text="thought B", elapsed_ms=5000),
+        _tool(seq=5, call_id="t2", phase="start", status="pending", function_name="exec"),
+        _tool(
+            seq=6,
+            call_id="t2",
+            phase="update",
+            content="b-out",
+            elapsed_ms=20,
+            function_name="exec",
+        ),
+        _text(seq=7, channel="assistant", text="done", elapsed_ms=3000),
+    )
+    path = _write(tmp_path, events=events, prompt="p", final_text="done")
+    lines = _read_lines(path)
+    shape = []
+    for row in lines:
+        if row["type"] == "turn" and row.get("part") == "thought":
+            shape.append(("thought", row["content"], row.get("elapsed_ms")))
+        elif row["type"] == "tool_call":
+            shape.append(("tool", row["tool_call_id"], row.get("elapsed_ms")))
+        elif row["type"] == "observation":
+            shape.append(("obs", row["tool_call_id"], None))
+        elif row["type"] == "turn" and row.get("role") == "user":
+            shape.append(("user", row["content"], None))
+        elif row["type"] == "turn" and row.get("role") == "assistant":
+            shape.append(("assistant", row["content"], row.get("elapsed_ms")))
+        elif row["type"] == "terminal":
+            shape.append(("terminal", None, None))
+    assert shape == [
+        ("user", "p", None),
+        ("thought", "thought A", 8000.0),
+        ("tool", "t1", 12.0),
+        ("obs", "t1", None),
+        ("thought", "thought B", 5000.0),
+        ("tool", "t2", 20.0),
+        ("obs", "t2", None),
+        ("assistant", "done", 3000.0),
+        ("terminal", None, None),
+    ]
+    assert lines[0]["role"] == "user"
+
+
+def test_writer_merges_consecutive_thoughts_without_tool(tmp_path: Path) -> None:
+    events = (
+        _text(seq=1, channel="thought", text="A", elapsed_ms=10),
+        _text(seq=2, channel="thought", text="B", elapsed_ms=20),
+        _text(seq=3, channel="assistant", text="ok"),
+    )
+    path = _write(tmp_path, events=events, prompt="p", final_text="ok")
+    lines = _read_lines(path)
+    thoughts = [x for x in lines if x.get("part") == "thought"]
+    assert len(thoughts) == 1
+    assert thoughts[0]["content"] == "AB"
+    assert thoughts[0]["elapsed_ms"] == 30.0
+    assert [x["type"] for x in lines] == ["turn", "turn", "turn", "terminal"]
+
+
+def test_writer_does_not_copy_thought_elapsed_onto_final_assistant(
+    tmp_path: Path,
+) -> None:
+    events = (
+        _text(seq=1, channel="thought", text="plan", elapsed_ms=9000),
+        _tool(seq=2, call_id="t1", phase="start", status="pending"),
+        _tool(seq=3, call_id="t1", phase="update", content="out", elapsed_ms=8),
+    )
+    path = _write(tmp_path, events=events, prompt="p", final_text="done")
+    lines = _read_lines(path)
+    thought = next(x for x in lines if x.get("part") == "thought")
+    assistant = next(
+        x
+        for x in lines
+        if x["type"] == "turn" and x.get("role") == "assistant" and x.get("part") != "thought"
+    )
+    assert thought["elapsed_ms"] == 9000.0
+    assert "elapsed_ms" not in assistant
+
+
+def test_writer_omits_thought_elapsed_when_absent(tmp_path: Path) -> None:
+    events = (
+        _text(seq=1, channel="thought", text="plan"),
+        _tool(seq=2, call_id="t1", phase="update", content="out", status="completed"),
+    )
+    path = _write(tmp_path, events=events, prompt="p", final_text="done")
+    thought = next(x for x in _read_lines(path) if x.get("part") == "thought")
+    assert "elapsed_ms" not in thought
+    assert "started_at" not in thought
+
+
+def test_writer_flushes_assistant_when_a_tool_follows(tmp_path: Path) -> None:
+    events = (
+        _text(seq=1, channel="assistant", text="mid", elapsed_ms=1100),
+        _tool(seq=2, call_id="t1", phase="update", content="out", elapsed_ms=5),
+        _text(seq=3, channel="assistant", text="end", elapsed_ms=400),
+    )
+    path = _write(tmp_path, events=events, prompt="p", final_text="end")
+    lines = _read_lines(path)
+    assistants = [
+        x
+        for x in lines
+        if x["type"] == "turn" and x.get("role") == "assistant" and x.get("part") != "thought"
+    ]
+    assert [x["content"] for x in assistants] == ["mid", "end"]
+    assert assistants[0]["elapsed_ms"] == 1100.0
+    assert assistants[1]["elapsed_ms"] == 400.0
+    types = [x["type"] for x in lines]
+    assert types == ["turn", "turn", "tool_call", "observation", "turn", "terminal"]
+
+
 def test_writer_drops_invalid_timing(tmp_path: Path) -> None:
     events = (
         {

--- a/tests/adapters/test_trajectory_tool_observation.py
+++ b/tests/adapters/test_trajectory_tool_observation.py
@@ -538,6 +538,63 @@ def test_acp_mapper_copies_vendor_elapsed_and_at(tmp_path: Path) -> None:
     assert tool["elapsed_ms"] == 1500.0
 
 
+def test_acp_mapper_copies_at_onto_text_and_core_derives_thought_elapsed(
+    tmp_path: Path,
+) -> None:
+    events = (
+        {
+            "type": "session_update",
+            "session_id": "s1",
+            "channel": "thought",
+            "text": "Now",
+            "at": "2026-08-14T12:00:00.000Z",
+        },
+        {
+            "type": "session_update",
+            "session_id": "s1",
+            "channel": "thought",
+            "text": " write it.",
+            "at": "2026-08-14T12:00:01.250Z",
+        },
+        {
+            "type": "session_update",
+            "session_id": "s1",
+            "at": "2026-08-14T12:00:01.300Z",
+            "title": "bash",
+            "kind": "execute",
+            "tool_call_id": "c1",
+            "update": {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "c1",
+                "title": "echo hi",
+                "kind": "execute",
+                "status": "pending",
+            },
+        },
+    )
+    mapped = acp_session_events_to_bora(events)
+    texts = [e for e in mapped if e.get("kind") == "text"]
+    assert all(e.get("at") for e in texts)
+    tools = [e for e in mapped if e.get("kind") == "tool"]
+    assert tools[0]["args"] == {"command": "echo hi"}
+    assert not any(
+        e.get("kind") == "tool" and e.get("seq", 0) > tools[-1]["seq"] for e in mapped[1:]
+    )
+    path = _write(tmp_path, events=mapped, prompt="p", final_text="done")
+    lines = _read_lines(path)
+    thought = next(x for x in lines if x.get("part") == "thought")
+    assert thought["elapsed_ms"] == 1250.0
+    tool = next(x for x in lines if x["type"] == "tool_call")
+    assert tool["args"] == {"command": "echo hi"}
+    assert [x["type"] for x in lines] == [
+        "turn",
+        "turn",
+        "tool_call",
+        "turn",
+        "terminal",
+    ]
+
+
 def test_writer_keeps_explicit_ended_at_over_later_at(tmp_path: Path) -> None:
     events = (
         {

--- a/tests/plugins/test_nooa_trajectory_map.py
+++ b/tests/plugins/test_nooa_trajectory_map.py
@@ -218,6 +218,39 @@ def test_tool_call_copies_vendor_elapsed_ms() -> None:
     assert update["at"] == "2026-08-14T12:00:01Z"
 
 
+def test_return_result_emits_assistant_with_last_llm_elapsed() -> None:
+    mapped = to_bora_trajectory_events(
+        (
+            {
+                "event_type": "LLMCallStart",
+                "at": "2026-08-14T12:00:00.000Z",
+            },
+            {
+                "event_type": "LLMCallEnd",
+                "at": "2026-08-14T12:00:08.405Z",
+            },
+            {
+                "event_type": "LLMComplete",
+                "reasoning_content": "return the aggregates",
+            },
+            {
+                "event_type": "ToolCallEvent",
+                "tool_call_id": "ret1",
+                "name": "return_result",
+                "arguments": {"result": {"ok": True}},
+                "timestamp": "2026-08-14T12:00:08.406Z",
+            },
+        )
+    )
+    thought = next(e for e in mapped if e.get("channel") == "thought")
+    assert thought["elapsed_ms"] == 8405.0
+    assistant = next(e for e in mapped if e.get("channel") == "assistant")
+    assert assistant["elapsed_ms"] == 8405.0
+    assert "ok" in assistant["text"]
+    tools = [e for e in mapped if e.get("kind") == "tool"]
+    assert any(e.get("function_name") == "return_result" for e in tools)
+
+
 async def _passthrough(value: object) -> object:
     return value
 

--- a/website/content/docs/reference/results-and-pass.en.mdx
+++ b/website/content/docs/reference/results-and-pass.en.mdx
@@ -71,7 +71,7 @@ So: to show a package run on the public board, use **suite run → upload-suite*
 ## Browse
 
 [Viewer](/docs/run/local-viewer).  
-Attempt pages may show **Timing** (and **Tokens** when present). Trajectory tool-call rows may show a duration when the sealed step has `elapsed_ms`. Time / tokens / step duration are **hints**, not PASS.
+Attempt pages may show **Timing** (and **Tokens** when present). Trajectory steps follow file order (thought next to the tools it precedes). A step may show a duration when the sealed row has `elapsed_ms`. Time / tokens / step duration are **hints**, not PASS.
 
 ## Failure kinds
 

--- a/website/content/docs/reference/results-and-pass.mdx
+++ b/website/content/docs/reference/results-and-pass.mdx
@@ -71,7 +71,7 @@ description: Result 怎么读；pass@k 是 job 指标，不是整包 PASS。
 ## 本机翻看
 
 [Viewer](/docs/run/local-viewer)：Jobs → Tasks → Attempt。  
-Attempt 页可有 **Timing**（及有数据时的 **Tokens**）条。轨迹 `tool_call` 在密封行带 `elapsed_ms` 时显示单步耗时。耗时 / token / 单步耗时 **只是参考**，不是 PASS。
+Attempt 页可有 **Timing**（及有数据时的 **Tokens**）条。轨迹按文件顺序展示（thought 紧挨着它后面的工具）。密封行带 `elapsed_ms` 时步骤头显示单步耗时。耗时 / token / 单步耗时 **只是参考**，不是 PASS。
 
 ## 失败怎么分
 

--- a/website/content/docs/run/local-viewer.en.mdx
+++ b/website/content/docs/run/local-viewer.en.mdx
@@ -33,7 +33,7 @@ uv run bora view examples/core --open /jobs/<id>
 | Attempt | Outcome, **Timing** (and **Tokens** when present), actors, evidence tabs |
 
 Timing comes from Attempt `phase_timing` (`prepare` / `run` / `evaluate` / `cleanup`); hover bar segments for durations.  
-When a sealed `tool_call` row carries `elapsed_ms`, the step header shows that duration. Missing timing is omitted — Viewer does not invent it from file mtimes or the page clock.  
+Trajectory steps follow the sealed file order: a thought, then the tools that thought invoked, then the next thought. When a sealed step (thought, `tool_call`, or final assistant) carries `elapsed_ms`, the step header shows that duration. Missing timing is omitted — Viewer does not invent it from file mtimes or the page clock.  
 Time / tokens / step duration are **hints**, not PASS. Trajectory is not scoring authority. Each **tool-call** row (and other long rows) can collapse; the observational PASS note has expand-all / collapse-all, matching the Hub Attempt page.
 
 Viewer does **not** talk to Registry — see [Hub](/docs/share/hub). SPA details: `apps/viewer/README.md`.

--- a/website/content/docs/run/local-viewer.mdx
+++ b/website/content/docs/run/local-viewer.mdx
@@ -35,7 +35,7 @@ uv run bora view examples/core --open /jobs/<id>
 | Attempt | 结果条、**Timing**（有数据时还有 **Tokens**）、角色、证据页签（Trajectory / Agent / …） |
 
 Timing 来自 Attempt `phase_timing`（prepare / run / evaluate / cleanup）；hover 色条看分段耗时。  
-密封的 `tool_call` 若带 `elapsed_ms`，步骤头会显示该步耗时；没有就不画标签——Viewer 不会用文件 mtime 或页面时钟补造。  
+轨迹按密封文件顺序展示：一段 thought，紧接着它调用的工具，再下一段 thought。密封行（thought / `tool_call` / 最终 assistant）若带 `elapsed_ms`，步骤头会显示该步耗时；没有就不画标签——Viewer 不会用文件 mtime 或页面时钟补造。  
 耗时、token、单步耗时 **只是参考**，不是 PASS。轨迹也不是评分依据。Trajectory 里每条 **tool-call**（以及过长行）可折叠；观测 PASS 条上有全部展开 / 全部收起，与 Hub Attempt 页一致。
 
 Viewer **不连** Registry。远程目录见 [Hub](/docs/share/hub)。改 SPA 看仓库 `apps/viewer/README.md`。

--- a/website/content/docs/share/hub.en.mdx
+++ b/website/content/docs/share/hub.en.mdx
@@ -16,7 +16,7 @@ Hub (`apps/hub`) is the web UI on top of Registry—browse shared packages and r
 - Leaderboard: complete, release-bound suite rows only. Incomplete or draft-bound runs stay on the task Jobs list. Sortable headers. Observational metrics, not suite PASS. Expand a row for **profiles** / **plugin** tabs (secret-free YAML and rehydrate commands; plugins open the marketplace)  
 - Plugin detail: L0–L5 **declared-slot** timeline; expand jumps into the in-package file preview. The browser never executes plugin code  
 - Signed-in **Home**: jobs you uploaded, orgs, datasets/tasks you can maintain, plugins you uploaded. Signed-out visitors go to sign-in. No publish / upload / release buttons  
-- List search sits on the same row as **Your organizations | Explore**; file-tree pane height is stable; trajectory tool-call rows collapse; a step shows duration only when `elapsed_ms` is on the sealed row  
+- List search sits on the same row as **Your organizations | Explore**; file-tree pane height is stable; trajectory tool-call rows collapse; steps follow sealed file order; a step shows duration only when `elapsed_ms` is on the sealed row  
 
 - **Sign in with GitHub** (browser OAuth; CLI stays on Device Flow)
 

--- a/website/content/docs/share/hub.mdx
+++ b/website/content/docs/share/hub.mdx
@@ -16,7 +16,7 @@ Hub（`apps/hub`）是连 Registry 的网页端，用来浏览共享的包与跑
 - Leaderboard：只列出**完备且绑定 release** 的 suite；缺题结果与 draft 绑定跑次不上榜，仍出现在 Task **Jobs**。可点表头排序；观测指标，非 suite PASS。展开行有 **profiles** / **plugin** 页签（无密钥 YAML 与再跑命令；插件进 marketplace）  
 - 插件详情：L0–L5 **声明槽**时间线，点开跳到包内文件预览；浏览器不执行插件  
 - 登录后的 **Home**：你上传的 Jobs、组织、可维护 Dataset / Task、你上传的插件。未登录会去登录页。无 publish / upload / release 按钮  
-- 列表搜索与 **Your organizations | Explore** 同一行；文件树分栏高度固定；轨迹里 tool-call 可折叠；步骤头只在密封行带 `elapsed_ms` 时显示耗时  
+- 列表搜索与 **Your organizations | Explore** 同一行；文件树分栏高度固定；轨迹按密封文件顺序展示、tool-call 可折叠；步骤头只在密封行带 `elapsed_ms` 时显示耗时  
 
 - **用 GitHub 登录**（浏览器 OAuth；CLI 仍是 Device Flow）
 


### PR DESCRIPTION
Closes #111

Operators can read a trajectory as a ReAct loop: thought → tool → observation → thought → …, each burst with its own observational duration. The old type-bucket fold (one fat thought, then every tool, then one final assistant) is gone — no compatibility path.

## What changed

- Design (`docs/design/05-runtime/evidence.md`) names the layer-C row order and who writes it:
  `user → (thought? → tool_call → observation)* → assistant (final) → permission* → terminal`.
  Core is the only layer-C author. Timing stays observational; missing `elapsed_ms` is omitted.
- Core writer walks layer B in `seq` order. Consecutive thoughts without a tool still merge as one burst. A thought after a tool is its own row. `elapsed_ms` stays on that burst; thought wait is not copied onto the final assistant.
- Tests: `thought A → tool1 → thought B → tool2` stays interleaved; per-burst timing; no-tool / single-thought shapes still readable.
- Hub and Viewer already render `trajectory.jsonl` in file order — no new row type. Reader pages and CLI skills describe the sealed order.

## Acceptance

- [x] Design names the ReAct row order and who writes layer C
- [x] Core writer emits thought/tool/observation in layer-B `seq` order (no all-thoughts-then-all-tools bucket)
- [x] Each thought / tool burst keeps its own `elapsed_ms` when the adapter supplied it; omit when absent
- [x] Hub and Viewer show the interleaved steps without a new row type
- [x] Trajectory remains observational (not PASS)

## Local CI

- python-core: ruff format/check, pyright, 546 passed
- website build: passed
- viewer / hub: unchanged (path filter should skip)

## Out of scope

- Inferring duration from file mtimes or the Viewer clock
- Requiring every executor to emit timing
- Rewriting nooa / dsh / ACP just to fake ReAct order (layer B is already ordered)
- Harbor ATIF as a first-class on-disk format
- Suite-level PASS