### PR TITLE
feat(viewer): delete local Jobs (cascade suite attempts)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -116,7 +116,8 @@ BORA/
 │   │   │                      # phase 体在 run_l0.py / run_l1_phases.py
 │   │   ├── suite/             # suite_run、fingerprint、suite_metrics
 │   │   ├── registry_ops/      # results / publish / login / org / list（注入 client factory）
-│   │   └── plugin_ops/        # plugin install / publish / image_contribute bake
+│   │   ├── plugin_ops/        # plugin install / publish / image_contribute bake
+│   │   └── local_jobs/        # 本机 Job 删除（Viewer / bora jobs delete；suite 级联 Attempt）
 │   ├── config/                # Core 1（load_and_lock + constants/yaml_io/overrides/digest/validate）
 │   ├── runtime/               # Core 2：identity、lifecycle、coordinator、task_worker、
 │   │                          # parent_agent_service + agent_service_protocol/evidence

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Agent benchmarks usually score the model and leave the **harness**—orchestrati
 - **Drop an existing harness into a shared boundary** — keep your workflow; the outer layer unifies config lock, isolation (host / Docker), visibility, and independent scoring for cross-framework reproduction
 - **Batch a full Dataset or a parameter matrix** — run every task in a suite, or campaign over allowlisted overrides such as seed / profile
 - **Aggregate suite scores and archive job results** — suite runs write observational `pass_rate` / `mean_score`; push them to the Registry when you need a shared results store
-- **Browse local runs in a Web UI** — `bora view` opens Jobs → Tasks → Attempt for suite jobs and single-task Attempts in the opened Database; drill into a run for Trajectory, multi-role Time/Usage, and optional provenance links
+- **Browse local runs in a Web UI** — `bora view` opens Jobs → Tasks → Attempt for suite jobs and single-task Attempts in the opened Database; drill into a run for Trajectory, multi-role Time/Usage, and optional provenance links. A Jobs row can delete that local tree (suite delete always cascades Attempts); `bora jobs delete --local … --yes` is the same use case
 - **Share packages and results on Registry / Hub** — upload a Dataset draft then `bora release`, or publish a release directly; invite members; share private results. Public Leaderboard lists complete, release-bound suite runs; incomplete or draft-bound rows stay on Jobs
 - **Review and export trajectories** — each invoke lands on disk; `bora evidence` exports a sealed copy for failure analysis or training pipelines
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,7 @@
 - **把已有 harness 接到统一边界** — 保留你自己的 workflow，外层统一锁定配置、隔离（本机 / Docker）、可见性与独立打分，便于跨框架复现
 - **整份 Dataset 或参数矩阵批量跑** — 一次跑完套件内多个 task，或用 campaign 扫 seed / profile 等允许覆盖的参数
 - **Suite 聚合分与 job 结果归档** — suite 跑完写入观测用的 `pass_rate` / `mean_score`；需要共享时可以上传到 Registry
-- **本机浏览跑次** — `bora view` 打开 Jobs → Tasks → Attempt，覆盖 suite job 与单题 Attempt；可钻进 run 看 Trajectory、多角色 Time/Usage 与 provenance 外链
+- **本机浏览跑次** — `bora view` 打开 Jobs → Tasks → Attempt，覆盖 suite job 与单题 Attempt；可钻进 run 看 Trajectory、多角色 Time/Usage 与 provenance 外链。Jobs 行可删本机证据树（删 suite 始终级联 Attempt）；CLI 对等 `bora jobs delete --local … --yes`
 - **用 Registry / Hub 共享包与结果** — 先上传 Dataset draft 再 `bora release`，或直接发 release；邀请成员、分享私有结果。公开 Leaderboard 只列完备且绑定 release 的 suite；缺题或 draft 绑定行只出现在 Jobs
 - **复盘与导出轨迹** — 每次 invoke 落盘证据；需要时 `bora evidence` 导出，供失败分析或训练管线
 

--- a/apps/viewer/AGENTS.md
+++ b/apps/viewer/AGENTS.md
@@ -27,10 +27,15 @@ When UI conflicts with taste: **DESIGN.md wins**.
    framework / docker / `provenance.upstream.url`. Multi-role groups Trajectory
    and Agent tree by `profile_id`. Usage/trajectory are observational ≠ PASS.
 5. **Breadcrumb** — `Jobs > jobId > taskId > runId` with `>` separators; click to navigate
-6. **Delete a local Job** — Jobs row action. Preview paths / bytes / cascade
-   `run_id`s, then confirm. Suite delete always removes referenced Attempts.
-   No delete control on an inner trial. Does not call Registry. Same
-   Application use case as `bora jobs delete --local … --yes`.
+6. **Delete a local Job** — Jobs row menu or bulk selection. Preview paths /
+   bytes / cascade `run_id`s, then confirm. Suite delete always removes
+   referenced Attempts. No delete control on an inner trial. Does not call
+   Registry. Same Application use case as `bora jobs delete --local … --yes`.
+7. **Pin / note (this browser)** — `localStorage` keyed by `database_id` +
+   `job_id`. Not written to evidence, lock, or Registry. Pinned rows sort
+   first. Action icon (always on): note, else pin, else hover settings.
+   Hover a note icon to read the note.
+   Click the settings/note control to open the menu (do not open on hover).
 
 **Out of scope unless user asks:**
 

--- a/apps/viewer/AGENTS.md
+++ b/apps/viewer/AGENTS.md
@@ -27,13 +27,19 @@ When UI conflicts with taste: **DESIGN.md wins**.
    framework / docker / `provenance.upstream.url`. Multi-role groups Trajectory
    and Agent tree by `profile_id`. Usage/trajectory are observational ≠ PASS.
 5. **Breadcrumb** — `Jobs > jobId > taskId > runId` with `>` separators; click to navigate
+6. **Delete a local Job** — Jobs row action. Preview paths / bytes / cascade
+   `run_id`s, then confirm. Suite delete always removes referenced Attempts.
+   No delete control on an inner trial. Does not call Registry. Same
+   Application use case as `bora jobs delete --local … --yes`.
 
 **Out of scope unless user asks:**
 
 - Public catalog, OAuth, Postgres, Leaderboard SPA (#22)
+- Hub / Registry write (publish, upload, release, remote delete)
 - Package file-tree / task-package browser (removed; Jobs is the product surface)
 - Marketing mesh gradients, dark neon skins, custom CSS component kits
 - Fabricating Harbor-only files or empty evidence tabs
+- Soft-delete trash, live cancel, `l1-work` cleanup, deleting one Attempt inside a suite
 
 ## Stack (mandatory)
 
@@ -75,6 +81,8 @@ Python API under `/api/*` (see `src/bora/viewer/`):
 | `GET /api/health` | Liveness |
 | `GET /api/jobs` | Job list (suite-runs + single-task Attempts) |
 | `GET /api/jobs/{id}` | Job detail + task rows |
+| `GET /api/jobs/{id}/delete-preview` | Paths, bytes, cascade run ids, confirm token; refuse reasons |
+| `DELETE /api/jobs/{id}?confirm=` | Hard-delete after preview token (suite cascades Attempts) |
 | `GET /api/jobs/{id}/tasks/{task_id}` | Task detail + enriched trials list + commands |
 | `GET /api/jobs/{id}/tasks/{task_id}/trials` | Trials list (suite + local evidence) |
 | `GET /api/jobs/{id}/tasks/{task_id}/trials/{run_id}` | Attempt meta + `available_tabs` |

--- a/apps/viewer/DESIGN.md
+++ b/apps/viewer/DESIGN.md
@@ -138,10 +138,12 @@ BORA Viewer is a **local results console** for one opened Database (no Registry)
 1. **Jobs** — suite runs under `.bora/suite-runs/` and unclaimed single Attempts
 2. **Tasks** — per-task rows inside a job summary
 3. **Trial / task detail** — run meta, reward/status, copyable `bora` command
-4. **Delete a Job** — Jobs-row action only. Suite delete always cascades
-   referenced Attempts. There is no control to delete one inner Attempt.
-   Preview paths and sizes, then confirm. Hub publish / upload / release stay
-   out of this UI.
+4. **Job row menu** — action slot is note, else pin, else hover settings.
+   Hover a note icon for the text. Click for Pin / Note / Delete.
+   Checkboxes select rows; with a selection, the filter-row count becomes
+   a bulk delete. Pin and notes live in this browser only. Delete still
+   previews, then confirms; suite delete always cascades Attempts. Hub
+   write stays out.
 
 Design is **Vercel product chrome**, not marketing hero mesh:
 
@@ -157,7 +159,7 @@ Upstream design inventory (marketing + full tokens) lives in the source
 
 | Route | Content |
 | --- | --- |
-| `/` | Jobs table: search, column sort, filters; delete row after preview |
+| `/` | Jobs table: search, filters, select, hover-reveal click menu (pin / note / delete) |
 | `/jobs/:jobId` | Tasks table for that suite run (no per-Attempt delete) |
 | `/jobs/:jobId/tasks/:taskId` | Trial-level detail + command strip |
 

--- a/apps/viewer/DESIGN.md
+++ b/apps/viewer/DESIGN.md
@@ -133,11 +133,15 @@ components:
 
 ## Overview
 
-BORA Viewer is a **local read-only results console**:
+BORA Viewer is a **local results console** for one opened Database (no Registry).
 
-1. **Jobs** — suite runs under `.bora/suite-runs/`
+1. **Jobs** — suite runs under `.bora/suite-runs/` and unclaimed single Attempts
 2. **Tasks** — per-task rows inside a job summary
 3. **Trial / task detail** — run meta, reward/status, copyable `bora` command
+4. **Delete a Job** — Jobs-row action only. Suite delete always cascades
+   referenced Attempts. There is no control to delete one inner Attempt.
+   Preview paths and sizes, then confirm. Hub publish / upload / release stay
+   out of this UI.
 
 Design is **Vercel product chrome**, not marketing hero mesh:
 
@@ -153,8 +157,8 @@ Upstream design inventory (marketing + full tokens) lives in the source
 
 | Route | Content |
 | --- | --- |
-| `/` | Jobs table: search, column sort, filters |
-| `/jobs/:jobId` | Tasks table for that suite run |
+| `/` | Jobs table: search, column sort, filters; delete row after preview |
+| `/jobs/:jobId` | Tasks table for that suite run (no per-Attempt delete) |
 | `/jobs/:jobId/tasks/:taskId` | Trial-level detail + command strip |
 
 Breadcrumb: `Jobs > {jobId} > {taskId}` with `>` separators; every non-current

--- a/apps/viewer/src/components/delete-job-dialog.tsx
+++ b/apps/viewer/src/components/delete-job-dialog.tsx
@@ -10,26 +10,47 @@ import {
 import { jobDisplayName } from "@/lib/routes";
 import { formatBytes } from "@/lib/utils";
 
-type Props = {
+type PreviewRow = {
   job: Job;
-  onClose: () => void;
-  onDeleted: () => void;
+  preview: DeletePreview | null;
+  error: string | null;
 };
 
-export function DeleteJobDialog({ job, onClose, onDeleted }: Props) {
-  const [preview, setPreview] = useState<DeletePreview | null>(null);
+type Props = {
+  jobs: Job[];
+  onClose: () => void;
+  onDeleted: (jobIds: string[]) => void;
+};
+
+export function DeleteJobDialog({ jobs, onClose, onDeleted }: Props) {
+  const [rows, setRows] = useState<PreviewRow[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
+  const ids = jobs.map((j) => j.job_id).join(",");
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    fetchDeletePreview(job.job_id)
-      .then((data) => {
-        if (cancelled) return;
-        setPreview(data);
-        setError(null);
+    Promise.all(
+      jobs.map(async (job) => {
+        try {
+          const preview = await fetchDeletePreview(job.job_id);
+          return { job, preview, error: preview.can_delete ? null : preview.error?.message || "cannot delete" };
+        } catch (e) {
+          return {
+            job,
+            preview: null,
+            error: e instanceof Error ? e.message : String(e),
+          };
+        }
+      }),
+    )
+      .then((next) => {
+        if (!cancelled) {
+          setRows(next);
+          setError(null);
+        }
       })
       .catch((e: Error) => {
         if (!cancelled) setError(e.message);
@@ -40,22 +61,41 @@ export function DeleteJobDialog({ job, onClose, onDeleted }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [job.job_id]);
+  }, [ids, jobs]);
+
+  const ready = rows.filter((r) => r.preview?.can_delete && r.preview.confirm_token);
+  const blocked = rows.filter((r) => r.error);
+  const paths = ready.flatMap((r) => r.preview?.paths || []);
+  const bytes = ready.reduce((sum, r) => sum + (r.preview?.bytes || 0), 0);
+  const cascade = ready.reduce((sum, r) => sum + (r.preview?.cascade_run_ids.length || 0), 0);
+  const bulk = jobs.length > 1;
+  const singleKind = rows[0]?.preview?.kind || jobs[0]?.source_kind || "job";
 
   async function onConfirm() {
-    if (!preview?.can_delete || !preview.confirm_token) return;
+    if (ready.length === 0) return;
     setBusy(true);
-    try {
-      await deleteJob(job.job_id, preview.confirm_token);
-      onDeleted();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-      setBusy(false);
+    const deleted: string[] = [];
+    const failures: string[] = [];
+    for (const row of ready) {
+      const token = row.preview?.confirm_token;
+      if (!token) continue;
+      try {
+        await deleteJob(row.job.job_id, token);
+        deleted.push(row.job.job_id);
+      } catch (e) {
+        failures.push(
+          `${jobDisplayName(row.job)}: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
     }
+    if (deleted.length && !failures.length) {
+      onDeleted(deleted);
+      return;
+    }
+    if (deleted.length) onDeleted(deleted);
+    setError(failures.join(" · ") || "nothing can be deleted");
+    setBusy(false);
   }
-
-  const kind = preview?.kind || job.source_kind || "job";
-  const refuse = preview?.error?.message || error;
 
   return (
     <div
@@ -72,14 +112,21 @@ export function DeleteJobDialog({ job, onClose, onDeleted }: Props) {
       >
         <div className="border-b border-hairline px-4 py-3">
           <h2 id="delete-job-title" className="text-sm font-medium text-ink">
-            Delete {kind} job
+            {bulk ? `Delete ${jobs.length} jobs` : `Delete ${singleKind} job`}
           </h2>
           <p className="mt-1 text-xs text-mute font-mono truncate">
-            {jobDisplayName(job)}
+            {bulk
+              ? jobs.map((j) => jobDisplayName(j)).join(", ")
+              : jobDisplayName(jobs[0])}
           </p>
         </div>
         <div className="px-4 py-3 space-y-3 text-sm">
-          {kind === "suite" ? (
+          {bulk ? (
+            <p className="text-body">
+              This removes each selected Job. Suite rows also delete every
+              Attempt they reference.
+            </p>
+          ) : singleKind === "suite" ? (
             <p className="text-body">
               This removes the suite tree and every Attempt it references. Those
               Attempts will not come back as singles.
@@ -88,13 +135,18 @@ export function DeleteJobDialog({ job, onClose, onDeleted }: Props) {
             <p className="text-body">This removes this Attempt directory.</p>
           )}
           {loading && <p className="text-mute">Loading preview...</p>}
-          {refuse && <p className="text-error">{refuse}</p>}
-          {preview && (
+          {error ? <p className="text-error">{error}</p> : null}
+          {blocked.map((row) => (
+            <p key={row.job.job_id} className="text-error">
+              {jobDisplayName(row.job)}: {row.error}
+            </p>
+          ))}
+          {paths.length > 0 && (
             <>
               <ul className="max-h-48 overflow-auto rounded-[6px] border border-hairline bg-canvas-soft divide-y divide-hairline">
-                {preview.paths.map((row) => (
+                {paths.map((row) => (
                   <li
-                    key={row.locator}
+                    key={`${row.locator}-${row.run_id || ""}`}
                     className="flex items-start justify-between gap-3 px-2.5 py-1.5"
                   >
                     <span className="font-mono text-xs break-all">
@@ -110,11 +162,9 @@ export function DeleteJobDialog({ job, onClose, onDeleted }: Props) {
                 ))}
               </ul>
               <p className="text-xs text-mute tabular">
-                {formatBytes(preview.bytes)} total
-                {preview.cascade_run_ids.length
-                  ? ` · ${preview.cascade_run_ids.length} attempt${
-                      preview.cascade_run_ids.length === 1 ? "" : "s"
-                    }`
+                {formatBytes(bytes)} total
+                {cascade
+                  ? ` · ${cascade} attempt${cascade === 1 ? "" : "s"}`
                   : ""}
               </p>
             </>
@@ -127,9 +177,9 @@ export function DeleteJobDialog({ job, onClose, onDeleted }: Props) {
           <Button
             type="button"
             onClick={() => void onConfirm()}
-            disabled={busy || loading || !preview?.can_delete}
+            disabled={busy || loading || ready.length === 0}
           >
-            {busy ? "Deleting..." : "Delete"}
+            {busy ? "Deleting..." : bulk ? `Delete ${ready.length}` : "Delete"}
           </Button>
         </div>
       </div>

--- a/apps/viewer/src/components/delete-job-dialog.tsx
+++ b/apps/viewer/src/components/delete-job-dialog.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  deleteJob,
+  fetchDeletePreview,
+  type DeletePreview,
+  type Job,
+} from "@/lib/api";
+import { jobDisplayName } from "@/lib/routes";
+import { formatBytes } from "@/lib/utils";
+
+type Props = {
+  job: Job;
+  onClose: () => void;
+  onDeleted: () => void;
+};
+
+export function DeleteJobDialog({ job, onClose, onDeleted }: Props) {
+  const [preview, setPreview] = useState<DeletePreview | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetchDeletePreview(job.job_id)
+      .then((data) => {
+        if (cancelled) return;
+        setPreview(data);
+        setError(null);
+      })
+      .catch((e: Error) => {
+        if (!cancelled) setError(e.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [job.job_id]);
+
+  async function onConfirm() {
+    if (!preview?.can_delete || !preview.confirm_token) return;
+    setBusy(true);
+    try {
+      await deleteJob(job.job_id, preview.confirm_token);
+      onDeleted();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setBusy(false);
+    }
+  }
+
+  const kind = preview?.kind || job.source_kind || "job";
+  const refuse = preview?.error?.message || error;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-ink/40 p-4"
+      role="presentation"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="delete-job-title"
+        className="w-full max-w-lg rounded-[8px] border border-hairline bg-canvas shadow-[0_8px_24px_-8px_#00000024]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="border-b border-hairline px-4 py-3">
+          <h2 id="delete-job-title" className="text-sm font-medium text-ink">
+            Delete {kind} job
+          </h2>
+          <p className="mt-1 text-xs text-mute font-mono truncate">
+            {jobDisplayName(job)}
+          </p>
+        </div>
+        <div className="px-4 py-3 space-y-3 text-sm">
+          {kind === "suite" ? (
+            <p className="text-body">
+              This removes the suite tree and every Attempt it references. Those
+              Attempts will not come back as singles.
+            </p>
+          ) : (
+            <p className="text-body">This removes this Attempt directory.</p>
+          )}
+          {loading && <p className="text-mute">Loading preview...</p>}
+          {refuse && <p className="text-error">{refuse}</p>}
+          {preview && (
+            <>
+              <ul className="max-h-48 overflow-auto rounded-[6px] border border-hairline bg-canvas-soft divide-y divide-hairline">
+                {preview.paths.map((row) => (
+                  <li
+                    key={row.locator}
+                    className="flex items-start justify-between gap-3 px-2.5 py-1.5"
+                  >
+                    <span className="font-mono text-xs break-all">
+                      {row.locator}
+                      {!row.exists ? (
+                        <span className="text-mute"> (missing)</span>
+                      ) : null}
+                    </span>
+                    <span className="tabular text-xs text-mute shrink-0">
+                      {formatBytes(row.bytes)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+              <p className="text-xs text-mute tabular">
+                {formatBytes(preview.bytes)} total
+                {preview.cascade_run_ids.length
+                  ? ` · ${preview.cascade_run_ids.length} attempt${
+                      preview.cascade_run_ids.length === 1 ? "" : "s"
+                    }`
+                  : ""}
+              </p>
+            </>
+          )}
+        </div>
+        <div className="flex justify-end gap-2 border-t border-hairline px-4 py-3">
+          <Button type="button" variant="ghost" onClick={onClose} disabled={busy}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => void onConfirm()}
+            disabled={busy || loading || !preview?.can_delete}
+          >
+            {busy ? "Deleting..." : "Delete"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/job-check.tsx
+++ b/apps/viewer/src/components/job-check.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react";
+
+type Props = {
+  checked: boolean;
+  indeterminate?: boolean;
+  label: string;
+  onChange: (next: boolean) => void;
+};
+
+export function JobCheck({ checked, indeterminate, label, onChange }: Props) {
+  const ref = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (ref.current) ref.current.indeterminate = Boolean(indeterminate);
+  }, [indeterminate]);
+
+  return (
+    <input
+      ref={ref}
+      type="checkbox"
+      checked={checked}
+      aria-label={label}
+      className="h-3.5 w-3.5 shrink-0 rounded-[3px] border-hairline accent-ink"
+      onClick={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+      onChange={(e) => {
+        e.stopPropagation();
+        onChange(e.target.checked);
+      }}
+    />
+  );
+}

--- a/apps/viewer/src/components/job-note-dialog.tsx
+++ b/apps/viewer/src/components/job-note-dialog.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useId, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import type { Job } from "@/lib/api";
+import { jobDisplayName } from "@/lib/routes";
+
+const NOTE_MAX = 2000;
+
+type Props = {
+  job: Job;
+  initialNote: string;
+  onClose: () => void;
+  onSave: (note: string) => void;
+};
+
+export function JobNoteDialog({ job, initialNote, onClose, onSave }: Props) {
+  const [text, setText] = useState(initialNote);
+  const titleId = useId();
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  function submit() {
+    onSave(text.trim());
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-ink/40 p-4"
+      role="presentation"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="w-full max-w-lg rounded-[8px] border border-hairline bg-canvas shadow-[0_8px_24px_-8px_#00000024]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="border-b border-hairline px-4 py-3">
+          <h2 id={titleId} className="text-sm font-medium text-ink">
+            Note
+          </h2>
+          <p className="mt-1 text-xs text-mute font-mono truncate">
+            {jobDisplayName(job)}
+          </p>
+        </div>
+        <div className="px-4 py-3 space-y-2">
+          <textarea
+            autoFocus
+            value={text}
+            maxLength={NOTE_MAX}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                e.preventDefault();
+                submit();
+              }
+            }}
+            placeholder="Local note for this browser. Not written to evidence."
+            className="min-h-[8rem] w-full resize-y rounded-[6px] border border-hairline bg-canvas px-3 py-2 text-sm text-ink placeholder:text-mute focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink/15 focus-visible:border-hairline-strong"
+            aria-label="Job note"
+          />
+          <p className="text-xs text-mute tabular">
+            {text.length}/{NOTE_MAX} · stays in this browser
+          </p>
+        </div>
+        <div className="flex justify-end gap-2 border-t border-hairline px-4 py-3">
+          <Button type="button" variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={submit}>
+            Save
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/job-row-actions.tsx
+++ b/apps/viewer/src/components/job-row-actions.tsx
@@ -1,0 +1,97 @@
+import { Pin, Settings, StickyNote, Trash2 } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { Job } from "@/lib/api";
+import type { JobPref } from "@/lib/job-prefs";
+import { hasJobNote } from "@/lib/job-prefs";
+import { jobDisplayName } from "@/lib/routes";
+
+type Props = {
+  job: Job;
+  pref: JobPref;
+  onPin: () => void;
+  onNote: () => void;
+  onDelete: () => void;
+};
+
+export function JobRowActions({ job, pref, onPin, onNote, onDelete }: Props) {
+  const [open, setOpen] = useState(false);
+  const noted = hasJobNote(pref);
+  const pinned = Boolean(pref.pinned);
+  const keepVisible = noted || pinned;
+  const name = jobDisplayName(job);
+  const icon = noted ? (
+    <StickyNote className="h-4 w-4" />
+  ) : pinned ? (
+    <Pin className="h-4 w-4" />
+  ) : (
+    <Settings className="h-4 w-4" />
+  );
+
+  const trigger = (
+    <DropdownMenuTrigger asChild>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        data-job-actions=""
+        data-has-note={noted ? "" : undefined}
+        data-pinned={pinned && !noted ? "" : undefined}
+        aria-label={`Actions for ${name}`}
+        aria-haspopup="menu"
+        className="h-7 w-7 opacity-0 transition-opacity focus-visible:opacity-100 [@media(hover:none)]:opacity-100"
+        style={open || keepVisible ? { opacity: 1 } : undefined}
+      >
+        {icon}
+      </Button>
+    </DropdownMenuTrigger>
+  );
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      {noted ? (
+        <TooltipProvider delayDuration={200}>
+          <Tooltip open={open ? false : undefined}>
+            <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+            <TooltipContent side="left" className="max-w-sm break-all">
+              {pref.note}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        trigger
+      )}
+      <DropdownMenuContent align="end" onCloseAutoFocus={(e) => e.preventDefault()}>
+        <DropdownMenuItem
+          onSelect={() => {
+            onPin();
+          }}
+        >
+          <Pin className="h-3.5 w-3.5" />
+          {pref.pinned ? "Unpin" : "Pin"}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onNote}>
+          <StickyNote className="h-3.5 w-3.5" />
+          Note
+        </DropdownMenuItem>
+        <DropdownMenuItem className="text-error focus:text-error" onSelect={onDelete}>
+          <Trash2 className="h-3.5 w-3.5" />
+          Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/viewer/src/index.css
+++ b/apps/viewer/src/index.css
@@ -169,3 +169,11 @@
   font-family: var(--font-mono);
   font-size: 13px;
 }
+
+/* Table-row hover is more reliable than Tailwind group-hover on <tr>. */
+tbody tr.group:hover [data-job-actions],
+tbody tr.group:focus-within [data-job-actions],
+[data-job-actions][data-has-note],
+[data-job-actions][data-pinned] {
+  opacity: 1;
+}

--- a/apps/viewer/src/lib/api.ts
+++ b/apps/viewer/src/lib/api.ts
@@ -162,6 +162,36 @@ export type TrajectoryStep = {
 
 export type Breadcrumb = { label: string; href: string | null };
 
+export type DeletePath = {
+  locator: string;
+  bytes: number;
+  role: "suite" | "attempt" | string;
+  exists: boolean;
+  run_id?: string;
+};
+
+export type DeletePreview = {
+  ok: boolean;
+  job_id: string;
+  kind: "suite" | "single" | string;
+  can_delete: boolean;
+  paths: DeletePath[];
+  bytes: number;
+  cascade_run_ids: string[];
+  confirm_token: string;
+  error?: { code?: string; message?: string } | null;
+};
+
+export type DeleteResult = {
+  ok: boolean;
+  job_id: string;
+  kind: "suite" | "single" | string;
+  deleted: string[];
+  missing: string[];
+  bytes: number;
+  cascade_run_ids: string[];
+};
+
 async function getJson<T>(path: string): Promise<T> {
   const res = await fetch(path, { headers: { Accept: "application/json" } });
   const data = (await res.json().catch(() => ({}))) as {
@@ -172,6 +202,28 @@ async function getJson<T>(path: string): Promise<T> {
     throw new Error(data.message || data.error || `HTTP ${res.status}`);
   }
   return data as T;
+}
+
+export function fetchDeletePreview(jobId: string) {
+  return getJson<DeletePreview>(
+    `/api/jobs/${encodeURIComponent(jobId)}/delete-preview`,
+  );
+}
+
+export async function deleteJob(jobId: string, confirmToken: string) {
+  const q = new URLSearchParams({ confirm: confirmToken });
+  const res = await fetch(`/api/jobs/${encodeURIComponent(jobId)}?${q}`, {
+    method: "DELETE",
+    headers: { Accept: "application/json" },
+  });
+  const data = (await res.json().catch(() => ({}))) as {
+    error?: string;
+    message?: string;
+  } & DeleteResult;
+  if (!res.ok) {
+    throw new Error(data.message || data.error || `HTTP ${res.status}`);
+  }
+  return data;
 }
 
 export function fetchJobs() {

--- a/apps/viewer/src/lib/job-prefs.ts
+++ b/apps/viewer/src/lib/job-prefs.ts
@@ -1,0 +1,77 @@
+/** Operator chrome for Jobs rows. Browser-local only; not evidence. */
+
+export type JobPref = {
+  pinned: boolean;
+  note: string;
+};
+
+const STORAGE_KEY = "bora-viewer-job-prefs";
+
+type Store = Record<string, Record<string, JobPref>>;
+
+export function emptyJobPref(): JobPref {
+  return { pinned: false, note: "" };
+}
+
+export function prefsScope(databaseId: string | null | undefined): string {
+  const text = (databaseId || "").trim();
+  return text || "_";
+}
+
+export function hasJobNote(pref: JobPref | undefined): boolean {
+  return Boolean(pref?.note.trim());
+}
+
+function readStore(): Store {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const data = JSON.parse(raw) as unknown;
+    if (!data || typeof data !== "object" || Array.isArray(data)) return {};
+    return data as Store;
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: Store): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    /* quota / private mode */
+  }
+}
+
+export function loadJobPrefs(databaseId: string): Record<string, JobPref> {
+  const scope = prefsScope(databaseId);
+  const bucket = readStore()[scope];
+  if (!bucket || typeof bucket !== "object") return {};
+  const out: Record<string, JobPref> = {};
+  for (const [jobId, raw] of Object.entries(bucket)) {
+    if (!raw || typeof raw !== "object") continue;
+    const pinned = Boolean((raw as JobPref).pinned);
+    const note = typeof (raw as JobPref).note === "string" ? (raw as JobPref).note : "";
+    if (!pinned && !note.trim()) continue;
+    out[jobId] = { pinned, note };
+  }
+  return out;
+}
+
+export function saveJobPrefs(
+  databaseId: string,
+  prefs: Record<string, JobPref>,
+): void {
+  const scope = prefsScope(databaseId);
+  const store = readStore();
+  const bucket: Record<string, JobPref> = {};
+  for (const [jobId, pref] of Object.entries(prefs)) {
+    if (!pref.pinned && !pref.note.trim()) continue;
+    bucket[jobId] = { pinned: pref.pinned, note: pref.note };
+  }
+  if (Object.keys(bucket).length === 0) {
+    delete store[scope];
+  } else {
+    store[scope] = bucket;
+  }
+  writeStore(store);
+}

--- a/apps/viewer/src/lib/utils.ts
+++ b/apps/viewer/src/lib/utils.ts
@@ -38,6 +38,22 @@ export function formatAxisLabel(raw: string | null | undefined): {
   return { text: `${parts[0]}+...`, title: parts.join("+") };
 }
 
+export function formatBytes(value: number | null | undefined): string {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) return "-";
+  if (n < 1024) return `${Math.round(n)} B`;
+  const units = ["KB", "MB", "GB"];
+  let amount = n / 1024;
+  let unit = units[0];
+  for (const next of units.slice(1)) {
+    if (amount < 1024) break;
+    amount /= 1024;
+    unit = next;
+  }
+  const digits = amount < 10 ? 1 : 0;
+  return `${amount.toFixed(digits)} ${unit}`;
+}
+
 export function formatDate(iso: string | null | undefined): string {
   if (!iso) return "-";
   try {

--- a/apps/viewer/src/pages/JobsPage.tsx
+++ b/apps/viewer/src/pages/JobsPage.tsx
@@ -1,7 +1,8 @@
-import { Search } from "lucide-react";
+import { Search, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { DeleteJobDialog } from "@/components/delete-job-dialog";
 import { Shell } from "@/components/layout";
 import {
   compareValues,
@@ -25,6 +26,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
 import { fetchJobs, type Job } from "@/lib/api";
 import { jobDisplayName, jobHref } from "@/lib/routes";
 import { AxisLabel } from "@/components/axis-label";
@@ -53,6 +55,8 @@ export function JobsPage() {
   const [model, setModel] = useState("all");
   const [sortKey, setSortKey] = useState<string | null>("started");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [pendingDelete, setPendingDelete] = useState<Job | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -73,7 +77,7 @@ export function JobsPage() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [reloadToken]);
 
   const kinds = useMemo(
     () =>
@@ -276,26 +280,29 @@ export function JobsPage() {
                 <TableHead>{head("started", "Started")}</TableHead>
                 <TableHead>Duration</TableHead>
                 <TableHead>{head("trials_total", "Trials")}</TableHead>
+                <TableHead className="w-12">
+                  <span className="sr-only">Actions</span>
+                </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {loading && (
                 <TableRow>
-                  <TableCell colSpan={8} className="text-mute py-10 text-center">
+                  <TableCell colSpan={9} className="text-mute py-10 text-center">
                     Loading jobs...
                   </TableCell>
                 </TableRow>
               )}
               {!loading && error && (
                 <TableRow>
-                  <TableCell colSpan={8} className="text-error py-10 text-center">
+                  <TableCell colSpan={9} className="text-error py-10 text-center">
                     {error}
                   </TableCell>
                 </TableRow>
               )}
               {!loading && !error && filtered.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={8} className="text-mute py-10 text-center">
+                  <TableCell colSpan={9} className="text-mute py-10 text-center">
                     No jobs yet. Run{" "}
                     <code className="font-mono text-xs bg-canvas-soft px-1.5 py-0.5 rounded">
                       bora run &lt;database&gt;
@@ -353,12 +360,36 @@ export function JobsPage() {
                     <TableCell className="tabular">
                       {formatTrials(job.trials_done, job.trials_total)}
                     </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Delete job ${jobDisplayName(job)}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setPendingDelete(job);
+                        }}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </TableCell>
                   </TableRow>
                 ))}
             </TableBody>
           </Table>
         </div>
       </div>
+      {pendingDelete ? (
+        <DeleteJobDialog
+          job={pendingDelete}
+          onClose={() => setPendingDelete(null)}
+          onDeleted={() => {
+            setPendingDelete(null);
+            setReloadToken((n) => n + 1);
+          }}
+        />
+      ) : null}
     </Shell>
   );
 }

--- a/apps/viewer/src/pages/JobsPage.tsx
+++ b/apps/viewer/src/pages/JobsPage.tsx
@@ -1,8 +1,11 @@
 import { Search, Trash2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { DeleteJobDialog } from "@/components/delete-job-dialog";
+import { JobCheck } from "@/components/job-check";
+import { JobNoteDialog } from "@/components/job-note-dialog";
+import { JobRowActions } from "@/components/job-row-actions";
 import { Shell } from "@/components/layout";
 import {
   compareValues,
@@ -18,6 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -26,8 +30,13 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Button } from "@/components/ui/button";
 import { fetchJobs, type Job } from "@/lib/api";
+import {
+  emptyJobPref,
+  loadJobPrefs,
+  saveJobPrefs,
+  type JobPref,
+} from "@/lib/job-prefs";
 import { jobDisplayName, jobHref } from "@/lib/routes";
 import { AxisLabel } from "@/components/axis-label";
 import { HoverTip } from "@/components/hover-tip";
@@ -55,7 +64,10 @@ export function JobsPage() {
   const [model, setModel] = useState("all");
   const [sortKey, setSortKey] = useState<string | null>("started");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
-  const [pendingDelete, setPendingDelete] = useState<Job | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<Job[] | null>(null);
+  const [pendingNote, setPendingNote] = useState<Job | null>(null);
+  const [prefs, setPrefs] = useState<Record<string, JobPref>>({});
+  const [selected, setSelected] = useState<Record<string, true>>({});
   const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
@@ -78,6 +90,33 @@ export function JobsPage() {
       cancelled = true;
     };
   }, [reloadToken]);
+
+  useEffect(() => {
+    setPrefs(loadJobPrefs(dbId));
+  }, [dbId]);
+
+  const writePrefs = useCallback(
+    (next: Record<string, JobPref>) => {
+      setPrefs(next);
+      saveJobPrefs(dbId, next);
+    },
+    [dbId],
+  );
+
+  function prefFor(jobId: string): JobPref {
+    return prefs[jobId] || emptyJobPref();
+  }
+
+  function patchPref(jobId: string, patch: Partial<JobPref>) {
+    const merged: JobPref = { ...prefFor(jobId), ...patch };
+    const next = { ...prefs };
+    if (!merged.pinned && !merged.note.trim()) {
+      delete next[jobId];
+    } else {
+      next[jobId] = merged;
+    }
+    writePrefs(next);
+  }
 
   const kinds = useMemo(
     () =>
@@ -133,36 +172,64 @@ export function JobsPage() {
         j.agent_label,
         j.model_label,
         j.environment,
+        prefs[j.job_id]?.note,
       ]
         .filter(Boolean)
         .join(" ")
         .toLowerCase();
       return hay.includes(query);
     });
-    if (sortKey && sortDir) {
+    rows = [...rows].sort((a, b) => {
+      const pin = Number(Boolean(prefs[b.job_id]?.pinned)) - Number(Boolean(prefs[a.job_id]?.pinned));
+      if (pin !== 0) return pin;
+      if (!sortKey || !sortDir) return 0;
       const key = sortKey as SortKey;
-      rows = [...rows].sort((a, b) => {
-        const av =
-          key === "result"
-            ? (a.mean_score ?? a.result)
-            : key === "trials_total"
-              ? a.trials_total
-              : key === "job_name"
-                ? jobDisplayName(a)
-                : a[key];
-        const bv =
-          key === "result"
-            ? (b.mean_score ?? b.result)
-            : key === "trials_total"
-              ? b.trials_total
-              : key === "job_name"
-                ? jobDisplayName(b)
-                : b[key];
-        return compareValues(av, bv, sortDir);
-      });
-    }
+      const av =
+        key === "result"
+          ? (a.mean_score ?? a.result)
+          : key === "trials_total"
+            ? a.trials_total
+            : key === "job_name"
+              ? jobDisplayName(a)
+              : a[key];
+      const bv =
+        key === "result"
+          ? (b.mean_score ?? b.result)
+          : key === "trials_total"
+            ? b.trials_total
+            : key === "job_name"
+              ? jobDisplayName(b)
+              : b[key];
+      return compareValues(av, bv, sortDir);
+    });
     return rows;
-  }, [jobs, q, kind, source, showSourceFilter, agent, model, sortKey, sortDir]);
+  }, [jobs, q, kind, source, showSourceFilter, agent, model, sortKey, sortDir, prefs]);
+
+  const selectedVisible = filtered.filter((j) => selected[j.job_id]);
+  const selectedCount = selectedVisible.length;
+  const allVisibleSelected =
+    filtered.length > 0 && selectedVisible.length === filtered.length;
+  const someVisibleSelected = selectedVisible.length > 0 && !allVisibleSelected;
+
+  function toggleOne(jobId: string, next: boolean) {
+    setSelected((prev) => {
+      const copy = { ...prev };
+      if (next) copy[jobId] = true;
+      else delete copy[jobId];
+      return copy;
+    });
+  }
+
+  function toggleAllVisible(next: boolean) {
+    setSelected((prev) => {
+      const copy = { ...prev };
+      for (const job of filtered) {
+        if (next) copy[job.job_id] = true;
+        else delete copy[job.job_id];
+      }
+      return copy;
+    });
+  }
 
   function onSort(key: string) {
     const next = nextSort(sortKey, sortDir, key);
@@ -263,15 +330,39 @@ export function JobsPage() {
             </SelectContent>
           </Select>
           <div className="flex-1" />
-          <span className="text-xs text-mute">
-            {filtered.length} job{filtered.length === 1 ? "" : "s"}
-          </span>
+          {selectedCount > 0 ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="text-error hover:text-error"
+              onClick={() => {
+                const rows = filtered.filter((j) => selected[j.job_id]);
+                if (rows.length) setPendingDelete(rows);
+              }}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Delete {selectedCount}
+            </Button>
+          ) : (
+            <span className="text-xs text-mute">
+              {filtered.length} job{filtered.length === 1 ? "" : "s"}
+            </span>
+          )}
         </div>
 
         <div className="rounded-[8px] border border-hairline overflow-hidden">
           <Table>
             <TableHeader>
               <TableRow className="hover:bg-transparent">
+                <TableHead className="w-8 pr-0">
+                  <JobCheck
+                    checked={allVisibleSelected}
+                    indeterminate={someVisibleSelected}
+                    label="Select all jobs"
+                    onChange={toggleAllVisible}
+                  />
+                </TableHead>
                 <TableHead>{head("job_name", "Job Name")}</TableHead>
                 <TableHead>{head("agent_label", "Agents")}</TableHead>
                 <TableHead>{head("model_label", "Models")}</TableHead>
@@ -280,7 +371,7 @@ export function JobsPage() {
                 <TableHead>{head("started", "Started")}</TableHead>
                 <TableHead>Duration</TableHead>
                 <TableHead>{head("trials_total", "Trials")}</TableHead>
-                <TableHead className="w-12">
+                <TableHead className="w-7 pl-0 pr-2">
                   <span className="sr-only">Actions</span>
                 </TableHead>
               </TableRow>
@@ -288,21 +379,21 @@ export function JobsPage() {
             <TableBody>
               {loading && (
                 <TableRow>
-                  <TableCell colSpan={9} className="text-mute py-10 text-center">
+                  <TableCell colSpan={10} className="text-mute py-10 text-center">
                     Loading jobs...
                   </TableCell>
                 </TableRow>
               )}
               {!loading && error && (
                 <TableRow>
-                  <TableCell colSpan={9} className="text-error py-10 text-center">
+                  <TableCell colSpan={10} className="text-error py-10 text-center">
                     {error}
                   </TableCell>
                 </TableRow>
               )}
               {!loading && !error && filtered.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={9} className="text-mute py-10 text-center">
+                  <TableCell colSpan={10} className="text-mute py-10 text-center">
                     No jobs yet. Run{" "}
                     <code className="font-mono text-xs bg-canvas-soft px-1.5 py-0.5 rounded">
                       bora run &lt;database&gt;
@@ -320,9 +411,17 @@ export function JobsPage() {
                 filtered.map((job) => (
                   <TableRow
                     key={job.job_id}
-                    className="cursor-pointer"
-                    onClick={() => navigate(jobHref(job))}
+                    className="group cursor-pointer"
+                    onClick={(e) => {
+                      const el = e.target as HTMLElement;
+                      if (el.closest("input, button, [role='menu'], [role='menuitem']")) {
+                        return;
+                      }
+                      navigate(jobHref(job));
+                    }}
                     onKeyDown={(e) => {
+                      const el = e.target as HTMLElement;
+                      if (el.closest("input, button")) return;
                       if (e.key === "Enter") {
                         navigate(jobHref(job));
                       }
@@ -330,11 +429,16 @@ export function JobsPage() {
                     tabIndex={0}
                     role="link"
                   >
+                    <TableCell className="w-8 pr-0">
+                      <JobCheck
+                        checked={Boolean(selected[job.job_id])}
+                        label={`Select ${jobDisplayName(job)}`}
+                        onChange={(next) => toggleOne(job.job_id, next)}
+                      />
+                    </TableCell>
                     <TableCell className="font-medium max-w-[16rem]">
                       <HoverTip content={jobDisplayName(job)}>
-                        <span className="block truncate">
-                          {jobDisplayName(job)}
-                        </span>
+                        <span className="block truncate">{jobDisplayName(job)}</span>
                       </HoverTip>
                     </TableCell>
                     <TableCell className="max-w-[14rem]">
@@ -360,19 +464,18 @@ export function JobsPage() {
                     <TableCell className="tabular">
                       {formatTrials(job.trials_done, job.trials_total)}
                     </TableCell>
-                    <TableCell className="text-right">
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        aria-label={`Delete job ${jobDisplayName(job)}`}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setPendingDelete(job);
-                        }}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
+                    <TableCell className="w-7 pl-0 pr-2 text-right">
+                      <JobRowActions
+                        job={job}
+                        pref={prefFor(job.job_id)}
+                        onPin={() =>
+                          patchPref(job.job_id, {
+                            pinned: !prefFor(job.job_id).pinned,
+                          })
+                        }
+                        onNote={() => setPendingNote(job)}
+                        onDelete={() => setPendingDelete([job])}
+                      />
                     </TableCell>
                   </TableRow>
                 ))}
@@ -380,11 +483,30 @@ export function JobsPage() {
           </Table>
         </div>
       </div>
+      {pendingNote ? (
+        <JobNoteDialog
+          job={pendingNote}
+          initialNote={prefFor(pendingNote.job_id).note}
+          onClose={() => setPendingNote(null)}
+          onSave={(note) => {
+            patchPref(pendingNote.job_id, { note });
+            setPendingNote(null);
+          }}
+        />
+      ) : null}
       {pendingDelete ? (
         <DeleteJobDialog
-          job={pendingDelete}
+          jobs={pendingDelete}
           onClose={() => setPendingDelete(null)}
-          onDeleted={() => {
+          onDeleted={(jobIds) => {
+            const nextPrefs = { ...prefs };
+            const nextSelected = { ...selected };
+            for (const id of jobIds) {
+              delete nextPrefs[id];
+              delete nextSelected[id];
+            }
+            writePrefs(nextPrefs);
+            setSelected(nextSelected);
             setPendingDelete(null);
             setReloadToken((n) => n + 1);
           }}

--- a/docs/design/12-hub-dataset-and-leaderboard.md
+++ b/docs/design/12-hub-dataset-and-leaderboard.md
@@ -11,6 +11,7 @@
 > [!important] 设计决定
 > Dataset 在 Registry 上按 git 隐喻维护：**一份可覆盖的 draft** 与 **不可变 releases**。ACL 在 dataset 上，不在 task 上。Hub 是只读操作面，不提供 publish / upload / release 按钮。
 > Leaderboard 行是**完备的 suite 跑次**，不是 suite-level PASS。缺题结果不上榜；题上 FAIL 仍算完备。公开榜只收绑定 **release** 的完备 suite；draft 绑定行只出现在 Jobs。
+> 本地 Viewer 可删除**当前打开的** Database 根下的 Job 树（suite 始终级联 Attempt）。这不是第二条 Control Plane，也不写 Hub / Registry。
 
 ## Dataset：draft 与 release
 
@@ -116,18 +117,44 @@ Plugin 页把 provide/on chips 换成 **L0–L5 声明槽时间线**：
 
 ## 本地 Viewer（操作面）
 
-本地 Viewer 绑定**一个** Database 根，不连 Registry。
+本地 Viewer 绑定**一个** Database 根，不连 Registry。Hub 的写路径（publish / upload / release）仍只在 CLI；本地 Viewer **不是**第二条 Control Plane。
 
 - `bora view --dev` 只起 API，不要求预构建 SPA；Vite 源是 UI。两进程契约：API 端口 + UI 端口。
 - CLI 接受打开路径（job / task / run），深链到同一套客户端路由。
 - Jobs 列出该根下的 suite-run **和** 单题 Attempt（database 级与 task-local `.bora/runs`）；用 `source_kind` 区分。不扫描其它 Database。
 
+### 本机 Job 删除
+
+操作者可从 Jobs 列表删除**一行**本地 Job。删除是擦除该 Database 根下的证据树，不是改 `result.json`、分数或 PASS。同一 `run_id` / `suite_run_id` 若已上传到 Hub，Registry 行是另一对象，本地删除不调用 Registry。
+
+| 动作 | 磁盘 | 之后 |
+| --- | --- | --- |
+| 删除 `source_kind=single` | 该 Attempt 树：`<db>/.bora/runs/<run_id>/` 或 `tasks/<id>/.bora/runs/<run_id>/` | 该行消失；其它 Job 不动 |
+| 删除 `source_kind=suite` | suite 树 **以及它引用的每一个 Attempt**（`task_refs` / `attempts[]` / `attempt_run_ids`） | suite 与这些 Attempt 都消失；**不得**再以 single 回流 |
+| 从 suite 内删一条 Attempt | **拒绝** | 只能删整行 suite Job，或什么都不删 |
+
+级联是 suite 删除的**唯一**行为，不是开关。没有「只删 suite 元数据」的路径。
+
+硬规则：
+
+1. 二次确认：先 preview（相对路径、字节数、将删除的 `run_id`），再确认。CLI 对等入口需要显式 `--yes`。
+2. suite 仍在进行（`progress.json` 未结束，或 `cancel.requested` 仍在）→ 拒绝。
+3. 引用的 Attempt 仍被**另一尚未删除的** suite 认领 → 拒绝（不得静默偷走）。
+4. 路径逃逸（`..`、多段 id）→ 拒绝。路径字符串由 evidence locator 拥有（`.bora/runs/`、`.bora/suite-runs/`）。
+5. Preview / 删除载荷不得含密钥或 host 绝对路径。
+6. 不重算 suite 指标；没有「去掉一条 Attempt 再改 `summary.json`」。
+7. `l1-work/`（`--keep-workspace` 残留）不在本操作范围内。
+
+同一 Application 用例同时服务 Viewer HTTP 与 CLI。HTTP 只路由。
+
 ## 非目标
 
 - Hub GUI 写操作（publish / upload-suite / release 按钮）
+- 经 Viewer 删除 / 改可见性 Registry 行
 - per-task ACL、多份 named draft
 - suite-level PASS 权威
 - Viewer 跨 Dataset 扫描
 - 证据等级升级
 - Leaderboard 条内嵌 L0–L5 时间线（时间线只在插件详情）
 - 按 job 实际走过的槽画执行图（需要 run evidence，不是声明槽）
+- 软删除回收站 / 事后 gc；v1 是确认后的硬删除

--- a/skills/bora-cli/SKILL.md
+++ b/skills/bora-cli/SKILL.md
@@ -53,6 +53,7 @@ uv run bora --help
 | `bora results share\|unshare …`                               | Grant / revoke private result access (owner only)                                                  |
 | `bora results export-profiles <suite_run_id> --out …`         | Rehydrate job binding as profiles.yaml (locators only)                                             |
 | `bora view <database> [--dev] [--open …]`                     | Local Jobs UI (no Registry). `--dev` starts Vite when possible; `--open` deep-links a job/task/run |
+| `bora jobs delete --local <db> --job <id> --yes`              | Delete a local Job tree (suite always cascades Attempts). Preview without `--yes`; not Registry |
 | `bora publish … --org … [--draft] [--replace]`                | Package publish; `--draft` overwrites the draft slot; `--replace` is org-owner only                |
 | `bora release <database_id>`                                  | Owner: promote the current dataset draft to an immutable version                                   |
 | `bora registry delete\|set-visibility <id@ver>`               | Org-owner package delete (`--yes`) / visibility flip                                               |

--- a/skills/bora-cli/references/commands.md
+++ b/skills/bora-cli/references/commands.md
@@ -141,11 +141,22 @@ bora results upload-suite <db> --suite-run <8-hex> --public [--with-attempts]
 
 ## `bora view`
 
-- Local read-only Database UI. No Registry.
+- Local Database UI. No Registry. Jobs row can delete a local Job after preview.
 - `--dev`: API only; starts `apps/viewer` Vite when possible, else prints the
   two-process fallback. Advertise `:5173` only after Vite is listening.
 - `--open /jobs/<id>` (or a task/run path) deep-links after a local run.
 - Jobs list includes suite runs **and** single-task Attempts in the opened Database.
+
+## `bora jobs delete`
+
+- Same use case as Viewer Job delete. **Not** `bora results delete` (Registry).
+- `--local <database>` `--job <id>`: `id` is a suite_run_id or an **unclaimed**
+  single `run_id`.
+- Without `--yes`: print preview JSON (paths, bytes, cascade run ids) and exit 2.
+- With `--yes`: hard-delete those trees. Suite delete always cascades referenced
+  Attempts; they must not reappear as singles.
+- Refuses: inner Attempt still claimed by a suite; in-progress suite /
+  live `cancel.requested`; path escape; Attempt claimed by another remaining suite.
 
 ## Registry owner ops
 

--- a/src/bora/application/composition.py
+++ b/src/bora/application/composition.py
@@ -74,6 +74,13 @@ def build_results_commands() -> Any:
     return ResultsCommands(client_factory=build_registry_client)
 
 
+def build_local_jobs_commands() -> Any:
+    """Local Job delete for Viewer / ``bora jobs delete`` (no Registry)."""
+    from bora.application.local_jobs import LocalJobsCommands
+
+    return LocalJobsCommands()
+
+
 def build_registry_list_commands() -> Any:
     """Package list/show/delete/visibility and local cache helpers."""
     from bora.application.registry_ops.registry_list_command import RegistryListCommands

--- a/src/bora/application/local_jobs/__init__.py
+++ b/src/bora/application/local_jobs/__init__.py
@@ -1,0 +1,5 @@
+"""Local Job operator use cases (Viewer / CLI; no Registry)."""
+
+from bora.application.local_jobs.delete_job import LocalJobsCommands
+
+__all__ = ["LocalJobsCommands"]

--- a/src/bora/application/local_jobs/delete_job.py
+++ b/src/bora/application/local_jobs/delete_job.py
@@ -1,0 +1,343 @@
+"""Delete a local Viewer Job (single Attempt or cascading suite)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+from bora.config.errors import ConfigError
+from bora.evidence.locators import (
+    default_suite_runs_root,
+    resolve_evidence_root,
+    safe_id_segment,
+)
+from bora.registry.resolve import resolve_database_root
+
+_FINISHED_PROGRESS = frozenset(
+    {"complete", "completed", "finished", "done", "cancelled", "canceled"}
+)
+
+
+def _load_json_object(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _confine(root: Path, path: Path, *, location: str) -> Path:
+    root_r = root.expanduser().resolve(strict=False)
+    cand = path.expanduser().resolve(strict=False)
+    try:
+        cand.relative_to(root_r)
+    except ValueError as exc:
+        raise ConfigError(
+            "invalid_package",
+            "path escapes database sandbox",
+            location=location,
+        ) from exc
+    return cand
+
+
+def _portable(root: Path, path: Path) -> str:
+    rel = path.resolve(strict=False).relative_to(root.resolve(strict=False))
+    text = rel.as_posix()
+    if not text or text.startswith(".."):
+        raise ConfigError(
+            "invalid_package",
+            "path escapes database sandbox",
+            location=text or ".",
+        )
+    return text
+
+
+def _tree_bytes(path: Path) -> int:
+    if not path.exists():
+        return 0
+    if path.is_file() and not path.is_symlink():
+        try:
+            return int(path.stat().st_size)
+        except OSError:
+            return 0
+    total = 0
+    for dirpath, _dirnames, filenames in os.walk(path, followlinks=False):
+        for name in filenames:
+            fp = Path(dirpath) / name
+            if fp.is_symlink():
+                continue
+            try:
+                total += int(fp.stat().st_size)
+            except OSError:
+                continue
+    return total
+
+
+def _collect_referenced_run_ids(summary: dict[str, Any]) -> list[str]:
+    ids: list[str] = []
+    seen: set[str] = set()
+
+    def _add(raw: object) -> None:
+        text = str(raw or "").strip()
+        if not text or text in seen:
+            return
+        seen.add(text)
+        ids.append(text)
+
+    refs = summary.get("task_refs")
+    if isinstance(refs, list):
+        for ref in refs:
+            if not isinstance(ref, dict):
+                continue
+            _add(ref.get("run_id"))
+            extra = ref.get("attempt_run_ids")
+            if isinstance(extra, list):
+                for item in extra:
+                    _add(item)
+    tasks = summary.get("tasks")
+    if isinstance(tasks, list):
+        for task in tasks:
+            if isinstance(task, dict):
+                _add(task.get("run_id"))
+    attempts = summary.get("attempts")
+    if isinstance(attempts, list):
+        for attempt in attempts:
+            if isinstance(attempt, dict):
+                _add(attempt.get("run_id"))
+    return ids
+
+
+def _suites_claiming_run(root: Path, run_id: str, *, exclude: str | None = None) -> list[str]:
+    suite_root = default_suite_runs_root(root)
+    if not suite_root.is_dir():
+        return []
+    claimants: list[str] = []
+    for child in sorted(suite_root.iterdir(), key=lambda p: p.name):
+        if not child.is_dir() or (exclude and child.name == exclude):
+            continue
+        try:
+            safe_id_segment(child.name, field="job_id")
+        except ConfigError:
+            continue
+        summary = _load_json_object(child / "summary.json")
+        if summary is None:
+            continue
+        if run_id in _collect_referenced_run_ids(summary):
+            claimants.append(child.name)
+    return claimants
+
+
+def _suite_in_progress(suite_dir: Path) -> bool:
+    if (suite_dir / "cancel.requested").is_file():
+        return True
+    progress = _load_json_object(suite_dir / "progress.json")
+    if progress is None:
+        return False
+    status = str(progress.get("status") or "").strip().lower()
+    return status not in _FINISHED_PROGRESS
+
+
+def _resolve_attempt_dir(root: Path, run_id: str) -> Path | None:
+    try:
+        rid = safe_id_segment(run_id, field="run_id")
+    except ConfigError:
+        return None
+    try:
+        return resolve_evidence_root(root, rid, require_task_match=False)
+    except ConfigError:
+        return None
+
+
+def _path_entry(
+    root: Path,
+    path: Path | None,
+    *,
+    locator: str,
+    role: str,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    exists = bool(path is not None and path.exists())
+    confined = _confine(root, path, location=locator) if path is not None else None
+    if confined is not None:
+        locator = _portable(root, confined)
+    entry: dict[str, Any] = {
+        "locator": locator,
+        "bytes": _tree_bytes(confined) if confined is not None and exists else 0,
+        "role": role,
+        "exists": exists,
+    }
+    if run_id:
+        entry["run_id"] = run_id
+    return entry
+
+
+def _confirm_token(job_id: str, kind: str, locators: list[str]) -> str:
+    payload = "\n".join([job_id, kind, *locators])
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
+
+
+class LocalJobsCommands:
+    """Preview / delete local Job trees. No Registry, no score rewrite."""
+
+    def preview_delete_job(self, database_root: Path | str, *, job_id: str) -> dict[str, Any]:
+        root = resolve_database_root(database_root)
+        job_id = safe_id_segment(job_id, field="job_id")
+        suite_dir = _confine(
+            root,
+            default_suite_runs_root(root) / job_id,
+            location=job_id,
+        )
+        if (suite_dir / "summary.json").is_file():
+            return self._preview_suite(root, job_id=job_id, suite_dir=suite_dir)
+        return self._preview_single(root, job_id=job_id)
+
+    def delete_job(
+        self,
+        database_root: Path | str,
+        *,
+        job_id: str,
+        confirm_token: str | None = None,
+        yes: bool = False,
+    ) -> dict[str, Any]:
+        preview = self.preview_delete_job(database_root, job_id=job_id)
+        if not preview.get("can_delete"):
+            raw_err = preview.get("error")
+            err = raw_err if isinstance(raw_err, dict) else {}
+            raise ConfigError(
+                str(err.get("code") or "invalid_request"),
+                str(err.get("message") or "cannot delete job"),
+                location=job_id,
+            )
+        token = (confirm_token or "").strip()
+        if yes and not token:
+            token = str(preview["confirm_token"])
+        if not token:
+            raise ConfigError(
+                "confirm_required",
+                "pass --yes or a confirm token from delete-preview",
+                location=job_id,
+            )
+        if token != preview["confirm_token"]:
+            raise ConfigError(
+                "confirm_mismatch",
+                "confirm token does not match current preview",
+                location=job_id,
+            )
+        root = resolve_database_root(database_root)
+        deleted: list[str] = []
+        missing: list[str] = []
+        for item in preview["paths"]:
+            locator = str(item["locator"])
+            path = _confine(root, root / locator, location=locator)
+            if path.is_dir() or path.is_file():
+                if path.is_dir():
+                    shutil.rmtree(path)
+                else:
+                    path.unlink()
+                deleted.append(locator)
+            else:
+                missing.append(locator)
+        return {
+            "ok": True,
+            "job_id": preview["job_id"],
+            "kind": preview["kind"],
+            "deleted": deleted,
+            "missing": missing,
+            "bytes": preview["bytes"],
+            "cascade_run_ids": preview["cascade_run_ids"],
+        }
+
+    def _preview_suite(self, root: Path, *, job_id: str, suite_dir: Path) -> dict[str, Any]:
+        summary = _load_json_object(suite_dir / "summary.json") or {}
+        run_ids = _collect_referenced_run_ids(summary)
+        error: dict[str, str] | None = None
+        if _suite_in_progress(suite_dir):
+            error = {
+                "code": "job_in_progress",
+                "message": "suite is still in progress or cancel is live",
+            }
+        else:
+            stolen: list[str] = []
+            for rid in run_ids:
+                others = _suites_claiming_run(root, rid, exclude=job_id)
+                if others:
+                    stolen.append(rid)
+            if stolen:
+                error = {
+                    "code": "job_claimed_elsewhere",
+                    "message": ("attempt still claimed by another suite: " + ", ".join(stolen)),
+                }
+        paths = [
+            _path_entry(
+                root,
+                suite_dir,
+                locator=f".bora/suite-runs/{job_id}",
+                role="suite",
+            )
+        ]
+        for rid in run_ids:
+            found = _resolve_attempt_dir(root, rid)
+            paths.append(
+                _path_entry(
+                    root,
+                    found,
+                    locator=f".bora/runs/{rid}",
+                    role="attempt",
+                    run_id=rid,
+                )
+            )
+        locators = [str(p["locator"]) for p in paths]
+        return {
+            "ok": True,
+            "job_id": job_id,
+            "kind": "suite",
+            "can_delete": error is None,
+            "paths": paths,
+            "bytes": sum(int(p["bytes"]) for p in paths),
+            "cascade_run_ids": run_ids,
+            "confirm_token": _confirm_token(job_id, "suite", locators),
+            "error": error,
+        }
+
+    def _preview_single(self, root: Path, *, job_id: str) -> dict[str, Any]:
+        found = _resolve_attempt_dir(root, job_id)
+        if found is None:
+            raise ConfigError(
+                "unknown_task",
+                f"job not found: {job_id}",
+                location=job_id,
+            )
+        claimants = _suites_claiming_run(root, job_id)
+        error: dict[str, str] | None = None
+        if claimants:
+            error = {
+                "code": "job_inner_attempt",
+                "message": "cannot delete an attempt that still belongs to a suite",
+            }
+        paths = [
+            _path_entry(
+                root,
+                found,
+                locator=f".bora/runs/{job_id}",
+                role="attempt",
+                run_id=job_id,
+            )
+        ]
+        locators = [str(p["locator"]) for p in paths]
+        return {
+            "ok": True,
+            "job_id": job_id,
+            "kind": "single",
+            "can_delete": error is None,
+            "paths": paths,
+            "bytes": sum(int(p["bytes"]) for p in paths),
+            "cascade_run_ids": [],
+            "confirm_token": _confirm_token(job_id, "single", locators),
+            "error": error,
+        }

--- a/src/bora/cli/README.md
+++ b/src/bora/cli/README.md
@@ -100,7 +100,8 @@ Credentials file `~/.bora/credentials` (mode `0600`):
 | `bora results export-profiles` | Export suite `job_overlay` → re-runnable `profiles.yaml` (#59) |
 | `bora results share\|unshare` | Share / revoke private result access (owner only) |
 | `bora results delete\|set-visibility` | Delete or flip visibility (`--kind attempt\|suite`; delete needs `--yes`) |
-| `bora view` | Local read-only Database Web UI (no Registry). `--dev` starts API and Vite when possible; `--open` deep-links a job/task/run |
+| `bora view` | Local Database Web UI (no Registry). `--dev` starts API and Vite when possible; `--open` deep-links a job/task/run |
+| `bora jobs delete` | Delete a local Job under `--local` (suite always cascades Attempts). Requires `--yes` |
 
 Discover flags with `uv run bora <cmd> -h`.
 
@@ -115,6 +116,9 @@ uv run bora tasks examples/core
 uv run bora view examples/core
 # uv run bora view tests/fixtures/databases/suite-min --port 8765 --no-browser
 # uv run bora view examples/core --dev --open /jobs/<id>
+# Preview local delete, then confirm (suite cascades Attempts; not Registry)
+# uv run bora jobs delete --local examples/core --job <id>
+# uv run bora jobs delete --local examples/core --job <id> --yes
 
 uv run bora lock examples/core --task config-minimal
 

--- a/src/bora/cli/cmd_jobs.py
+++ b/src/bora/cli/cmd_jobs.py
@@ -1,0 +1,56 @@
+"""CLI local Jobs commands (delete on-disk evidence; no Registry)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+
+def register(app: typer.Typer) -> None:
+    """Create and mount the ``jobs`` sub-app."""
+
+    sub = typer.Typer(
+        name="jobs",
+        help="Local Jobs under a Database root (no Registry).",
+        no_args_is_help=True,
+        add_completion=False,
+    )
+
+    @sub.command("delete")
+    def jobs_delete_command(
+        local: Annotated[
+            Path,
+            typer.Option("--local", help="Local Database root (bora.database/1)."),
+        ],
+        job: Annotated[
+            str,
+            typer.Option("--job", help="Job id: suite_run_id or unclaimed single run_id."),
+        ],
+        yes: Annotated[
+            bool,
+            typer.Option("--yes", help="Confirm destructive delete (required)."),
+        ] = False,
+    ) -> None:
+        """Delete a local Job tree. Suite delete always cascades Attempts."""
+        from bora.application.composition import build_local_jobs_commands
+        from bora.config.errors import ConfigError
+
+        cmds = build_local_jobs_commands()
+        try:
+            if not yes:
+                preview = cmds.preview_delete_job(local, job_id=job)
+                typer.echo(
+                    json.dumps(preview, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+                )
+                typer.echo("refusing to delete without --yes", err=True)
+                raise typer.Exit(code=2)
+            summary = cmds.delete_job(local, job_id=job, yes=True)
+        except ConfigError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=2) from exc
+        typer.echo(json.dumps(summary, ensure_ascii=False, separators=(",", ":"), sort_keys=True))
+
+    app.add_typer(sub, name="jobs")

--- a/src/bora/cli/main.py
+++ b/src/bora/cli/main.py
@@ -19,6 +19,7 @@ from bora.cli import (
     cmd_cancel_submit,
     cmd_evidence_status,
     cmd_executors_publish_login,
+    cmd_jobs,
     cmd_plugin,
     cmd_registry,
     cmd_results,
@@ -66,6 +67,7 @@ cmd_plugin.register(app)
 cmd_registry.register(app)
 cmd_cache.register(app)
 cmd_results.register(app)
+cmd_jobs.register(app)
 cmd_view_tasks_lock.register(app)
 
 

--- a/src/bora/evidence/locators.py
+++ b/src/bora/evidence/locators.py
@@ -18,6 +18,32 @@ def default_runs_root(database_root: Path | str) -> Path:
     return Path(database_root) / ".bora" / "runs"
 
 
+def default_suite_runs_root(database_root: Path | str) -> Path:
+    """Database-root suite job directory: ``<db>/.bora/suite-runs``."""
+    return Path(database_root) / ".bora" / "suite-runs"
+
+
+def safe_id_segment(value: str, *, field: str) -> str:
+    """Single path segment (job_id / task_id / run_id); reject traversal."""
+    from bora.config.errors import ConfigError
+
+    text = (value or "").strip()
+    if (
+        not text
+        or text in {".", ".."}
+        or "/" in text
+        or "\\" in text
+        or ".." in text
+        or text.startswith(".")
+    ):
+        raise ConfigError(
+            "invalid_package",
+            f"invalid {field}: {value!r}",
+            location=field,
+        )
+    return text
+
+
 def portable_run_locator(
     run_dir: Path | str,
     *,

--- a/src/bora/viewer/jobs.py
+++ b/src/bora/viewer/jobs.py
@@ -19,31 +19,12 @@ from bora.application.suite import (
 )
 from bora.config.database import load_database_manifest
 from bora.config.errors import ConfigError
-from bora.evidence.locators import default_runs_root
+from bora.evidence.locators import default_runs_root, default_suite_runs_root, safe_id_segment
 from bora.viewer.browse import commands_for
 
 
-def safe_id_segment(value: str, *, field: str) -> str:
-    """Single path segment (job_id / task_id / run_id); reject traversal."""
-    text = (value or "").strip()
-    if (
-        not text
-        or text in {".", ".."}
-        or "/" in text
-        or "\\" in text
-        or ".." in text
-        or text.startswith(".")
-    ):
-        raise ConfigError(
-            "invalid_package",
-            f"invalid {field}: {value!r}",
-            location=field,
-        )
-    return text
-
-
 def _suite_root(database_root: Path) -> Path:
-    return database_root.expanduser().resolve(strict=False) / ".bora" / "suite-runs"
+    return default_suite_runs_root(database_root.expanduser().resolve(strict=False))
 
 
 def _load_summary(path: Path) -> dict[str, Any]:

--- a/src/bora/viewer/server.py
+++ b/src/bora/viewer/server.py
@@ -11,7 +11,7 @@ import webbrowser
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
-from urllib.parse import unquote, urlparse
+from urllib.parse import parse_qs, unquote, urlparse
 
 from bora.config.errors import ConfigError
 from bora.viewer import browse, jobs, trials
@@ -19,6 +19,16 @@ from bora.viewer import browse, jobs, trials
 # Default bind: loopback only.
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
+
+_WRITE_CONFLICT = frozenset({"job_in_progress", "job_claimed_elsewhere", "job_inner_attempt"})
+
+
+def _job_write_status(exc: ConfigError) -> int:
+    if exc.error_code == "unknown_task":
+        return 404
+    if exc.error_code in _WRITE_CONFLICT:
+        return 409
+    return 400
 
 
 def _bind_url(host: str, port: int) -> str:
@@ -166,11 +176,39 @@ def make_handler(
         def do_OPTIONS(self) -> None:  # noqa: N802
             self.do_GET()
 
+        def do_DELETE(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            path = unquote(parsed.path)
+            if not path.startswith("/api/jobs/"):
+                _error(self, 404, "not_found", "unknown API path")
+                return
+            parts = [p for p in path[len("/api/jobs/") :].split("/") if p]
+            if len(parts) != 1:
+                _error(self, 404, "not_found", "unknown jobs API path")
+                return
+            qs = parse_qs(parsed.query)
+            confirm = (qs.get("confirm") or [""])[0]
+            self._api_job_delete(parts[0], confirm)
+
+        def _api_job_delete(self, job_id: str, confirm: str) -> None:
+            from bora.application.composition import build_local_jobs_commands
+
+            try:
+                payload = build_local_jobs_commands().delete_job(
+                    root,
+                    job_id=job_id,
+                    confirm_token=confirm or None,
+                )
+            except ConfigError as exc:
+                _error(self, _job_write_status(exc), exc.error_code, str(exc))
+                return
+            _json(self, 200, payload)
+
         def _cors(self) -> None:
             if not cors_origin:
                 return
             self.send_header("Access-Control-Allow-Origin", cors_origin)
-            self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+            self.send_header("Access-Control-Allow-Methods", "GET, DELETE, OPTIONS")
             self.send_header("Access-Control-Allow-Headers", "Content-Type")
 
         def _serve_file(self, path: Path, content_type: str) -> None:
@@ -207,6 +245,15 @@ def make_handler(
             query = urlparse(self.path).query
             q = trials.parse_query(query)
             try:
+                if len(parts) == 2 and parts[1] == "delete-preview":
+                    from bora.application.composition import build_local_jobs_commands
+
+                    _json(
+                        self,
+                        200,
+                        build_local_jobs_commands().preview_delete_job(root, job_id=job_id),
+                    )
+                    return
                 if len(parts) == 1:
                     _json(self, 200, jobs.get_job(root, job_id))
                     return

--- a/tests/viewer/test_jobs_delete_cli.py
+++ b/tests/viewer/test_jobs_delete_cli.py
@@ -1,0 +1,88 @@
+"""CLI ``bora jobs delete`` uses the local Job delete use case."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from bora.cli.main import app
+
+REPO = Path(__file__).resolve().parents[2]
+SUITE = REPO / "tests" / "fixtures" / "databases" / "suite-min"
+
+
+def _clean_db(tmp_path: Path) -> Path:
+    db = tmp_path / "db"
+    shutil.copytree(SUITE, db, ignore=shutil.ignore_patterns(".bora"))
+    return db
+
+
+def test_cli_jobs_delete_requires_yes(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    evidence = db / ".bora" / "runs" / "run_cli_single"
+    evidence.mkdir(parents=True)
+    (evidence / "result.json").write_text(
+        json.dumps({"task_id": "alpha", "status": "PASS", "score": 1.0}) + "\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    preview = runner.invoke(
+        app,
+        ["jobs", "delete", "--local", str(db), "--job", "run_cli_single"],
+    )
+    assert preview.exit_code == 2
+    payload = json.loads(preview.stdout)
+    assert payload["kind"] == "single"
+    assert payload["can_delete"] is True
+    assert "refusing to delete without --yes" in preview.stderr
+    assert evidence.is_dir()
+
+    done = runner.invoke(
+        app,
+        ["jobs", "delete", "--local", str(db), "--job", "run_cli_single", "--yes"],
+    )
+    assert done.exit_code == 0, done.stdout + done.stderr
+    out = json.loads(done.stdout)
+    assert out["ok"] is True
+    assert not evidence.exists()
+
+
+def test_cli_jobs_delete_suite_cascade(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    suite_dir = db / ".bora" / "suite-runs" / "suite_cli"
+    suite_dir.mkdir(parents=True)
+    (suite_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "schema": "bora.suite.summary/1",
+                "suite_run_id": "suite_cli",
+                "task_refs": [
+                    {
+                        "task_id": "alpha",
+                        "run_id": "run_cli_a",
+                        "attempt_run_ids": ["run_cli_a"],
+                    }
+                ],
+                "tasks": [{"task_id": "alpha", "run_id": "run_cli_a"}],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    attempt = db / ".bora" / "runs" / "run_cli_a"
+    attempt.mkdir(parents=True)
+    (attempt / "result.json").write_text(
+        json.dumps({"task_id": "alpha", "status": "PASS", "score": 1.0}) + "\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    done = runner.invoke(
+        app,
+        ["jobs", "delete", "--local", str(db), "--job", "suite_cli", "--yes"],
+    )
+    assert done.exit_code == 0, done.stdout + done.stderr
+    assert not suite_dir.exists()
+    assert not attempt.exists()

--- a/tests/viewer/test_local_job_delete.py
+++ b/tests/viewer/test_local_job_delete.py
@@ -1,0 +1,244 @@
+"""Local Job delete: single erase, suite cascade, fail-closed refusals."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from bora.application.composition import build_local_jobs_commands
+from bora.config.errors import ConfigError
+from bora.viewer import jobs
+
+REPO = Path(__file__).resolve().parents[2]
+SUITE = REPO / "tests" / "fixtures" / "databases" / "suite-min"
+
+
+def _clean_db(tmp_path: Path) -> Path:
+    db = tmp_path / "db"
+    shutil.copytree(SUITE, db, ignore=shutil.ignore_patterns(".bora"))
+    return db
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _seed_attempt(
+    db: Path, run_id: str, *, task_id: str = "alpha", task_local: bool = False
+) -> Path:
+    evidence = (
+        db / "tasks" / task_id / ".bora" / "runs" / run_id
+        if task_local
+        else db / ".bora" / "runs" / run_id
+    )
+    _write_json(
+        evidence / "result.json",
+        {"task_id": task_id, "status": "PASS", "score": 1.0},
+    )
+    return evidence
+
+
+def _seed_suite(
+    db: Path,
+    job_id: str = "suite_demo_job_001",
+    *,
+    run_ids: list[str] | None = None,
+    extra_attempts: list[str] | None = None,
+) -> str:
+    run_ids = run_ids or ["run_a", "run_b"]
+    suite_dir = db / ".bora" / "suite-runs" / job_id
+    tasks = [
+        {"task_id": "alpha", "status": "PASS", "score": 1.0, "run_id": run_ids[0]},
+    ]
+    refs = [
+        {"task_id": "alpha", "status": "PASS", "score": 1.0, "run_id": run_ids[0]},
+    ]
+    if len(run_ids) > 1:
+        tasks.append({"task_id": "beta", "status": "FAIL", "score": 0.0, "run_id": run_ids[1]})
+        refs.append(
+            {
+                "task_id": "beta",
+                "status": "FAIL",
+                "score": 0.0,
+                "run_id": run_ids[1],
+                "attempt_run_ids": extra_attempts or [run_ids[1]],
+            }
+        )
+    _write_json(
+        suite_dir / "summary.json",
+        {
+            "schema": "bora.suite.summary/1",
+            "suite_run_id": job_id,
+            "database_id": "test/suite-min",
+            "tasks": tasks,
+            "task_refs": refs,
+            "attempts": [
+                {"task_id": "alpha", "run_id": rid}
+                if i == 0
+                else {"task_id": "beta", "run_id": rid}
+                for i, rid in enumerate(run_ids)
+            ],
+            "metrics": {"n_tasks": len(tasks), "n_pass": 1, "n_fail": max(0, len(tasks) - 1)},
+        },
+    )
+    return job_id
+
+
+def _job_ids(db: Path) -> set[str]:
+    return {item["job_id"] for item in jobs.list_jobs(db)["items"]}
+
+
+def test_delete_single_removes_attempt_dir(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    _seed_attempt(db, "run_single_alpha")
+    cmds = build_local_jobs_commands()
+    preview = cmds.preview_delete_job(db, job_id="run_single_alpha")
+    assert preview["kind"] == "single"
+    assert preview["can_delete"] is True
+    assert preview["bytes"] > 0
+    locators = [p["locator"] for p in preview["paths"]]
+    assert ".bora/runs/run_single_alpha" in locators
+
+    with pytest.raises(ConfigError, match="confirm_required"):
+        cmds.delete_job(db, job_id="run_single_alpha")
+
+    out = cmds.delete_job(db, job_id="run_single_alpha", yes=True)
+    assert out["ok"] is True
+    assert not (db / ".bora" / "runs" / "run_single_alpha").exists()
+    assert "run_single_alpha" not in _job_ids(db)
+
+
+def test_delete_task_local_single(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    evidence = _seed_attempt(db, "run_task_local", task_id="beta", task_local=True)
+    cmds = build_local_jobs_commands()
+    cmds.delete_job(db, job_id="run_task_local", yes=True)
+    assert not evidence.exists()
+    assert "run_task_local" not in _job_ids(db)
+
+
+def test_delete_suite_cascades_attempts(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite(db, extra_attempts=["run_b", "run_b2"])
+    for rid in ("run_a", "run_b", "run_b2"):
+        _seed_attempt(db, rid, task_id="alpha" if rid == "run_a" else "beta")
+    leftover = _seed_attempt(db, "run_other")
+
+    cmds = build_local_jobs_commands()
+    preview = cmds.preview_delete_job(db, job_id=job_id)
+    assert preview["kind"] == "suite"
+    assert set(preview["cascade_run_ids"]) >= {"run_a", "run_b", "run_b2"}
+    assert any(p["locator"].endswith(f"suite-runs/{job_id}") for p in preview["paths"])
+
+    cmds.delete_job(db, job_id=job_id, yes=True)
+    listed = _job_ids(db)
+    assert job_id not in listed
+    assert "run_a" not in listed
+    assert "run_b" not in listed
+    assert "run_b2" not in listed
+    assert "run_other" in listed
+    assert leftover.is_dir()
+    assert not (db / ".bora" / "suite-runs" / job_id).exists()
+    assert not (db / ".bora" / "runs" / "run_a").exists()
+
+
+def test_refuse_inner_attempt_delete(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    _seed_suite(db)
+    _seed_attempt(db, "run_a")
+    cmds = build_local_jobs_commands()
+    preview = cmds.preview_delete_job(db, job_id="run_a")
+    assert preview["can_delete"] is False
+    assert preview["error"]["code"] == "job_inner_attempt"
+    with pytest.raises(ConfigError, match="job_inner_attempt"):
+        cmds.delete_job(db, job_id="run_a", yes=True)
+    assert (db / ".bora" / "runs" / "run_a").is_dir()
+
+
+def test_refuse_in_progress_suite(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite(db)
+    _seed_attempt(db, "run_a")
+    _write_json(
+        db / ".bora" / "suite-runs" / job_id / "progress.json",
+        {"schema": "bora.suite.progress/1", "status": "running", "done": 0, "total": 2},
+    )
+    cmds = build_local_jobs_commands()
+    preview = cmds.preview_delete_job(db, job_id=job_id)
+    assert preview["can_delete"] is False
+    assert preview["error"]["code"] == "job_in_progress"
+    with pytest.raises(ConfigError, match="job_in_progress"):
+        cmds.delete_job(db, job_id=job_id, yes=True)
+    assert (db / ".bora" / "suite-runs" / job_id / "summary.json").is_file()
+
+
+def test_refuse_live_cancel_request(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite(db)
+    (db / ".bora" / "suite-runs" / job_id / "cancel.requested").write_text("{}\n", encoding="utf-8")
+    cmds = build_local_jobs_commands()
+    with pytest.raises(ConfigError, match="job_in_progress"):
+        cmds.delete_job(db, job_id=job_id, yes=True)
+
+
+def test_complete_progress_allows_delete(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite(db)
+    _seed_attempt(db, "run_a")
+    _seed_attempt(db, "run_b")
+    _write_json(
+        db / ".bora" / "suite-runs" / job_id / "progress.json",
+        {"schema": "bora.suite.progress/1", "status": "complete", "done": 2, "total": 2},
+    )
+    cmds = build_local_jobs_commands()
+    cmds.delete_job(db, job_id=job_id, yes=True)
+    assert job_id not in _job_ids(db)
+
+
+def test_refuse_claimed_by_another_suite(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    _seed_suite(db, "suite_one", run_ids=["run_shared", "run_only_one"])
+    _seed_suite(db, "suite_two", run_ids=["run_shared", "run_only_two"])
+    _seed_attempt(db, "run_shared")
+    _seed_attempt(db, "run_only_one")
+    cmds = build_local_jobs_commands()
+    preview = cmds.preview_delete_job(db, job_id="suite_one")
+    assert preview["can_delete"] is False
+    assert preview["error"]["code"] == "job_claimed_elsewhere"
+    with pytest.raises(ConfigError, match="job_claimed_elsewhere"):
+        cmds.delete_job(db, job_id="suite_one", yes=True)
+    assert (db / ".bora" / "runs" / "run_shared").is_dir()
+
+
+def test_refuse_path_escape(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    cmds = build_local_jobs_commands()
+    with pytest.raises(ConfigError, match="invalid_package"):
+        cmds.preview_delete_job(db, job_id="../etc")
+    with pytest.raises(ConfigError, match="invalid_package"):
+        cmds.delete_job(db, job_id="a/b", yes=True)
+
+
+def test_unknown_job(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    cmds = build_local_jobs_commands()
+    with pytest.raises(ConfigError, match="unknown_task"):
+        cmds.preview_delete_job(db, job_id="missing_job")
+
+
+def test_confirm_token_mismatch(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    _seed_attempt(db, "run_single_alpha")
+    cmds = build_local_jobs_commands()
+    with pytest.raises(ConfigError, match="confirm_mismatch"):
+        cmds.delete_job(db, job_id="run_single_alpha", confirm_token="nope")
+    cmds.delete_job(
+        db,
+        job_id="run_single_alpha",
+        confirm_token=cmds.preview_delete_job(db, job_id="run_single_alpha")["confirm_token"],
+    )
+    assert "run_single_alpha" not in _job_ids(db)

--- a/tests/viewer/test_viewer_job_delete_http.py
+++ b/tests/viewer/test_viewer_job_delete_http.py
@@ -1,0 +1,167 @@
+"""HTTP surface for local Job delete (preview + confirm)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import threading
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+import pytest
+
+from bora.viewer.server import make_handler
+
+REPO = Path(__file__).resolve().parents[2]
+SUITE = REPO / "tests" / "fixtures" / "databases" / "suite-min"
+
+
+def _minimal_spa(tmp_path: Path) -> Path:
+    root = tmp_path / "spa"
+    root.mkdir()
+    (root / "index.html").write_text(
+        "<!doctype html><html><head><title>BORA Viewer</title></head>"
+        '<body><div id="root"></div></body></html>\n',
+        encoding="utf-8",
+    )
+    return root
+
+
+def _clean_db(tmp_path: Path) -> Path:
+    db = tmp_path / "db"
+    shutil.copytree(SUITE, db, ignore=shutil.ignore_patterns(".bora"))
+    return db
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+
+def _seed_attempt(db: Path, run_id: str) -> None:
+    _write_json(
+        db / ".bora" / "runs" / run_id / "result.json",
+        {"task_id": "alpha", "status": "PASS", "score": 1.0},
+    )
+
+
+def _seed_suite(db: Path, job_id: str, run_ids: list[str]) -> None:
+    _write_json(
+        db / ".bora" / "suite-runs" / job_id / "summary.json",
+        {
+            "schema": "bora.suite.summary/1",
+            "suite_run_id": job_id,
+            "tasks": [{"task_id": "alpha", "status": "PASS", "score": 1.0, "run_id": run_ids[0]}],
+            "task_refs": [
+                {
+                    "task_id": "alpha",
+                    "status": "PASS",
+                    "score": 1.0,
+                    "run_id": run_ids[0],
+                    "attempt_run_ids": run_ids,
+                }
+            ],
+            "attempts": [{"task_id": "alpha", "run_id": rid} for rid in run_ids],
+        },
+    )
+
+
+@pytest.fixture()
+def viewer_db(tmp_path: Path):
+    db = _clean_db(tmp_path)
+    assets = _minimal_spa(tmp_path)
+    handler = make_handler(db, assets, cors_origin="http://127.0.0.1:5173")
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        yield db, base
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _json(url: str, *, method: str = "GET") -> dict:
+    req = Request(url, method=method, headers={"Accept": "application/json"})
+    with urlopen(req, timeout=5) as resp:  # noqa: S310
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def test_http_delete_single(viewer_db: tuple[Path, str]) -> None:
+    db, base = viewer_db
+    _seed_attempt(db, "run_http_single")
+    preview = _json(f"{base}/api/jobs/run_http_single/delete-preview")
+    assert preview["kind"] == "single"
+    assert preview["can_delete"] is True
+    assert preview["confirm_token"]
+    with pytest.raises(HTTPError) as missing:
+        _json(f"{base}/api/jobs/run_http_single", method="DELETE")
+    assert missing.value.code == 400
+    deleted = _json(
+        f"{base}/api/jobs/run_http_single?confirm={preview['confirm_token']}",
+        method="DELETE",
+    )
+    assert deleted["ok"] is True
+    listed = _json(f"{base}/api/jobs")
+    assert all(item["job_id"] != "run_http_single" for item in listed["items"])
+    assert not (db / ".bora" / "runs" / "run_http_single").exists()
+
+
+def test_http_delete_suite_cascade(viewer_db: tuple[Path, str]) -> None:
+    db, base = viewer_db
+    _seed_suite(db, "suite_http", ["run_http_a", "run_http_b"])
+    _seed_attempt(db, "run_http_a")
+    _seed_attempt(db, "run_http_b")
+    preview = _json(f"{base}/api/jobs/suite_http/delete-preview")
+    assert preview["kind"] == "suite"
+    assert set(preview["cascade_run_ids"]) >= {"run_http_a", "run_http_b"}
+    _json(
+        f"{base}/api/jobs/suite_http?confirm={preview['confirm_token']}",
+        method="DELETE",
+    )
+    listed = _json(f"{base}/api/jobs")
+    ids = {item["job_id"] for item in listed["items"]}
+    assert "suite_http" not in ids
+    assert "run_http_a" not in ids
+    assert "run_http_b" not in ids
+
+
+def test_http_refuse_inner_attempt(viewer_db: tuple[Path, str]) -> None:
+    db, base = viewer_db
+    _seed_suite(db, "suite_http", ["run_inner"])
+    _seed_attempt(db, "run_inner")
+    preview = _json(f"{base}/api/jobs/run_inner/delete-preview")
+    assert preview["can_delete"] is False
+    assert preview["error"]["code"] == "job_inner_attempt"
+    with pytest.raises(HTTPError) as ei:
+        _json(
+            f"{base}/api/jobs/run_inner?confirm={preview['confirm_token']}",
+            method="DELETE",
+        )
+    assert ei.value.code == 409
+
+
+def test_http_refuse_escape(viewer_db: tuple[Path, str]) -> None:
+    _db, base = viewer_db
+    with pytest.raises(HTTPError) as ei:
+        _json(f"{base}/api/jobs/%2e%2e/delete-preview")
+    assert ei.value.code == 400
+
+
+def test_http_cors_allows_delete(viewer_db: tuple[Path, str]) -> None:
+    _db, base = viewer_db
+    req = Request(
+        f"{base}/api/jobs/x",
+        method="OPTIONS",
+        headers={
+            "Origin": "http://127.0.0.1:5173",
+            "Access-Control-Request-Method": "DELETE",
+        },
+    )
+    with urlopen(req, timeout=5) as resp:  # noqa: S310
+        allow = resp.headers.get("Access-Control-Allow-Methods") or ""
+        assert "DELETE" in allow
+        assert resp.headers.get("Access-Control-Allow-Origin") == "http://127.0.0.1:5173"

--- a/website/content/docs/reference/cli.en.mdx
+++ b/website/content/docs/reference/cli.en.mdx
@@ -22,6 +22,7 @@ uv run bora plugin list
 uv run bora plugin uninstall <plugin_id>
 uv run bora evidence --help
 uv run bora view <dataset> [--dev] [--open /jobs/<id>]
+uv run bora jobs delete --local <dataset> --job <id> --yes
 # Registry / results (login required; see [Registry](/docs/share/registry))
 uv run bora publish <dataset> --org <org> [--draft] [--public] [--replace]
 uv run bora release <database_id> [--public] [--replace]

--- a/website/content/docs/reference/cli.mdx
+++ b/website/content/docs/reference/cli.mdx
@@ -22,6 +22,7 @@ uv run bora plugin list
 uv run bora plugin uninstall <plugin_id>
 uv run bora evidence --help
 uv run bora view <dataset> [--dev] [--open /jobs/<id>]
+uv run bora jobs delete --local <dataset> --job <id> --yes
 # Registry / 结果（需 login；细节见 [Registry](/docs/share/registry)）
 uv run bora publish <dataset> --org <org> [--draft] [--public] [--replace]
 uv run bora release <database_id> [--public] [--replace]

--- a/website/content/docs/run/local-viewer.en.mdx
+++ b/website/content/docs/run/local-viewer.en.mdx
@@ -5,6 +5,8 @@ description: Browse suite runs in the browser — no Registry.
 
 After a suite or a single-task run, use Viewer for scores, trajectories, and copyable commands. It reads the **opened** Database only (`.bora/suite-runs/` and `.bora/runs/`) and never talks to Registry.
 
+From the Jobs table you can delete a local Job after a path preview. Deleting a suite always removes the Attempts it references; they do not come back as singles. You cannot delete one Attempt from inside a suite. This is a local erase, not a Registry delete (`bora results delete` is a different object). The same use case is `bora jobs delete --local <dataset> --job <id> --yes`.
+
 ## Open
 
 ```bash

--- a/website/content/docs/run/local-viewer.mdx
+++ b/website/content/docs/run/local-viewer.mdx
@@ -5,6 +5,8 @@ description: 浏览器里翻 suite 跑次，不连 Registry。
 
 跑完 suite 或单题后，想对照分数、点开轨迹、复制命令——用 Viewer。它读打开的那一个 Dataset：`.bora/suite-runs/` 与 `.bora/runs/`，不连 Registry。
 
+Jobs 表可以删掉本机一行 Job（先 preview 路径，再确认）。删 suite 会一并删掉它引用的全部 Attempt，不会再以 single 冒出来。不能从 suite 里单独删一条 Attempt。这是擦本地证据，不是 Registry 删除（`bora results delete` 是另一对象）。CLI 对等：`bora jobs delete --local <dataset> --job <id> --yes`。
+
 ## 打开
 
 ```bash


### PR DESCRIPTION
Closes #116

Local Viewer / CLI can erase a Job under the opened Database root. Suite delete always cascades referenced Attempts so they do not reappear as singles. Hub / Registry writes stay out.

## Semantics

- Single Job → that Attempt tree only (`<db>/.bora/runs/<id>/` or task-local).
- Suite Job → `.bora/suite-runs/<id>/` **and** every referenced Attempt.
- No inner-Attempt delete. Preview first; destructive call needs a confirm token / `--yes`.
- Refuse in-progress suite, live `cancel.requested`, path escape, and Attempts still claimed by another remaining suite.

## Commits

1. Design lock (`docs/design/12`, viewer DESIGN / AGENTS)
2. `build_local_jobs_commands()` + locators + tests
3. Viewer preview / DELETE + Jobs confirm dialog
4. `bora jobs delete --local <db> --job <id> --yes`
5. Reader-facing docs (no issue numbers)

## Verification

- python-core CI equivalent: ruff + pyright + 592 passed
- python-registry: 99 passed, 2 skipped
- viewer: `pnpm lint` + `pnpm build`
- website: `pnpm build`
- Subagent acceptance vs #116: ACCEPT
- ACP smoke: `bora run examples/journeys --task terminal-jsonl-agg --profiles examples/journeys/profiles.yaml` → PASS (L1, score 1.0)