### PR TITLE
fix(plugins): opt-in extensions, Official/name ids, reuse official ACP image

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ agent_profiles:
 # format: bora.profiles/1
 # bindings:
 #   solver:
-#     executor: acp
+#     executor: Official/acp
 #     options: { entry: codex }  # see: bora executors
 #     model: gpt-5.4-mini
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -134,7 +134,7 @@ agent_profiles:
 # format: bora.profiles/1
 # bindings:
 #   solver:
-#     executor: acp
+#     executor: Official/acp
 #     options: { entry: codex }  # 以 bora executors 为准
 #     model: gpt-5.4-mini
 ```

--- a/docs/design/05-runtime/provider-l1.md
+++ b/docs/design/05-runtime/provider-l1.md
@@ -23,7 +23,7 @@ Provider 负责代码运行位置和 OS 级限制：
 ## Docker L1 镜像来源（package 拥有 Dockerfile）
 
 1. `provider.kind: docker` 时，package 必须提供 **`environment/Dockerfile`**（或 `provider.dockerfile` 指向的 package 内路径）。
-2. Runtime prepare：**确保官方基座** `bora-attempt:l1`（仓库 `docker/attempt`）。若每个绑定 profile 都是 first-party `executor: acp`、选中的 `extensions` 不要求 bake、且 package Dockerfile 仅 `FROM bora-attempt:l1`（无 `COPY`/`RUN`/其它层），**直接复用**官方 tag，**不**再 `buildx --load` 出 `bora-pkg:*`。否则 **`docker build -f <package Dockerfile>`** 得到 Attempt 用 image。**`image_digest` 写入 evidence**。本地 tag 只是 `docker run` 别名，不是寻址身份；Agent 流量仍是 `session_id` → 已绑定 target 上的 `docker exec`。
+2. Runtime prepare：**确保官方基座** `bora-attempt:l1`（仓库 `docker/attempt`）。若每个绑定 profile 都是 `executor: Official/acp`、选中的 `extensions` 不要求 bake、且 package Dockerfile 仅 `FROM bora-attempt:l1`（无 `COPY`/`RUN`/其它层），**直接复用**官方 tag，**不**再 `buildx --load` 出 `bora-pkg:*`。否则 **`docker build -f <package Dockerfile>`** 得到 Attempt 用 image。**`image_digest` 写入 evidence**。本地 tag 只是 `docker run` 别名，不是寻址身份；Agent 流量仍是 `session_id` → 已绑定 target 上的 `docker exec`。
 3. 官方基座构建一次、多处 `FROM` 复用；上游基座由 package Dockerfile 自行 `FROM` 并安装**同一 pin 表**声明的入口（禁止 package 自选 floating 版本）。官方基座自身的 `build_input_digest` 覆盖 `Dockerfile` + `install-executors.sh` + `acp-entries.lock.json`；**不**因本条改变 `bora-attempt:l1` 的 tag 名。
 4. **基座预装（设计契约）：** 最低 coding-agent 验收 entry 的 **engine + ACP 入口** bake-in：
    - Mode 1：`codex`+`codex-acp`、`claude`+`claude-agent-acp`、**`pi`+`pi-acp`**；

--- a/docs/design/05-runtime/provider-l1.md
+++ b/docs/design/05-runtime/provider-l1.md
@@ -23,7 +23,7 @@ Provider 负责代码运行位置和 OS 级限制：
 ## Docker L1 镜像来源（package 拥有 Dockerfile）
 
 1. `provider.kind: docker` 时，package 必须提供 **`environment/Dockerfile`**（或 `provider.dockerfile` 指向的 package 内路径）。
-2. Runtime prepare：**确保官方基座** `bora-attempt:l1`（仓库 `docker/attempt`）→ **`docker build -f <package Dockerfile>`** 得到 Attempt 用 image → **`image_digest` 写入 evidence**。本地 tag 只是 `docker run` 别名，不是寻址身份；Agent 流量仍是 `session_id` → 已绑定 target 上的 `docker exec`。
+2. Runtime prepare：**确保官方基座** `bora-attempt:l1`（仓库 `docker/attempt`）。若每个绑定 profile 都是 first-party `executor: acp`、选中的 `extensions` 不要求 bake、且 package Dockerfile 仅 `FROM bora-attempt:l1`（无 `COPY`/`RUN`/其它层），**直接复用**官方 tag，**不**再 `buildx --load` 出 `bora-pkg:*`。否则 **`docker build -f <package Dockerfile>`** 得到 Attempt 用 image。**`image_digest` 写入 evidence**。本地 tag 只是 `docker run` 别名，不是寻址身份；Agent 流量仍是 `session_id` → 已绑定 target 上的 `docker exec`。
 3. 官方基座构建一次、多处 `FROM` 复用；上游基座由 package Dockerfile 自行 `FROM` 并安装**同一 pin 表**声明的入口（禁止 package 自选 floating 版本）。官方基座自身的 `build_input_digest` 覆盖 `Dockerfile` + `install-executors.sh` + `acp-entries.lock.json`；**不**因本条改变 `bora-attempt:l1` 的 tag 名。
 4. **基座预装（设计契约）：** 最低 coding-agent 验收 entry 的 **engine + ACP 入口** bake-in：
    - Mode 1：`codex`+`codex-acp`、`claude`+`claude-agent-acp`、**`pi`+`pi-acp`**；
@@ -47,13 +47,14 @@ package Dockerfile
 本地 tag：
 
 ```text
+bora-attempt:l1                                          # 官方 ACP + FROM-only + 无选中 bake
 bora-pkg:{content_key[:12]}
-bora-pkg:{content_key[:12]}-{plugin}-{bake_input[:12]}   # 仅当 image_contribute bake
+bora-pkg:{content_key[:12]}-{plugin}-{bake_input[:12]}   # 仅当 extensions 选中 image_contribute bake
 ```
 
-`content_key` / `bake_input` 是上述输入的 digest。同一组输入第二次 prepare **跳过** `buildx --load`，复用已有 tag 与 image id。只改 `parameters` / `agent_profiles` / bindings（Dockerfile 与 bake 输入不变）**不得**产生新 tag。
+`plugin` 段不得含 `/`（`org/name` 在 tag 里写成 `org--name`）。`content_key` / `bake_input` 是上述输入的 digest。同一组输入第二次 prepare **跳过** `buildx --load`，复用已有 tag 与 image id。只改 `parameters` / `agent_profiles` / bindings（Dockerfile 与 bake 输入不变）**不得**产生新 tag。
 
-Bake 后缀来自 bake **输入** digest，禁止用 inspect id。绑定外置 executor 但 contribute 链为空或缺少 `Dockerfile.bake` 仍 fail closed。workspace、`ctx.params`、gold **不**进入镜像。
+Bake 后缀来自 bake **输入** digest，禁止用 inspect id。bake **只**覆盖本 job 各 profile `extensions` 选中的 contribute；`executor:` 单独出现不 bake。绑定外置 executor 但 contribute 链为空或缺少 `Dockerfile.bake` 仍 fail closed。workspace、`ctx.params`、gold **不**进入镜像。
 
 ### Attempt 拥有的 volume 与 env 容器随 Attempt 死亡
 

--- a/docs/design/11-extension-plugins.md
+++ b/docs/design/11-extension-plugins.md
@@ -34,7 +34,7 @@
 1. `profiles.executor`（及 `extensions` 显式绑定）选择 provide；**禁止** `resolve_executor` dual path / `bora.agent_executors` 旁路  
 2. **nooa 等生态插件外置**（`plugins/` + install），不进 first-party bootstrap  
 3. `bora plugin install` **只写本地 cache**（`$BORA_HOME/plugins`），**永不改写** profiles / task.yaml  
-4. **Recognition ≠ Ready**：install 可见 ≠ L1 镜像可跑；Ready 来自 `image_contribute` bake。Core 对每个已安装且声明 contribute、并带 `docker/Dockerfile.bake` 的**外置**插件链式 `docker buildx`（context = 插件根）。绑定了外置 executor 但链为空或缺 bake 文件 → fail closed。Core **不**按插件名解释 bake token。官方 ACP 五 entry 仍在 `docker/attempt` 基座 bake-in。  
+4. **Recognition ≠ Ready**：install 可见 ≠ L1 镜像可跑；Ready 来自本 profile `extensions` 选中的 `image_contribute` bake。`executor:` 只选 `provide(executor)`，**不**暗示 bake / trajectory / 其它 `on:`。MULTI 链只含 first-party/default **加上** 本 profile `extensions` 点名的插件；已安装但未列入的外置插件不进链、不进镜像。绑定了外置 executor 但未选中 contribute 或缺 bake 文件 → fail closed。Core **不**按插件名解释 bake token。官方 ACP 五 entry 仍在 `docker/attempt` 基座 bake-in。  
 5. PASS 只来自独立 evaluator；扩展链不得发明 PASS  
 6. 凭据只经 scoped projection；不进 lock / evidence  
 
@@ -90,25 +90,69 @@ evaluate     → evaluation_input_contribute → evaluation_runtime
 
 - 根 `plugin.yaml`：`plugin_id`、`version`、`slots.provide` / `slots.on` + entry  
 - 可选 `docker/Dockerfile.bake`（L1 Ready）  
-- install：`bora plugin install <path|org/id@ver>` → `~/.bora/plugins`  
+- install：`bora plugin install <path|org/name@version>` → `~/.bora/plugins`；index 记录 `plugin_id` / version / digest  
 - Hub/Registry：`package_kind=plugin`；media type `application/vnd.bora.plugin.v1.tar+gzip`  
 - Dataset 与 plugin **fail closed** 区分（Hub 列表过滤 / detail 拒绝混开）
+
+### `plugin_id` = `org/name`
+
+绑定只认 **`plugin_id`**，不认 `ExecutorSPI.kind`。两个安装不得共享同一 `plugin_id`（后写覆盖）。
+
+| 来源 | `plugin_id` 形状 |
+| --- | --- |
+| first-party contrib | 短 id：`acp`、`openai-http`、`mock`（+ `default` multi） |
+| 仓内示例（未 publish） | 可暂用短 id（`nooa`、`dsh`、`slot-probe`） |
+| Hub 上架 / Registry 安装 | **必须** `org/name`（与 Dataset `database_id` 同形；不是 `org.name`） |
+
+`plugin_id` 写在 `plugin.yaml`，path install 与 Hub install 读同一字段。不另设 `org-id`。`bora plugin publish --org` 必须等于 `plugin_id` 的前缀，否则拒绝；Hub 展示该 org，不改写 id。Registry 定位器是 `org/name@version`（或 digest）；本地 cache 记下 org/name、version、digest。
+
+两家厂商各出 nooa 类机制时分别是 `acme/nooa` 与 `other/nooa`；profiles 写全 id。Core 槽 id（`executor`、`image_contribute`、…）仍归 Core。
 
 ### First-party vs 外置
 
 | 来源 | 例子 |
 | --- | --- |
 | first-party contrib（bootstrap） | `acp`、`openai-http`、`mock` + `defaults` multi |
-| 外置 install | `nooa`、`slot-probe`（仓库 `plugins/` 仅示例，不进 Core） |
+| 外置 install | `nooa`、`dsh`、`slot-probe`（仓库 `plugins/` 仅示例，不进 Core） |
 
 ---
 
 ## 配置与绑定
 
-- Job binding 在 `profiles.yaml`：`executor` / `options` / `extensions`（binding 字段）  
+- Job binding 在 `profiles.yaml`：`executor` / `options` / `extensions`（binding 字段）；选择按 **profile（role）**，不是 task 级插件列表  
 - member `task.yaml` 只声明 role slot，禁止内联 binding  
-- `bora lock` 解析每个 profile → `extension_bindings` 进 digest  
+- `bora lock` 解析每个 profile → `extension_bindings` 进 digest（快照，不是选择器）  
 - 切换机制：**同一 harness**，改 profiles +（必要时）install，不改 harness 业务代码  
+
+### `extensions` 按 profile 显式 opt-in
+
+字段名保持 **`extensions`**。未列入的已安装插件不进入 MULTI 链、不 bake。
+
+```yaml
+bindings:
+  planner:
+    executor: nooa                 # 只选 provide(executor)；不暗示 bake
+    extensions:
+      - plugin: nooa               # 该插件登记的全部槽（provide + on）
+  reviewer:
+    executor: dsh
+    extensions:
+      - plugin: dsh
+        slots: [image_contribute]  # 只开列出的槽
+      # 单槽写法（与历史上 {slot, plugin} 同义）：
+      # - slot: trajectory_collect
+      #   plugin: dsh
+```
+
+规则：
+
+1. 省略 `slots` → 打开该插件已登记的每一个槽。  
+2. `slots: [...]` → 只开列出的槽；未知槽或该插件未登记 → fail closed。  
+3. `{slot, plugin}` → 恰好那一个槽。  
+4. `executor:` **不**隐含 `image_contribute`。纯 ACP profile 省略 `extensions`。  
+5. 外置 executor 已绑定但 `extensions` 未选中 contribute（或缺 bake）→ L1 fail closed。  
+6. 同一 job 里不同 role 可独立绑定不同插件。  
+7. 省略 `executor:` 时，若某条 `- plugin: …`（全槽）含该插件的 executor provide，可用它补上；两套都写时以 `executor:` 为准。
 
 ### nooa 绑定形状
 
@@ -119,6 +163,8 @@ evaluate     → evaluation_input_contribute → evaluation_runtime
 bindings:
   solver:
     executor: nooa
+    extensions:
+      - plugin: nooa
     model: openai/glm-5.2
     api_key: litellm_api_key          # env locator；值不进 lock
     # base_url: https://…/v1          # 可选；否则回落 litellm_base_url / OPENAI_BASE_URL
@@ -128,6 +174,16 @@ bindings:
 ```
 
 L1：bake 安装 `nooa` + **in-container worker**；parent 把 model/base_url/密钥投影进 worker；host SPI 不是 L1 成功路径。
+
+### 官方 ACP 镜像（不另打 `bora-pkg`）
+
+下列条件**同时**成立时，prepare **不** `buildx --load` package 标签；Attempt 镜像就是已有官方 `bora-attempt:l1`：
+
+- 每个已绑定 profile 都是 first-party `executor: acp`（无外置 executor）；  
+- 选中的 `extensions` 不要求 `image_contribute` bake；  
+- package Dockerfile 相对官方基座是空操作（今天：仅 `FROM bora-attempt:l1`，无 `COPY` / `RUN` / 其它层）。
+
+Dockerfile 另有文件或其它 `FROM`，或任一选中扩展要 bake，仍走 `bora-pkg:{content}`（+ bake 后缀）。evidence 仍记 `image_digest`。`bora-attempt:l1` 的 hash 规则不变。
 
 ---
 

--- a/docs/design/11-extension-plugins.md
+++ b/docs/design/11-extension-plugins.md
@@ -100,9 +100,9 @@ evaluate     → evaluation_input_contribute → evaluation_runtime
 
 | 来源 | `plugin_id` 形状 |
 | --- | --- |
-| first-party contrib | 短 id：`acp`、`openai-http`、`mock`（+ `default` multi） |
+| first-party contrib | **`Official/<name>`**：`Official/acp`、`Official/openai-http`、`Official/mock`（+ `Official/default` multi）。不用短 id 特例。 |
 | 仓内示例（未 publish） | 可暂用短 id（`nooa`、`dsh`、`slot-probe`） |
-| Hub 上架 / Registry 安装 | **必须** `org/name`（与 Dataset `database_id` 同形；不是 `org.name`） |
+| Hub 上架 / Registry 安装 | **必须** `org/name`（与 Dataset `database_id` 同形；不是 `org.name`）。官方包用 org `Official`。 |
 
 `plugin_id` 写在 `plugin.yaml`，path install 与 Hub install 读同一字段。不另设 `org-id`。`bora plugin publish --org` 必须等于 `plugin_id` 的前缀，否则拒绝；Hub 展示该 org，不改写 id。Registry 定位器是 `org/name@version`（或 digest）；本地 cache 记下 org/name、version、digest。
 
@@ -112,7 +112,7 @@ evaluate     → evaluation_input_contribute → evaluation_runtime
 
 | 来源 | 例子 |
 | --- | --- |
-| first-party contrib（bootstrap） | `acp`、`openai-http`、`mock` + `defaults` multi |
+| first-party contrib（bootstrap） | `Official/acp`、`Official/openai-http`、`Official/mock` + `Official/default` multi |
 | 外置 install | `nooa`、`dsh`、`slot-probe`（仓库 `plugins/` 仅示例，不进 Core） |
 
 ---
@@ -179,7 +179,7 @@ L1：bake 安装 `nooa` + **in-container worker**；parent 把 model/base_url/�
 
 下列条件**同时**成立时，prepare **不** `buildx --load` package 标签；Attempt 镜像就是已有官方 `bora-attempt:l1`：
 
-- 每个已绑定 profile 都是 first-party `executor: acp`（无外置 executor）；  
+- 每个已绑定 profile 都是 `executor: Official/acp`（无外置 executor）；  
 - 选中的 `extensions` 不要求 `image_contribute` bake；  
 - package Dockerfile 相对官方基座是空操作（今天：仅 `FROM bora-attempt:l1`，无 `COPY` / `RUN` / 其它层）。
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -78,7 +78,7 @@ credentials — not parent host SPI success.
 
 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) path: official
 JSON-RPC SDK (`deepseek-harness-sdk`), not ACP. Same journeys harness; bind
-`executor: dsh` + `model` + locator `deepseek_api_key`. L1 bake installs the
+`executor: dsh` + `extensions: [{plugin: dsh}]` + `model` + locator `deepseek_api_key`. L1 bake installs the
 wheels in the Attempt image — host `--extra dsh` is only for L0 host SPI.
 
 ```bash

--- a/examples/core/profiles.yaml
+++ b/examples/core/profiles.yaml
@@ -1,24 +1,24 @@
 format: bora.profiles/1
 bindings:
   mock-default:
-    executor: mock
+    executor: Official/mock
     model: none
   solver:
-    executor: acp
+    executor: Official/acp
     options:
       entry: codex
     model: gpt-5.4-mini
   http-solver:
-    executor: openai-http
+    executor: Official/openai-http
     model: gpt-4.1-mini
   primary:
-    executor: acp
+    executor: Official/acp
     options:
       entry: opencode
     model: zai-coding-plan/glm-5.2
     api_key: glm_coding_api_key
   secondary:
-    executor: acp
+    executor: Official/acp
     options:
       entry: pi
     model: zai-coding-cn/glm-5.2
@@ -27,6 +27,8 @@ bindings:
   # External nooa host SPI (task-local lib.agents; after bora plugin install)
   nooa-solver:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:FixedAnswerAgent"
       method: "run"

--- a/examples/core/tasks/plugin-agent-executor/README.md
+++ b/examples/core/tasks/plugin-agent-executor/README.md
@@ -1,8 +1,8 @@
 # plugin-agent-executor
 
-Second **executor mechanism** (`openai-http`) via harness-scheduled `Agent.session`/`invoke`.
+Second **executor mechanism** (`Official/openai-http`) via harness-scheduled `Agent.session`/`invoke`.
 
-Profile uses `executor: openai-http` (HTTP plugin path) instead of builtin Codex.
+Profile uses `executor: Official/openai-http` (HTTP plugin path) instead of builtin Codex.
 Harness only materializes parent agent result and publishes; evaluator requires
 `answer == 42`.
 

--- a/examples/journeys/profiles.dsh.read-only.yaml
+++ b/examples/journeys/profiles.dsh.read-only.yaml
@@ -12,6 +12,8 @@ format: bora.profiles/1
 bindings:
   solver:
     executor: dsh
+    extensions:
+      - plugin: dsh
     model: deepseek-v4-flash
     api_key: deepseek_api_key
     options:

--- a/examples/journeys/profiles.dsh.yaml
+++ b/examples/journeys/profiles.dsh.yaml
@@ -13,6 +13,8 @@ format: bora.profiles/1
 bindings:
   solver:
     executor: dsh
+    extensions:
+      - plugin: dsh
     model: deepseek-v4-flash
     api_key: deepseek_api_key
     options:

--- a/examples/journeys/profiles.nooa.yaml
+++ b/examples/journeys/profiles.nooa.yaml
@@ -12,6 +12,8 @@ format: bora.profiles/1
 bindings:
   solver:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:JsonlAggAgent"
       method: "run"
@@ -19,6 +21,8 @@ bindings:
     api_key: litellm_api_key
   user:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:UserSimAgent"
       method: "run"
@@ -26,6 +30,8 @@ bindings:
     api_key: litellm_api_key
   service:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:ServiceAgent"
       method: "run"
@@ -33,6 +39,8 @@ bindings:
     api_key: litellm_api_key
   specialist:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:SpecialistAgent"
       method: "run"
@@ -40,6 +48,8 @@ bindings:
     api_key: litellm_api_key
   planner:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:PlannerAgent"
       method: "run"
@@ -47,6 +57,8 @@ bindings:
     api_key: litellm_api_key
   reducer:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:ReducerAgent"
       method: "run"

--- a/examples/journeys/profiles.yaml
+++ b/examples/journeys/profiles.yaml
@@ -1,36 +1,36 @@
 format: bora.profiles/1
 bindings:
   solver:
-    executor: acp
+    executor: Official/acp
     options:
       entry: pi
     model: zai-coding-cn/glm-5.2
     api_key: glm_coding_api_key
   user:
-    executor: acp
+    executor: Official/acp
     options:
       entry: grok-build
     model: entry-default
   service:
-    executor: acp
+    executor: Official/acp
     options:
       entry: opencode
     model: zai-coding-plan/glm-5.2
     api_key: glm_coding_api_key
   specialist:
-    executor: acp
+    executor: Official/acp
     options:
       entry: pi
     model: zai-coding-cn/glm-5.2
     api_key: glm_coding_api_key
   planner:
-    executor: acp
+    executor: Official/acp
     options:
       entry: opencode
     model: zai-coding-plan/glm-5.2
     api_key: glm_coding_api_key
   reducer:
-    executor: acp
+    executor: Official/acp
     options:
       entry: grok-build
     model: entry-default

--- a/examples/l1/profiles.yaml
+++ b/examples/l1/profiles.yaml
@@ -1,28 +1,28 @@
 format: bora.profiles/1
 bindings:
   solver:
-    executor: acp
+    executor: Official/acp
     options:
       entry: codex
     model: gpt-5.4-mini
   pi-solver:
-    executor: acp
+    executor: Official/acp
     options:
       entry: pi
     model: zai-coding-cn/glm-5.2
     api_key: glm_coding_api_key
   planner:
-    executor: acp
+    executor: Official/acp
     options:
       entry: codex
     model: gpt-5.4-mini
   reviewer:
-    executor: acp
+    executor: Official/acp
     options:
       entry: codex
     model: gpt-5.4-mini
   worker:
-    executor: acp
+    executor: Official/acp
     options:
       entry: codex
     model: gpt-5.4-mini

--- a/examples/slot-probe/README.md
+++ b/examples/slot-probe/README.md
@@ -1,6 +1,6 @@
 # example/slot-probe
 
-Database for **multi-slot extension SPI** regression ([Issue #71](https://github.com/ZJU-REAL/BORA/issues/71)).
+Database for **multi-slot extension SPI** regression.
 
 Companion plugin: [`plugins/slot-probe`](../../plugins/slot-probe/).
 

--- a/examples/slot-probe/profiles.yaml
+++ b/examples/slot-probe/profiles.yaml
@@ -4,13 +4,18 @@ bindings:
   # slot-probe multi hooks still attach via install (env / trajectory / open / …).
   probe-nooa:
     executor: nooa
+    extensions:
+      - plugin: nooa
+      - plugin: slot-probe
     options:
       agent: "lib.agents:FixedAnswerAgent"
       method: "run"
     model: none
   # L1: real ACP in attempt-container.
   probe-acp:
-    executor: acp
+    executor: Official/acp
+    extensions:
+      - plugin: slot-probe
     options:
       entry: pi
     model: zai-coding-cn/glm-5.2

--- a/examples/tau3-airline/profiles.yaml
+++ b/examples/tau3-airline/profiles.yaml
@@ -1,12 +1,12 @@
 format: bora.profiles/1
 bindings:
   user:
-    executor: acp
+    executor: Official/acp
     options:
       entry: grok-build
     model: entry-default
   service:
-    executor: acp
+    executor: Official/acp
     options:
       entry: grok-build
     model: entry-default

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -35,6 +35,8 @@ edits `profiles.yaml` / `bora.yaml` / `task.yaml`.
 bindings:
   solver:
     executor: dsh
+    extensions:
+      - plugin: dsh
     model: deepseek-v4-flash
     api_key: deepseek_api_key          # env locator
     options:
@@ -78,7 +80,7 @@ uv run bora run examples/journeys --task terminal-jsonl-agg \
 ## Recognition ≠ Ready ≠ bind
 
 - **install** → Recognition only (`plugin list` / executor visible)
-- **profiles `executor: dsh`** → bind (+ model / api_key locator)
+- **profiles `executor: dsh` + `extensions: [{plugin: dsh}]`** → bind and bake (+ model / api_key locator)
 - **L1 Ready** → `image_contribute` bake installs the SDK wheels +
   `bora-executor-dsh`; invoke is **docker exec** with projected `DEEPSEEK_API_KEY`
 

--- a/plugins/nooa/README.md
+++ b/plugins/nooa/README.md
@@ -36,6 +36,8 @@ Install updates `~/.bora/plugins` (or `$BORA_HOME/plugins`) only — **never** e
 bindings:
   solver:
     executor: nooa
+    extensions:
+      - plugin: nooa
     model: openai/glm-5.2
     api_key: litellm_api_key          # env locator
     # base_url: http://127.0.0.1:8000/v1   # optional; else litellm_base_url / OPENAI_BASE_URL
@@ -57,7 +59,7 @@ uv run bora run examples/journeys \
 ## Recognition ≠ Ready ≠ bind
 
 - **install** → Recognition only (`plugin list` / executor visible)
-- **profiles `executor: nooa`** → bind (+ model / base_url / api_key)
+- **profiles `executor: nooa` + `extensions: [{plugin: nooa}]`** → bind and bake (+ model / base_url / api_key)
 - **L1 Ready** → `image_contribute` bake installs `nooa` + `bora-executor-nooa` in the Attempt image; invoke is **docker exec** with projected credentials
 
 ## L1 Ready strategy

--- a/services/registry/result_service.py
+++ b/services/registry/result_service.py
@@ -309,7 +309,9 @@ class ResultService:
                     continue
                 pid = str(item.get("plugin_id") or "").strip()
                 key = pid.casefold()
-                if not pid or key in seen or key in {"default", "acp", "openai-http"}:
+                from bora.plugins.manifest import is_official_plugin
+
+                if not pid or key in seen or is_official_plugin(pid):
                     continue
                 seen.add(key)
                 row = {"plugin_id": pid}

--- a/skills/bora-cli/SKILL.md
+++ b/skills/bora-cli/SKILL.md
@@ -75,7 +75,7 @@ uv run bora executors -v
 Coding-agent packages use:
 
 ```yaml
-executor: acp
+executor: Official/acp
 options:
   entry: opencode # or codex | claude-code | pi | grok-build | …
 ```

--- a/skills/bora-cli/references/commands.md
+++ b/skills/bora-cli/references/commands.md
@@ -22,7 +22,7 @@ Stdout JSON (high level):
 - `-v` adds tools/session/stream + richer entry fields
 - No package path; no secrets; exit 0
 
-**Author packages with:** `executor: acp` + `options.entry: <entry_id from acp_entries>`.
+**Author packages with:** `executor: Official/acp` + `options.entry: <entry_id from acp_entries>`.
 
 ## `bora lock`
 

--- a/skills/bora-cli/references/failures.md
+++ b/skills/bora-cli/references/failures.md
@@ -3,7 +3,7 @@
 | Symptom | Check |
 | --- | --- |
 | exit 2, empty stdout on lock | Config error on stderr (`unknown_profile`, schema, etc.) |
-| lock `unsupported_capability` / `unsupported executor` | Kind not in `bora executors` `.supported` — coding agents need `executor: acp` |
+| lock `unsupported_capability` / `unsupported executor` | Kind not in `bora executors` `.supported` — coding agents need `executor: Official/acp` |
 | lock `options.entry required` | ACP profile missing `options.entry` |
 | Agent ERROR offline | Expected under `BORA_OFFLINE_AGENT=1` |
 | `l1_executor_unbound` | L1 invoke has no SPI ``bind_to_target`` (or placement resolver missing) |

--- a/skills/bora-config-package/SKILL.md
+++ b/skills/bora-config-package/SKILL.md
@@ -230,7 +230,7 @@ evaluation:
 format: bora.profiles/1
 bindings:
   solver:
-    executor: acp
+    executor: Official/acp
     options:
       entry: opencode       # registry: codex | claude-code | pi | opencode | grok-build
     model: entry-default
@@ -318,11 +318,11 @@ uv run bora plugin list        # installed mechanism plugins (e.g. nooa)
 | Surface | Meaning |
 | --- | --- |
 | `.supported` | Valid `agent_profiles[].executor` values (this install): typically `acp`, `openai-http`, … |
-| `.acp_entries[]` | When `executor: acp`, valid `options.entry` ids + host binary readiness |
+| `.acp_entries[]` | When `executor: Official/acp`, valid `options.entry` ids + host binary readiness |
 | `.host_ready` | Kinds that can run here (ACP needs at least one ready entry; HTTP needs no CLI) |
 | Installed plugins | Extra executor plugin_ids after `bora plugin install` (Recognition only) |
 
-**Target (coding agents):** `executor: acp` + `options.entry: <registry-id>`.  
+**Target (coding agents):** `executor: Official/acp` + `options.entry: <registry-id>`.  
 **Do not** write `executor: codex|pi|opencode|claude-code` — lock fails (`unsupported_capability`) or L1 fails (`l1_executor_unbound`).
 
 **External mechanism (e.g. nooa):** `executor: nooa` + `options.agent: "lib.agents:Class"` in

--- a/skills/bora-config-package/references/bora-yaml.md
+++ b/skills/bora-config-package/references/bora-yaml.md
@@ -62,7 +62,7 @@ uv run bora executors -v   # + tools/session/stream; .acp_entries[] for ACP
 ```
 
 - **`.supported`**: kinds valid for yaml `executor:` (this BORA install).
-- **Coding agents (ACP Target):** `executor: acp` + `options.entry`.
+- **Coding agents (ACP Target):** `executor: Official/acp` + `options.entry`.
 - **HTTP agents:** e.g. `executor: openai-http` (+ optional `base_url` / `api_key` locator).
 - Unknown kind fails at lock (`unsupported_capability`).
 - Private CLI kinds (`codex` / `pi` / `opencode` / `claude-code` as **executor**) are **removed**; use ACP entry ids instead.
@@ -72,12 +72,12 @@ uv run bora executors -v   # + tools/session/stream; .acp_entries[] for ACP
 ```yaml
 agent_profiles:
   - id: codex-acp
-    executor: acp
+    executor: Official/acp
     model: entry-default          # or a model the entry accepts
     options:
       entry: codex                # registry entry_id
   - id: pi-acp
-    executor: acp
+    executor: Official/acp
     model: zai-coding-cn/glm-5.2
     api_key: glm_coding_api_key   # host env locator name only
     options:
@@ -86,7 +86,7 @@ agent_profiles:
 
 | Field | Rule |
 | --- | --- |
-| `options.entry` | **Required** when `executor: acp`. Registry ids (discover via `bora executors -v` → `acp_entries`): typically `codex`, `claude-code`, `pi`, `opencode`, `grok-build`. |
+| `options.entry` | **Required** when `executor: Official/acp`. Registry ids (discover via `bora executors -v` → `acp_entries`): typically `codex`, `claude-code`, `pi`, `opencode`, `grok-build`. |
 | `options.command` / `version` / `install_command` / … | **Forbidden** in package yaml (registry owns pins). |
 | Host readiness | Per-entry `engine_ready` + `acp_entry_ready` in inventory — not the same as yaml `executor` kind. |
 

--- a/skills/bora-config-package/references/isolation.md
+++ b/skills/bora-config-package/references/isolation.md
@@ -16,7 +16,7 @@
   (see docs/design/05-runtime/provider-l1.md).
   Upstream base: `FROM <image>` then install required ACP entries in that Dockerfile.
   Secrets never baked into image layers.
-- Coding agents on L1: `executor: acp` + `options.entry`; parent ACP client +
+- Coding agents on L1: `executor: Official/acp` + `options.entry`; parent ACP client +
   `docker exec` placement — no private CLI scrape.
 
 ## L1 Dockerfile depth tiers (conversion)

--- a/skills/bora-platform/SKILL.md
+++ b/skills/bora-platform/SKILL.md
@@ -47,7 +47,7 @@ Authoring / porting / scenario-homogeneous Datasets: load `$bora-config-package`
 3. **Adapters** named by mechanism/protocol/resource (`acp`, `openai-http`, `postgresql`, docker; ACP **entries** `codex`/`pi`/…) — never Benchmark/task/domain names.
 4. **Do not claim** suite-wide `isolated` or `real-benchmark-verified` from one happy path.
 5. **Skills only describe shipped surfaces** — never invent CLI flags or Core APIs.
-6. **Coding-agent Target:** `executor: acp` + `options.entry` — not private CLI `executor: codex|pi|…`.
+6. **Coding-agent Target:** `executor: Official/acp` + `options.entry` — not private CLI `executor: codex|pi|…`.
 7. **Plugins:** fixed L0–L5 extension points + registry; `bora plugin install` never rewrites profiles; Recognition ≠ L1 Ready (`image_contribute` bake); no executor dual path.
 8. **Hub Leaderboard / Task Jobs need suite uploads** — `bora results upload` (single Attempt) is not enough for primary Hub surfaces; use suite run + `bora results upload-suite` (often `--with-attempts`). Public Leaderboard further requires a **complete**, **release-bound** suite; incomplete or draft-bound rows stay on Jobs. Detail: `$bora-cli` § Hub visibility.
 

--- a/skills/bora-platform/references/red-lines.md
+++ b/skills/bora-platform/references/red-lines.md
@@ -14,7 +14,7 @@
 
 ## Adapter naming
 
-- **OK:** yaml `executor: acp` + `options.entry: codex|pi|opencode|…`; `openai-http`; `postgresql`; docker provider.
+- **OK:** yaml `executor: Official/acp` + `options.entry: codex|pi|opencode|…`; `openai-http`; `postgresql`; docker provider.
 - **Forbidden:** `executor: codex|pi|opencode|claude-code` as private CLI kinds (migrated); `TerminalBenchAdapter`; task-id branches; domain names as production adapter modules.
 
 ## Plugins

--- a/skills/bora-platform/references/shipped-surfaces.md
+++ b/skills/bora-platform/references/shipped-surfaces.md
@@ -7,7 +7,7 @@ Prefer mechanism packages under `examples/core/` and `examples/l1/`. Full list: 
 | `examples/core --task config-minimal` | `bora lock` success |
 | `examples/core --task sdk-agent-session` | Host multi-invoke + independent PASS |
 | `examples/core --task attempt-trajectory` | Per-invoke Core `trajectory.jsonl` + `Result.logs` |
-| `examples/core --task builtin-executor-conformance` | Profile-only switch (`executor: acp` + `options.entry`) |
+| `examples/core --task builtin-executor-conformance` | Profile-only switch (`executor: Official/acp` + `options.entry`) |
 | `examples/core --task builtin-executor-mixed` | Two ACP profiles, independent sessions/trees |
 | `examples/core --task hard-ceiling-trajectory` | N+1 invoke denied pre-effect |
 | `examples/core --task environment-action-denied` | Env action deny-before-mutation |

--- a/skills/bora-plugin/references/authoring.md
+++ b/skills/bora-plugin/references/authoring.md
@@ -131,6 +131,8 @@ format: bora.profiles/1
 bindings:
   solver:
     executor: my-mech
+    extensions:
+      - plugin: my-mech
     model: openai/glm-5.2
     api_key: litellm_api_key # locator
     options:

--- a/skills/bora-plugin/references/mechanism.md
+++ b/skills/bora-plugin/references/mechanism.md
@@ -5,9 +5,9 @@ authoring agents only; it does not own new contract.
 
 ## Registry
 
-- First-party contrib bootstraps in Core: `acp`, `openai-http`, `mock` + default multi handlers.
+- First-party contrib bootstraps in Core: `Official/acp`, `Official/openai-http`, `Official/mock` + `Official/default` multi handlers.
 - External `bora plugin install` joins the same table. Recognition = first-party ∪ installed `provide(executor)`.
-- `profiles.executor: <plugin_id>` is sugar for the executor provide. `extensions:` can bind other slots explicitly.
+- `profiles.executor: <plugin_id>` is sugar for the executor provide. MULTI / bake slots join only via `extensions`.
 - Resolve: explicit binding > lower priority wins; a tie with no explicit pick fail-closes.
 - `bora lock` writes the resolved graph as `extension_bindings` (plugin_id / slot / source / priority / digest).
 
@@ -41,7 +41,7 @@ close        → before_agent_close → executor.close → after_agent_close
 
 ## Coexists with ACP
 
-The default coding-agent inlet remains first-party `executor: acp` + `options.entry`.
+The default coding-agent inlet remains first-party `executor: Official/acp` + `options.entry`.
 An external plugin is an optional mechanism. The **same harness** switches via
 profiles. ACP is not the trajectory schema authority.
 

--- a/skills/bora-sdk-harness/SKILL.md
+++ b/skills/bora-sdk-harness/SKILL.md
@@ -28,7 +28,7 @@ from bora_sdk import (
 
 ## Minimal harness
 
-Profile **ids** come from package `agent_profiles` (which use `executor: acp` +
+Profile **ids** come from package `agent_profiles` (which use `executor: Official/acp` +
 `options.entry` for coding agents). Harness only opens profiles by id — never
 branches Core policy on entry/executor name.
 

--- a/skills/bora-sdk-harness/references/antipatterns.md
+++ b/skills/bora-sdk-harness/references/antipatterns.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | Treat `completed` as PASS | Independent evaluator only |
 | `if executor == "codex":` / `if entry == "pi":` for Core policy | Switch `agent_profiles` / `active_profile` / `parameters.roles` |
-| Write `executor: codex` in package yaml | `executor: acp` + `options.entry: codex` (etc.) |
+| Write `executor: codex` in package yaml | `executor: Official/acp` + `options.entry: codex` (etc.) |
 | Read `~/.codex/auth.json` or print secrets | Rely on Runtime projection |
 | Write training JSON by hand under package | Use Core `trajectory.jsonl` under Result.logs |
 | Soft CallLimit as the only hard ceiling | `limits.agent_invocations` in yaml (Runtime) |

--- a/src/bora/adapters/executor_capabilities.py
+++ b/src/bora/adapters/executor_capabilities.py
@@ -33,7 +33,7 @@ class ExecutorCapabilities:
 
 
 BUILTIN_CAPABILITIES: Final[dict[str, ExecutorCapabilities]] = {
-    "acp": ExecutorCapabilities(
+    "Official/acp": ExecutorCapabilities(
         kind="acp",
         tools="native",
         structured_output="validated-text",
@@ -44,7 +44,7 @@ BUILTIN_CAPABILITIES: Final[dict[str, ExecutorCapabilities]] = {
         credential_env_names=(),
         binary="",
     ),
-    "openai-http": ExecutorCapabilities(
+    "Official/openai-http": ExecutorCapabilities(
         kind="openai-http",
         tools="unsupported",
         structured_output="validated-text",
@@ -59,6 +59,12 @@ BUILTIN_CAPABILITIES: Final[dict[str, ExecutorCapabilities]] = {
 
 def get_capabilities(kind: str) -> ExecutorCapabilities | None:
     found = BUILTIN_CAPABILITIES.get(kind)
+    if found is not None:
+        return found
+    from bora.plugins.manifest import split_plugin_id
+
+    _org, name = split_plugin_id(kind)
+    found = BUILTIN_CAPABILITIES.get(name)
     if found is not None:
         return found
     return _plugin_published_capabilities(kind)
@@ -123,7 +129,7 @@ def _describe_from_provider(impl: Any) -> dict[str, Any] | None:
 
 def required_kinds_for_v014() -> frozenset[str]:
     """Historical name: coding-agent surface is now ACP."""
-    return frozenset({"acp"})
+    return frozenset({"Official/acp"})
 
 
 def residual_kinds() -> frozenset[str]:

--- a/src/bora/adapters/executor_inventory.py
+++ b/src/bora/adapters/executor_inventory.py
@@ -11,22 +11,18 @@ from bora.adapters.executor_capabilities import BUILTIN_CAPABILITIES, get_capabi
 from bora.adapters.path_probe import WhichFn, probe_commands
 
 _BINARY_CANDIDATES: Mapping[str, tuple[str, ...]] = {
-    "acp": (),
-    "openai-http": (),
-    "openai": (),
-    "openai_responses": (),
+    "Official/acp": (),
+    "Official/openai-http": (),
 }
 
-_API_ALIASES: frozenset[str] = frozenset({"openai", "openai_responses"})
+_API_ALIASES: frozenset[str] = frozenset()
 
 # First-party contrib ids. Installed plugins join via provide(executor).
 _FIRST_PARTY_KINDS: frozenset[str] = frozenset(
     {
-        "acp",
-        "mock",
-        "openai-http",
-        "openai",
-        "openai_responses",
+        "Official/acp",
+        "Official/mock",
+        "Official/openai-http",
     }
 )
 
@@ -174,7 +170,9 @@ def build_executor_inventory(
     rows = [describe_executor(k, which=which, verbose=verbose) for k in supported]
     acp_rows = [describe_acp_entry(eid, which=which, verbose=verbose) for eid in list_entry_ids()]
     for row in rows:
-        if row.get("kind") == "acp":
+        from bora.plugins.manifest import is_official_acp
+
+        if is_official_acp(str(row.get("kind") or "")):
             row["host_ready"] = any(r.get("host_ready") for r in acp_rows)
             row["acp_entries_ready"] = sorted(
                 r["entry_id"] for r in acp_rows if r.get("host_ready")

--- a/src/bora/adapters/provider_docker/images.py
+++ b/src/bora/adapters/provider_docker/images.py
@@ -207,6 +207,26 @@ def package_local_tag(content_digest: str) -> str:
     return f"bora-pkg:{content_digest[:12]}"
 
 
+def is_official_base_noop_dockerfile(text: str) -> bool:
+    """True when the Dockerfile is only ``FROM bora-attempt:l1`` (optional AS)."""
+    lines = dockerfile_logical_lines(text)
+    if len(lines) != 1:
+        return False
+    line = lines[0]
+    if not line.upper().startswith("FROM "):
+        return False
+    tokens = [t for t in line.split()[1:] if not t.startswith("-")]
+    if not tokens:
+        return False
+    image = tokens[0]
+    if image != _OFFICIAL_BASE_TAG and image.rsplit("/", 1)[-1] != _OFFICIAL_BASE_TAG:
+        return False
+    extra = tokens[1:]
+    if not extra:
+        return True
+    return len(extra) == 2 and extra[0].upper() == "AS"
+
+
 def inspect_image_digest(tag: str) -> str | None:
     """Evidence digest for an existing local tag, or None if missing."""
     proc = subprocess.run(

--- a/src/bora/application/attempt/run_l1_prepare.py
+++ b/src/bora/application/attempt/run_l1_prepare.py
@@ -29,6 +29,7 @@ def prepare_l1_runtime(
     from bora.application.plugin_ops.image_contribute_bake import (
         ImageContributeError,
         apply_image_contribute_bake,
+        should_reuse_official_attempt_image,
     )
     from bora.config.model import thaw
 
@@ -38,15 +39,20 @@ def prepare_l1_runtime(
         provider = {}
     dockerfile_rel = str(provider.get("dockerfile") or "environment/Dockerfile")
     platform = str(provider.get("platform") or "linux/arm64")
-    # Official base (FROM bora-attempt:l1) then package Dockerfile → Attempt image.
-    # Tag is content-addressed (Dockerfile + FROM digest + COPY set); not lock.digest.
-    ensure_base_image(Path.cwd())
-    pkg_image = build_package_image(
-        package_root=package_root,
-        dockerfile_rel=dockerfile_rel,
-        platform=platform,
-        repo_root=Path.cwd(),
-    )
+    # Official ACP + FROM-only Dockerfile + no selected bake reuses bora-attempt:l1.
+    # Otherwise official base then package Dockerfile → content-addressed tag.
+    official = ensure_base_image(Path.cwd())
+    df = package_root / dockerfile_rel
+    dockerfile_text = df.read_text(encoding="utf-8") if df.is_file() else ""
+    if should_reuse_official_attempt_image(lock, dockerfile_text):
+        pkg_image = official
+    else:
+        pkg_image = build_package_image(
+            package_root=package_root,
+            dockerfile_rel=dockerfile_rel,
+            platform=platform,
+            repo_root=Path.cwd(),
+        )
     # Lifecycle prepare + image_contribute consume (fail closed).
     hook_prepare(lock, {"phase": "l1_prepare", "package_image": pkg_image.image_tag})
     try:

--- a/src/bora/application/plugin_ops/image_contribute_bake.py
+++ b/src/bora/application/plugin_ops/image_contribute_bake.py
@@ -19,18 +19,17 @@ from typing import Any
 from bora.adapters.provider_docker.images import (
     hash_copy_sources,
     inspect_image_digest,
+    is_official_base_noop_dockerfile,
     parse_dockerfile_copy_sources,
 )
 from bora.adapters.provider_docker.types import DockerImageLock
 from bora.config.model import LockedTaskConfig, thaw
 from bora.plugins.bootstrap import ensure_bootstrapped
 from bora.plugins.lifecycle import collect_image_contribute
+from bora.plugins.manifest import is_official_acp, is_official_plugin
 from bora.plugins.protocol import intent_from_profile
 from bora.plugins.resolve import resolve
 from bora.plugins.store import list_installed, resolve_package_root
-
-# First-party contrib: official L1 image BOM, not this bake path.
-FIRST_PARTY_PLUGIN_IDS: frozenset[str] = frozenset({"acp", "openai-http", "mock"})
 
 
 class ImageContributeError(Exception):
@@ -54,7 +53,9 @@ def _await(coro: Any) -> Any:
 def graphs_for_lock(lock: LockedTaskConfig) -> list[Any]:
     """Resolve materialized graphs for every agent profile (for multi-slot chains)."""
     reg = ensure_bootstrapped()
-    profiles = thaw(lock.agent_profiles) if lock.agent_profiles else []
+    profiles = (
+        thaw(getattr(lock, "agent_profiles", None)) if getattr(lock, "agent_profiles", None) else []
+    )
     graphs: list[Any] = []
     if not isinstance(profiles, list) or not profiles:
         return graphs
@@ -84,7 +85,9 @@ def collect_declares_for_lock(lock: LockedTaskConfig) -> list[Any]:
 
 
 def bound_executor_ids(lock: LockedTaskConfig) -> list[str]:
-    profiles = thaw(lock.agent_profiles) if lock.agent_profiles else []
+    profiles = (
+        thaw(getattr(lock, "agent_profiles", None)) if getattr(lock, "agent_profiles", None) else []
+    )
     if not isinstance(profiles, list):
         return []
     out: list[str] = []
@@ -151,8 +154,25 @@ def _base_content_digest(base_image: DockerImageLock) -> str:
     return base_image.build_input_digest or base_image.image_tag
 
 
+def plugin_id_for_image_tag(plugin_id: str) -> str:
+    """Docker tags cannot contain ``/``; Hub ``org/name`` becomes ``org--name``."""
+    return plugin_id.replace("/", "--")
+
+
 def baked_image_tag(base_image: DockerImageLock, plugin_id: str, bake_digest: str) -> str:
-    return f"{base_image.image_tag}-{plugin_id}-{bake_digest[:12]}"
+    return f"{base_image.image_tag}-{plugin_id_for_image_tag(plugin_id)}-{bake_digest[:12]}"
+
+
+def should_reuse_official_attempt_image(lock: LockedTaskConfig, dockerfile_text: str) -> bool:
+    """Official ACP + FROM-only package Dockerfile + no selected bake → reuse base."""
+    bound = bound_executor_ids(lock)
+    if not bound or any(not is_official_acp(kind) for kind in bound):
+        return False
+    declares = collect_declares_for_lock(lock)
+    external = [p for p in _plugin_ids_from_declares(declares) if not is_official_plugin(p)]
+    if external:
+        return False
+    return is_official_base_noop_dockerfile(dockerfile_text)
 
 
 def bake_plugin_layer(
@@ -231,7 +251,7 @@ def apply_image_contribute_bake(
     """Collect contribute declares and bake required plugin layers (fail closed)."""
     declares = collect_declares_for_lock(lock)
     bound = bound_executor_ids(lock)
-    external_bound = [k for k in bound if k not in FIRST_PARTY_PLUGIN_IDS]
+    external_bound = [k for k in bound if not is_official_plugin(k)]
     declared = _plugin_ids_from_declares(declares)
     meta: dict[str, Any] = {
         "declares": declares,
@@ -247,7 +267,7 @@ def apply_image_contribute_bake(
                 kind="image_contribute_unsatisfied",
             )
 
-    plugins_to_bake = [p for p in declared if p not in FIRST_PARTY_PLUGIN_IDS]
+    plugins_to_bake = [p for p in declared if not is_official_plugin(p)]
     if not plugins_to_bake:
         meta["status"] = "skipped"
         return base_image, meta

--- a/src/bora/application/plugin_ops/plugin_install_remote.py
+++ b/src/bora/application/plugin_ops/plugin_install_remote.py
@@ -64,6 +64,12 @@ class PluginInstallCommand:
             extract_dir.mkdir()
             extract_archive(archive, extract_dir)
             entry = install_from_path(extract_dir)
+        if entry.plugin_id != package_id:
+            raise ConfigError(
+                "plugin_id_mismatch",
+                f"plugin.yaml plugin_id {entry.plugin_id!r} does not match locator {package_id!r}",
+                location=locator,
+            )
         return {
             "ok": True,
             "plugin_id": entry.plugin_id,

--- a/src/bora/application/plugin_ops/plugin_publish.py
+++ b/src/bora/application/plugin_ops/plugin_publish.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from bora.config.errors import ConfigError
-from bora.plugins.manifest import load_manifest
+from bora.plugins.manifest import PluginManifestError, load_manifest, require_namespaced_plugin_id
 from bora.registry.client import RegistryError
 from bora.registry.plugin_package import (
     PLUGIN_MEDIA_TYPE,
@@ -38,13 +38,6 @@ class PluginPublishCommand:
                 location=str(root),
             ) from exc
 
-        package_digest = compute_plugin_digest(root)
-        archive, blob_digest, size = build_plugin_archive(root)
-        client = self._client_factory(
-            registry_url=registry_url,
-            token=token,
-            require_token=True,
-        )
         org_id = (org or "").strip()
         if not org_id:
             raise ConfigError(
@@ -52,8 +45,18 @@ class PluginPublishCommand:
                 "plugin publish requires --org",
                 location="registry",
             )
+        try:
+            package_id = require_namespaced_plugin_id(manifest.plugin_id, org=org_id)
+        except PluginManifestError as exc:
+            raise ConfigError(exc.kind, exc.message, location="plugin.yaml:/plugin_id") from exc
 
-        package_id = f"{org_id}/{manifest.plugin_id}"
+        package_digest = compute_plugin_digest(root)
+        archive, blob_digest, size = build_plugin_archive(root)
+        client = self._client_factory(
+            registry_url=registry_url,
+            token=token,
+            require_token=True,
+        )
         visibility = "public" if public else "private"
         try:
             info = client.publish(

--- a/src/bora/application/suite/suite_config_fingerprint.py
+++ b/src/bora/application/suite/suite_config_fingerprint.py
@@ -17,12 +17,10 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+from bora.plugins.manifest import is_official_plugin
+
 # Fields allowed in actors_summary / fingerprint material (no secrets).
 _ACTOR_KEYS = ("profile_id", "entry", "executor", "model", "options")
-
-# Builtin executor kinds are not marketplace plugins (Hub plugin tab).
-_BUILTIN_EXECUTOR_KINDS = frozenset({"acp", "openai-http"})
-_SKIP_PLUGIN_IDS = frozenset({"default", "acp", "openai-http"})
 
 
 def _profile_entry(profile: Mapping[str, Any]) -> str:
@@ -129,7 +127,7 @@ def fingerprint_for_actors(actors: Sequence[Mapping[str, str]]) -> str:
 
 def _plugin_ref(plugin_id: str, version: str | None = None) -> dict[str, str] | None:
     pid = plugin_id.strip()
-    if not pid or pid.casefold() in _SKIP_PLUGIN_IDS:
+    if not pid or is_official_plugin(pid):
         return None
     row = {"plugin_id": pid}
     if version is not None and str(version).strip():
@@ -193,7 +191,7 @@ def plugins_from_job_overlay(overlay: Mapping[str, Any] | None) -> list[dict[str
         if not isinstance(executor, str):
             continue
         kind = executor.strip()
-        if not kind or kind.casefold() in _BUILTIN_EXECUTOR_KINDS:
+        if not kind or is_official_plugin(kind):
             continue
         ref = _plugin_ref(kind)
         if ref is not None:

--- a/src/bora/config/capabilities.py
+++ b/src/bora/config/capabilities.py
@@ -53,11 +53,9 @@ class DeclarationCapabilityCatalog:
     # Kept for introspection / tests; runtime answer is known_executor_kinds().
     EXECUTOR_KINDS: frozenset[str] = frozenset(
         {
-            "acp",
-            "mock",
-            "openai",
-            "openai-http",
-            "openai_responses",
+            "Official/acp",
+            "Official/mock",
+            "Official/openai-http",
         }
     )
     ENVIRONMENT_KINDS: frozenset[str] = frozenset(

--- a/src/bora/config/profiles.py
+++ b/src/bora/config/profiles.py
@@ -380,7 +380,9 @@ def display_agent_name(binding: Mapping[str, Any]) -> str:
     if isinstance(label, str) and label.strip():
         return label.strip()
     executor = str(binding.get("executor") or "").strip()
-    if executor == "acp":
+    from bora.plugins.manifest import is_official_acp
+
+    if is_official_acp(executor):
         options = binding.get("options")
         if isinstance(options, Mapping):
             entry = options.get("entry")

--- a/src/bora/config/validate.py
+++ b/src/bora/config/validate.py
@@ -194,7 +194,9 @@ def validate_document(
             )
         # Spec 19: executor: acp requires options.entry from static registry.
         # Packages must not override command/version/install.
-        if executor == "acp":
+        from bora.plugins.manifest import is_official_acp
+
+        if is_official_acp(executor):
             from bora.adapters.acp_registry import get_entry
 
             options = profile.get("options")

--- a/src/bora/plugins/conflict.py
+++ b/src/bora/plugins/conflict.py
@@ -101,8 +101,8 @@ def order_chain(
     by_plugin = {c.plugin_id: c for c in candidates}
     slot_explicit = [e for e in explicit if e.slot == slot]
 
-    # Start from registered candidates.
-    selected: dict[str, Candidate] = {c.plugin_id: c for c in candidates}
+    # Opt-in: first-party / default only. Installed plugins join via extensions.
+    selected: dict[str, Candidate] = {c.plugin_id: c for c in candidates if _auto_on_multi_chain(c)}
 
     replace_default = any(e.replace_default for e in slot_explicit)
     if replace_default:
@@ -130,3 +130,7 @@ def order_chain(
     # Provide-slot ties fail closed in pick_one; chains need multi-plugin coexistence.
     del slot  # slot used only for error context in provide path
     return sorted(selected.values(), key=lambda c: (c.priority, c.plugin_id))
+
+
+def _auto_on_multi_chain(candidate: Candidate) -> bool:
+    return bool(candidate.is_default) or candidate.source in {"default", "first-party"}

--- a/src/bora/plugins/contrib/acp/__init__.py
+++ b/src/bora/plugins/contrib/acp/__init__.py
@@ -15,7 +15,7 @@ from bora.plugins.slots import (
     TRAJECTORY_COLLECT,
 )
 
-PLUGIN_ID = "acp"
+PLUGIN_ID = "Official/acp"
 # Stronger than default multi (1000); weaker than explicit profile binding.
 ACP_PRIORITY = 100
 

--- a/src/bora/plugins/contrib/mock/__init__.py
+++ b/src/bora/plugins/contrib/mock/__init__.py
@@ -10,8 +10,8 @@ from bora.plugins.registry import ExtensionRegistry
 from bora.plugins.slots import EXECUTOR
 from bora.runtime.offline import is_offline_agent
 
-PLUGIN_ID = "mock"
-PRIORITY = 900  # weak; only selected via profiles executor: mock
+PLUGIN_ID = "Official/mock"
+PRIORITY = 900  # weak; only selected via profiles executor: Official/mock
 
 
 class MockExecutorSPI(ExecutorSPI):

--- a/src/bora/plugins/contrib/openai_http/__init__.py
+++ b/src/bora/plugins/contrib/openai_http/__init__.py
@@ -7,7 +7,7 @@ from typing import Any
 from bora.plugins.registry import ExtensionRegistry
 from bora.plugins.slots import EXECUTOR
 
-PLUGIN_ID = "openai-http"
+PLUGIN_ID = "Official/openai-http"
 PRIORITY = 120
 
 
@@ -33,15 +33,6 @@ def register_openai_http_contrib(registry: ExtensionRegistry) -> None:
         PLUGIN_ID,
         _factory,
         priority=PRIORITY,
-        source="first-party",
-        is_factory=True,
-    )
-    # Alias used by older profiles/tests.
-    registry.provide(
-        EXECUTOR,
-        "openai",
-        _factory,
-        priority=PRIORITY + 1,
         source="first-party",
         is_factory=True,
     )

--- a/src/bora/plugins/defaults/__init__.py
+++ b/src/bora/plugins/defaults/__init__.py
@@ -47,7 +47,7 @@ from bora.plugins.slots import (
     get_slot_kind,
 )
 
-PLUGIN_ID = "default"
+PLUGIN_ID = "Official/default"
 
 
 def _default_eval_runtime(**_kwargs: Any) -> dict[str, Any]:

--- a/src/bora/plugins/manifest.py
+++ b/src/bora/plugins/manifest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -10,6 +11,8 @@ import yaml
 
 PLUGIN_FORMAT = "bora.plugin/1"
 MANIFEST_NAMES = ("plugin.yaml", "bora.plugin.yaml")
+# Same slash form as Dataset database_id. Not org.name.
+_PLUGIN_ID_SEGMENT = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
 
 
 class PluginManifestError(Exception):
@@ -19,6 +22,51 @@ class PluginManifestError(Exception):
         super().__init__(message)
         self.kind = kind
         self.message = message
+
+
+def split_plugin_id(plugin_id: str) -> tuple[str | None, str]:
+    """Return ``(org, name)`` for ``org/name``, or ``(None, short_id)``."""
+    if "/" not in plugin_id:
+        return None, plugin_id
+    org, name = plugin_id.split("/", 1)
+    return org, name
+
+
+def normalize_plugin_id(raw: str) -> str:
+    """Validate short ``name`` or Hub ``org/name``. Reject ``org.name``."""
+    plugin_id = raw.strip()
+    if not plugin_id:
+        raise PluginManifestError("plugin_id required", kind="plugin_manifest_invalid")
+    if plugin_id.count("/") > 1:
+        raise PluginManifestError(
+            f"plugin_id must be name or org/name, not {plugin_id!r}",
+            kind="plugin_id_invalid",
+        )
+    org, name = split_plugin_id(plugin_id)
+    parts = (org, name) if org is not None else (name,)
+    if any(p is None or not _PLUGIN_ID_SEGMENT.fullmatch(p) for p in parts):
+        raise PluginManifestError(
+            f"plugin_id must be name or org/name, not {plugin_id!r}",
+            kind="plugin_id_invalid",
+        )
+    return plugin_id
+
+
+def require_namespaced_plugin_id(plugin_id: str, *, org: str) -> str:
+    """Hub-bound id must be ``org/name`` whose prefix equals *org*."""
+    org_id = org.strip()
+    prefix, name = split_plugin_id(plugin_id)
+    if prefix is None or not name:
+        raise PluginManifestError(
+            f"Hub plugin_id must be org/name, not {plugin_id!r}",
+            kind="plugin_id_not_namespaced",
+        )
+    if prefix != org_id:
+        raise PluginManifestError(
+            f"plugin_id prefix {prefix!r} does not match upload org {org_id!r}",
+            kind="plugin_org_mismatch",
+        )
+    return plugin_id
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,6 +114,7 @@ def parse_manifest_mapping(raw: dict[str, Any], *, location: str = "plugin.yaml"
     version = raw.get("version")
     if not isinstance(plugin_id, str) or not plugin_id.strip():
         raise PluginManifestError("plugin_id required", kind="plugin_manifest_invalid")
+    plugin_id = normalize_plugin_id(plugin_id)
     if not isinstance(version, str) or not version.strip():
         raise PluginManifestError("version required", kind="plugin_manifest_invalid")
 
@@ -115,7 +164,7 @@ def parse_manifest_mapping(raw: dict[str, Any], *, location: str = "plugin.yaml"
 
     return PluginManifest(
         format=PLUGIN_FORMAT,
-        plugin_id=plugin_id.strip(),
+        plugin_id=plugin_id,
         version=version.strip(),
         provide=_entries("provide"),
         on=_entries("on"),

--- a/src/bora/plugins/manifest.py
+++ b/src/bora/plugins/manifest.py
@@ -11,8 +11,10 @@ import yaml
 
 PLUGIN_FORMAT = "bora.plugin/1"
 MANIFEST_NAMES = ("plugin.yaml", "bora.plugin.yaml")
-# Same slash form as Dataset database_id. Not org.name.
-_PLUGIN_ID_SEGMENT = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
+# First-party org. Hub-bound packages use the same org/name form.
+OFFICIAL_ORG = "Official"
+# Same slash form as Dataset database_id. Not org.name. Official is mixed-case.
+_PLUGIN_ID_SEGMENT = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$")
 
 
 class PluginManifestError(Exception):
@@ -50,6 +52,20 @@ def normalize_plugin_id(raw: str) -> str:
             kind="plugin_id_invalid",
         )
     return plugin_id
+
+
+def official_plugin_id(name: str) -> str:
+    return f"{OFFICIAL_ORG}/{name}"
+
+
+def is_official_plugin(plugin_id: str) -> bool:
+    org, _name = split_plugin_id(plugin_id)
+    return org == OFFICIAL_ORG
+
+
+def is_official_acp(plugin_id: str) -> bool:
+    org, name = split_plugin_id(plugin_id)
+    return org == OFFICIAL_ORG and name == "acp"
 
 
 def require_namespaced_plugin_id(plugin_id: str, *, org: str) -> str:

--- a/src/bora/plugins/protocol.py
+++ b/src/bora/plugins/protocol.py
@@ -69,6 +69,20 @@ class ExplicitBinding:
     source: str = "explicit"
 
 
+@dataclass(frozen=True, slots=True)
+class ExtensionSelect:
+    """One ``profiles.extensions`` row before per-slot expansion.
+
+    ``slots is None`` means every slot that plugin registered (provide + on).
+    """
+
+    plugin: str
+    slots: tuple[str, ...] | None = None
+    priority: int | None = None
+    replace_default: bool = False
+    source: str = "explicit"
+
+
 @dataclass
 class BindingIntent:
     """Per-profile binding intent used at resolve / lock time."""
@@ -77,6 +91,7 @@ class BindingIntent:
     executor: str | None = None  # sugar: executor slot selects this plugin's provide
     options: dict[str, Any] = field(default_factory=dict)
     extensions: list[ExplicitBinding] = field(default_factory=list)
+    extension_selects: list[ExtensionSelect] = field(default_factory=list)
     # Optional model / locator fields carried for factory materialize.
     model: str | None = None
     base_url: str | None = None
@@ -153,25 +168,23 @@ def intent_from_profile(profile: Mapping[str, Any]) -> BindingIntent:
     options_raw = profile.get("options")
     options: dict[str, Any] = dict(options_raw) if isinstance(options_raw, Mapping) else {}
     extensions: list[ExplicitBinding] = []
+    extension_selects: list[ExtensionSelect] = []
     ext_raw = profile.get("extensions")
-    if isinstance(ext_raw, Sequence) and not isinstance(ext_raw, (str, bytes)):
-        for item in ext_raw:
-            if not isinstance(item, Mapping):
-                continue
-            slot = item.get("slot")
-            plugin = item.get("plugin")
-            if not isinstance(slot, str) or not isinstance(plugin, str):
-                continue
-            prio = item.get("priority")
-            extensions.append(
-                ExplicitBinding(
-                    slot=str(slot),
-                    plugin=str(plugin),
-                    priority=int(prio) if prio is not None else None,
-                    replace_default=bool(item.get("replace_default")),
-                    source="explicit",
-                )
-            )
+    if ext_raw is None:
+        ext_raw = []
+    if not isinstance(ext_raw, Sequence) or isinstance(ext_raw, (str, bytes)):
+        from bora.plugins.errors import ExtensionRegistryError
+
+        raise ExtensionRegistryError(
+            "extensions must be a list of mappings",
+            kind="invalid_extension_binding",
+        )
+    for item in ext_raw:
+        parsed_binding, parsed_select = parse_extension_row(item)
+        if parsed_binding is not None:
+            extensions.append(parsed_binding)
+        if parsed_select is not None:
+            extension_selects.append(parsed_select)
     model_raw = profile.get("model")
     model = str(model_raw) if model_raw is not None else None
     base_url_raw = profile.get("base_url")
@@ -189,7 +202,89 @@ def intent_from_profile(profile: Mapping[str, Any]) -> BindingIntent:
         executor=executor,
         options=options,
         extensions=extensions,
+        extension_selects=extension_selects,
         model=model,
         base_url=base_url,
         api_key=api_key,
+    )
+
+
+def parse_extension_row(item: Any) -> tuple[ExplicitBinding | None, ExtensionSelect | None]:
+    """Parse one extensions row. ``{slot, plugin}`` is a single-slot binding."""
+    from bora.plugins.errors import ExtensionRegistryError
+
+    if not isinstance(item, Mapping):
+        raise ExtensionRegistryError(
+            "each extensions row must be a mapping",
+            kind="invalid_extension_binding",
+        )
+    plugin_raw = item.get("plugin")
+    if not isinstance(plugin_raw, str) or not plugin_raw.strip():
+        raise ExtensionRegistryError(
+            "extensions row requires plugin",
+            kind="invalid_extension_binding",
+        )
+    plugin = plugin_raw.strip()
+    slot_raw = item.get("slot")
+    slots_raw = item.get("slots")
+    prio = item.get("priority")
+    priority = int(prio) if prio is not None else None
+    replace_default = bool(item.get("replace_default"))
+    if slot_raw is not None and slots_raw is not None:
+        raise ExtensionRegistryError(
+            "extensions row cannot set both slot and slots",
+            kind="invalid_extension_binding",
+        )
+    if slot_raw is not None:
+        if not isinstance(slot_raw, str) or not slot_raw.strip():
+            raise ExtensionRegistryError(
+                "extensions.slot must be a non-empty string",
+                kind="invalid_extension_binding",
+            )
+        return (
+            ExplicitBinding(
+                slot=slot_raw.strip(),
+                plugin=plugin,
+                priority=priority,
+                replace_default=replace_default,
+                source="explicit",
+            ),
+            None,
+        )
+    if slots_raw is not None:
+        if not isinstance(slots_raw, Sequence) or isinstance(slots_raw, (str, bytes)):
+            raise ExtensionRegistryError(
+                "extensions.slots must be a list of slot ids",
+                kind="invalid_extension_binding",
+            )
+        if not slots_raw:
+            raise ExtensionRegistryError(
+                "extensions.slots must not be empty",
+                kind="invalid_extension_binding",
+            )
+        slots: list[str] = []
+        for slot in slots_raw:
+            if not isinstance(slot, str) or not slot.strip():
+                raise ExtensionRegistryError(
+                    "extensions.slots entries must be non-empty strings",
+                    kind="invalid_extension_binding",
+                )
+            slots.append(slot.strip())
+        return (
+            None,
+            ExtensionSelect(
+                plugin=plugin,
+                slots=tuple(slots),
+                priority=priority,
+                replace_default=replace_default,
+            ),
+        )
+    return (
+        None,
+        ExtensionSelect(
+            plugin=plugin,
+            slots=None,
+            priority=priority,
+            replace_default=replace_default,
+        ),
     )

--- a/src/bora/plugins/registry.py
+++ b/src/bora/plugins/registry.py
@@ -157,6 +157,10 @@ class ExtensionRegistry:
     def plugins_for_slot(self, slot: str) -> list[str]:
         return sorted((self._rows.get(slot) or {}).keys())
 
+    def slots_for_plugin(self, plugin_id: str) -> list[str]:
+        """Public slots this plugin registered (provide + on), stable order."""
+        return [slot for slot, rows in self._rows.items() if plugin_id in rows]
+
     def clear(self) -> None:
         self._rows.clear()
 

--- a/src/bora/plugins/resolve.py
+++ b/src/bora/plugins/resolve.py
@@ -5,17 +5,22 @@ from __future__ import annotations
 from typing import Any
 
 from bora.plugins.conflict import order_chain, pick_one
-from bora.plugins.errors import ExtensionMaterializeError
+from bora.plugins.errors import (
+    ExtensionMaterializeError,
+    ExtensionPluginNotFoundError,
+    UnknownExtensionSlotError,
+)
 from bora.plugins.protocol import (
     BindingIntent,
     BindingRecord,
     ExplicitBinding,
     ExtensionGraph,
+    ExtensionSelect,
     HandlerRef,
     ProviderRef,
 )
 from bora.plugins.registry import ExtensionRegistry, Registration
-from bora.plugins.slots import ALL_PUBLIC_SLOTS, EXECUTOR, SlotKind, get_slot_kind
+from bora.plugins.slots import ALL_PUBLIC_SLOTS, EXECUTOR, SlotKind, get_slot_kind, is_public_slot
 
 
 def resolve(
@@ -31,8 +36,16 @@ def resolve(
     """
     graph = ExtensionGraph(profile_id=intent.profile_id)
     explicit = list(intent.extensions)
+    explicit.extend(expand_extension_selects(intent.extension_selects, registry))
+    for binding in explicit:
+        if not is_public_slot(binding.slot):
+            raise UnknownExtensionSlotError(
+                f"unknown extension slot: {binding.slot!r}",
+                kind="unknown_extension_slot",
+            )
 
     # Sugar: profiles executor: <plugin_id> → explicit binding for executor slot.
+    # Appended last so it wins over an all-slots ``- plugin:`` row.
     if intent.executor:
         explicit.append(
             ExplicitBinding(
@@ -50,6 +63,8 @@ def resolve(
         slot_explicit = [e for e in explicit if e.slot == slot]
 
         if kind is SlotKind.PROVIDE:
+            if slot != EXECUTOR and not slot_explicit:
+                candidates = [c for c in candidates if _auto_on_provide(c)]
             if not candidates and not slot_explicit:
                 # Optional provide slots may be empty (e.g. env_action when unused).
                 # executor is required when profiles set executor field (handled by
@@ -185,3 +200,52 @@ def resolve_for_lock(
 ) -> ExtensionGraph:
     """Resolve without constructing heavy SPI instances (lock field only)."""
     return resolve(intent, registry, materialize=False)
+
+
+def expand_extension_selects(
+    selects: list[ExtensionSelect],
+    registry: ExtensionRegistry,
+) -> list[ExplicitBinding]:
+    """Turn ``- plugin:`` / ``slots:`` rows into per-slot explicit bindings."""
+    out: list[ExplicitBinding] = []
+    for sel in selects:
+        registered = registry.slots_for_plugin(sel.plugin)
+        if not registered:
+            raise ExtensionPluginNotFoundError(
+                f"plugin {sel.plugin!r} is not registered",
+                kind="extension_plugin_not_found",
+            )
+        if sel.slots is None:
+            wanted = list(registered)
+        else:
+            wanted = []
+            for slot in sel.slots:
+                if not is_public_slot(slot):
+                    raise UnknownExtensionSlotError(
+                        f"unknown extension slot: {slot!r}",
+                        kind="unknown_extension_slot",
+                    )
+                if slot not in registered:
+                    raise ExtensionPluginNotFoundError(
+                        f"plugin {sel.plugin!r} did not register slot {slot!r}",
+                        kind="extension_slot_unregistered",
+                    )
+                wanted.append(slot)
+        for slot in wanted:
+            out.append(
+                ExplicitBinding(
+                    slot=slot,
+                    plugin=sel.plugin,
+                    priority=sel.priority,
+                    replace_default=sel.replace_default,
+                    source=sel.source,
+                )
+            )
+    return out
+
+
+def _auto_on_provide(candidate: Any) -> bool:
+    return bool(getattr(candidate, "is_default", False)) or getattr(candidate, "source", "") in {
+        "default",
+        "first-party",
+    }

--- a/src/bora/plugins/store.py
+++ b/src/bora/plugins/store.py
@@ -144,6 +144,7 @@ def install_from_path(source: Path) -> IndexEntry:
     rel = f"{manifest.plugin_id}/{manifest.version}"
     dest = package_dir(manifest.plugin_id, manifest.version)
     dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp_prefix = manifest.plugin_id.replace("/", ".")
 
     # Idempotent: same digest already installed.
     if dest.is_dir():
@@ -163,7 +164,7 @@ def install_from_path(source: Path) -> IndexEntry:
         shutil.rmtree(dest)
 
     tmp_parent = dest.parent
-    tmp = Path(tempfile.mkdtemp(prefix=f".{manifest.plugin_id}.", dir=str(tmp_parent)))
+    tmp = Path(tempfile.mkdtemp(prefix=f".{tmp_prefix}.", dir=str(tmp_parent)))
     try:
         shutil.copytree(source, tmp / "pkg")
         os.replace(tmp / "pkg", dest)
@@ -209,10 +210,12 @@ def uninstall(plugin_id: str) -> bool:
     dest = plugins_root() / entry.path
     if dest.is_dir():
         shutil.rmtree(dest)
-    # Clean empty parent plugin_id dir
+    # Clean empty parent dirs (org/name nests two levels).
     parent = dest.parent
-    if parent.is_dir() and not any(parent.iterdir()):
+    root = plugins_root()
+    while parent != root and parent.is_dir() and not any(parent.iterdir()):
         parent.rmdir()
+        parent = parent.parent
     index.plugins = [p for p in index.plugins if p.plugin_id != plugin_id]
     save_index(index)
     return True

--- a/src/bora/viewer/trials/surface.py
+++ b/src/bora/viewer/trials/surface.py
@@ -86,7 +86,9 @@ def _profile_variant(profile: dict[str, Any]) -> str | None:
     val = opts.get("label")
     if isinstance(val, str) and val.strip():
         return val.strip()
-    if str(profile.get("executor") or "").strip() == "acp":
+    from bora.plugins.manifest import is_official_acp
+
+    if is_official_acp(str(profile.get("executor") or "").strip()):
         entry = opts.get("entry")
         if isinstance(entry, str) and entry.strip():
             return entry.strip()

--- a/tests/acceptance/test_acp_public_failures.py
+++ b/tests/acceptance/test_acp_public_failures.py
@@ -32,7 +32,7 @@ parameters: {}
 provider: {kind: local, assurance: l0}
 agent_profiles:
   - id: bad
-    executor: acp
+    executor: Official/acp
     model: m
     options: {entry: not-registered}
 limits: {wall_time_seconds: 10, agent_invocations: 1, environment_actions: 0}

--- a/tests/acceptance/test_config_lock_cli.py
+++ b/tests/acceptance/test_config_lock_cli.py
@@ -41,7 +41,7 @@ def test_success_smoke() -> None:
     assert "resolution" in data
     # #59 job overlay is exportable with lock summary (no secrets).
     assert "job_overlay" in data
-    assert data["job_overlay"]["bindings"]["mock-default"]["executor"] == "mock"
+    assert data["job_overlay"]["bindings"]["mock-default"]["executor"] == "Official/mock"
     # No host absolute package path leakage.
     assert str(MINIMAL.resolve()) not in result.stdout
 

--- a/tests/acceptance/test_executors_cli.py
+++ b/tests/acceptance/test_executors_cli.py
@@ -36,13 +36,13 @@ def test_executors_lists_supported_and_host_probe() -> None:
         "executors",
         "acp_entries",
     }
-    assert "acp" in data["supported"]
-    assert "openai-http" in data["supported"]
+    assert "Official/acp" in data["supported"]
+    assert "Official/openai-http" in data["supported"]
     for gone in ("codex", "pi", "opencode", "claude-code"):
         assert gone not in data["supported"]
 
     by_kind = {r["kind"]: r for r in data["executors"]}
-    http = by_kind["openai-http"]
+    http = by_kind["Official/openai-http"]
     assert http["execution_mode"] == "api-client"
     assert http["host_ready"] is True
     assert "sk-" not in result.stdout.lower()
@@ -56,6 +56,6 @@ def test_executors_verbose_adds_detail() -> None:
     assert result.returncode == 0, result.stderr
     data = json.loads(result.stdout)
     by_kind = {r["kind"]: r for r in data["executors"]}
-    assert by_kind["acp"].get("tools") is not None or data.get("acp_entries")
+    assert by_kind["Official/acp"].get("tools") is not None or data.get("acp_entries")
     acp_rows = {r["entry_id"]: r for r in data["acp_entries"]}
     assert "credential_env_names" in acp_rows["opencode"]

--- a/tests/acceptance/test_plugin_registry.py
+++ b/tests/acceptance/test_plugin_registry.py
@@ -10,15 +10,15 @@ from bora.adapters.agent_registry import discover_executor_kinds, resolve_execut
 
 def test_discover_includes_builtins() -> None:
     kinds = discover_executor_kinds()
-    assert "acp" in kinds
-    assert "openai-http" in kinds
+    assert "Official/acp" in kinds
+    assert "Official/openai-http" in kinds
     assert "codex" not in kinds
 
 
 def test_resolve_acp_and_openai() -> None:
-    a = resolve_executor("acp", model="entry-default", entry="opencode")
+    a = resolve_executor("Official/acp", model="entry-default", entry="opencode")
     assert getattr(a, "kind", None) == "acp"
-    o = resolve_executor("openai-http", model="gpt-4.1-mini")
+    o = resolve_executor("Official/openai-http", model="gpt-4.1-mini")
     assert o is not None
 
 

--- a/tests/adapters/test_executor_inventory.py
+++ b/tests/adapters/test_executor_inventory.py
@@ -26,13 +26,13 @@ def test_probe_binary_miss() -> None:
 
 
 def test_describe_acp_kind() -> None:
-    row = describe_executor("acp", which=lambda _n: None, verbose=False)
-    assert row["kind"] == "acp"
+    row = describe_executor("Official/acp", which=lambda _n: None, verbose=False)
+    assert row["kind"] == "Official/acp"
     assert row["execution_mode"] == "acp-stdio"
 
 
 def test_describe_api_client_no_binary() -> None:
-    row = describe_executor("openai-http", which=lambda _n: None, verbose=False)
+    row = describe_executor("Official/openai-http", which=lambda _n: None, verbose=False)
     assert row["execution_mode"] == "api-client"
     assert row["binary_on_path"] is None
     assert row["host_ready"] is True
@@ -60,8 +60,8 @@ def test_inventory_aggregates() -> None:
         }.get(name)
 
     inv = build_executor_inventory(which=fake_which, verbose=False)
-    assert "acp" in inv["supported"]
-    assert "openai-http" in inv["supported"]
+    assert "Official/acp" in inv["supported"]
+    assert "Official/openai-http" in inv["supported"]
     assert "codex" not in inv["supported"]
     entry_ids = {r["entry_id"] for r in inv["acp_entries"]}
     assert "codex" in entry_ids

--- a/tests/adapters/test_known_executor_kinds.py
+++ b/tests/adapters/test_known_executor_kinds.py
@@ -11,7 +11,7 @@ def test_catalog_matches_known_executor_kinds() -> None:
     catalog = DeclarationCapabilityCatalog()
     known = known_executor_kinds()
     assert set(supported_executor_kinds()) == set(known)
-    for kind in ("acp", "mock", "openai-http"):
+    for kind in ("Official/acp", "Official/mock", "Official/openai-http"):
         assert catalog.supports_executor_kind(kind)
         assert kind in known
     assert not catalog.supports_executor_kind("not-a-real-executor")

--- a/tests/application/test_l1_stage_cleanup.py
+++ b/tests/application/test_l1_stage_cleanup.py
@@ -95,7 +95,7 @@ def _lock() -> SimpleNamespace:
         digest="sha256:" + "c" * 64,
         task_id="sample",
         parameters={"harness_timeout_seconds": 5},
-        agent_profiles=[{"id": "solver", "executor": "mock"}],
+        agent_profiles=[{"id": "solver", "executor": "Official/mock"}],
         provider={"kind": "docker"},
         limits={"agent_invocations": 1, "wall_time_seconds": 30},
         evaluation={

--- a/tests/application/test_suite_config_fingerprint.py
+++ b/tests/application/test_suite_config_fingerprint.py
@@ -27,14 +27,14 @@ def test_actors_summary_sorted_and_secret_free() -> None:
     profiles = [
         {
             "id": "worker",
-            "executor": "acp",
+            "executor": "Official/acp",
             "model": "m2",
             "api_key": "SECRET_LOCATOR",
             "options": {"entry": "pi"},
         },
         {
             "id": "planner",
-            "executor": "acp",
+            "executor": "Official/acp",
             "model": "m1",
             "options": {"entry": "codex"},
         },
@@ -53,17 +53,17 @@ def test_job_overlay_axis_ignores_role_topology_diff() -> None:
     suite_overlay = {
         "bindings": {
             "solver": {
-                "executor": "acp",
+                "executor": "Official/acp",
                 "options": {"entry": "pi"},
                 "model": "m",
             },
             "user": {
-                "executor": "acp",
+                "executor": "Official/acp",
                 "options": {"entry": "grok-build"},
                 "model": "entry-default",
             },
             "service": {
-                "executor": "acp",
+                "executor": "Official/acp",
                 "options": {"entry": "opencode"},
                 "model": "m2",
             },
@@ -99,7 +99,7 @@ def test_job_overlay_conflict_not_homogeneous() -> None:
     suite_overlay = {
         "bindings": {
             "solver": {
-                "executor": "acp",
+                "executor": "Official/acp",
                 "options": {"entry": "pi"},
                 "model": "m1",
             }
@@ -108,7 +108,7 @@ def test_job_overlay_conflict_not_homogeneous() -> None:
     conflict = {
         "bindings": {
             "solver": {
-                "executor": "acp",
+                "executor": "Official/acp",
                 "options": {"entry": "codex"},
                 "model": "m1",
             }
@@ -125,20 +125,30 @@ def test_job_overlay_conflict_not_homogeneous() -> None:
 def test_job_overlays_compatible_helper() -> None:
     suite = {
         "bindings": {
-            "a": {"executor": "acp", "options": {"entry": "pi"}, "model": "m"},
-            "b": {"executor": "acp", "options": {"entry": "codex"}, "model": "n"},
+            "a": {"executor": "Official/acp", "options": {"entry": "pi"}, "model": "m"},
+            "b": {"executor": "Official/acp", "options": {"entry": "codex"}, "model": "n"},
         }
     }
     assert job_overlays_compatible(suite, [None, {"bindings": {"a": suite["bindings"]["a"]}}])
     assert not job_overlays_compatible(
         suite,
-        [{"bindings": {"a": {"executor": "acp", "options": {"entry": "opencode"}, "model": "m"}}}],
+        [
+            {
+                "bindings": {
+                    "a": {
+                        "executor": "Official/acp",
+                        "options": {"entry": "opencode"},
+                        "model": "m",
+                    }
+                }
+            }
+        ],
     )
 
 
 def test_homogeneous_true_identical_topology() -> None:
     a = actors_summary_from_profiles(
-        [{"id": "solo", "executor": "acp", "model": "x", "options": {"entry": "pi"}}]
+        [{"id": "solo", "executor": "Official/acp", "model": "x", "options": {"entry": "pi"}}]
     )
     fields = compute_suite_config_fields([a, a, a])
     assert fields["config_homogeneous"] is True
@@ -167,7 +177,7 @@ def test_derive_labels_nooa_uses_executor_not_options_agent() -> None:
 def test_empty_agent_tasks_do_not_break_fallback_homogeneity() -> None:
     """No-agent tasks + identical agent tasks remain homogeneous (fallback path)."""
     solo = actors_summary_from_profiles(
-        [{"id": "solo", "executor": "acp", "model": "x", "options": {"entry": "pi"}}]
+        [{"id": "solo", "executor": "Official/acp", "model": "x", "options": {"entry": "pi"}}]
     )
     fields = compute_suite_config_fields([[], solo, solo])
     assert fields["config_homogeneous"] is True
@@ -176,10 +186,24 @@ def test_empty_agent_tasks_do_not_break_fallback_homogeneity() -> None:
 
 def test_fallback_different_models_not_homogeneous() -> None:
     a = actors_summary_from_profiles(
-        [{"id": "solo", "executor": "acp", "model": "gpt-a", "options": {"entry": "codex"}}]
+        [
+            {
+                "id": "solo",
+                "executor": "Official/acp",
+                "model": "gpt-a",
+                "options": {"entry": "codex"},
+            }
+        ]
     )
     b = actors_summary_from_profiles(
-        [{"id": "solo", "executor": "acp", "model": "gpt-b", "options": {"entry": "codex"}}]
+        [
+            {
+                "id": "solo",
+                "executor": "Official/acp",
+                "model": "gpt-b",
+                "options": {"entry": "codex"},
+            }
+        ]
     )
     fields = compute_suite_config_fields([a, b])
     assert fields["config_homogeneous"] is False
@@ -188,8 +212,8 @@ def test_fallback_different_models_not_homogeneous() -> None:
 def test_fingerprint_stable() -> None:
     actors = actors_summary_from_profiles(
         [
-            {"id": "b", "executor": "openai-http", "model": "m"},
-            {"id": "a", "executor": "acp", "model": "n", "options": {"entry": "pi"}},
+            {"id": "b", "executor": "Official/openai-http", "model": "m"},
+            {"id": "a", "executor": "Official/acp", "model": "n", "options": {"entry": "pi"}},
         ]
     )
     assert fingerprint_for_actors(actors) == fingerprint_for_actors(list(reversed(actors)))
@@ -252,7 +276,7 @@ def test_plugins_from_extension_bindings_skip_defaults() -> None:
             "before_run": {
                 "kind": "on",
                 "chain": [
-                    {"plugin": "default", "source": "default"},
+                    {"plugin": "Official/default", "source": "default"},
                     {"plugin": "slot-probe", "version": "1.0.0"},
                 ],
             },
@@ -267,9 +291,8 @@ def test_plugins_from_job_overlay_skips_builtin_executors() -> None:
     overlay = {
         "bindings": {
             "solver": {"executor": "nooa", "model": "m"},
-            "user": {"executor": "acp", "options": {"entry": "codex"}},
-            "alt": {"executor": "ACP"},
-            "http": {"executor": "OpenAI-HTTP"},
+            "user": {"executor": "Official/acp", "options": {"entry": "codex"}},
+            "http": {"executor": "Official/openai-http"},
         }
     }
     refs = plugins_from_job_overlay(overlay)

--- a/tests/capabilities/test_agent_invocation_quota.py
+++ b/tests/capabilities/test_agent_invocation_quota.py
@@ -48,7 +48,7 @@ def test_parent_service_uses_shared_quota(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.delenv("BORA_OFFLINE_AGENT", raising=False)
     q = AgentInvocationQuota(limit=1)
     svc = ParentAgentService(
-        profiles=[{"id": "p", "executor": "mock", "model": "m"}],
+        profiles=[{"id": "p", "executor": "Official/mock", "model": "m"}],
         agent_invocation_limit=1,
         attempt_id="att-1",
         offline_env="",
@@ -72,7 +72,7 @@ def test_assemble_parent_and_authority_share_quota(tmp_path: Path) -> None:
     trial = factory.new_trial(run, "sha256:" + "d" * 64)
     attempt = factory.new_attempt(trial)
     service, _timeout, authority = assemble_parent_agent_service(
-        profiles=[{"id": "p", "executor": "mock", "model": "m"}],
+        profiles=[{"id": "p", "executor": "Official/mock", "model": "m"}],
         package_root=tmp_path,
         attempt=attempt,
         inv_limit=2,

--- a/tests/config/test_acp_profile.py
+++ b/tests/config/test_acp_profile.py
@@ -61,14 +61,14 @@ def test_acp_profile_lock_snapshot(tmp_path: Path) -> None:
         pkg,
         {
             "opencode-acp": {
-                "executor": "acp",
+                "executor": "Official/acp",
                 "model": "entry-default",
                 "options": {"entry": "opencode"},
             }
         },
     )
     profiles = thaw(lock.agent_profiles)
-    assert profiles[0]["executor"] == "acp"
+    assert profiles[0]["executor"] == "Official/acp"
     assert profiles[0]["options"]["entry"] == "opencode"
     assert "_acp_lock" not in profiles[0]["options"]
     blob = str(profiles)
@@ -79,7 +79,7 @@ def test_acp_profile_lock_snapshot(tmp_path: Path) -> None:
 def test_acp_missing_entry_fails(tmp_path: Path) -> None:
     pkg = _write_pkg(tmp_path / "pkg", ["bad"])
     with pytest.raises(ConfigError):
-        _lock(pkg, {"bad": {"executor": "acp", "model": "m", "options": {}}})
+        _lock(pkg, {"bad": {"executor": "Official/acp", "model": "m", "options": {}}})
 
 
 def test_acp_unknown_entry_fails(tmp_path: Path) -> None:
@@ -89,7 +89,7 @@ def test_acp_unknown_entry_fails(tmp_path: Path) -> None:
             pkg,
             {
                 "bad": {
-                    "executor": "acp",
+                    "executor": "Official/acp",
                     "model": "m",
                     "options": {"entry": "not-registered"},
                 }
@@ -104,7 +104,7 @@ def test_acp_package_cannot_override_command(tmp_path: Path) -> None:
             pkg,
             {
                 "bad": {
-                    "executor": "acp",
+                    "executor": "Official/acp",
                     "model": "m",
                     "options": {"entry": "opencode", "command": ["evil"]},
                 }

--- a/tests/config/test_agent_isolation.py
+++ b/tests/config/test_agent_isolation.py
@@ -72,7 +72,7 @@ evaluation:
 
 _P1_BINDINGS = {
     "p1": {
-        "executor": "acp",
+        "executor": "Official/acp",
         "model": "entry-default",
         "options": {"entry": "codex"},
     }

--- a/tests/config/test_docker_dockerfile_required.py
+++ b/tests/config/test_docker_dockerfile_required.py
@@ -61,7 +61,7 @@ evaluation:
 
 _P1_BINDINGS = {
     "p1": {
-        "executor": "acp",
+        "executor": "Official/acp",
         "model": "entry-default",
         "options": {"entry": "pi"},
     }

--- a/tests/config/test_load_and_lock.py
+++ b/tests/config/test_load_and_lock.py
@@ -24,7 +24,7 @@ CORE_DB = REPO / "examples" / "core"
 
 # Role bindings for config-minimal / config-invalid (from Database profiles.yaml).
 MOCK_BINDINGS: dict[str, dict[str, Any]] = {
-    "mock-default": {"executor": "mock", "model": "none"},
+    "mock-default": {"executor": "Official/mock", "model": "none"},
 }
 
 
@@ -60,7 +60,7 @@ def test_lock_success_deterministic(
     assert a.canonical_payload() == b.canonical_payload()
     assert a.digest.startswith("sha256:")
     assert len(a.digest) == len("sha256:") + 64
-    assert thaw(a.agent_profiles)[0]["executor"] == "mock"
+    assert thaw(a.agent_profiles)[0]["executor"] == "Official/mock"
     assert a.job_overlay is not None
 
 
@@ -302,4 +302,4 @@ def test_database_profiles_load_via_cli_path(
         profile_bindings=bindings,
     )
     assert thaw(locked.agent_profiles)[0]["id"] == "mock-default"
-    assert thaw(locked.agent_profiles)[0]["executor"] == "mock"
+    assert thaw(locked.agent_profiles)[0]["executor"] == "Official/mock"

--- a/tests/config/test_profile_upstream_fields.py
+++ b/tests/config/test_profile_upstream_fields.py
@@ -55,7 +55,7 @@ def test_accepts_base_url_and_api_key_locator(tmp_path: Path) -> None:
         capabilities=DeclarationCapabilityCatalog(),
         profile_bindings={
             "glm": {
-                "executor": "openai-http",
+                "executor": "Official/openai-http",
                 "model": "glm-4.7",
                 "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
                 "api_key": "zhipu_coding_api_key",
@@ -77,7 +77,7 @@ def test_rejects_secret_like_api_key(tmp_path: Path) -> None:
             capabilities=DeclarationCapabilityCatalog(),
             profile_bindings={
                 "bad": {
-                    "executor": "openai-http",
+                    "executor": "Official/openai-http",
                     "model": "glm-4.7",
                     "api_key": "sk-this-is-a-secret-value-not-a-locator",
                 }
@@ -96,7 +96,7 @@ def test_rejects_non_url_base(tmp_path: Path) -> None:
             capabilities=DeclarationCapabilityCatalog(),
             profile_bindings={
                 "bad": {
-                    "executor": "openai-http",
+                    "executor": "Official/openai-http",
                     "model": "glm-4.7",
                     "base_url": "not-a-url",
                 }
@@ -108,7 +108,7 @@ def test_resolve_executor_honors_profile_fields() -> None:
     from bora.adapters.agent_registry import resolve_executor
 
     ex = resolve_executor(
-        "openai-http",
+        "Official/openai-http",
         model="glm-4.7",
         base_url="https://open.bigmodel.cn/api/coding/paas/v4",
         api_key="zhipu_coding_api_key",

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -56,7 +56,7 @@ def _write_task(tmp: Path, *, slots: list[dict], task_id: str = "t") -> Path:
 def test_reject_inline_binding_in_task_yaml(tmp_path: Path) -> None:
     pkg = _write_task(
         tmp_path,
-        slots=[{"id": "solver", "executor": "mock", "model": "none"}],
+        slots=[{"id": "solver", "executor": "Official/mock", "model": "none"}],
     )
     core = ConfigCore(package_reader=LocalPackageReader())
     with pytest.raises(ConfigError) as ei:
@@ -64,7 +64,7 @@ def test_reject_inline_binding_in_task_yaml(tmp_path: Path) -> None:
             pkg,
             "t",
             capabilities=DeclarationCapabilityCatalog(),
-            profile_bindings={"solver": {"executor": "mock", "model": "none"}},
+            profile_bindings={"solver": {"executor": "Official/mock", "model": "none"}},
         )
     assert ei.value.error_code == "invalid_schema"
     assert "role slots only" in str(ei.value).lower() or "job binding" in str(ei.value).lower()
@@ -92,7 +92,7 @@ def test_merge_bindings_and_cli_override(tmp_path: Path) -> None:
         capabilities=DeclarationCapabilityCatalog(),
         profile_bindings={
             "solver": {
-                "executor": "acp",
+                "executor": "Official/acp",
                 "options": {"entry": "codex"},
                 "model": "gpt-5.4-mini",
             }
@@ -104,7 +104,7 @@ def test_merge_bindings_and_cli_override(tmp_path: Path) -> None:
     )
     profiles = thaw(locked.agent_profiles)
     assert profiles[0]["id"] == "solver"
-    assert profiles[0]["executor"] == "acp"
+    assert profiles[0]["executor"] == "Official/acp"
     assert profiles[0]["options"]["entry"] == "pi"
     assert profiles[0]["model"] == "claude-haiku-4-5"
     assert locked.job_overlay is not None
@@ -133,7 +133,7 @@ def test_profiles_document_parse(tmp_path: Path) -> None:
                 "format": "bora.profiles/1",
                 "bindings": {
                     "solver": {
-                        "executor": "acp",
+                        "executor": "Official/acp",
                         "options": {"entry": "codex"},
                         "model": "m",
                     }
@@ -149,23 +149,23 @@ def test_profiles_document_parse(tmp_path: Path) -> None:
 
 def test_assert_slots_helper() -> None:
     with pytest.raises(ConfigError):
-        assert_slots_have_no_inline_binding([{"id": "x", "executor": "mock"}])
+        assert_slots_have_no_inline_binding([{"id": "x", "executor": "Official/mock"}])
     assert_slots_have_no_inline_binding([{"id": "x"}])
 
 
 def test_merge_helper() -> None:
     rows = merge_bindings_onto_slots(
         [{"id": "solver"}],
-        {"solver": {"executor": "mock", "model": "none"}},
+        {"solver": {"executor": "Official/mock", "model": "none"}},
     )
-    assert rows[0]["executor"] == "mock"
+    assert rows[0]["executor"] == "Official/mock"
 
 
 def test_job_overlay_omits_secrets() -> None:
     overlay = project_job_overlay(
         {
             "solver": {
-                "executor": "acp",
+                "executor": "Official/acp",
                 "options": {"entry": "pi"},
                 "model": "m",
                 "api_key": "MY_KEY_LOCATOR",
@@ -187,7 +187,7 @@ def test_job_overlay_to_profiles_roundtrip(tmp_path: Path) -> None:
     overlay = project_job_overlay(
         {
             "solver": {
-                "executor": "acp",
+                "executor": "Official/acp",
                 "options": {"entry": "pi"},
                 "model": "m",
                 "api_key": "LOC",
@@ -244,7 +244,7 @@ def test_display_agent_name_never_uses_options_agent() -> None:
         )
         == "nooa"
     )
-    assert display_agent_name({"executor": "acp", "options": {"entry": "pi"}}) == "pi"
+    assert display_agent_name({"executor": "Official/acp", "options": {"entry": "pi"}}) == "pi"
     assert display_agent_name({"executor": "dsh"}) == "dsh"
 
 
@@ -252,7 +252,7 @@ def test_display_labels_from_overlay_joins_distinct() -> None:
     agent, model = display_labels_from_overlay(
         {
             "bindings": {
-                "a": {"executor": "acp", "options": {"entry": "pi"}, "model": "m1"},
+                "a": {"executor": "Official/acp", "options": {"entry": "pi"}, "model": "m1"},
                 "b": {"executor": "dsh", "model": "m2"},
             }
         }

--- a/tests/config/test_provenance.py
+++ b/tests/config/test_provenance.py
@@ -17,7 +17,7 @@ from bora.config.provenance import merge_provenance, validate_provenance
 
 REPO = Path(__file__).resolve().parents[2]
 MINIMAL = REPO / "examples" / "core" / "tasks" / "config-minimal"
-MOCK_BINDINGS = {"mock-default": {"executor": "mock", "model": "none"}}
+MOCK_BINDINGS = {"mock-default": {"executor": "Official/mock", "model": "none"}}
 
 
 def _minimal_task_yaml(*, extra: str = "", task_id: str = "config-minimal") -> str:

--- a/tests/executors/test_capability_matrix.py
+++ b/tests/executors/test_capability_matrix.py
@@ -12,20 +12,20 @@ from bora.adapters.executor_capabilities import (
 
 def test_acp_kind_registered() -> None:
     kinds = discover_executor_kinds()
-    assert "acp" in kinds
-    assert "openai-http" in kinds
+    assert "Official/acp" in kinds
+    assert "Official/openai-http" in kinds
     assert "codex" not in kinds
     assert "pi" not in kinds
-    assert get_capabilities("acp") is not None
-    assert get_capabilities("acp").execution_mode == "acp-stdio"  # type: ignore[union-attr]
+    assert get_capabilities("Official/acp") is not None
+    assert get_capabilities("Official/acp").execution_mode == "acp-stdio"  # type: ignore[union-attr]
 
 
 def test_required_surface_is_acp() -> None:
-    assert required_kinds_for_v014() == frozenset({"acp"})
+    assert required_kinds_for_v014() == frozenset({"Official/acp"})
 
 
 def test_capability_fields_frozen() -> None:
-    for kind in ("acp", "openai-http"):
+    for kind in ("Official/acp", "Official/openai-http"):
         cap = BUILTIN_CAPABILITIES[kind]
         assert cap.stream in {"native-events", "synthetic-lifecycle"}
         assert cap.execution_mode in {"cli-process", "api-client", "acp-stdio"}
@@ -49,7 +49,7 @@ def test_private_kinds_gone() -> None:
 
 
 def test_resolve_acp_constructor() -> None:
-    ex = resolve_executor("acp", model="entry-default", entry="opencode")
+    ex = resolve_executor("Official/acp", model="entry-default", entry="opencode")
     assert getattr(ex, "kind", None) == "acp"
     # SPI may wrap adapters.acp.AcpExecutor
     inner = getattr(ex, "_inner", ex)

--- a/tests/fixtures/databases/publish-min/profiles.yaml
+++ b/tests/fixtures/databases/publish-min/profiles.yaml
@@ -1,5 +1,5 @@
 format: bora.profiles/1
 bindings:
   mock-default:
-    executor: mock
+    executor: Official/mock
     model: none

--- a/tests/plugins/test_acp_nooa_contrib.py
+++ b/tests/plugins/test_acp_nooa_contrib.py
@@ -42,13 +42,13 @@ def test_acp_provide_selected_by_profile_executor() -> None:
     reg = ExtensionRegistry()
     bootstrap_registry(reg, include_mock=False, include_openai_http=False)
     graph = resolve(
-        BindingIntent(profile_id="solver", executor="acp", options={"entry": "pi"}),
+        BindingIntent(profile_id="solver", executor="Official/acp", options={"entry": "pi"}),
         reg,
         materialize=False,
     )
     assert graph.providers[EXECUTOR].plugin_id == ACP_ID
     lock = extension_graph_to_lock(graph)
-    assert lock["executor"]["plugin"] == "acp"
+    assert lock["executor"]["plugin"] == "Official/acp"
     assert lock["executor"]["source"] == "profile_executor_field"
 
 
@@ -113,7 +113,7 @@ def test_dual_profile_acp_and_nooa_session_graphs(bora_home_with_nooa: Path) -> 
             },
             {
                 "id": "user",
-                "executor": "acp",
+                "executor": "Official/acp",
                 "model": "m",
                 "options": {"entry": "pi"},
             },
@@ -160,7 +160,7 @@ def test_acp_entry_missing_fail_closed() -> None:
     reg = ExtensionRegistry()
     bootstrap_registry(reg, include_mock=False, include_openai_http=False)
     svc = ParentAgentService(
-        profiles=[{"id": "p", "executor": "acp", "model": "m", "options": {}}],
+        profiles=[{"id": "p", "executor": "Official/acp", "model": "m", "options": {}}],
         agent_invocation_limit=1,
         attempt_id="a",
         offline_env="",

--- a/tests/plugins/test_extension_bindings_lock.py
+++ b/tests/plugins/test_extension_bindings_lock.py
@@ -30,7 +30,7 @@ def test_lock_cli_extension_bindings_solver_acp() -> None:
     data = json.loads(proc.stdout)
     bindings = data["extension_bindings"]
     assert "solver" in bindings
-    assert bindings["solver"]["executor"]["plugin"] == "acp"
+    assert bindings["solver"]["executor"]["plugin"] == "Official/acp"
     assert bindings["solver"]["executor"]["source"] == "profile_executor_field"
     assert bindings["solver"]["executor"]["kind"] == "provide"
     assert bindings["solver"]["before_agent_invoke"]["kind"] == "on"

--- a/tests/plugins/test_extensions_opt_in.py
+++ b/tests/plugins/test_extensions_opt_in.py
@@ -1,0 +1,182 @@
+"""extensions opt-in: installed plugins stay off MULTI unless named."""
+
+from __future__ import annotations
+
+import pytest
+
+from bora.plugins.defaults import register_defaults
+from bora.plugins.errors import ExtensionPluginNotFoundError, UnknownExtensionSlotError
+from bora.plugins.protocol import BindingIntent, ExtensionSelect, intent_from_profile
+from bora.plugins.registry import ExtensionRegistry
+from bora.plugins.resolve import resolve
+from bora.plugins.slots import EXECUTOR, IMAGE_CONTRIBUTE, TRAJECTORY_COLLECT
+
+
+class _FakeExec:
+    kind = "fake"
+
+    def open(self, **kwargs):  # type: ignore[no-untyped-def]
+        del kwargs
+
+    def close(self) -> None:
+        return None
+
+    def invoke(self, prompt: str, **kwargs):  # type: ignore[no-untyped-def]
+        del kwargs
+        return {"ok": True, "text": prompt}
+
+
+async def _passthrough(ctx, value, nxt):  # type: ignore[no-untyped-def]
+    del ctx
+    return await nxt(value)
+
+
+def _reg_with_external() -> ExtensionRegistry:
+    reg = ExtensionRegistry()
+    register_defaults(reg)
+    reg.provide(EXECUTOR, "Official/acp", _FakeExec(), priority=100, source="first-party")
+    reg.provide(EXECUTOR, "nooa", _FakeExec(), priority=110, source="installed")
+    reg.on(IMAGE_CONTRIBUTE, "nooa", _passthrough, priority=110, source="installed")
+    reg.on(TRAJECTORY_COLLECT, "nooa", _passthrough, priority=110, source="installed")
+    reg.provide(EXECUTOR, "dsh", _FakeExec(), priority=110, source="installed")
+    reg.on(IMAGE_CONTRIBUTE, "dsh", _passthrough, priority=110, source="installed")
+    reg.on(TRAJECTORY_COLLECT, "dsh", _passthrough, priority=110, source="installed")
+    return reg
+
+
+def _chain_plugins(graph, slot: str) -> list[str]:
+    return [h.plugin_id for h in graph.chain(slot)]
+
+
+def test_acp_only_does_not_attach_installed_contribute() -> None:
+    graph = resolve(
+        BindingIntent(profile_id="solver", executor="Official/acp"), _reg_with_external()
+    )
+    assert graph.providers[EXECUTOR].plugin_id == "Official/acp"
+    assert "nooa" not in _chain_plugins(graph, IMAGE_CONTRIBUTE)
+    assert "dsh" not in _chain_plugins(graph, IMAGE_CONTRIBUTE)
+    assert "nooa" not in _chain_plugins(graph, TRAJECTORY_COLLECT)
+    assert "dsh" not in _chain_plugins(graph, TRAJECTORY_COLLECT)
+
+
+def test_all_slots_row_attaches_bake_and_collect() -> None:
+    graph = resolve(
+        BindingIntent(
+            profile_id="solver",
+            executor="nooa",
+            extension_selects=[ExtensionSelect(plugin="nooa")],
+        ),
+        _reg_with_external(),
+    )
+    assert graph.providers[EXECUTOR].plugin_id == "nooa"
+    assert "nooa" in _chain_plugins(graph, IMAGE_CONTRIBUTE)
+    assert "nooa" in _chain_plugins(graph, TRAJECTORY_COLLECT)
+    assert "dsh" not in _chain_plugins(graph, IMAGE_CONTRIBUTE)
+
+
+def test_listed_slots_do_not_attach_unlisted() -> None:
+    graph = resolve(
+        BindingIntent(
+            profile_id="solver",
+            executor="dsh",
+            extension_selects=[
+                ExtensionSelect(plugin="dsh", slots=(IMAGE_CONTRIBUTE,)),
+            ],
+        ),
+        _reg_with_external(),
+    )
+    assert "dsh" in _chain_plugins(graph, IMAGE_CONTRIBUTE)
+    assert "dsh" not in _chain_plugins(graph, TRAJECTORY_COLLECT)
+
+
+def test_unknown_slot_fail_closed() -> None:
+    with pytest.raises(UnknownExtensionSlotError):
+        resolve(
+            BindingIntent(
+                profile_id="s",
+                extension_selects=[ExtensionSelect(plugin="dsh", slots=("not_a_slot",))],
+            ),
+            _reg_with_external(),
+        )
+
+
+def test_unregistered_slot_fail_closed() -> None:
+    with pytest.raises(ExtensionPluginNotFoundError) as ei:
+        resolve(
+            BindingIntent(
+                profile_id="s",
+                extension_selects=[
+                    ExtensionSelect(plugin="dsh", slots=("before_agent_invoke",)),
+                ],
+            ),
+            _reg_with_external(),
+        )
+    assert ei.value.kind == "extension_slot_unregistered"
+
+
+def test_two_roles_bind_independently() -> None:
+    reg = _reg_with_external()
+    planner = resolve(
+        BindingIntent(
+            profile_id="planner",
+            executor="nooa",
+            extension_selects=[ExtensionSelect(plugin="nooa")],
+        ),
+        reg,
+    )
+    reviewer = resolve(
+        BindingIntent(
+            profile_id="reviewer",
+            executor="dsh",
+            extension_selects=[ExtensionSelect(plugin="dsh", slots=(IMAGE_CONTRIBUTE,))],
+        ),
+        reg,
+    )
+    assert planner.providers[EXECUTOR].plugin_id == "nooa"
+    assert reviewer.providers[EXECUTOR].plugin_id == "dsh"
+    assert "nooa" in _chain_plugins(planner, TRAJECTORY_COLLECT)
+    assert "dsh" not in _chain_plugins(reviewer, TRAJECTORY_COLLECT)
+    assert "dsh" in _chain_plugins(reviewer, IMAGE_CONTRIBUTE)
+    assert "nooa" not in _chain_plugins(reviewer, IMAGE_CONTRIBUTE)
+
+
+def test_executor_field_alone_does_not_bake() -> None:
+    graph = resolve(
+        BindingIntent(profile_id="solver", executor="nooa"),
+        _reg_with_external(),
+    )
+    assert graph.providers[EXECUTOR].plugin_id == "nooa"
+    assert "nooa" not in _chain_plugins(graph, IMAGE_CONTRIBUTE)
+
+
+def test_all_slots_row_can_omit_executor_field() -> None:
+    graph = resolve(
+        BindingIntent(
+            profile_id="solver",
+            extension_selects=[ExtensionSelect(plugin="nooa")],
+        ),
+        _reg_with_external(),
+    )
+    assert graph.providers[EXECUTOR].plugin_id == "nooa"
+
+
+def test_intent_from_profile_parses_all_three_shapes() -> None:
+    intent = intent_from_profile(
+        {
+            "id": "solver",
+            "executor": "dsh",
+            "extensions": [
+                {"plugin": "nooa"},
+                {"plugin": "dsh", "slots": ["image_contribute"]},
+                {"slot": "trajectory_collect", "plugin": "dsh"},
+            ],
+        }
+    )
+    assert intent.executor == "dsh"
+    assert len(intent.extension_selects) == 2
+    assert intent.extension_selects[0].plugin == "nooa"
+    assert intent.extension_selects[0].slots is None
+    assert intent.extension_selects[1].slots == (IMAGE_CONTRIBUTE,)
+    assert len(intent.extensions) == 1
+    assert intent.extensions[0].slot == TRAJECTORY_COLLECT
+    assert intent.extensions[0].plugin == "dsh"

--- a/tests/plugins/test_image_contribute_bake.py
+++ b/tests/plugins/test_image_contribute_bake.py
@@ -39,18 +39,18 @@ def test_bound_executor_ids() -> None:
     lock = _lock_with_profiles(
         [
             {"id": "s", "executor": "nooa", "options": {"agent": "x:Y"}},
-            {"id": "t", "executor": "acp"},
+            {"id": "t", "executor": "Official/acp"},
             {"id": "u", "executor": "nooa"},
         ]
     )
-    assert bound_executor_ids(lock) == ["nooa", "acp"]
+    assert bound_executor_ids(lock) == ["nooa", "Official/acp"]
 
 
 def test_apply_skips_first_party_only() -> None:
-    lock = _lock_with_profiles([{"id": "s", "executor": "acp"}])
+    lock = _lock_with_profiles([{"id": "s", "executor": "Official/acp"}])
     with patch(
         "bora.application.plugin_ops.image_contribute_bake.collect_declares_for_lock",
-        return_value=[{"plugin": "acp"}],
+        return_value=[{"plugin": "Official/acp"}],
     ):
         out, meta = apply_image_contribute_bake(
             lock=lock, base_image=_base(), platform="linux/arm64"

--- a/tests/plugins/test_official_acp_image.py
+++ b/tests/plugins/test_official_acp_image.py
@@ -1,0 +1,173 @@
+"""Official ACP reuses bora-attempt:l1; extra Dockerfile layers still build."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import patch
+
+from bora.adapters.provider_docker.images import is_official_base_noop_dockerfile
+from bora.adapters.provider_docker.types import DockerImageLock
+from bora.application.plugin_ops.image_contribute_bake import (
+    apply_image_contribute_bake,
+    baked_image_tag,
+    plugin_id_for_image_tag,
+    should_reuse_official_attempt_image,
+)
+from bora.config.model import LockedTaskConfig
+
+
+def _lock(profiles: list[dict[str, Any]]) -> LockedTaskConfig:
+    return cast(LockedTaskConfig, SimpleNamespace(agent_profiles=profiles))
+
+
+def _base() -> DockerImageLock:
+    return DockerImageLock(
+        kind="docker-attempt",
+        platform="linux/arm64",
+        image_tag="bora-attempt:l1",
+        image_digest="sha256:official",
+        build_input_digest="sha256:official-in",
+    )
+
+
+def test_noop_dockerfile_detection() -> None:
+    assert is_official_base_noop_dockerfile("FROM bora-attempt:l1\n")
+    assert is_official_base_noop_dockerfile("# comment\nFROM bora-attempt:l1 AS base\n")
+    assert not is_official_base_noop_dockerfile("FROM bora-attempt:l1\nCOPY x /x\n")
+    assert not is_official_base_noop_dockerfile("FROM bora-attempt:l1\nRUN true\n")
+    assert not is_official_base_noop_dockerfile("FROM other:latest\n")
+
+
+def test_reuse_official_acp_from_only() -> None:
+    lock = _lock([{"id": "s", "executor": "Official/acp", "options": {"entry": "pi"}}])
+    with patch(
+        "bora.application.plugin_ops.image_contribute_bake.collect_declares_for_lock",
+        return_value=[],
+    ):
+        assert should_reuse_official_attempt_image(lock, "FROM bora-attempt:l1\n") is True
+
+
+def test_copy_or_run_still_builds_package_tag() -> None:
+    lock = _lock([{"id": "s", "executor": "Official/acp", "options": {"entry": "pi"}}])
+    with patch(
+        "bora.application.plugin_ops.image_contribute_bake.collect_declares_for_lock",
+        return_value=[],
+    ):
+        assert (
+            should_reuse_official_attempt_image(
+                lock, "FROM bora-attempt:l1\nCOPY environment/tool.sh /bin/tool\n"
+            )
+            is False
+        )
+        assert (
+            should_reuse_official_attempt_image(lock, "FROM bora-attempt:l1\nRUN true\n") is False
+        )
+
+
+def test_external_executor_does_not_reuse() -> None:
+    lock = _lock([{"id": "s", "executor": "dsh"}])
+    with patch(
+        "bora.application.plugin_ops.image_contribute_bake.collect_declares_for_lock",
+        return_value=[{"plugin": "dsh"}],
+    ):
+        assert should_reuse_official_attempt_image(lock, "FROM bora-attempt:l1\n") is False
+
+
+def test_selected_bake_does_not_reuse() -> None:
+    lock = _lock(
+        [
+            {
+                "id": "s",
+                "executor": "Official/acp",
+                "options": {"entry": "pi"},
+                "extensions": [{"plugin": "dsh", "slots": ["image_contribute"]}],
+            }
+        ]
+    )
+    with patch(
+        "bora.application.plugin_ops.image_contribute_bake.collect_declares_for_lock",
+        return_value=[{"plugin": "dsh"}],
+    ):
+        assert should_reuse_official_attempt_image(lock, "FROM bora-attempt:l1\n") is False
+
+
+def test_apply_acp_only_does_not_bake_installed_declares() -> None:
+    lock = _lock([{"id": "s", "executor": "Official/acp", "options": {"entry": "pi"}}])
+    with patch(
+        "bora.application.plugin_ops.image_contribute_bake.collect_declares_for_lock",
+        return_value=[{"plugin": "Official/acp"}],
+    ):
+        out, meta = apply_image_contribute_bake(
+            lock=lock, base_image=_base(), platform="linux/arm64"
+        )
+    assert out.image_tag == "bora-attempt:l1"
+    assert meta["status"] == "skipped"
+    assert meta["baked"] == []
+
+
+def test_prepare_reuses_official_tag_without_buildx(
+    tmp_path,
+    monkeypatch,  # type: ignore[no-untyped-def]
+) -> None:
+    import bora.application.attempt.extension_hooks as hooks
+    import bora.application.attempt.run_l1_prepare as prep
+    import bora.application.plugin_ops.image_contribute_bake as bake
+    from bora.application.attempt.run_l1_prepare import prepare_l1_runtime
+    from bora.runtime.identity import IdentityFactory
+
+    (tmp_path / "environment").mkdir()
+    (tmp_path / "environment" / "Dockerfile").write_text("FROM bora-attempt:l1\n", encoding="utf-8")
+    official = _base()
+
+    class FakeDocker:
+        def __init__(self, *, image_lock_path):  # type: ignore[no-untyped-def]
+            del image_lock_path
+
+        def prepare(self, attempt, **_kwargs):  # type: ignore[no-untyped-def]
+            from bora.adapters.provider_docker.types import DockerRuntime
+
+            return DockerRuntime(
+                attempt=attempt,
+                image_lock=official,
+                workdir_host=tmp_path / "work",
+            )
+
+    def _must_not_build(**_kwargs: object) -> DockerImageLock:
+        raise AssertionError("must not build package image")
+
+    monkeypatch.setattr(prep, "ensure_base_image", lambda _cwd: official)
+    monkeypatch.setattr(prep, "build_package_image", _must_not_build)
+    monkeypatch.setattr(prep, "ensure_image_lock", lambda _cwd: tmp_path / "lock.json")
+    monkeypatch.setattr(prep, "DockerProvider", FakeDocker)
+    monkeypatch.setattr(hooks, "hook_prepare", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        bake, "apply_image_contribute_bake", lambda **kw: (kw["base_image"], {"status": "skipped"})
+    )
+    monkeypatch.setattr(bake, "should_reuse_official_attempt_image", lambda *_a, **_k: True)
+
+    factory = IdentityFactory()
+    run = factory.new_run()
+    trial = factory.new_trial(run, "sha256:" + "a" * 64)
+    lock = SimpleNamespace(
+        digest="sha256:" + "a" * 64,
+        task_id="terminal-jsonl-agg",
+        provider={"kind": "docker", "dockerfile": "environment/Dockerfile"},
+        agent_profiles=[{"id": "s", "executor": "Official/acp", "options": {"entry": "pi"}}],
+    )
+    _docker, runtime, meta = prepare_l1_runtime(
+        tmp_path,
+        lock,
+        tmp_path / "run",
+        attempt=factory.new_attempt(trial),
+    )
+    assert runtime.image_lock is not None
+    assert runtime.image_lock.image_tag == "bora-attempt:l1"
+    assert meta["image_tag"] == "bora-attempt:l1"
+
+
+def test_namespaced_plugin_id_in_bake_tag() -> None:
+    assert plugin_id_for_image_tag("acme/nooa") == "acme--nooa"
+    tag = baked_image_tag(_base(), "acme/nooa", "d" * 24)
+    assert tag.startswith("bora-attempt:l1-acme--nooa-")
+    assert "/" not in tag.split(":", 1)[1]

--- a/tests/plugins/test_plugin_identity.py
+++ b/tests/plugins/test_plugin_identity.py
@@ -20,13 +20,15 @@ def test_normalize_short_and_namespaced() -> None:
     assert normalize_plugin_id("nooa") == "nooa"
     assert normalize_plugin_id("sample-echo") == "sample-echo"
     assert normalize_plugin_id("acme/nooa") == "acme/nooa"
+    assert normalize_plugin_id("Official/acp") == "Official/acp"
+    assert normalize_plugin_id("Official/openai-http") == "Official/openai-http"
     assert split_plugin_id("acme/nooa") == ("acme", "nooa")
     assert split_plugin_id("dsh") == (None, "dsh")
 
 
 @pytest.mark.parametrize(
     "raw",
-    ["Acme/nooa", "org.name", "acme//nooa", "acme/nooa/extra", "-bad", "acme/", "/nooa", ""],
+    ["org.name", "acme//nooa", "acme/nooa/extra", "-bad", "acme/", "/nooa", ""],
 )
 def test_normalize_rejects_invalid(raw: str) -> None:
     with pytest.raises(PluginManifestError) as ei:

--- a/tests/plugins/test_plugin_identity.py
+++ b/tests/plugins/test_plugin_identity.py
@@ -1,0 +1,112 @@
+"""plugin_id identity: short in-repo ids, Hub org/name, path install cache."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bora.config.errors import ConfigError
+from bora.plugins.manifest import (
+    PluginManifestError,
+    normalize_plugin_id,
+    parse_manifest_mapping,
+    require_namespaced_plugin_id,
+    split_plugin_id,
+)
+
+
+def test_normalize_short_and_namespaced() -> None:
+    assert normalize_plugin_id("nooa") == "nooa"
+    assert normalize_plugin_id("sample-echo") == "sample-echo"
+    assert normalize_plugin_id("acme/nooa") == "acme/nooa"
+    assert split_plugin_id("acme/nooa") == ("acme", "nooa")
+    assert split_plugin_id("dsh") == (None, "dsh")
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["Acme/nooa", "org.name", "acme//nooa", "acme/nooa/extra", "-bad", "acme/", "/nooa", ""],
+)
+def test_normalize_rejects_invalid(raw: str) -> None:
+    with pytest.raises(PluginManifestError) as ei:
+        normalize_plugin_id(raw)
+    assert ei.value.kind in {"plugin_id_invalid", "plugin_manifest_invalid"}
+
+
+def test_parse_manifest_keeps_namespaced_id() -> None:
+    manifest = parse_manifest_mapping(
+        {
+            "format": "bora.plugin/1",
+            "plugin_id": "acme/dsh",
+            "version": "0.1.0",
+            "slots": {"provide": [{"id": "executor", "entry": "pkg:fn"}]},
+        }
+    )
+    assert manifest.plugin_id == "acme/dsh"
+
+
+def test_hub_publish_requires_org_prefix() -> None:
+    assert require_namespaced_plugin_id("test/sample-echo", org="test") == "test/sample-echo"
+    with pytest.raises(PluginManifestError) as short:
+        require_namespaced_plugin_id("sample-echo", org="test")
+    assert short.value.kind == "plugin_id_not_namespaced"
+    with pytest.raises(PluginManifestError) as mismatch:
+        require_namespaced_plugin_id("other/sample-echo", org="test")
+    assert mismatch.value.kind == "plugin_org_mismatch"
+
+
+def test_publish_command_rejects_org_mismatch(tmp_path: Path) -> None:
+    from bora.application.plugin_ops.plugin_publish import PluginPublishCommand
+
+    root = tmp_path / "plug"
+    root.mkdir()
+    (root / "plugin.yaml").write_text(
+        "format: bora.plugin/1\nplugin_id: acme/echo\nversion: 0.0.1\n",
+        encoding="utf-8",
+    )
+    cmd = PluginPublishCommand(client_factory=lambda **_k: None)
+    with pytest.raises(ConfigError) as ei:
+        cmd.publish_plugin(root, org="other")
+    assert ei.value.error_code == "plugin_org_mismatch"
+
+
+def test_publish_command_rejects_short_plugin_id(tmp_path: Path) -> None:
+    from bora.application.plugin_ops.plugin_publish import PluginPublishCommand
+
+    root = tmp_path / "plug"
+    root.mkdir()
+    (root / "plugin.yaml").write_text(
+        "format: bora.plugin/1\nplugin_id: sample-echo\nversion: 0.0.1\n",
+        encoding="utf-8",
+    )
+    cmd = PluginPublishCommand(client_factory=lambda **_k: None)
+    with pytest.raises(ConfigError) as ei:
+        cmd.publish_plugin(root, org="test")
+    assert ei.value.error_code == "plugin_id_not_namespaced"
+
+
+def test_path_install_namespaced_id_and_digest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("BORA_HOME", str(home))
+    from bora.plugins.store import install_from_path, list_installed, uninstall
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "plugin.yaml").write_text(
+        "format: bora.plugin/1\nplugin_id: acme/echo\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+    (src / "readme.txt").write_text("hi\n", encoding="utf-8")
+    entry = install_from_path(src)
+    assert entry.plugin_id == "acme/echo"
+    assert entry.version == "0.1.0"
+    assert entry.digest.startswith("sha256:")
+    assert (home / "plugins" / "acme" / "echo" / "0.1.0" / "plugin.yaml").is_file()
+    assert list_installed()[0].plugin_id == "acme/echo"
+    assert uninstall("acme/echo") is True
+    assert list_installed() == []
+    assert not (home / "plugins" / "acme").exists()

--- a/tests/plugins/test_registry_resolve.py
+++ b/tests/plugins/test_registry_resolve.py
@@ -11,7 +11,7 @@ from bora.plugins.defaults import register_defaults
 from bora.plugins.errors import ExtensionPluginNotFoundError, UnknownExtensionSlotError
 from bora.plugins.lock_bind import extension_graph_to_lock
 from bora.plugins.middleware import run_chain
-from bora.plugins.protocol import BindingIntent, ExplicitBinding
+from bora.plugins.protocol import BindingIntent, ExplicitBinding, ExtensionSelect
 from bora.plugins.registry import ExtensionRegistry
 from bora.plugins.resolve import resolve
 from bora.plugins.slots import BEFORE_AGENT_INVOKE, EXECUTOR
@@ -65,11 +65,11 @@ def test_two_intents_do_not_pollute() -> None:
     reg = ExtensionRegistry()
     register_defaults(reg)
     reg.provide(EXECUTOR, "nooa", _FakeExec(), priority=10, source="first-party")
-    reg.provide(EXECUTOR, "acp", _FakeExec(), priority=10, source="first-party")
+    reg.provide(EXECUTOR, "Official/acp", _FakeExec(), priority=10, source="first-party")
     g1 = resolve(BindingIntent(profile_id="solver", executor="nooa"), reg)
-    g2 = resolve(BindingIntent(profile_id="user", executor="acp"), reg)
+    g2 = resolve(BindingIntent(profile_id="user", executor="Official/acp"), reg)
     assert g1.providers[EXECUTOR].plugin_id == "nooa"
-    assert g2.providers[EXECUTOR].plugin_id == "acp"
+    assert g2.providers[EXECUTOR].plugin_id == "Official/acp"
     assert g1.profile_id == "solver"
     assert g2.profile_id == "user"
 
@@ -77,16 +77,16 @@ def test_two_intents_do_not_pollute() -> None:
 def test_lock_bind_includes_source_priority_replaced_default() -> None:
     reg = ExtensionRegistry()
     register_defaults(reg)
-    reg.provide(EXECUTOR, "acp", _FakeExec(), priority=100, source="first-party")
-    graph = resolve(BindingIntent(profile_id="solver", executor="acp"), reg)
+    reg.provide(EXECUTOR, "Official/acp", _FakeExec(), priority=100, source="first-party")
+    graph = resolve(BindingIntent(profile_id="solver", executor="Official/acp"), reg)
     frag = extension_graph_to_lock(graph)
     row = frag["executor"]
     assert row["kind"] == "provide"
-    assert row["plugin"] == "acp"
+    assert row["plugin"] == "Official/acp"
     assert row["source"] == "profile_executor_field"
     assert "priority" in row
     assert frag[BEFORE_AGENT_INVOKE]["kind"] == "on"
-    assert frag[BEFORE_AGENT_INVOKE]["chain"][0]["plugin"] == "default"
+    assert frag[BEFORE_AGENT_INVOKE]["chain"][0]["plugin"] == "Official/default"
 
 
 def test_multi_chain_order_lower_priority_number_first() -> None:
@@ -104,7 +104,16 @@ def test_multi_chain_order_lower_priority_number_first() -> None:
 
     make("late", 100)
     make("early", 10)
-    graph = resolve(BindingIntent(profile_id="s"), reg)
+    graph = resolve(
+        BindingIntent(
+            profile_id="s",
+            extension_selects=[
+                ExtensionSelect(plugin="late"),
+                ExtensionSelect(plugin="early"),
+            ],
+        ),
+        reg,
+    )
     result = asyncio.run(run_chain(graph, BEFORE_AGENT_INVOKE, "prompt"))
     assert result == "prompt"
     assert order[0] == "enter:early"
@@ -128,10 +137,10 @@ def test_executor_field_plugin_not_registered_fail_closed() -> None:
 def test_profile_executor_field_selects_plugin() -> None:
     reg = ExtensionRegistry()
     register_defaults(reg)
-    reg.provide(EXECUTOR, "acp", _FakeExec(), priority=100, source="first-party")
+    reg.provide(EXECUTOR, "Official/acp", _FakeExec(), priority=100, source="first-party")
     graph = resolve(
-        BindingIntent(profile_id="solver", executor="acp", options={"entry": "pi"}),
+        BindingIntent(profile_id="solver", executor="Official/acp", options={"entry": "pi"}),
         reg,
     )
-    assert graph.providers[EXECUTOR].plugin_id == "acp"
+    assert graph.providers[EXECUTOR].plugin_id == "Official/acp"
     assert graph.providers[EXECUTOR].source == "profile_executor_field"

--- a/tests/plugins/test_slot_wiring_agent_bookends.py
+++ b/tests/plugins/test_slot_wiring_agent_bookends.py
@@ -100,7 +100,14 @@ def _svc_with_spies() -> tuple[ParentAgentService, _FakeExecutor, list[str]]:
     reg.on(BEFORE_AGENT_INVOKE, "spy", rewrite_prompt, priority=10, source="test")
 
     svc = ParentAgentService(
-        profiles=[{"id": "p1", "executor": "fake", "model": "m"}],
+        profiles=[
+            {
+                "id": "p1",
+                "executor": "fake",
+                "model": "m",
+                "extensions": [{"plugin": "spy"}],
+            }
+        ],
         agent_invocation_limit=5,
         attempt_id="att_test",
         offline_env="",
@@ -145,7 +152,14 @@ def test_open_hook_fail_closed_no_half_open_session() -> None:
 
     reg.on(BEFORE_AGENT_OPEN, "spy", boom, priority=10, source="test")
     svc = ParentAgentService(
-        profiles=[{"id": "p1", "executor": "fake", "model": "m"}],
+        profiles=[
+            {
+                "id": "p1",
+                "executor": "fake",
+                "model": "m",
+                "extensions": [{"plugin": "spy"}],
+            }
+        ],
         agent_invocation_limit=2,
         attempt_id="att_fail",
         offline_env="",

--- a/tests/plugins/test_slot_wiring_env.py
+++ b/tests/plugins/test_slot_wiring_env.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 from bora.application.attempt import extension_hooks as hooks
 from bora.environment.manager import EnvironmentManager
 from bora.plugins.defaults import register_defaults
-from bora.plugins.protocol import BindingIntent
+from bora.plugins.protocol import BindingIntent, ExtensionSelect
 from bora.plugins.registry import ExtensionRegistry
 from bora.plugins.resolve import resolve
 from bora.plugins.slots import ENV_ACTION, ENV_INJECT, ENV_PREPARE_COMMANDS, ENV_TEARDOWN_COMMANDS
@@ -18,7 +18,7 @@ from bora.plugins.slots import ENV_ACTION, ENV_INJECT, ENV_PREPARE_COMMANDS, ENV
 
 def _lock() -> Any:
     return SimpleNamespace(
-        agent_profiles=[{"id": "p", "executor": "acp", "options": {"entry": "pi"}}]
+        agent_profiles=[{"id": "p", "executor": "Official/acp", "options": {"entry": "pi"}}]
     )
 
 
@@ -55,7 +55,14 @@ def test_env_prepare_handler_does_real_work_and_rewrites_handoff(tmp_path: Path)
     reg.on(ENV_PREPARE_COMMANDS, "spy-env", after_prepare, priority=10, source="test")
     reg.on(ENV_INJECT, "spy-env", inject, priority=10, source="test")
     reg.on(ENV_TEARDOWN_COMMANDS, "spy-env", teardown, priority=10, source="test")
-    graph = resolve(BindingIntent(profile_id="p"), reg, materialize=True)
+    graph = resolve(
+        BindingIntent(
+            profile_id="p",
+            extension_selects=[ExtensionSelect(plugin="spy-env")],
+        ),
+        reg,
+        materialize=True,
+    )
 
     lock = _lock()
     handoff = {"ok": True, "resource": "postgresql"}
@@ -117,7 +124,14 @@ def test_env_action_provide_materializes() -> None:
         return AllowAll()
 
     reg.provide(ENV_ACTION, "gate-plugin", factory, priority=10, source="test", is_factory=True)
-    graph = resolve(BindingIntent(profile_id="p"), reg, materialize=True)
+    graph = resolve(
+        BindingIntent(
+            profile_id="p",
+            extension_selects=[ExtensionSelect(plugin="gate-plugin")],
+        ),
+        reg,
+        materialize=True,
+    )
     lock = _lock()
     with patch.object(hooks, "graph_for_lock", return_value=graph):
         spi = hooks.hook_env_action(lock, {"op": "prepare"})

--- a/tests/plugins/test_slot_wiring_eval.py
+++ b/tests/plugins/test_slot_wiring_eval.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 from bora.application.attempt import extension_hooks as hooks
 from bora.plugins.defaults import register_defaults
 from bora.plugins.lock_bind import extension_graph_to_lock
-from bora.plugins.protocol import BindingIntent
+from bora.plugins.protocol import BindingIntent, ExtensionSelect
 from bora.plugins.registry import ExtensionRegistry
 from bora.plugins.resolve import resolve
 from bora.plugins.slots import EVALUATION_INPUT_CONTRIBUTE, EVALUATION_RUNTIME, SCORE_POSTPROCESS
@@ -17,7 +17,7 @@ from bora.plugins.slots import EVALUATION_INPUT_CONTRIBUTE, EVALUATION_RUNTIME, 
 
 def _lock() -> Any:
     return SimpleNamespace(
-        agent_profiles=[{"id": "p", "executor": "acp", "options": {"entry": "pi"}}]
+        agent_profiles=[{"id": "p", "executor": "Official/acp", "options": {"entry": "pi"}}]
     )
 
 
@@ -48,7 +48,11 @@ def test_evaluation_input_and_score_postprocess_rewrite() -> None:
 
     reg.on(EVALUATION_INPUT_CONTRIBUTE, "spy", ein, priority=10, source="test")
     reg.on(SCORE_POSTPROCESS, "spy", spp, priority=10, source="test")
-    graph = resolve(BindingIntent(profile_id="p"), reg, materialize=True)
+    graph = resolve(
+        BindingIntent(profile_id="p", extension_selects=[ExtensionSelect(plugin="spy")]),
+        reg,
+        materialize=True,
+    )
 
     lock = _lock()
     with patch.object(hooks, "graph_for_lock", return_value=graph):
@@ -74,7 +78,14 @@ def test_l3_bindings_appear_in_lock_fragment() -> None:
         return await nxt(value)
 
     reg.on(SCORE_POSTPROCESS, "score-spy", spp, priority=50, source="test")
-    graph = resolve(BindingIntent(profile_id="solver"), reg, materialize=False)
+    graph = resolve(
+        BindingIntent(
+            profile_id="solver",
+            extension_selects=[ExtensionSelect(plugin="score-spy")],
+        ),
+        reg,
+        materialize=False,
+    )
     frag = extension_graph_to_lock(graph)
     assert SCORE_POSTPROCESS in frag
     assert frag[SCORE_POSTPROCESS]["kind"] == "on"

--- a/tests/plugins/test_slot_wiring_trajectory.py
+++ b/tests/plugins/test_slot_wiring_trajectory.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from bora.plugins.defaults import register_defaults
-from bora.plugins.protocol import BindingIntent
+from bora.plugins.protocol import BindingIntent, ExtensionSelect
 from bora.plugins.registry import ExtensionRegistry
 from bora.plugins.resolve import resolve
 from bora.plugins.slots import (
@@ -86,7 +86,11 @@ def test_trajectory_chain_enriches_metadata_and_evidence_extra(tmp_path: Path) -
     reg.on(EVIDENCE_EXTRA, "spy", extras, priority=10, source="test")
     # trajectory_seal provide stays on default marker
 
-    graph = resolve(BindingIntent(profile_id="p"), reg, materialize=True)
+    graph = resolve(
+        BindingIntent(profile_id="p", extension_selects=[ExtensionSelect(plugin="spy")]),
+        reg,
+        materialize=True,
+    )
     inv_dir = tmp_path / "inv_001"
     inv_dir.mkdir()
     handle = _FakeHandle(inv_dir)
@@ -150,7 +154,11 @@ def test_trajectory_rewrite_on_collect_changes_prompt_written(tmp_path: Path) ->
         return out
 
     reg.on(TRAJECTORY_COLLECT, "spy", collect, priority=10, source="test")
-    graph = resolve(BindingIntent(profile_id="p"), reg, materialize=True)
+    graph = resolve(
+        BindingIntent(profile_id="p", extension_selects=[ExtensionSelect(plugin="spy")]),
+        reg,
+        materialize=True,
+    )
     inv_dir = tmp_path / "inv_002"
     inv_dir.mkdir()
     handle = _FakeHandle(inv_dir)

--- a/tests/registry/test_plugin_package_e2e.py
+++ b/tests/registry/test_plugin_package_e2e.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 import threading
 from http.server import ThreadingHTTPServer
 from pathlib import Path
@@ -67,7 +68,17 @@ def test_publish_plugin_preview_and_install(
 
     _ensure_org(registry_server["url"], registry_server["token"])
 
-    summary = publish_plugin(PLUGIN_FIXTURE, public=False, org=TEST_ORG)
+    namespaced = tmp_path / "sample-echo"
+    shutil.copytree(PLUGIN_FIXTURE, namespaced)
+    yaml_path = namespaced / "plugin.yaml"
+    yaml_path.write_text(
+        yaml_path.read_text(encoding="utf-8").replace(
+            "plugin_id: sample-echo",
+            f"plugin_id: {TEST_ORG}/sample-echo",
+        ),
+        encoding="utf-8",
+    )
+    summary = publish_plugin(namespaced, public=False, org=TEST_ORG)
     assert summary["ok"] is True
     assert summary["package_kind"] == "plugin"
     assert summary["media_type"] == PLUGIN_MEDIA_TYPE
@@ -121,7 +132,8 @@ def test_publish_plugin_preview_and_install(
 
     installed = install_plugin_from_registry(ref)
     assert installed["ok"] is True
-    assert installed["plugin_id"] == "sample-echo"
+    assert installed["plugin_id"] == f"{TEST_ORG}/sample-echo"
+    assert installed["digest"].startswith("sha256:")
     assert (home / "plugins" / "index.json").is_file()
 
 

--- a/tests/registry/test_registry_operator.py
+++ b/tests/registry/test_registry_operator.py
@@ -332,7 +332,7 @@ def _write_suite_summary(db: Path, suite_run_id: str) -> Path:
         "job_overlay": {
             "bindings": {
                 "solver": {
-                    "executor": "acp",
+                    "executor": "Official/acp",
                     "options": {"entry": "pi"},
                     "model": "m1",
                     "api_key": "LOCATOR_ONLY",

--- a/tests/registry/test_suite_completeness.py
+++ b/tests/registry/test_suite_completeness.py
@@ -149,9 +149,9 @@ def test_suite_plugins_and_uploaded_by_me_filter(tmp_path: Path) -> None:
     )
     meta["plugins"] = [
         {"plugin_id": "nooa", "version": "0.1.0"},
-        {"plugin_id": "default"},
-        {"plugin_id": "ACP"},
-        {"plugin_id": "openai-http"},
+        {"plugin_id": "Official/default"},
+        {"plugin_id": "Official/acp"},
+        {"plugin_id": "Official/openai-http"},
         {"plugin_id": "nooa"},
     ]
     payload = results.upload_suite(meta=meta, archive=archive, auth=alice)

--- a/tests/security/test_acp_lock_no_secret.py
+++ b/tests/security/test_acp_lock_no_secret.py
@@ -48,7 +48,7 @@ def test_acp_lock_snapshot_is_safe(tmp_path: Path) -> None:
         capabilities=DeclarationCapabilityCatalog(),
         profile_bindings={
             "p": {
-                "executor": "acp",
+                "executor": "Official/acp",
                 "model": "entry-default",
                 "options": {"entry": "codex"},
                 "api_key": "OPENAI_API_KEY",

--- a/tests/security/test_executor_env_projection.py
+++ b/tests/security/test_executor_env_projection.py
@@ -33,7 +33,7 @@ def test_agent_service_with_acp_offline_no_secret_in_evidence(
         profiles=[
             {
                 "id": "p1",
-                "executor": "acp",
+                "executor": "Official/acp",
                 "model": "entry-default",
                 "options": {"entry": "opencode"},
             }

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -67,7 +67,7 @@ def _write_evidence(db: Path, run_id: str, *, task_id: str = "alpha") -> Path:
                 "profiles": [
                     {
                         "id": "main",
-                        "executor": "acp",
+                        "executor": "Official/acp",
                         "model": "test-model",
                         "options": {"entry": "pi"},
                         "capabilities": {"execution_mode": "acp-stdio"},
@@ -189,15 +189,15 @@ def test_resolve_and_trial_detail(tmp_path: Path) -> None:
     assert "verifier" in tabs
     assert "lock" in tabs
     assert "runtime" in tabs
-    assert detail["trial"].get("framework") == "acp"
+    assert detail["trial"].get("framework") == "Official/acp"
     assert detail["trial"].get("docker") is None
     actors = detail["trial"].get("actors") or []
     assert len(actors) == 1
     assert actors[0]["role"] == "main"
     assert actors[0]["agent"] == "pi"
     assert actors[0]["model"] == "test-model"
-    assert actors[0].get("executor_kind") == "acp"
-    assert detail["trial"].get("executor_kind") == "acp"
+    assert actors[0].get("executor_kind") == "Official/acp"
+    assert detail["trial"].get("executor_kind") == "Official/acp"
     assert actors[0]["invokes"] == 1
     assert actors[0]["latency_ms_sum"] == pytest.approx(1234.5)
     assert actors[0]["time_label"]
@@ -411,14 +411,14 @@ def _write_multi_role_evidence(db: Path, run_id: str, *, task_id: str = "alpha")
                 "profiles": [
                     {
                         "id": "user-grok",
-                        "executor": "acp",
+                        "executor": "Official/acp",
                         "model": "entry-default",
                         "options": {"entry": "grok"},
                         "capabilities": {"execution_mode": "acp-stdio"},
                     },
                     {
                         "id": "service-opencode",
-                        "executor": "acp",
+                        "executor": "Official/acp",
                         "model": "glm-5.2",
                         "options": {"entry": "opencode"},
                         "capabilities": {"execution_mode": "acp-stdio"},
@@ -573,7 +573,7 @@ def test_legacy_usage_cost_only_no_used_as_tokens(tmp_path: Path) -> None:
                 "profiles": [
                     {
                         "id": "main-pi",
-                        "executor": "acp",
+                        "executor": "Official/acp",
                         "options": {"entry": "pi"},
                         "capabilities": {"execution_mode": "acp-stdio"},
                     }

--- a/website/content/docs/agents/acp-profiles.en.mdx
+++ b/website/content/docs/agents/acp-profiles.en.mdx
@@ -1,6 +1,6 @@
 ---
 title: ACP profiles
-description: "Plug coding agents with executor: acp + options.entry."
+description: "Plug coding agents with executor: Official/acp + options.entry."
 ---
 
 ## Recommended config
@@ -8,7 +8,7 @@ description: "Plug coding agents with executor: acp + options.entry."
 ```yaml
 agent_profiles:
   - id: main
-    executor: acp
+    executor: Official/acp
     model: gpt-5.4-mini
     options:
       entry: codex
@@ -16,7 +16,7 @@ agent_profiles:
 
 | Field | Note |
 | --- | --- |
-| `executor` | Use `acp` for coding agents |
+| `executor` | Use `Official/acp` for coding agents |
 | `options.entry` | **Required**; discover with `bora executors -v` |
 | `model` | Model id for that entry |
 | `api_key` | Optional env **name** |

--- a/website/content/docs/agents/acp-profiles.mdx
+++ b/website/content/docs/agents/acp-profiles.mdx
@@ -1,6 +1,6 @@
 ---
 title: ACP Profiles
-description: "用 executor: acp + options.entry 接 coding agent。"
+description: "用 executor: Official/acp + options.entry 接 coding agent。"
 ---
 
 ## 推荐配置
@@ -8,7 +8,7 @@ description: "用 executor: acp + options.entry 接 coding agent。"
 ```yaml
 agent_profiles:
   - id: main
-    executor: acp
+    executor: Official/acp
     model: gpt-5.4-mini
     options:
       entry: codex
@@ -17,7 +17,7 @@ agent_profiles:
 
 | 字段 | 说明 |
 | --- | --- |
-| `executor` | coding agent 用 `acp`（不要用已废弃的 `executor: codex` 等） |
+| `executor` | coding agent 用 `Official/acp`（不要用已废弃的 `executor: codex` 等） |
 | `options.entry` | **必填**；本机可用 id 以 `bora executors -v` 为准 |
 | `model` | 交给该 entry 的模型 |
 | `api_key` | 可选；**环境变量名** |

--- a/website/content/docs/agents/multi-agent.en.mdx
+++ b/website/content/docs/agents/multi-agent.en.mdx
@@ -13,12 +13,12 @@ parameters:
 
 agent_profiles:
   - id: planner-pi
-    executor: acp
+    executor: Official/acp
     options:
       entry: pi
     model: …
   - id: worker-codex
-    executor: acp
+    executor: Official/acp
     options:
       entry: codex
     model: …

--- a/website/content/docs/agents/multi-agent.mdx
+++ b/website/content/docs/agents/multi-agent.mdx
@@ -13,12 +13,12 @@ parameters:
 
 agent_profiles:
   - id: planner-pi
-    executor: acp
+    executor: Official/acp
     options:
       entry: pi
     model: …
   - id: worker-codex
-    executor: acp
+    executor: Official/acp
     options:
       entry: codex
     model: …

--- a/website/content/docs/author/tutorial.en.mdx
+++ b/website/content/docs/author/tutorial.en.mdx
@@ -38,7 +38,7 @@ provider:
 
 agent_profiles:
   - id: main
-    executor: acp
+    executor: Official/acp
     model: gpt-5.4-mini
     options:
       entry: codex

--- a/website/content/docs/author/tutorial.mdx
+++ b/website/content/docs/author/tutorial.mdx
@@ -43,7 +43,7 @@ provider:
 
 agent_profiles:
   - id: main
-    executor: acp
+    executor: Official/acp
     model: gpt-5.4-mini
     options:
       entry: codex

--- a/website/content/docs/reference/config-fields.mdx
+++ b/website/content/docs/reference/config-fields.mdx
@@ -43,7 +43,7 @@ description: bora.yaml / task.yaml 字段与校验要点速查。
 
 ```yaml
 - id: main
-  executor: acp
+  executor: Official/acp
   model: gpt-5.4-mini
   options:
     entry: codex

--- a/website/content/docs/run/plugins.en.mdx
+++ b/website/content/docs/run/plugins.en.mdx
@@ -30,6 +30,8 @@ uv run bora plugin uninstall nooa
 bindings:
   solver:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:JsonlAggAgent"
       method: "run"
@@ -69,7 +71,9 @@ in-container).
 
 ## Relation to ACP
 
-The default coding-agent path remains `executor: acp` + `options.entry`. Plugins are
-**optional** mechanisms beside first-party ACP; the same harness switches only via profiles.
+The default coding-agent path remains `executor: Official/acp` + `options.entry`.
+Install does not bake a plugin into an ACP-only job. Name the plugin under
+`extensions` to opt in to bake and other `on:` slots. Plugins are **optional**
+mechanisms beside first-party ACP; the same harness switches only via profiles.
 
 Mechanism contracts live in design docs (`docs/design`); this page does not raise evidence grades.

--- a/website/content/docs/run/plugins.mdx
+++ b/website/content/docs/run/plugins.mdx
@@ -29,6 +29,8 @@ uv run bora plugin uninstall nooa
 bindings:
   solver:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:JsonlAggAgent"
       method: "run"
@@ -66,7 +68,9 @@ uv run bora run examples/journeys --task terminal-jsonl-agg \
 
 ## 与 ACP 的关系
 
-默认 coding-agent 路径仍是 `executor: acp` + `options.entry`。插件是 **可选** 机制，
-与 ACP first-party 并列；同一 harness 只靠 profiles 切换。
+默认 coding-agent 路径仍是 `executor: Official/acp` + `options.entry`。
+install 不会把未点名的插件 bake 进纯 ACP job。要 bake 或其它 `on:` 槽，在
+`extensions` 里写出插件。插件是 **可选** 机制，与 ACP first-party 并列；同一
+harness 只靠 profiles 切换。
 
 更多机制契约见设计文档（贡献者侧 `docs/design`）；本页不改变证据等级声明。

--- a/website/content/docs/run/switch-agent.en.mdx
+++ b/website/content/docs/run/switch-agent.en.mdx
@@ -21,12 +21,12 @@ parameters:
 
 agent_profiles:
   - id: codex-mini
-    executor: acp
+    executor: Official/acp
     model: gpt-5.4-mini
     options:
       entry: codex
   - id: pi-mini
-    executor: acp
+    executor: Official/acp
     model: zai-coding-cn/glm-5.2
     api_key: glm_coding_api_key
     options:

--- a/website/content/docs/run/switch-agent.mdx
+++ b/website/content/docs/run/switch-agent.mdx
@@ -21,12 +21,12 @@ parameters:
 
 agent_profiles:
   - id: codex-mini
-    executor: acp
+    executor: Official/acp
     model: gpt-5.4-mini
     options:
       entry: codex
   - id: pi-mini
-    executor: acp
+    executor: Official/acp
     model: zai-coding-cn/glm-5.2
     api_key: glm_coding_api_key   # 环境变量名
     options:


### PR DESCRIPTION
Closes #113.

## Summary

Install is Recognition only. A job no longer bakes or runs `on:` handlers for plugins the profile did not name. First-party plugins use the same `org/name` form as Hub packages (`Official/acp`, `Official/openai-http`, `Official/mock`, `Official/default`). Official ACP with a FROM-only package Dockerfile and no selected bake reuses `bora-attempt:l1` and does not create a leftover `bora-pkg:*` tag.

No backward compatibility: short first-party ids are gone from profiles and lock.

## Binding

```yaml
bindings:
  solver:
    executor: Official/acp          # provide(executor) only
    # omit extensions → ACP-only; installed nooa/dsh stay off the image
  planner:
    executor: nooa
    extensions:
      - plugin: nooa                # all slots this plugin registered
  reviewer:
    executor: dsh
    extensions:
      - plugin: dsh
        slots: [image_contribute]   # listed slots only
```

- `executor:` does not imply bake.
- Unknown / unregistered slots fail closed.
- Hub `bora plugin publish --org` must match the `plugin_id` prefix.

## Official ACP image

When every bound profile is `Official/acp`, no selected `extensions` require bake, and the package Dockerfile is only `FROM bora-attempt:l1`, prepare uses the official tag. Extra `COPY`/`RUN` or a selected bake still builds `bora-pkg:{content}` (+ bake suffix).

## Evidence

- Unit / lock / bake / image-skip tests.
- `python-core` equivalent: 604 passed; `python-registry`: 100 passed, 1 skipped; ruff + pyright clean; website build OK.
- Live L1: `bora run examples/journeys --task terminal-jsonl-agg --profiles examples/journeys/profiles.dsh.yaml` → **PASS**, `image_contribute.baked=['dsh']`, tag `bora-pkg:…-dsh-…` (nooa installed but not baked).
- ACP-only lock on the same host (dsh+nooa installed): executor `Official/acp`, `image_contribute` is only `Official/default`.

Does not raise a public smoke grade.

## Docs

Design: `docs/design/11-extension-plugins.md`, `docs/design/05-runtime/provider-l1.md`.
Reader: journeys nooa/dsh profiles, website plugins + ACP pages, root READMEs. No GitHub issue numbers on public pages.