### PR TITLE
feat(plugins): opt-in extensions, official slug, owner display names

### DIFF
--- a/apps/hub/src/components/display-name-editor.tsx
+++ b/apps/hub/src/components/display-name-editor.tsx
@@ -1,0 +1,128 @@
+import { Check, Pencil, X } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { HoverTip } from "@/components/hover-tip";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+export function DisplayNameEditor({
+  value,
+  canEdit,
+  headingClassName,
+  prefix,
+  onSave,
+}: {
+  value: string;
+  canEdit: boolean;
+  headingClassName?: string;
+  /** Locked ``org/`` prefix for plugin ids. Saved value is the leaf only. */
+  prefix?: string | null;
+  onSave: (next: string) => Promise<void>;
+}) {
+  const locked = (prefix || "").trim();
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!editing) setDraft(value);
+  }, [value, editing]);
+
+  const title = locked ? `${locked}${value}` : value;
+
+  async function submit() {
+    const next = draft.trim();
+    if (!next || next === value) {
+      setEditing(false);
+      setError(null);
+      return;
+    }
+    if (next.includes("/")) {
+      setError("Edit only the name after the org prefix");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await onSave(next);
+      setEditing(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (editing) {
+    return (
+      <form
+        className="flex flex-col gap-1 min-w-0"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void submit();
+        }}
+      >
+        <div className="flex items-center gap-1.5">
+          {locked ? (
+            <span className="font-mono text-sm text-mute shrink-0">{locked}</span>
+          ) : null}
+          <Input
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            aria-label="Display name"
+            maxLength={80}
+            autoFocus
+            disabled={busy}
+            className="h-8 w-36 shrink-0"
+          />
+          <Button
+            type="submit"
+            size="icon"
+            variant="secondary"
+            disabled={busy}
+            aria-label="Save"
+            className="h-8 w-8 shrink-0"
+          >
+            <Check className="size-4" />
+          </Button>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            disabled={busy}
+            aria-label="Cancel"
+            className="h-8 w-8 shrink-0"
+            onClick={() => {
+              setDraft(value);
+              setEditing(false);
+              setError(null);
+            }}
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
+        {error ? <p className="text-xs text-error">{error}</p> : null}
+      </form>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 min-w-0">
+      <h1 className={cn("min-w-0 truncate", headingClassName)}>{title}</h1>
+      {canEdit ? (
+        <HoverTip content="Edit display name">
+          <button
+            type="button"
+            className="inline-flex shrink-0 rounded-[6px] p-1 text-mute hover:text-body hover:bg-canvas-soft"
+            aria-label="Edit display name"
+            onClick={() => setEditing(true)}
+          >
+            <Pencil className="size-4" strokeWidth={1.75} />
+          </button>
+        </HoverTip>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/hub/src/components/official-mark.tsx
+++ b/apps/hub/src/components/official-mark.tsx
@@ -1,0 +1,19 @@
+import { BadgeCheck } from "lucide-react";
+
+import { HoverTip } from "@/components/hover-tip";
+
+const TIP = "Verified official plugin";
+
+export function OfficialMark({ className = "" }: { className?: string }) {
+  return (
+    <HoverTip content={TIP}>
+      <span
+        className={`inline-flex shrink-0 text-link ${className}`.trim()}
+        aria-label={TIP}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <BadgeCheck className="size-4" strokeWidth={2} aria-hidden />
+      </span>
+    </HoverTip>
+  );
+}

--- a/apps/hub/src/lib/api.ts
+++ b/apps/hub/src/lib/api.ts
@@ -40,6 +40,8 @@ export type PackageRelease = {
   package_kind?: "database" | "plugin" | string;
   created_at?: number;
   org_id?: string;
+  /** Registry marketplace display: upload org is on the official-org allowlist. */
+  official?: boolean;
   /** Present on by-digest / version get for plugins. */
   plugin_preview?: PluginPreview;
   /** Draft slot (entitled callers only). */

--- a/apps/hub/src/lib/api.ts
+++ b/apps/hub/src/lib/api.ts
@@ -48,6 +48,8 @@ export type PackageRelease = {
   is_draft?: boolean;
   slot?: string;
   uploaded_by?: string;
+  /** Owner-set marketplace title; id stays database_id. */
+  display_name?: string;
 };
 
 export type OrgRow = {
@@ -243,6 +245,19 @@ export function encodeDatasetId(id: string): string {
   return encodeURIComponent(id);
 }
 
+/** Hub plugin/package id is ``org/name``. Display edits only the name leaf. */
+export function splitPackageId(id: string): { org: string | null; name: string } {
+  const slash = id.indexOf("/");
+  if (slash <= 0 || slash === id.length - 1) return { org: null, name: id };
+  return { org: id.slice(0, slash), name: id.slice(slash + 1) };
+}
+
+export function packageDisplayTitle(id: string, displayName?: string | null): string {
+  const { org, name } = splitPackageId(id);
+  const leaf = (displayName || "").trim() || name;
+  return org ? `${org}/${leaf}` : leaf;
+}
+
 export function decodeDatasetId(param: string): string {
   return decodeURIComponent(param);
 }
@@ -428,6 +443,30 @@ export async function getOrg(
   token: string | null,
 ): Promise<OrgRow> {
   return requestJson(`/v1/orgs/${encodeURIComponent(orgId)}`, { token });
+}
+
+export async function updateOrgDisplayName(
+  orgId: string,
+  displayName: string,
+  token: string | null,
+): Promise<OrgRow> {
+  return requestJson(`/v1/orgs/${encodeURIComponent(orgId)}`, {
+    token,
+    method: "PATCH",
+    body: { display_name: displayName },
+  });
+}
+
+export async function updatePackageDisplayName(
+  packageId: string,
+  displayName: string,
+  token: string | null,
+): Promise<PackageRelease> {
+  return requestJson(`/v1/packages/${packageIdPath(packageId)}`, {
+    token,
+    method: "PATCH",
+    body: { display_name: displayName },
+  });
 }
 
 export async function listOrgMembers(

--- a/apps/hub/src/pages/OrganizationDetailPage.tsx
+++ b/apps/hub/src/pages/OrganizationDetailPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
 import { BreadcrumbNav } from "@/components/breadcrumb";
+import { DisplayNameEditor } from "@/components/display-name-editor";
 import { HoverTip } from "@/components/hover-tip";
 import { Shell } from "@/components/layout";
 import { SignInLink } from "@/components/sign-in-button";
@@ -24,6 +25,7 @@ import {
   listOrgInviteKeys,
   listOrgMembers,
   latestPackageByDatabase,
+  updateOrgDisplayName,
   listPackages,
   listResultShares,
   listSuites,
@@ -216,9 +218,15 @@ export function OrganizationDetailPage() {
       ) : (
         <>
           <div className="mb-4">
-            <h1 className="text-2xl font-semibold tracking-tight text-ink">
-              {title}
-            </h1>
+            <DisplayNameEditor
+              value={title}
+              canEdit={isOwner}
+              headingClassName="text-2xl font-semibold tracking-tight text-ink"
+              onSave={async (next) => {
+                const updated = await updateOrgDisplayName(orgId, next, token);
+                setOrg(updated);
+              }}
+            />
             <p className="font-mono text-sm text-mute mt-1">@{orgId}</p>
             {org?.role ? (
               <p className="text-xs text-body mt-1 capitalize">

--- a/apps/hub/src/pages/PluginDetailPage.tsx
+++ b/apps/hub/src/pages/PluginDetailPage.tsx
@@ -3,6 +3,8 @@ import { Link, useParams } from "react-router-dom";
 
 import { BreadcrumbNav } from "@/components/breadcrumb";
 import { CommandStrip } from "@/components/command-strip";
+import { DisplayNameEditor } from "@/components/display-name-editor";
+import { OfficialMark } from "@/components/official-mark";
 import { FileSplitPanel } from "@/components/file-split-panel";
 import { Shell } from "@/components/layout";
 import {
@@ -12,10 +14,13 @@ import {
 import {
   decodeDatasetId,
   decodeFileContent,
+  getOrg,
   getPackageByDigest,
   getPackageFile,
   listPackageFiles,
   listPackageVersions,
+  splitPackageId,
+  updatePackageDisplayName,
   type PackageRelease,
   type PluginPreview,
   RegistryHttpError,
@@ -39,6 +44,7 @@ export function PluginDetailPage() {
   const [fileLoading, setFileLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [canEditName, setCanEditName] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -78,6 +84,18 @@ export function PluginDetailPage() {
 
         setRelease(meta);
         setPreview(meta.plugin_preview || null);
+        if (token && meta.org_id) {
+          try {
+            const org = await getOrg(meta.org_id, token);
+            if (!cancelled) {
+              setCanEditName((org.role || "").toLowerCase() === "owner");
+            }
+          } catch {
+            if (!cancelled) setCanEditName(false);
+          }
+        } else if (!cancelled) {
+          setCanEditName(false);
+        }
 
         const files = await listPackageFiles(
           pluginId,
@@ -164,6 +182,8 @@ export function PluginDetailPage() {
     preview?.format ||
     (release?.package_kind === "plugin" ? "bora.plugin/1" : null);
 
+  const packageParts = useMemo(() => splitPackageId(pluginId), [pluginId]);
+
   const declared = useMemo(() => declaredSlotsFromPreview(preview), [preview]);
   const previewFiles = filePaths.length ? filePaths : preview?.files || [];
 
@@ -185,26 +205,29 @@ export function PluginDetailPage() {
 
       <div className="mb-4">
         <div className="flex flex-wrap items-center gap-2">
-          <h1 className="text-xl font-semibold tracking-tight text-ink font-mono">
-            {pluginId}
-          </h1>
+          <DisplayNameEditor
+            value={release?.display_name?.trim() || packageParts.name}
+            prefix={packageParts.org ? `${packageParts.org}/` : null}
+            canEdit={Boolean(token && canEditName && release)}
+            headingClassName="text-xl font-semibold tracking-tight text-ink"
+            onSave={async (next) => {
+              const updated = await updatePackageDisplayName(pluginId, next, token);
+              setRelease((prev) =>
+                prev ? { ...prev, display_name: updated.display_name || next } : prev,
+              );
+            }}
+          />
           {formatBadge ? (
             <span className="text-[11px] font-medium font-mono px-2 py-0.5 rounded border border-hairline bg-canvas-soft text-body">
               {formatBadge}
             </span>
-          ) : (
-            <span className="text-[11px] font-medium uppercase tracking-wide px-2 py-0.5 rounded border border-hairline bg-canvas-soft text-mute">
-              plugin
-            </span>
-          )}
-          {release?.official ? (
-            <span className="text-[11px] font-medium uppercase tracking-wide px-2 py-0.5 rounded border border-hairline bg-canvas-soft text-ink">
-              official
-            </span>
           ) : null}
+          {release?.official ? <OfficialMark /> : null}
         </div>
         {release ? (
           <p className="text-sm text-mute mt-1">
+            <span className="font-mono">@{pluginId}</span>
+            {" · "}
             v{release.version} · {release.visibility}
             {release.org_id ? (
               <>
@@ -217,11 +240,7 @@ export function PluginDetailPage() {
                   {release.org_id}
                 </Link>
               </>
-            ) : null}{" "}
-            ·{" "}
-            <span className="font-mono text-xs">
-              {release.package_digest.slice(0, 19)}…
-            </span>
+            ) : null}
           </p>
         ) : null}
       </div>

--- a/apps/hub/src/pages/PluginDetailPage.tsx
+++ b/apps/hub/src/pages/PluginDetailPage.tsx
@@ -197,6 +197,11 @@ export function PluginDetailPage() {
               plugin
             </span>
           )}
+          {release?.official ? (
+            <span className="text-[11px] font-medium uppercase tracking-wide px-2 py-0.5 rounded border border-hairline bg-canvas-soft text-ink">
+              official
+            </span>
+          ) : null}
         </div>
         {release ? (
           <p className="text-sm text-mute mt-1">

--- a/apps/hub/src/pages/PluginsPage.tsx
+++ b/apps/hub/src/pages/PluginsPage.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
 import { CatalogScopeBar } from "@/components/catalog-scope-bar";
 import { Shell } from "@/components/layout";
+import { OfficialMark } from "@/components/official-mark";
 import { SignInLink } from "@/components/sign-in-button";
 import {
   Table,
@@ -17,6 +18,7 @@ import {
   encodeDatasetId,
   listOrgs,
   listPackages,
+  packageDisplayTitle,
   type PackageRelease,
   RegistryHttpError,
 } from "@/lib/api";
@@ -203,16 +205,25 @@ export function PluginsPage() {
                       role="link"
                     >
                       <TableCell className="font-medium font-mono text-sm">
-                        <span className="inline-flex items-center gap-2">
-                          {row.database_id}
-                          <span className="text-[10px] font-sans font-medium uppercase tracking-wide px-1.5 py-0.5 rounded border border-hairline text-mute bg-canvas-soft">
-                            plugin
-                          </span>
-                          {row.official ? (
-                            <span className="text-[10px] font-sans font-medium uppercase tracking-wide px-1.5 py-0.5 rounded border border-hairline text-ink bg-canvas-soft">
-                              official
+                        <span className="inline-flex items-center gap-1.5 min-w-0">
+                          <span className="min-w-0">
+                            <span className="block truncate">
+                              {packageDisplayTitle(
+                                row.database_id,
+                                row.display_name,
+                              )}
                             </span>
-                          ) : null}
+                            {row.display_name &&
+                            packageDisplayTitle(
+                              row.database_id,
+                              row.display_name,
+                            ) !== row.database_id ? (
+                              <span className="block font-mono text-[11px] text-mute truncate">
+                                {row.database_id}
+                              </span>
+                            ) : null}
+                          </span>
+                          {row.official ? <OfficialMark /> : null}
                         </span>
                       </TableCell>
                       <TableCell className="font-mono text-xs text-mute">

--- a/apps/hub/src/pages/PluginsPage.tsx
+++ b/apps/hub/src/pages/PluginsPage.tsx
@@ -208,6 +208,11 @@ export function PluginsPage() {
                           <span className="text-[10px] font-sans font-medium uppercase tracking-wide px-1.5 py-0.5 rounded border border-hairline text-mute bg-canvas-soft">
                             plugin
                           </span>
+                          {row.official ? (
+                            <span className="text-[10px] font-sans font-medium uppercase tracking-wide px-1.5 py-0.5 rounded border border-hairline text-ink bg-canvas-soft">
+                              official
+                            </span>
+                          ) : null}
                         </span>
                       </TableCell>
                       <TableCell className="font-mono text-xs text-mute">

--- a/docs/design/05-runtime/provider-l1.md
+++ b/docs/design/05-runtime/provider-l1.md
@@ -23,7 +23,7 @@ Provider 负责代码运行位置和 OS 级限制：
 ## Docker L1 镜像来源（package 拥有 Dockerfile）
 
 1. `provider.kind: docker` 时，package 必须提供 **`environment/Dockerfile`**（或 `provider.dockerfile` 指向的 package 内路径）。
-2. Runtime prepare：**确保官方基座** `bora-attempt:l1`（仓库 `docker/attempt`）→ **`docker build -f <package Dockerfile>`** 得到 Attempt 用 image → **`image_digest` 写入 evidence**。本地 tag 只是 `docker run` 别名，不是寻址身份；Agent 流量仍是 `session_id` → 已绑定 target 上的 `docker exec`。
+2. Runtime prepare：**确保官方基座** `bora-attempt:l1`（仓库 `docker/attempt`）。若每个绑定 profile 都是 first-party `executor: acp`、选中的 `extensions` 不要求 bake、且 package Dockerfile 仅 `FROM bora-attempt:l1`（无 `COPY`/`RUN`/其它层），**直接复用**官方 tag，**不**再 `buildx --load` 出 `bora-pkg:*`。否则 **`docker build -f <package Dockerfile>`** 得到 Attempt 用 image。**`image_digest` 写入 evidence**。本地 tag 只是 `docker run` 别名，不是寻址身份；Agent 流量仍是 `session_id` → 已绑定 target 上的 `docker exec`。
 3. 官方基座构建一次、多处 `FROM` 复用；上游基座由 package Dockerfile 自行 `FROM` 并安装**同一 pin 表**声明的入口（禁止 package 自选 floating 版本）。官方基座自身的 `build_input_digest` 覆盖 `Dockerfile` + `install-executors.sh` + `acp-entries.lock.json`；**不**因本条改变 `bora-attempt:l1` 的 tag 名。
 4. **基座预装（设计契约）：** 最低 coding-agent 验收 entry 的 **engine + ACP 入口** bake-in：
    - Mode 1：`codex`+`codex-acp`、`claude`+`claude-agent-acp`、**`pi`+`pi-acp`**；
@@ -47,13 +47,14 @@ package Dockerfile
 本地 tag：
 
 ```text
+bora-attempt:l1                                          # first-party ACP + FROM-only + 无选中 bake
 bora-pkg:{content_key[:12]}
-bora-pkg:{content_key[:12]}-{plugin}-{bake_input[:12]}   # 仅当 image_contribute bake
+bora-pkg:{content_key[:12]}-{plugin}-{bake_input[:12]}   # 仅当 extensions 选中 image_contribute bake
 ```
 
-`content_key` / `bake_input` 是上述输入的 digest。同一组输入第二次 prepare **跳过** `buildx --load`，复用已有 tag 与 image id。只改 `parameters` / `agent_profiles` / bindings（Dockerfile 与 bake 输入不变）**不得**产生新 tag。
+`plugin` 段不得含 `/`（Hub `org/name` 在 tag 里写成 `org--name`）。`content_key` / `bake_input` 是上述输入的 digest。同一组输入第二次 prepare **跳过** `buildx --load`，复用已有 tag 与 image id。只改 `parameters` / `agent_profiles` / bindings（Dockerfile 与 bake 输入不变）**不得**产生新 tag。
 
-Bake 后缀来自 bake **输入** digest，禁止用 inspect id。绑定外置 executor 但 contribute 链为空或缺少 `Dockerfile.bake` 仍 fail closed。workspace、`ctx.params`、gold **不**进入镜像。
+Bake 后缀来自 bake **输入** digest，禁止用 inspect id。bake **只**覆盖本 job 各 profile `extensions` 选中的、已安装且带 `Dockerfile.bake` 的 contribute；`executor:` 单独出现不 bake。绑定已安装 executor 但 contribute 链为空或缺少 `Dockerfile.bake` 仍 fail closed。不要用「official org」跳过 bake。workspace、`ctx.params`、gold **不**进入镜像。
 
 ### Attempt 拥有的 volume 与 env 容器随 Attempt 死亡
 

--- a/docs/design/11-extension-plugins.md
+++ b/docs/design/11-extension-plugins.md
@@ -109,7 +109,7 @@ evaluate     → evaluation_input_contribute → evaluation_runtime
 
 `bora lock` / `bora run` / 路径 `bora plugin install` **只**从 bootstrap ∪ 本地 index resolve；缺绑定 id → fail closed。**不**问插件是否 official，**不**调 Registry，**不**用环境变量把 `nooa` 改写成 `${OFFICIAL_ORG}/nooa`（lock digest 不得随 env 漂移）。路径安装不需要凭据或 Registry URL。
 
-「Official」是 **市场展示策略**，不是运行时门闩。默认 allowlist 是单个 Core/Registry 常量（org `Official`）。可选覆盖只在 **Registry 进程**（如 `BORA_OFFICIAL_ORGS`）——不是前端 `VITE_*`，也不是 CLI→Registry 拉取。改 allowlist **不得**要求改 `plugins/nooa/plugin.yaml` 或 journeys profiles。
+「Official」是 **市场展示策略**，不是运行时门闩。默认 allowlist 是单个 Registry 常量（org slug `official`，与 `org-create` 小写规则一致）。可选覆盖只在 **Registry 进程**（如 `BORA_OFFICIAL_ORGS`）——不是前端 `VITE_*`，也不是 CLI→Registry 拉取。改 allowlist **不得**要求改 `plugins/nooa/plugin.yaml` 或 journeys profiles。比较时 casefold，避免 `Official` / `official` 漂移。
 
 Core 槽 id（`executor`、`image_contribute`、…）仍归 Core。
 

--- a/docs/design/11-extension-plugins.md
+++ b/docs/design/11-extension-plugins.md
@@ -34,7 +34,7 @@
 1. `profiles.executor`（及 `extensions` 显式绑定）选择 provide；**禁止** `resolve_executor` dual path / `bora.agent_executors` 旁路  
 2. **nooa 等生态插件外置**（`plugins/` + install），不进 first-party bootstrap  
 3. `bora plugin install` **只写本地 cache**（`$BORA_HOME/plugins`），**永不改写** profiles / task.yaml  
-4. **Recognition ≠ Ready**：install 可见 ≠ L1 镜像可跑；Ready 来自 `image_contribute` bake。Core 对每个已安装且声明 contribute、并带 `docker/Dockerfile.bake` 的**外置**插件链式 `docker buildx`（context = 插件根）。绑定了外置 executor 但链为空或缺 bake 文件 → fail closed。Core **不**按插件名解释 bake token。官方 ACP 五 entry 仍在 `docker/attempt` 基座 bake-in。  
+4. **Recognition ≠ Ready**：install 可见 ≠ L1 镜像可跑；Ready 来自本 profile `extensions` 选中的 `image_contribute` bake。`executor:` 只选 `provide(executor)`，**不**暗示 bake / trajectory / 其它 `on:`。MULTI 链只含 first-party/default **加上** 本 profile `extensions` 点名的插件；已安装但未列入的外置插件不进链、不进镜像。绑定了已安装 executor 但未选中 contribute 或缺 bake 文件 → fail closed。Core **不**按插件名解释 bake token。官方 ACP 五 entry 仍在 `docker/attempt` 基座 bake-in。不要用「official org」跳过 bake。
 5. PASS 只来自独立 evaluator；扩展链不得发明 PASS  
 6. 凭据只经 scoped projection；不进 lock / evidence  
 
@@ -90,25 +90,75 @@ evaluate     → evaluation_input_contribute → evaluation_runtime
 
 - 根 `plugin.yaml`：`plugin_id`、`version`、`slots.provide` / `slots.on` + entry  
 - 可选 `docker/Dockerfile.bake`（L1 Ready）  
-- install：`bora plugin install <path|org/id@ver>` → `~/.bora/plugins`  
+- install：`bora plugin install <path|org/name@version>` → `~/.bora/plugins`  
 - Hub/Registry：`package_kind=plugin`；media type `application/vnd.bora.plugin.v1.tar+gzip`  
 - Dataset 与 plugin **fail closed** 区分（Hub 列表过滤 / detail 拒绝混开）
+
+### 两套地址：本地短 id 与 Hub 地址
+
+同一包可以有 **本地 id** 和 **Hub 地址**。这是预期，不是缺陷。一份 profiles **不能**把两种地址混用于同一次安装。绑定只认 **`plugin_id`**，不认 `ExecutorSPI.kind`。两个安装不得共享同一 `plugin_id`（后写覆盖）。不要另设 `org-id` 字段。
+
+| 动作 | 操作者写的 / index 存的 id |
+| --- | --- |
+| 路径安装 `bora plugin install plugins/nooa` | `plugin.yaml` **短** id：`nooa`。不访问 Registry。 |
+| 仓内 first-party contrib（bootstrap） | 短 id：`acp`、`openai-http`、`mock`（+ `default` multi）。不经 install。 |
+| `profiles.yaml` / `bora lock` / `bora run` | **恰好**本地 index（或 bootstrap）里的 id。路径安装后写 `executor: nooa`。 |
+| `bora plugin publish --org Official` | Hub 包地址 **`Official/nooa`**。若 `plugin.yaml` 已是 `org/name`，`--org` 必须等于该前缀，否则拒绝。短 id → 拼接 `{org}/{plugin_id}`。 |
+| `bora plugin install Official/nooa@version` | 本地 index 记录 **Hub** id `Official/nooa`，以及 version 与 digest。该 cache 行的 profiles 写 `executor: Official/nooa`。 |
+| Hub 列表 / 详情 chip | Registry 在 **上传 org** 属于官方 org allowlist 时设 `official: true`。前端只渲染该布尔。 |
+
+`bora lock` / `bora run` / 路径 `bora plugin install` **只**从 bootstrap ∪ 本地 index resolve；缺绑定 id → fail closed。**不**问插件是否 official，**不**调 Registry，**不**用环境变量把 `nooa` 改写成 `${OFFICIAL_ORG}/nooa`（lock digest 不得随 env 漂移）。路径安装不需要凭据或 Registry URL。
+
+「Official」是 **市场展示策略**，不是运行时门闩。默认 allowlist 是单个 Core/Registry 常量（org `Official`）。可选覆盖只在 **Registry 进程**（如 `BORA_OFFICIAL_ORGS`）——不是前端 `VITE_*`，也不是 CLI→Registry 拉取。改 allowlist **不得**要求改 `plugins/nooa/plugin.yaml` 或 journeys profiles。
+
+Core 槽 id（`executor`、`image_contribute`、…）仍归 Core。
 
 ### First-party vs 外置
 
 | 来源 | 例子 |
 | --- | --- |
-| first-party contrib（bootstrap） | `acp`、`openai-http`、`mock` + `defaults` multi |
-| 外置 install | `nooa`、`slot-probe`（仓库 `plugins/` 仅示例，不进 Core） |
+| first-party contrib（bootstrap） | `acp`、`openai-http`、`mock` + `default` multi |
+| 外置 install | `nooa`、`dsh`、`slot-probe`（仓库 `plugins/` 仅示例，不进 Core） |
 
 ---
 
 ## 配置与绑定
 
-- Job binding 在 `profiles.yaml`：`executor` / `options` / `extensions`（binding 字段）  
+- Job binding 在 `profiles.yaml`：`executor` / `options` / `extensions`（binding 字段）；选择按 **profile（role）**，不是 task 级插件列表  
 - member `task.yaml` 只声明 role slot，禁止内联 binding  
-- `bora lock` 解析每个 profile → `extension_bindings` 进 digest  
+- `bora lock` 解析每个 profile → `extension_bindings` 进 digest（快照，不是选择器）  
 - 切换机制：**同一 harness**，改 profiles +（必要时）install，不改 harness 业务代码  
+
+### `extensions` 按 profile 显式 opt-in
+
+字段名保持 **`extensions`**。未列入的已安装插件不进入 MULTI 链、不 bake。Hub 安装后同一行写 Hub id（`Official/nooa`，…）。
+
+```yaml
+bindings:
+  planner:
+    executor: nooa                 # 只选 provide(executor)；不暗示 bake
+    extensions:
+      - plugin: nooa               # 该插件登记的全部槽（provide + on）
+  reviewer:
+    executor: dsh
+    extensions:
+      - plugin: dsh
+        slots: [image_contribute]  # 只开列出的槽
+      # 单槽写法（与历史上 {slot, plugin} 同义）：
+      # - slot: trajectory_collect
+      #   plugin: dsh
+```
+
+规则：
+
+1. 省略 `slots` → 打开该插件已登记的每一个槽（`provide` + `on`）。  
+2. `slots: [...]` → 只开列出的槽；未知槽或该插件未登记 → fail closed。  
+3. `{slot, plugin}` → 恰好那一个槽。  
+4. MULTI 链 **只**含本 profile `extensions` 点名的项。已安装但未列入的插件不进链、不进镜像。  
+5. `executor:` **不**隐含 `image_contribute`。纯 ACP profile 省略 `extensions`。  
+6. 绑定了**已安装** executor 但未选中 `image_contribute`（或缺 bake 文件）→ L1 fail closed。  
+7. 同一 job 里不同 role 可独立绑定不同插件。  
+8. 省略 `executor:` 时，若某条 `- plugin: …`（全槽）含该插件的 executor provide，可用它补上；两套都写时以 `executor:` 为准。
 
 ### nooa 绑定形状
 
@@ -119,6 +169,8 @@ evaluate     → evaluation_input_contribute → evaluation_runtime
 bindings:
   solver:
     executor: nooa
+    extensions:
+      - plugin: nooa
     model: openai/glm-5.2
     api_key: litellm_api_key          # env locator；值不进 lock
     # base_url: https://…/v1          # 可选；否则回落 litellm_base_url / OPENAI_BASE_URL
@@ -128,6 +180,16 @@ bindings:
 ```
 
 L1：bake 安装 `nooa` + **in-container worker**；parent 把 model/base_url/密钥投影进 worker；host SPI 不是 L1 成功路径。
+
+### 官方 ACP 镜像（不另打 `bora-pkg`）
+
+下列条件**同时**成立时，prepare **不** `buildx --load` package 标签；Attempt 镜像就是已有官方 `bora-attempt:l1`：
+
+- 每个已绑定 profile 都是 first-party `executor: acp`（无已安装/外置 executor）；  
+- 选中的 `extensions` 不要求 `image_contribute` bake；  
+- package Dockerfile 相对官方基座是空操作（今天：仅 `FROM bora-attempt:l1`，无 `COPY` / `RUN` / 其它层）。
+
+Dockerfile 另有文件或其它 `FROM`，或任一选中扩展要 bake，仍走 `bora-pkg:{content}`（+ bake 后缀）。evidence 仍记 `image_digest`。`bora-attempt:l1` 的 hash 规则不变。
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -78,8 +78,9 @@ credentials — not parent host SPI success.
 
 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) path: official
 JSON-RPC SDK (`deepseek-harness-sdk`), not ACP. Same journeys harness; bind
-`executor: dsh` + `model` + locator `deepseek_api_key`. L1 bake installs the
-wheels in the Attempt image — host `--extra dsh` is only for L0 host SPI.
+`executor: dsh` + `extensions: [{plugin: dsh}]` + `model` + locator
+`deepseek_api_key`. L1 bake installs the wheels in the Attempt image — host
+`--extra dsh` is only for L0 host SPI. `executor:` alone does not bake.
 
 ```bash
 uv run bora plugin install plugins/dsh

--- a/examples/core/profiles.yaml
+++ b/examples/core/profiles.yaml
@@ -27,6 +27,8 @@ bindings:
   # External nooa host SPI (task-local lib.agents; after bora plugin install)
   nooa-solver:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:FixedAnswerAgent"
       method: "run"

--- a/examples/journeys/profiles.dsh.read-only.yaml
+++ b/examples/journeys/profiles.dsh.read-only.yaml
@@ -12,6 +12,8 @@ format: bora.profiles/1
 bindings:
   solver:
     executor: dsh
+    extensions:
+      - plugin: dsh
     model: deepseek-v4-flash
     api_key: deepseek_api_key
     options:

--- a/examples/journeys/profiles.dsh.yaml
+++ b/examples/journeys/profiles.dsh.yaml
@@ -13,6 +13,8 @@ format: bora.profiles/1
 bindings:
   solver:
     executor: dsh
+    extensions:
+      - plugin: dsh
     model: deepseek-v4-flash
     api_key: deepseek_api_key
     options:

--- a/examples/journeys/profiles.nooa.yaml
+++ b/examples/journeys/profiles.nooa.yaml
@@ -12,6 +12,8 @@ format: bora.profiles/1
 bindings:
   solver:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:JsonlAggAgent"
       method: "run"
@@ -19,6 +21,8 @@ bindings:
     api_key: litellm_api_key
   user:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:UserSimAgent"
       method: "run"
@@ -26,6 +30,8 @@ bindings:
     api_key: litellm_api_key
   service:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:ServiceAgent"
       method: "run"
@@ -33,6 +39,8 @@ bindings:
     api_key: litellm_api_key
   specialist:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:SpecialistAgent"
       method: "run"
@@ -40,6 +48,8 @@ bindings:
     api_key: litellm_api_key
   planner:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:PlannerAgent"
       method: "run"
@@ -47,6 +57,8 @@ bindings:
     api_key: litellm_api_key
   reducer:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:ReducerAgent"
       method: "run"

--- a/examples/slot-probe/README.md
+++ b/examples/slot-probe/README.md
@@ -1,6 +1,6 @@
 # example/slot-probe
 
-Database for **multi-slot extension SPI** regression ([Issue #71](https://github.com/ZJU-REAL/BORA/issues/71)).
+Database for **multi-slot extension SPI** regression.
 
 Companion plugin: [`plugins/slot-probe`](../../plugins/slot-probe/).
 

--- a/examples/slot-probe/profiles.yaml
+++ b/examples/slot-probe/profiles.yaml
@@ -1,16 +1,21 @@
 format: bora.profiles/1
 bindings:
   # L0: nooa host SPI + package FixedAnswerAgent (deterministic, capability-catalog known).
-  # slot-probe multi hooks still attach via install (env / trajectory / open / …).
+  # slot-probe multi hooks attach only when named here (install is Recognition only).
   probe-nooa:
     executor: nooa
+    extensions:
+      - plugin: nooa
+      - plugin: slot-probe
     options:
       agent: "lib.agents:FixedAnswerAgent"
       method: "run"
     model: none
-  # L1: real ACP in attempt-container.
+  # L1: real ACP in attempt-container. slot-probe still needs an explicit row.
   probe-acp:
     executor: acp
+    extensions:
+      - plugin: slot-probe
     options:
       entry: pi
     model: zai-coding-cn/glm-5.2

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -35,6 +35,8 @@ edits `profiles.yaml` / `bora.yaml` / `task.yaml`.
 bindings:
   solver:
     executor: dsh
+    extensions:
+      - plugin: dsh
     model: deepseek-v4-flash
     api_key: deepseek_api_key          # env locator
     options:
@@ -78,8 +80,9 @@ uv run bora run examples/journeys --task terminal-jsonl-agg \
 ## Recognition ≠ Ready ≠ bind
 
 - **install** → Recognition only (`plugin list` / executor visible)
-- **profiles `executor: dsh`** → bind (+ model / api_key locator)
-- **L1 Ready** → `image_contribute` bake installs the SDK wheels +
+- **profiles `executor: dsh`** → bind provide only (+ model / api_key locator)
+- **`extensions: [{plugin: dsh}]`** → opt-in bake / trajectory collect (required for L1 Ready)
+- **L1 Ready** → selected `image_contribute` bake installs the SDK wheels +
   `bora-executor-dsh`; invoke is **docker exec** with projected `DEEPSEEK_API_KEY`
 
 Host SPI success is not L1 Ready. Offline (`BORA_OFFLINE_AGENT=1`) fail-closes

--- a/plugins/nooa/README.md
+++ b/plugins/nooa/README.md
@@ -36,6 +36,8 @@ Install updates `~/.bora/plugins` (or `$BORA_HOME/plugins`) only — **never** e
 bindings:
   solver:
     executor: nooa
+    extensions:
+      - plugin: nooa
     model: openai/glm-5.2
     api_key: litellm_api_key          # env locator
     # base_url: http://127.0.0.1:8000/v1   # optional; else litellm_base_url / OPENAI_BASE_URL
@@ -57,8 +59,9 @@ uv run bora run examples/journeys \
 ## Recognition ≠ Ready ≠ bind
 
 - **install** → Recognition only (`plugin list` / executor visible)
-- **profiles `executor: nooa`** → bind (+ model / base_url / api_key)
-- **L1 Ready** → `image_contribute` bake installs `nooa` + `bora-executor-nooa` in the Attempt image; invoke is **docker exec** with projected credentials
+- **profiles `executor: nooa`** → bind provide only (+ model / base_url / api_key)
+- **`extensions: [{plugin: nooa}]`** → opt-in bake / trajectory collect (required for L1 Ready)
+- **L1 Ready** → selected `image_contribute` bake installs `nooa` + `bora-executor-nooa` in the Attempt image; invoke is **docker exec** with projected credentials
 
 ## L1 Ready strategy
 

--- a/plugins/slot-probe/README.md
+++ b/plugins/slot-probe/README.md
@@ -1,7 +1,6 @@
 # slot-probe
 
-`bora.plugin/1` multi-slot **observability** plugin for extension SPI regression
-([Issue #71](https://github.com/ZJU-REAL/BORA/issues/71)).
+`bora.plugin/1` multi-slot **observability** plugin for extension SPI regression.
 
 Paired dataset: [`examples/slot-probe`](../../examples/slot-probe/).
 
@@ -54,7 +53,8 @@ Config capability catalog still allowlists **declaration** executor kinds
 installed plugin `provide(executor)`. The `slot-probe` package still **provides**
 an echo executor for experiments, but the shipped L0 profile binds **nooa** +
 package-local `lib.agents:FixedAnswerAgent` so lock/run stay green while multi
-hooks prove emit.
+hooks prove emit. Those hooks attach only when `profiles.extensions` names
+`slot-probe` (install alone does not join the chain).
 
 ## Anti-pattern
 

--- a/services/registry/.env.example
+++ b/services/registry/.env.example
@@ -23,3 +23,8 @@ BORA_GITHUB_LOGIN_ALLOWLIST=
 # GitHub OAuth App → Authorization callback URL must include e.g.:
 #   http://127.0.0.1:5174/login/callback
 #   http://localhost:5174/login/callback
+
+# Plugin marketplace official mark (Registry process only; not CLI lock/run).
+# Comma-separated upload org slugs (lowercase, same as org-create).
+# Unset → default org official. Replaces the default list when set.
+# BORA_OFFICIAL_ORGS=official

--- a/services/registry/app.py
+++ b/services/registry/app.py
@@ -638,6 +638,36 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
                 return
             _json_response(self, 200, payload)
 
+        def _patch_org(self, *, org_id: str, auth: TokenInfo) -> None:
+            body = self._read_json_body()
+            if body is None:
+                return
+            try:
+                payload = state.orgs.patch(
+                    org_id=org_id,
+                    display_name=body.get("display_name"),
+                    auth=auth,
+                )
+            except RegistryAppError as exc:
+                _app_error(self, exc)
+                return
+            _json_response(self, 200, payload)
+
+        def _patch_package_display_name(self, *, database_id: str, auth: TokenInfo) -> None:
+            body = self._read_json_body()
+            if body is None:
+                return
+            try:
+                payload = state.packages.patch_display_name(
+                    database_id=database_id,
+                    display_name=body.get("display_name"),
+                    auth=auth,
+                )
+            except RegistryAppError as exc:
+                _app_error(self, exc)
+                return
+            _json_response(self, 200, payload)
+
         def _claim_org(self, *, org_id: str, auth: TokenInfo) -> None:
             try:
                 payload = state.orgs.claim(org_id=org_id, auth=auth)

--- a/services/registry/official.py
+++ b/services/registry/official.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 
-DEFAULT_OFFICIAL_ORGS: tuple[str, ...] = ("Official",)
+DEFAULT_OFFICIAL_ORGS: tuple[str, ...] = ("official",)
 ENV_OFFICIAL_ORGS = "BORA_OFFICIAL_ORGS"
 
 
@@ -18,4 +18,5 @@ def official_orgs() -> frozenset[str]:
 def is_official_upload_org(org_id: str | None) -> bool:
     if not org_id:
         return False
-    return org_id in official_orgs()
+    allowed = {item.casefold() for item in official_orgs()}
+    return org_id.casefold() in allowed

--- a/services/registry/official.py
+++ b/services/registry/official.py
@@ -1,0 +1,21 @@
+"""Hub marketplace official-org policy. Not a lock/run gate."""
+
+from __future__ import annotations
+
+import os
+
+DEFAULT_OFFICIAL_ORGS: tuple[str, ...] = ("Official",)
+ENV_OFFICIAL_ORGS = "BORA_OFFICIAL_ORGS"
+
+
+def official_orgs() -> frozenset[str]:
+    raw = os.environ.get(ENV_OFFICIAL_ORGS, "").strip()
+    if raw:
+        return frozenset(part.strip() for part in raw.split(",") if part.strip())
+    return frozenset(DEFAULT_OFFICIAL_ORGS)
+
+
+def is_official_upload_org(org_id: str | None) -> bool:
+    if not org_id:
+        return False
+    return org_id in official_orgs()

--- a/services/registry/org_service.py
+++ b/services/registry/org_service.py
@@ -19,6 +19,26 @@ from services.registry.store import (
 )
 
 _ORG_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9_-]{0,62}[a-z0-9])?$")
+_DISPLAY_NAME_MAX = 80
+
+
+def _normalize_display_name(raw: object) -> str:
+    if not isinstance(raw, str):
+        raise RegistryAppError("invalid_request", "display_name must be a string", http_status=400)
+    name = " ".join(raw.split())
+    if any(ord(ch) < 32 for ch in name):
+        raise RegistryAppError(
+            "invalid_request",
+            "display_name cannot include control characters",
+            http_status=400,
+        )
+    if len(name) > _DISPLAY_NAME_MAX:
+        raise RegistryAppError(
+            "invalid_request",
+            f"display_name must be at most {_DISPLAY_NAME_MAX} characters",
+            http_status=400,
+        )
+    return name
 
 
 class OrgService:
@@ -72,6 +92,21 @@ class OrgService:
             d["role"] = role
             items.append(d)
         return {"items": items}
+
+    def patch(self, *, org_id: str, display_name: object, auth: TokenInfo) -> dict[str, Any]:
+        org_id = org_id.casefold()
+        self._require_owner(org_id, auth)
+        name = _normalize_display_name(display_name)
+        try:
+            org = self.meta.update_org_display_name(org_id, name)
+        except LookupError as exc:
+            raise RegistryAppError("not_found", "org not found", http_status=404) from exc
+        payload = org_to_dict(org)
+        if auth.user_id:
+            mem = self.meta.membership(org.org_id, auth.user_id)
+            if mem:
+                payload["role"] = mem.role
+        return payload
 
     def get_public(self, *, org_id: str, auth: TokenInfo) -> dict[str, Any]:
         org = self.meta.get_org(org_id.casefold())

--- a/services/registry/package_service.py
+++ b/services/registry/package_service.py
@@ -506,8 +506,6 @@ class PackageService:
     def patch_display_name(
         self, *, database_id: str, display_name: object, auth: TokenInfo
     ) -> dict[str, Any]:
-        from services.registry.org_service import _normalize_display_name
-
         row = self._latest_managed_release(database_id, auth)
         name = _normalize_plugin_name_segment(database_id, display_name)
         stored = self.meta.set_package_display_name(database_id, name)
@@ -521,11 +519,7 @@ class PackageService:
             database_id_prefix=database_id,
             include_private=True,
         )
-        owned = [
-            r
-            for r in rows
-            if r.database_id == database_id and self.can_manage(r, auth)
-        ]
+        owned = [r for r in rows if r.database_id == database_id and self.can_manage(r, auth)]
         if not owned:
             draft = self.meta.get_draft(database_id)
             if draft is not None and self.access.can_write_draft(

--- a/services/registry/package_service.py
+++ b/services/registry/package_service.py
@@ -13,6 +13,32 @@ from services.registry.errors import RegistryAppError
 from services.registry.store import DraftRow, ReleaseRow, TokenInfo, now, release_to_dict
 
 
+def _normalize_plugin_name_segment(database_id: str, raw: object) -> str:
+    """Store only the name leaf. ``org/name`` ids cannot change the org prefix."""
+    from services.registry.org_service import _normalize_display_name
+
+    name = _normalize_display_name(raw)
+    org, _leaf = (database_id.split("/", 1) + [""])[:2] if "/" in database_id else ("", database_id)
+    if "/" in name:
+        prefix, rest = name.split("/", 1)
+        if org and prefix.casefold() != org.casefold():
+            raise RegistryAppError(
+                "invalid_request",
+                "display_name cannot change the org prefix",
+                http_status=400,
+            )
+        name = _normalize_display_name(rest)
+    if not name:
+        raise RegistryAppError("invalid_request", "display_name required", http_status=400)
+    if "/" in name:
+        raise RegistryAppError(
+            "invalid_request",
+            "display_name is the name after org/, not org/name",
+            http_status=400,
+        )
+    return name
+
+
 class PackageService:
     def __init__(
         self,
@@ -289,6 +315,11 @@ class PackageService:
             items = [i for i in items if i.get("package_kind") == package_kind]
         if mine:
             items = self._filter_mine(items, auth)
+        labels = self.meta.package_display_names()
+        for item in items:
+            label = labels.get(str(item.get("database_id") or ""))
+            if label:
+                item["display_name"] = label
         return {"items": items}
 
     def _filter_mine(self, items: list[dict[str, Any]], auth: TokenInfo) -> list[dict[str, Any]]:
@@ -319,6 +350,10 @@ class PackageService:
         draft = self.meta.get_draft(database_id)
         if draft is not None and self.access.entitled_to_draft(draft, auth):
             items.insert(0, release_to_dict(draft.as_release()))
+        label = self.meta.get_package_display_name(database_id)
+        if label:
+            for item in items:
+                item["display_name"] = label
         return {"database_id": database_id, "items": items}
 
     def serve_meta(
@@ -336,6 +371,9 @@ class PackageService:
             version=version,
         )
         payload = release_to_dict(row)
+        label = self.meta.get_package_display_name(database_id)
+        if label:
+            payload["display_name"] = label
         try:
             from bora.registry.plugin_package import PLUGIN_MEDIA_TYPE
 
@@ -464,6 +502,39 @@ class PackageService:
             "version": version,
             "blob_deleted": blob_deleted,
         }
+
+    def patch_display_name(
+        self, *, database_id: str, display_name: object, auth: TokenInfo
+    ) -> dict[str, Any]:
+        from services.registry.org_service import _normalize_display_name
+
+        row = self._latest_managed_release(database_id, auth)
+        name = _normalize_plugin_name_segment(database_id, display_name)
+        stored = self.meta.set_package_display_name(database_id, name)
+        payload = release_to_dict(row)
+        if stored:
+            payload["display_name"] = stored
+        return payload
+
+    def _latest_managed_release(self, database_id: str, auth: TokenInfo) -> Any:
+        rows = self.meta.list_releases(
+            database_id_prefix=database_id,
+            include_private=True,
+        )
+        owned = [
+            r
+            for r in rows
+            if r.database_id == database_id and self.can_manage(r, auth)
+        ]
+        if not owned:
+            draft = self.meta.get_draft(database_id)
+            if draft is not None and self.access.can_write_draft(
+                draft, org_id=draft.org_id, auth=auth
+            ):
+                return draft.as_release()
+            raise RegistryAppError("forbidden", "org owner required", http_status=403)
+        owned.sort(key=lambda r: r.created_at, reverse=True)
+        return owned[0]
 
     def patch_visibility(
         self, *, database_id: str, version: str, visibility: str, auth: TokenInfo

--- a/services/registry/queries.py
+++ b/services/registry/queries.py
@@ -97,6 +97,22 @@ VALUES (?, ?, 'owner', ?)
 
 SELECT_ORG = "SELECT * FROM organizations WHERE org_id=?"
 
+UPDATE_ORG_DISPLAY_NAME = "UPDATE organizations SET display_name=? WHERE org_id=?"
+
+UPSERT_PACKAGE_DISPLAY_NAME = """
+INSERT INTO package_display_names(database_id, display_name, updated_at)
+VALUES (?, ?, ?)
+ON CONFLICT(database_id) DO UPDATE SET
+    display_name=excluded.display_name,
+    updated_at=excluded.updated_at
+"""
+
+SELECT_PACKAGE_DISPLAY_NAME = (
+    "SELECT display_name FROM package_display_names WHERE database_id=?"
+)
+
+SELECT_PACKAGE_DISPLAY_NAMES = "SELECT database_id, display_name FROM package_display_names"
+
 SELECT_MEMBERSHIP = "SELECT * FROM org_memberships WHERE org_id=? AND user_id=?"
 
 SELECT_USER_ORG_IDS = "SELECT org_id FROM org_memberships WHERE user_id=?"
@@ -233,6 +249,13 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
         role TEXT NOT NULL,
         created_at REAL NOT NULL,
         PRIMARY KEY (database_id, user_id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS package_display_names (
+        database_id TEXT PRIMARY KEY,
+        display_name TEXT NOT NULL DEFAULT '',
+        updated_at REAL NOT NULL
     )
     """,
 )

--- a/services/registry/routes.py
+++ b/services/registry/routes.py
@@ -355,6 +355,21 @@ ROUTES: tuple[Route, ...] = (
         pattern=r"/v1/packages/(.+)/versions/([^/]+)",
         groups=("database_id", "version"),
     ),
+    Route(
+        "PATCH",
+        "patch_org",
+        access="org_owner",
+        pattern=r"/v1/orgs/([^/]+)",
+        groups=("org_id",),
+    ),
+    Route(
+        "PATCH",
+        "patch_package_display_name",
+        access="bearer",
+        pattern=r"/v1/packages/([^/]+(?:/[^/]+)*)",
+        groups=("database_id",),
+        predicate=_package_id_list_ok,
+    ),
 )
 
 

--- a/services/registry/store.py
+++ b/services/registry/store.py
@@ -1023,6 +1023,44 @@ class MetadataStore(MetadataStoreProtocol):
                 raise ValueError("org already exists") from exc
         return row
 
+    def update_org_display_name(self, org_id: str, display_name: str) -> OrgRow:
+        with self._connect() as conn:
+            cur = self._exec(conn, Q.UPDATE_ORG_DISPLAY_NAME, (display_name, org_id))
+            if getattr(cur, "rowcount", 1) == 0:
+                raise LookupError("org not found")
+            conn.commit()
+        org = self.get_org(org_id)
+        if org is None:
+            raise LookupError("org not found")
+        return org
+
+    def set_package_display_name(self, database_id: str, display_name: str) -> str:
+        with self._connect() as conn:
+            self._exec(
+                conn,
+                Q.UPSERT_PACKAGE_DISPLAY_NAME,
+                (database_id, display_name, now()),
+            )
+            conn.commit()
+        return display_name
+
+    def get_package_display_name(self, database_id: str) -> str:
+        with self._connect() as conn:
+            cur = self._exec(conn, Q.SELECT_PACKAGE_DISPLAY_NAME, (database_id,))
+            row = cur.fetchone()
+        if row is None:
+            return ""
+        return str(row["display_name"] or "")
+
+    def package_display_names(self) -> dict[str, str]:
+        with self._connect() as conn:
+            cur = self._exec(conn, Q.SELECT_PACKAGE_DISPLAY_NAMES)
+            return {
+                str(r["database_id"]): str(r["display_name"] or "")
+                for r in cur.fetchall()
+                if r["display_name"]
+            }
+
     def get_org(self, org_id: str) -> OrgRow | None:
         with self._connect() as conn:
             cur = self._exec(conn, Q.SELECT_ORG, (org_id,))

--- a/services/registry/store.py
+++ b/services/registry/store.py
@@ -1557,6 +1557,10 @@ def release_to_dict(row: ReleaseRow) -> dict[str, Any]:
     }
     if row.org_id:
         out["org_id"] = row.org_id
+    if out.get("package_kind") == "plugin":
+        from services.registry.official import is_official_upload_org
+
+        out["official"] = is_official_upload_org(row.org_id)
     if row.uploaded_by:
         out["uploaded_by"] = row.uploaded_by
     if row.version == "draft":

--- a/skills/bora-plugin/references/authoring.md
+++ b/skills/bora-plugin/references/authoring.md
@@ -97,8 +97,10 @@ the image).
 ## `image_contribute` + bake
 
 The handler appends a declare (`{plugin: <id>}`) onto the chain list, then
-`return await nxt(base)`. Core `docker buildx`es each declared external plugin
-that has `docker/Dockerfile.bake`. **Context = installed plugin root.**
+`return await nxt(base)`. Core `docker buildx`es each **extensions-selected**
+installed plugin that registered `image_contribute` and ships
+`docker/Dockerfile.bake`. **Context = installed plugin root.**
+`executor:` alone does not bake.
 
 ```dockerfile
 ARG BASE_IMAGE
@@ -131,6 +133,8 @@ format: bora.profiles/1
 bindings:
   solver:
     executor: my-mech
+    extensions:
+      - plugin: my-mech
     model: openai/glm-5.2
     api_key: litellm_api_key # locator
     options:

--- a/skills/bora-plugin/references/mechanism.md
+++ b/skills/bora-plugin/references/mechanism.md
@@ -7,7 +7,9 @@ authoring agents only; it does not own new contract.
 
 - First-party contrib bootstraps in Core: `acp`, `openai-http`, `mock` + default multi handlers.
 - External `bora plugin install` joins the same table. Recognition = first-party ∪ installed `provide(executor)`.
-- `profiles.executor: <plugin_id>` is sugar for the executor provide. `extensions:` can bind other slots explicitly.
+- `profiles.executor: <plugin_id>` is sugar for the executor provide only. It does **not** enable bake / trajectory / other `on:` slots.
+- `extensions:` is the opt-in list (`- plugin: nooa`, or `slots: [...]`, or `{slot, plugin}`). Installed-but-unlisted plugins stay off MULTI chains and off the image.
+- Local path install and `bora run` use the short `plugin.yaml` id. Hub publish/install uses `org/name`.
 - Resolve: explicit binding > lower priority wins; a tie with no explicit pick fail-closes.
 - `bora lock` writes the resolved graph as `extension_bindings` (plugin_id / slot / source / priority / digest).
 

--- a/src/bora/adapters/provider_docker/images.py
+++ b/src/bora/adapters/provider_docker/images.py
@@ -207,6 +207,26 @@ def package_local_tag(content_digest: str) -> str:
     return f"bora-pkg:{content_digest[:12]}"
 
 
+def is_official_base_noop_dockerfile(text: str) -> bool:
+    """True when the Dockerfile is only ``FROM bora-attempt:l1`` (optional AS)."""
+    lines = dockerfile_logical_lines(text)
+    if len(lines) != 1:
+        return False
+    line = lines[0]
+    if not line.upper().startswith("FROM "):
+        return False
+    tokens = [t for t in line.split()[1:] if not t.startswith("-")]
+    if not tokens:
+        return False
+    image = tokens[0]
+    if image != _OFFICIAL_BASE_TAG and image.rsplit("/", 1)[-1] != _OFFICIAL_BASE_TAG:
+        return False
+    extra = tokens[1:]
+    if not extra:
+        return True
+    return len(extra) == 2 and extra[0].upper() == "AS"
+
+
 def inspect_image_digest(tag: str) -> str | None:
     """Evidence digest for an existing local tag, or None if missing."""
     proc = subprocess.run(

--- a/src/bora/application/attempt/run_l1_prepare.py
+++ b/src/bora/application/attempt/run_l1_prepare.py
@@ -29,6 +29,7 @@ def prepare_l1_runtime(
     from bora.application.plugin_ops.image_contribute_bake import (
         ImageContributeError,
         apply_image_contribute_bake,
+        should_reuse_official_attempt_image,
     )
     from bora.config.model import thaw
 
@@ -38,15 +39,20 @@ def prepare_l1_runtime(
         provider = {}
     dockerfile_rel = str(provider.get("dockerfile") or "environment/Dockerfile")
     platform = str(provider.get("platform") or "linux/arm64")
-    # Official base (FROM bora-attempt:l1) then package Dockerfile → Attempt image.
-    # Tag is content-addressed (Dockerfile + FROM digest + COPY set); not lock.digest.
-    ensure_base_image(Path.cwd())
-    pkg_image = build_package_image(
-        package_root=package_root,
-        dockerfile_rel=dockerfile_rel,
-        platform=platform,
-        repo_root=Path.cwd(),
-    )
+    # First-party ACP + FROM-only Dockerfile + no selected bake reuses bora-attempt:l1.
+    # Otherwise official base then package Dockerfile → content-addressed tag.
+    official = ensure_base_image(Path.cwd())
+    df = package_root / dockerfile_rel
+    dockerfile_text = df.read_text(encoding="utf-8") if df.is_file() else ""
+    if should_reuse_official_attempt_image(lock, dockerfile_text):
+        pkg_image = official
+    else:
+        pkg_image = build_package_image(
+            package_root=package_root,
+            dockerfile_rel=dockerfile_rel,
+            platform=platform,
+            repo_root=Path.cwd(),
+        )
     # Lifecycle prepare + image_contribute consume (fail closed).
     hook_prepare(lock, {"phase": "l1_prepare", "package_image": pkg_image.image_tag})
     try:

--- a/src/bora/application/plugin_ops/image_contribute_bake.py
+++ b/src/bora/application/plugin_ops/image_contribute_bake.py
@@ -278,7 +278,6 @@ def apply_image_contribute_bake(
     bound = bound_executor_ids(lock)
     external_bound = [k for k in bound if k not in FIRST_PARTY_PLUGIN_IDS]
     selected = selected_contribute_plugin_ids(lock)
-    declared = _plugin_ids_from_declares(declares)
     meta: dict[str, Any] = {
         "declares": declares,
         "baked": [],

--- a/src/bora/application/plugin_ops/image_contribute_bake.py
+++ b/src/bora/application/plugin_ops/image_contribute_bake.py
@@ -19,6 +19,7 @@ from typing import Any
 from bora.adapters.provider_docker.images import (
     hash_copy_sources,
     inspect_image_digest,
+    is_official_base_noop_dockerfile,
     parse_dockerfile_copy_sources,
 )
 from bora.adapters.provider_docker.types import DockerImageLock
@@ -27,6 +28,7 @@ from bora.plugins.bootstrap import ensure_bootstrapped
 from bora.plugins.lifecycle import collect_image_contribute
 from bora.plugins.protocol import intent_from_profile
 from bora.plugins.resolve import resolve
+from bora.plugins.slots import IMAGE_CONTRIBUTE
 from bora.plugins.store import list_installed, resolve_package_root
 
 # First-party contrib: official L1 image BOM, not this bake path.
@@ -54,7 +56,9 @@ def _await(coro: Any) -> Any:
 def graphs_for_lock(lock: LockedTaskConfig) -> list[Any]:
     """Resolve materialized graphs for every agent profile (for multi-slot chains)."""
     reg = ensure_bootstrapped()
-    profiles = thaw(lock.agent_profiles) if lock.agent_profiles else []
+    profiles = (
+        thaw(getattr(lock, "agent_profiles", None)) if getattr(lock, "agent_profiles", None) else []
+    )
     graphs: list[Any] = []
     if not isinstance(profiles, list) or not profiles:
         return graphs
@@ -84,7 +88,9 @@ def collect_declares_for_lock(lock: LockedTaskConfig) -> list[Any]:
 
 
 def bound_executor_ids(lock: LockedTaskConfig) -> list[str]:
-    profiles = thaw(lock.agent_profiles) if lock.agent_profiles else []
+    profiles = (
+        thaw(getattr(lock, "agent_profiles", None)) if getattr(lock, "agent_profiles", None) else []
+    )
     if not isinstance(profiles, list):
         return []
     out: list[str] = []
@@ -97,6 +103,30 @@ def bound_executor_ids(lock: LockedTaskConfig) -> list[str]:
             continue
         seen.add(kind)
         out.append(kind)
+    return out
+
+
+def _is_bootstrap_contribute(plugin_id: str, source: str) -> bool:
+    return (
+        plugin_id in FIRST_PARTY_PLUGIN_IDS
+        or plugin_id == "default"
+        or source in {"default", "first-party"}
+    )
+
+
+def selected_contribute_plugin_ids(lock: LockedTaskConfig) -> list[str]:
+    """Installed plugins this job selected on ``image_contribute`` (not bootstrap)."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for graph in graphs_for_lock(lock):
+        for href in graph.chain(IMAGE_CONTRIBUTE):
+            plugin_id = str(href.plugin_id)
+            if _is_bootstrap_contribute(plugin_id, str(href.source or "")):
+                continue
+            if plugin_id in seen:
+                continue
+            seen.add(plugin_id)
+            out.append(plugin_id)
     return out
 
 
@@ -151,8 +181,23 @@ def _base_content_digest(base_image: DockerImageLock) -> str:
     return base_image.build_input_digest or base_image.image_tag
 
 
+def plugin_id_for_image_tag(plugin_id: str) -> str:
+    """Docker tags cannot contain ``/``; Hub ``org/name`` becomes ``org--name``."""
+    return plugin_id.replace("/", "--")
+
+
 def baked_image_tag(base_image: DockerImageLock, plugin_id: str, bake_digest: str) -> str:
-    return f"{base_image.image_tag}-{plugin_id}-{bake_digest[:12]}"
+    return f"{base_image.image_tag}-{plugin_id_for_image_tag(plugin_id)}-{bake_digest[:12]}"
+
+
+def should_reuse_official_attempt_image(lock: LockedTaskConfig, dockerfile_text: str) -> bool:
+    """First-party ACP + FROM-only package Dockerfile + no selected bake → reuse base."""
+    bound = bound_executor_ids(lock)
+    if not bound or any(kind != "acp" for kind in bound):
+        return False
+    if selected_contribute_plugin_ids(lock):
+        return False
+    return is_official_base_noop_dockerfile(dockerfile_text)
 
 
 def bake_plugin_layer(
@@ -232,22 +277,24 @@ def apply_image_contribute_bake(
     declares = collect_declares_for_lock(lock)
     bound = bound_executor_ids(lock)
     external_bound = [k for k in bound if k not in FIRST_PARTY_PLUGIN_IDS]
+    selected = selected_contribute_plugin_ids(lock)
     declared = _plugin_ids_from_declares(declares)
     meta: dict[str, Any] = {
         "declares": declares,
         "baked": [],
         "bound_executors": bound,
         "external_bound": external_bound,
+        "selected_contribute": selected,
     }
 
     for kind in external_bound:
-        if kind not in declared:
+        if kind not in selected:
             raise ImageContributeError(
                 f"executor {kind!r} bound but image_contribute chain empty or unsatisfied",
                 kind="image_contribute_unsatisfied",
             )
 
-    plugins_to_bake = [p for p in declared if p not in FIRST_PARTY_PLUGIN_IDS]
+    plugins_to_bake = [p for p in selected if p not in FIRST_PARTY_PLUGIN_IDS]
     if not plugins_to_bake:
         meta["status"] = "skipped"
         return base_image, meta

--- a/src/bora/application/plugin_ops/plugin_install_remote.py
+++ b/src/bora/application/plugin_ops/plugin_install_remote.py
@@ -63,7 +63,7 @@ class PluginInstallCommand:
             extract_dir = Path(tmp) / "pkg"
             extract_dir.mkdir()
             extract_archive(archive, extract_dir)
-            entry = install_from_path(extract_dir)
+            entry = install_from_path(extract_dir, plugin_id=package_id)
         return {
             "ok": True,
             "plugin_id": entry.plugin_id,

--- a/src/bora/application/plugin_ops/plugin_publish.py
+++ b/src/bora/application/plugin_ops/plugin_publish.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from bora.config.errors import ConfigError
-from bora.plugins.manifest import load_manifest
+from bora.plugins.manifest import PluginManifestError, hub_plugin_package_id, load_manifest
 from bora.registry.client import RegistryError
 from bora.registry.plugin_package import (
     PLUGIN_MEDIA_TYPE,
@@ -38,13 +38,6 @@ class PluginPublishCommand:
                 location=str(root),
             ) from exc
 
-        package_digest = compute_plugin_digest(root)
-        archive, blob_digest, size = build_plugin_archive(root)
-        client = self._client_factory(
-            registry_url=registry_url,
-            token=token,
-            require_token=True,
-        )
         org_id = (org or "").strip()
         if not org_id:
             raise ConfigError(
@@ -52,8 +45,18 @@ class PluginPublishCommand:
                 "plugin publish requires --org",
                 location="registry",
             )
+        try:
+            package_id = hub_plugin_package_id(manifest.plugin_id, org=org_id)
+        except PluginManifestError as exc:
+            raise ConfigError(exc.kind, exc.message, location="plugin.yaml:/plugin_id") from exc
 
-        package_id = f"{org_id}/{manifest.plugin_id}"
+        package_digest = compute_plugin_digest(root)
+        archive, blob_digest, size = build_plugin_archive(root)
+        client = self._client_factory(
+            registry_url=registry_url,
+            token=token,
+            require_token=True,
+        )
         visibility = "public" if public else "private"
         try:
             info = client.publish(

--- a/src/bora/config/profiles.py
+++ b/src/bora/config/profiles.py
@@ -449,6 +449,9 @@ def project_job_overlay(
         for k in ("executor", "model", "base_url", "api_key", "label"):
             if k in raw and raw[k] is not None:
                 row[k] = raw[k]
+        extensions = raw.get("extensions")
+        if isinstance(extensions, Sequence) and not isinstance(extensions, (str, bytes)):
+            row["extensions"] = copy.deepcopy(list(extensions))
         options = secret_free_options(
             raw.get("options") if isinstance(raw.get("options"), Mapping) else None
         )

--- a/src/bora/plugins/conflict.py
+++ b/src/bora/plugins/conflict.py
@@ -101,8 +101,8 @@ def order_chain(
     by_plugin = {c.plugin_id: c for c in candidates}
     slot_explicit = [e for e in explicit if e.slot == slot]
 
-    # Start from registered candidates.
-    selected: dict[str, Candidate] = {c.plugin_id: c for c in candidates}
+    # Opt-in: first-party / default only. Installed plugins join via extensions.
+    selected: dict[str, Candidate] = {c.plugin_id: c for c in candidates if _auto_on_multi_chain(c)}
 
     replace_default = any(e.replace_default for e in slot_explicit)
     if replace_default:
@@ -130,3 +130,7 @@ def order_chain(
     # Provide-slot ties fail closed in pick_one; chains need multi-plugin coexistence.
     del slot  # slot used only for error context in provide path
     return sorted(selected.values(), key=lambda c: (c.priority, c.plugin_id))
+
+
+def _auto_on_multi_chain(candidate: Candidate) -> bool:
+    return bool(candidate.is_default) or candidate.source in {"default", "first-party"}

--- a/src/bora/plugins/load_installed.py
+++ b/src/bora/plugins/load_installed.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import importlib
 import sys
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
-from bora.plugins.manifest import PluginManifestError, load_manifest
+from bora.plugins.manifest import PluginManifest, PluginManifestError, load_manifest
 from bora.plugins.registry import ExtensionRegistry
 from bora.plugins.slots import get_slot_kind
 from bora.plugins.store import list_installed, resolve_package_root
@@ -44,6 +45,12 @@ def _import_entry(package_root: Path, entry: str) -> Any:
         raise
     except Exception as exc:  # noqa: BLE001
         raise PluginLoadError(f"import failed for {entry}: {exc}") from exc
+
+
+def _manifest_with_index_id(manifest: PluginManifest, plugin_id: str) -> PluginManifest:
+    if manifest.plugin_id == plugin_id:
+        return manifest
+    return replace(manifest, plugin_id=plugin_id)
 
 
 def register_manifest(
@@ -107,9 +114,10 @@ def load_installed_plugins(registry: ExtensionRegistry) -> list[str]:
             manifest = load_manifest(root)
         except PluginManifestError as exc:
             raise PluginLoadError(str(exc), kind=exc.kind) from exc
+        # Index id wins (Hub install stores org/name; path install keeps short id).
         register_manifest(
             registry,
-            manifest,
+            _manifest_with_index_id(manifest, entry.plugin_id),
             package_root=root,
             digest=entry.digest,
             source="installed",

--- a/src/bora/plugins/manifest.py
+++ b/src/bora/plugins/manifest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -10,6 +11,10 @@ import yaml
 
 PLUGIN_FORMAT = "bora.plugin/1"
 MANIFEST_NAMES = ("plugin.yaml", "bora.plugin.yaml")
+# Default Hub official-org allowlist. Runtime lock/run never consults this.
+DEFAULT_OFFICIAL_ORG = "Official"
+# Same slash form as Dataset database_id. Not org.name. Official is mixed-case.
+_PLUGIN_ID_SEGMENT = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$")
 
 
 class PluginManifestError(Exception):
@@ -19,6 +24,52 @@ class PluginManifestError(Exception):
         super().__init__(message)
         self.kind = kind
         self.message = message
+
+
+def split_plugin_id(plugin_id: str) -> tuple[str | None, str]:
+    """Return ``(org, name)`` for ``org/name``, or ``(None, short_id)``."""
+    if "/" not in plugin_id:
+        return None, plugin_id
+    org, name = plugin_id.split("/", 1)
+    return org, name
+
+
+def normalize_plugin_id(raw: str) -> str:
+    """Validate short ``name`` or Hub ``org/name``. Reject ``org.name``."""
+    plugin_id = raw.strip()
+    if not plugin_id:
+        raise PluginManifestError("plugin_id required", kind="plugin_manifest_invalid")
+    if plugin_id.count("/") > 1:
+        raise PluginManifestError(
+            f"plugin_id must be name or org/name, not {plugin_id!r}",
+            kind="plugin_id_invalid",
+        )
+    org, name = split_plugin_id(plugin_id)
+    parts = (org, name) if org is not None else (name,)
+    if any(p is None or not _PLUGIN_ID_SEGMENT.fullmatch(p) for p in parts):
+        raise PluginManifestError(
+            f"plugin_id must be name or org/name, not {plugin_id!r}",
+            kind="plugin_id_invalid",
+        )
+    return plugin_id
+
+
+def hub_plugin_package_id(plugin_id: str, *, org: str) -> str:
+    """Hub address for publish: short id concatenates; namespaced must match *org*."""
+    org_id = org.strip()
+    if not org_id:
+        raise PluginManifestError("org required", kind="plugin_org_required")
+    prefix, name = split_plugin_id(plugin_id)
+    if prefix is None:
+        if not name:
+            raise PluginManifestError("plugin_id required", kind="plugin_manifest_invalid")
+        return f"{org_id}/{name}"
+    if prefix != org_id:
+        raise PluginManifestError(
+            f"plugin_id prefix {prefix!r} does not match upload org {org_id!r}",
+            kind="plugin_org_mismatch",
+        )
+    return plugin_id
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,6 +117,7 @@ def parse_manifest_mapping(raw: dict[str, Any], *, location: str = "plugin.yaml"
     version = raw.get("version")
     if not isinstance(plugin_id, str) or not plugin_id.strip():
         raise PluginManifestError("plugin_id required", kind="plugin_manifest_invalid")
+    plugin_id = normalize_plugin_id(plugin_id)
     if not isinstance(version, str) or not version.strip():
         raise PluginManifestError("version required", kind="plugin_manifest_invalid")
 
@@ -115,7 +167,7 @@ def parse_manifest_mapping(raw: dict[str, Any], *, location: str = "plugin.yaml"
 
     return PluginManifest(
         format=PLUGIN_FORMAT,
-        plugin_id=plugin_id.strip(),
+        plugin_id=plugin_id,
         version=version.strip(),
         provide=_entries("provide"),
         on=_entries("on"),

--- a/src/bora/plugins/manifest.py
+++ b/src/bora/plugins/manifest.py
@@ -11,8 +11,8 @@ import yaml
 
 PLUGIN_FORMAT = "bora.plugin/1"
 MANIFEST_NAMES = ("plugin.yaml", "bora.plugin.yaml")
-# Default Hub official-org allowlist. Runtime lock/run never consults this.
-DEFAULT_OFFICIAL_ORG = "Official"
+# Default Hub official-org allowlist (org slug). Runtime lock/run never consults this.
+DEFAULT_OFFICIAL_ORG = "official"
 # Same slash form as Dataset database_id. Not org.name. Official is mixed-case.
 _PLUGIN_ID_SEGMENT = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$")
 

--- a/src/bora/plugins/protocol.py
+++ b/src/bora/plugins/protocol.py
@@ -69,6 +69,20 @@ class ExplicitBinding:
     source: str = "explicit"
 
 
+@dataclass(frozen=True, slots=True)
+class ExtensionSelect:
+    """One ``profiles.extensions`` row before per-slot expansion.
+
+    ``slots is None`` means every slot that plugin registered (provide + on).
+    """
+
+    plugin: str
+    slots: tuple[str, ...] | None = None
+    priority: int | None = None
+    replace_default: bool = False
+    source: str = "explicit"
+
+
 @dataclass
 class BindingIntent:
     """Per-profile binding intent used at resolve / lock time."""
@@ -77,6 +91,7 @@ class BindingIntent:
     executor: str | None = None  # sugar: executor slot selects this plugin's provide
     options: dict[str, Any] = field(default_factory=dict)
     extensions: list[ExplicitBinding] = field(default_factory=list)
+    extension_selects: list[ExtensionSelect] = field(default_factory=list)
     # Optional model / locator fields carried for factory materialize.
     model: str | None = None
     base_url: str | None = None
@@ -153,25 +168,23 @@ def intent_from_profile(profile: Mapping[str, Any]) -> BindingIntent:
     options_raw = profile.get("options")
     options: dict[str, Any] = dict(options_raw) if isinstance(options_raw, Mapping) else {}
     extensions: list[ExplicitBinding] = []
+    extension_selects: list[ExtensionSelect] = []
     ext_raw = profile.get("extensions")
-    if isinstance(ext_raw, Sequence) and not isinstance(ext_raw, (str, bytes)):
-        for item in ext_raw:
-            if not isinstance(item, Mapping):
-                continue
-            slot = item.get("slot")
-            plugin = item.get("plugin")
-            if not isinstance(slot, str) or not isinstance(plugin, str):
-                continue
-            prio = item.get("priority")
-            extensions.append(
-                ExplicitBinding(
-                    slot=str(slot),
-                    plugin=str(plugin),
-                    priority=int(prio) if prio is not None else None,
-                    replace_default=bool(item.get("replace_default")),
-                    source="explicit",
-                )
-            )
+    if ext_raw is None:
+        ext_raw = []
+    if not isinstance(ext_raw, Sequence) or isinstance(ext_raw, (str, bytes)):
+        from bora.plugins.errors import ExtensionRegistryError
+
+        raise ExtensionRegistryError(
+            "extensions must be a list of mappings",
+            kind="invalid_extension_binding",
+        )
+    for item in ext_raw:
+        parsed_binding, parsed_select = parse_extension_row(item)
+        if parsed_binding is not None:
+            extensions.append(parsed_binding)
+        if parsed_select is not None:
+            extension_selects.append(parsed_select)
     model_raw = profile.get("model")
     model = str(model_raw) if model_raw is not None else None
     base_url_raw = profile.get("base_url")
@@ -189,7 +202,89 @@ def intent_from_profile(profile: Mapping[str, Any]) -> BindingIntent:
         executor=executor,
         options=options,
         extensions=extensions,
+        extension_selects=extension_selects,
         model=model,
         base_url=base_url,
         api_key=api_key,
+    )
+
+
+def parse_extension_row(item: Any) -> tuple[ExplicitBinding | None, ExtensionSelect | None]:
+    """Parse one extensions row. ``{slot, plugin}`` is a single-slot binding."""
+    from bora.plugins.errors import ExtensionRegistryError
+
+    if not isinstance(item, Mapping):
+        raise ExtensionRegistryError(
+            "each extensions row must be a mapping",
+            kind="invalid_extension_binding",
+        )
+    plugin_raw = item.get("plugin")
+    if not isinstance(plugin_raw, str) or not plugin_raw.strip():
+        raise ExtensionRegistryError(
+            "extensions row requires plugin",
+            kind="invalid_extension_binding",
+        )
+    plugin = plugin_raw.strip()
+    slot_raw = item.get("slot")
+    slots_raw = item.get("slots")
+    prio = item.get("priority")
+    priority = int(prio) if prio is not None else None
+    replace_default = bool(item.get("replace_default"))
+    if slot_raw is not None and slots_raw is not None:
+        raise ExtensionRegistryError(
+            "extensions row cannot set both slot and slots",
+            kind="invalid_extension_binding",
+        )
+    if slot_raw is not None:
+        if not isinstance(slot_raw, str) or not slot_raw.strip():
+            raise ExtensionRegistryError(
+                "extensions.slot must be a non-empty string",
+                kind="invalid_extension_binding",
+            )
+        return (
+            ExplicitBinding(
+                slot=slot_raw.strip(),
+                plugin=plugin,
+                priority=priority,
+                replace_default=replace_default,
+                source="explicit",
+            ),
+            None,
+        )
+    if slots_raw is not None:
+        if not isinstance(slots_raw, Sequence) or isinstance(slots_raw, (str, bytes)):
+            raise ExtensionRegistryError(
+                "extensions.slots must be a list of slot ids",
+                kind="invalid_extension_binding",
+            )
+        if not slots_raw:
+            raise ExtensionRegistryError(
+                "extensions.slots must not be empty",
+                kind="invalid_extension_binding",
+            )
+        slots: list[str] = []
+        for slot in slots_raw:
+            if not isinstance(slot, str) or not slot.strip():
+                raise ExtensionRegistryError(
+                    "extensions.slots entries must be non-empty strings",
+                    kind="invalid_extension_binding",
+                )
+            slots.append(slot.strip())
+        return (
+            None,
+            ExtensionSelect(
+                plugin=plugin,
+                slots=tuple(slots),
+                priority=priority,
+                replace_default=replace_default,
+            ),
+        )
+    return (
+        None,
+        ExtensionSelect(
+            plugin=plugin,
+            slots=None,
+            priority=priority,
+            replace_default=replace_default,
+        ),
     )

--- a/src/bora/plugins/registry.py
+++ b/src/bora/plugins/registry.py
@@ -157,6 +157,14 @@ class ExtensionRegistry:
     def plugins_for_slot(self, slot: str) -> list[str]:
         return sorted((self._rows.get(slot) or {}).keys())
 
+    def slots_for_plugin(self, plugin_id: str) -> list[str]:
+        """Public slots this plugin registered (provide + on)."""
+        found: list[str] = []
+        for slot, rows in self._rows.items():
+            if plugin_id in rows:
+                found.append(slot)
+        return found
+
     def clear(self) -> None:
         self._rows.clear()
 

--- a/src/bora/plugins/resolve.py
+++ b/src/bora/plugins/resolve.py
@@ -5,17 +5,22 @@ from __future__ import annotations
 from typing import Any
 
 from bora.plugins.conflict import order_chain, pick_one
-from bora.plugins.errors import ExtensionMaterializeError
+from bora.plugins.errors import (
+    ExtensionMaterializeError,
+    ExtensionPluginNotFoundError,
+    UnknownExtensionSlotError,
+)
 from bora.plugins.protocol import (
     BindingIntent,
     BindingRecord,
     ExplicitBinding,
     ExtensionGraph,
+    ExtensionSelect,
     HandlerRef,
     ProviderRef,
 )
 from bora.plugins.registry import ExtensionRegistry, Registration
-from bora.plugins.slots import ALL_PUBLIC_SLOTS, EXECUTOR, SlotKind, get_slot_kind
+from bora.plugins.slots import ALL_PUBLIC_SLOTS, EXECUTOR, SlotKind, get_slot_kind, is_public_slot
 
 
 def resolve(
@@ -31,8 +36,16 @@ def resolve(
     """
     graph = ExtensionGraph(profile_id=intent.profile_id)
     explicit = list(intent.extensions)
+    explicit.extend(expand_extension_selects(intent.extension_selects, registry))
+    for binding in explicit:
+        if not is_public_slot(binding.slot):
+            raise UnknownExtensionSlotError(
+                f"unknown extension slot: {binding.slot!r}",
+                kind="unknown_extension_slot",
+            )
 
     # Sugar: profiles executor: <plugin_id> → explicit binding for executor slot.
+    # Appended last so it wins over an all-slots ``- plugin:`` row.
     if intent.executor:
         explicit.append(
             ExplicitBinding(
@@ -50,6 +63,8 @@ def resolve(
         slot_explicit = [e for e in explicit if e.slot == slot]
 
         if kind is SlotKind.PROVIDE:
+            if slot != EXECUTOR and not slot_explicit:
+                candidates = [c for c in candidates if _auto_on_provide(c)]
             if not candidates and not slot_explicit:
                 # Optional provide slots may be empty (e.g. env_action when unused).
                 # executor is required when profiles set executor field (handled by
@@ -185,3 +200,52 @@ def resolve_for_lock(
 ) -> ExtensionGraph:
     """Resolve without constructing heavy SPI instances (lock field only)."""
     return resolve(intent, registry, materialize=False)
+
+
+def expand_extension_selects(
+    selects: list[ExtensionSelect],
+    registry: ExtensionRegistry,
+) -> list[ExplicitBinding]:
+    """Turn ``- plugin:`` / ``slots:`` rows into per-slot explicit bindings."""
+    out: list[ExplicitBinding] = []
+    for sel in selects:
+        registered = registry.slots_for_plugin(sel.plugin)
+        if not registered:
+            raise ExtensionPluginNotFoundError(
+                f"plugin {sel.plugin!r} is not registered",
+                kind="extension_plugin_not_found",
+            )
+        if sel.slots is None:
+            wanted = list(registered)
+        else:
+            wanted = []
+            for slot in sel.slots:
+                if not is_public_slot(slot):
+                    raise UnknownExtensionSlotError(
+                        f"unknown extension slot: {slot!r}",
+                        kind="unknown_extension_slot",
+                    )
+                if slot not in registered:
+                    raise ExtensionPluginNotFoundError(
+                        f"plugin {sel.plugin!r} did not register slot {slot!r}",
+                        kind="extension_slot_unregistered",
+                    )
+                wanted.append(slot)
+        for slot in wanted:
+            out.append(
+                ExplicitBinding(
+                    slot=slot,
+                    plugin=sel.plugin,
+                    priority=sel.priority,
+                    replace_default=sel.replace_default,
+                    source=sel.source,
+                )
+            )
+    return out
+
+
+def _auto_on_provide(candidate: Any) -> bool:
+    return bool(getattr(candidate, "is_default", False)) or getattr(candidate, "source", "") in {
+        "default",
+        "first-party",
+    }

--- a/src/bora/plugins/store.py
+++ b/src/bora/plugins/store.py
@@ -130,27 +130,31 @@ class contextlib_suppress:
         return True
 
 
-def install_from_path(source: Path) -> IndexEntry:
+def install_from_path(source: Path, *, plugin_id: str | None = None) -> IndexEntry:
     """Copy a plugin package into the local cache and update index.
 
     Does **not** modify project profiles / bora.yaml / task.yaml (§7.5).
+    *plugin_id* overrides the manifest id (Hub install records ``org/name``).
     """
     source = source.expanduser().resolve(strict=False)
     if not source.is_dir():
         raise PluginManifestError(f"plugin path is not a directory: {source}")
 
     manifest = load_manifest(source)
+    resolved_id = plugin_id.strip() if isinstance(plugin_id, str) and plugin_id.strip() else None
+    index_id = resolved_id or manifest.plugin_id
     digest = compute_tree_digest(source)
-    rel = f"{manifest.plugin_id}/{manifest.version}"
-    dest = package_dir(manifest.plugin_id, manifest.version)
+    rel = f"{index_id}/{manifest.version}"
+    dest = package_dir(index_id, manifest.version)
     dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp_prefix = index_id.replace("/", ".")
 
     # Idempotent: same digest already installed.
     if dest.is_dir():
         existing = compute_tree_digest(dest)
         if existing == digest:
             entry = IndexEntry(
-                plugin_id=manifest.plugin_id,
+                plugin_id=index_id,
                 version=manifest.version,
                 digest=digest,
                 path=rel,
@@ -163,7 +167,7 @@ def install_from_path(source: Path) -> IndexEntry:
         shutil.rmtree(dest)
 
     tmp_parent = dest.parent
-    tmp = Path(tempfile.mkdtemp(prefix=f".{manifest.plugin_id}.", dir=str(tmp_parent)))
+    tmp = Path(tempfile.mkdtemp(prefix=f".{tmp_prefix}.", dir=str(tmp_parent)))
     try:
         shutil.copytree(source, tmp / "pkg")
         os.replace(tmp / "pkg", dest)
@@ -181,7 +185,7 @@ def install_from_path(source: Path) -> IndexEntry:
         )
 
     entry = IndexEntry(
-        plugin_id=manifest.plugin_id,
+        plugin_id=index_id,
         version=manifest.version,
         digest=digest,
         path=rel,
@@ -209,10 +213,12 @@ def uninstall(plugin_id: str) -> bool:
     dest = plugins_root() / entry.path
     if dest.is_dir():
         shutil.rmtree(dest)
-    # Clean empty parent plugin_id dir
+    # Clean empty parent dirs (org/name nests two levels).
     parent = dest.parent
-    if parent.is_dir() and not any(parent.iterdir()):
+    root = plugins_root()
+    while parent != root and parent.is_dir() and not any(parent.iterdir()):
         parent.rmdir()
+        parent = parent.parent
     index.plugins = [p for p in index.plugins if p.plugin_id != plugin_id]
     save_index(index)
     return True

--- a/src/bora/registry/client.py
+++ b/src/bora/registry/client.py
@@ -547,6 +547,29 @@ class RegistryClient:
             raise RegistryError("org_list_failed", f"status {status}", status=status)
         return json.loads(raw.decode("utf-8"))
 
+    def patch_org(self, org_id: str, *, display_name: str) -> dict[str, Any]:
+        status, raw, _ = self._request(
+            "PATCH",
+            f"/v1/orgs/{quote(org_id, safe='')}",
+            body=json.dumps({"display_name": display_name}, sort_keys=True).encode("utf-8"),
+            headers=self._headers(content_type="application/json"),
+        )
+        if status != 200:
+            raise RegistryError("org_patch_failed", f"status {status}", status=status)
+        return json.loads(raw.decode("utf-8"))
+
+    def patch_package_display_name(self, database_id: str, *, display_name: str) -> dict[str, Any]:
+        path = f"/v1/packages/{quote(database_id, safe='/')}"
+        status, raw, _ = self._request(
+            "PATCH",
+            path,
+            body=json.dumps({"display_name": display_name}, sort_keys=True).encode("utf-8"),
+            headers=self._headers(content_type="application/json"),
+        )
+        if status != 200:
+            raise RegistryError("package_patch_failed", f"status {status}", status=status)
+        return json.loads(raw.decode("utf-8"))
+
     def add_org_member(self, *, org_id: str, user_id: str, role: str = "member") -> dict[str, Any]:
         body = {"user_id": user_id, "role": role}
         status, raw, _ = self._request(

--- a/tests/plugins/test_extension_bindings_lock.py
+++ b/tests/plugins/test_extension_bindings_lock.py
@@ -7,10 +7,17 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def test_lock_cli_extension_bindings_solver_acp() -> None:
+def _chain_plugins(bindings: dict, slot: str) -> set[str]:
+    row = bindings.get(slot) or {}
+    return {str(item.get("plugin")) for item in (row.get("chain") or [])}
+
+
+def _lock(*args: str) -> dict:
     proc = subprocess.run(
         [
             sys.executable,
@@ -20,6 +27,7 @@ def test_lock_cli_extension_bindings_solver_acp() -> None:
             str(ROOT / "examples/journeys"),
             "--task",
             "terminal-jsonl-agg",
+            *args,
         ],
         cwd=ROOT,
         capture_output=True,
@@ -27,7 +35,11 @@ def test_lock_cli_extension_bindings_solver_acp() -> None:
         check=False,
     )
     assert proc.returncode == 0, proc.stderr or proc.stdout
-    data = json.loads(proc.stdout)
+    return json.loads(proc.stdout)
+
+
+def test_lock_cli_extension_bindings_solver_acp() -> None:
+    data = _lock()
     bindings = data["extension_bindings"]
     assert "solver" in bindings
     assert bindings["solver"]["executor"]["plugin"] == "acp"
@@ -35,3 +47,26 @@ def test_lock_cli_extension_bindings_solver_acp() -> None:
     assert bindings["solver"]["executor"]["kind"] == "provide"
     assert bindings["solver"]["before_agent_invoke"]["kind"] == "on"
     assert any(e.get("pointer") == "/extension_bindings" for e in data.get("resolution") or [])
+    assert "dsh" not in _chain_plugins(bindings["solver"], "image_contribute")
+    assert "nooa" not in _chain_plugins(bindings["solver"], "image_contribute")
+
+
+def _installed_plugin_ids() -> set[str]:
+    from bora.plugins.store import list_installed
+
+    return {entry.plugin_id for entry in list_installed()}
+
+
+def test_lock_dsh_profile_selects_dsh_not_nooa() -> None:
+    ids = _installed_plugin_ids()
+    if "dsh" not in ids or "nooa" not in ids:
+        pytest.skip("path-install dsh and nooa to lock the journeys dsh profile")
+    data = _lock("--profiles", str(ROOT / "examples/journeys/profiles.dsh.yaml"))
+    solver = data["extension_bindings"]["solver"]
+    assert solver["executor"]["plugin"] == "dsh"
+    contribute = _chain_plugins(solver, "image_contribute")
+    collect = _chain_plugins(solver, "trajectory_collect")
+    assert "dsh" in contribute
+    assert "dsh" in collect
+    assert "nooa" not in contribute
+    assert "nooa" not in collect

--- a/tests/plugins/test_extensions_opt_in.py
+++ b/tests/plugins/test_extensions_opt_in.py
@@ -1,0 +1,180 @@
+"""extensions opt-in: installed plugins stay off MULTI unless named."""
+
+from __future__ import annotations
+
+import pytest
+
+from bora.plugins.defaults import register_defaults
+from bora.plugins.errors import ExtensionPluginNotFoundError, UnknownExtensionSlotError
+from bora.plugins.protocol import BindingIntent, ExtensionSelect, intent_from_profile
+from bora.plugins.registry import ExtensionRegistry
+from bora.plugins.resolve import resolve
+from bora.plugins.slots import EXECUTOR, IMAGE_CONTRIBUTE, TRAJECTORY_COLLECT
+
+
+class _FakeExec:
+    kind = "fake"
+
+    def open(self, **kwargs):  # type: ignore[no-untyped-def]
+        del kwargs
+
+    def close(self) -> None:
+        return None
+
+    def invoke(self, prompt: str, **kwargs):  # type: ignore[no-untyped-def]
+        del kwargs
+        return {"ok": True, "text": prompt}
+
+
+async def _passthrough(ctx, value, nxt):  # type: ignore[no-untyped-def]
+    del ctx
+    return await nxt(value)
+
+
+def _reg_with_external() -> ExtensionRegistry:
+    reg = ExtensionRegistry()
+    register_defaults(reg)
+    reg.provide(EXECUTOR, "acp", _FakeExec(), priority=100, source="first-party")
+    reg.provide(EXECUTOR, "nooa", _FakeExec(), priority=110, source="installed")
+    reg.on(IMAGE_CONTRIBUTE, "nooa", _passthrough, priority=110, source="installed")
+    reg.on(TRAJECTORY_COLLECT, "nooa", _passthrough, priority=110, source="installed")
+    reg.provide(EXECUTOR, "dsh", _FakeExec(), priority=110, source="installed")
+    reg.on(IMAGE_CONTRIBUTE, "dsh", _passthrough, priority=110, source="installed")
+    reg.on(TRAJECTORY_COLLECT, "dsh", _passthrough, priority=110, source="installed")
+    return reg
+
+
+def _chain_plugins(graph, slot: str) -> list[str]:
+    return [h.plugin_id for h in graph.chain(slot)]
+
+
+def test_acp_only_does_not_attach_installed_contribute() -> None:
+    graph = resolve(BindingIntent(profile_id="solver", executor="acp"), _reg_with_external())
+    assert graph.providers[EXECUTOR].plugin_id == "acp"
+    assert "nooa" not in _chain_plugins(graph, IMAGE_CONTRIBUTE)
+    assert "dsh" not in _chain_plugins(graph, IMAGE_CONTRIBUTE)
+    assert "nooa" not in _chain_plugins(graph, TRAJECTORY_COLLECT)
+    assert "dsh" not in _chain_plugins(graph, TRAJECTORY_COLLECT)
+
+
+def test_all_slots_row_attaches_bake_and_collect() -> None:
+    graph = resolve(
+        BindingIntent(
+            profile_id="solver",
+            executor="nooa",
+            extension_selects=[ExtensionSelect(plugin="nooa")],
+        ),
+        _reg_with_external(),
+    )
+    assert graph.providers[EXECUTOR].plugin_id == "nooa"
+    assert "nooa" in _chain_plugins(graph, IMAGE_CONTRIBUTE)
+    assert "nooa" in _chain_plugins(graph, TRAJECTORY_COLLECT)
+    assert "dsh" not in _chain_plugins(graph, IMAGE_CONTRIBUTE)
+
+
+def test_listed_slots_do_not_attach_unlisted() -> None:
+    graph = resolve(
+        BindingIntent(
+            profile_id="solver",
+            executor="dsh",
+            extension_selects=[
+                ExtensionSelect(plugin="dsh", slots=(IMAGE_CONTRIBUTE,)),
+            ],
+        ),
+        _reg_with_external(),
+    )
+    assert "dsh" in _chain_plugins(graph, IMAGE_CONTRIBUTE)
+    assert "dsh" not in _chain_plugins(graph, TRAJECTORY_COLLECT)
+
+
+def test_unknown_slot_fail_closed() -> None:
+    with pytest.raises(UnknownExtensionSlotError):
+        resolve(
+            BindingIntent(
+                profile_id="s",
+                extension_selects=[ExtensionSelect(plugin="dsh", slots=("not_a_slot",))],
+            ),
+            _reg_with_external(),
+        )
+
+
+def test_unregistered_slot_fail_closed() -> None:
+    with pytest.raises(ExtensionPluginNotFoundError) as ei:
+        resolve(
+            BindingIntent(
+                profile_id="s",
+                extension_selects=[
+                    ExtensionSelect(plugin="dsh", slots=("before_agent_invoke",)),
+                ],
+            ),
+            _reg_with_external(),
+        )
+    assert ei.value.kind == "extension_slot_unregistered"
+
+
+def test_two_roles_bind_independently() -> None:
+    reg = _reg_with_external()
+    planner = resolve(
+        BindingIntent(
+            profile_id="planner",
+            executor="nooa",
+            extension_selects=[ExtensionSelect(plugin="nooa")],
+        ),
+        reg,
+    )
+    reviewer = resolve(
+        BindingIntent(
+            profile_id="reviewer",
+            executor="dsh",
+            extension_selects=[ExtensionSelect(plugin="dsh", slots=(IMAGE_CONTRIBUTE,))],
+        ),
+        reg,
+    )
+    assert planner.providers[EXECUTOR].plugin_id == "nooa"
+    assert reviewer.providers[EXECUTOR].plugin_id == "dsh"
+    assert "nooa" in _chain_plugins(planner, TRAJECTORY_COLLECT)
+    assert "dsh" not in _chain_plugins(reviewer, TRAJECTORY_COLLECT)
+    assert "dsh" in _chain_plugins(reviewer, IMAGE_CONTRIBUTE)
+    assert "nooa" not in _chain_plugins(reviewer, IMAGE_CONTRIBUTE)
+
+
+def test_executor_field_alone_does_not_bake() -> None:
+    graph = resolve(
+        BindingIntent(profile_id="solver", executor="nooa"),
+        _reg_with_external(),
+    )
+    assert graph.providers[EXECUTOR].plugin_id == "nooa"
+    assert "nooa" not in _chain_plugins(graph, IMAGE_CONTRIBUTE)
+
+
+def test_all_slots_row_can_omit_executor_field() -> None:
+    graph = resolve(
+        BindingIntent(
+            profile_id="solver",
+            extension_selects=[ExtensionSelect(plugin="nooa")],
+        ),
+        _reg_with_external(),
+    )
+    assert graph.providers[EXECUTOR].plugin_id == "nooa"
+
+
+def test_intent_from_profile_parses_all_three_shapes() -> None:
+    intent = intent_from_profile(
+        {
+            "id": "solver",
+            "executor": "dsh",
+            "extensions": [
+                {"plugin": "nooa"},
+                {"plugin": "dsh", "slots": ["image_contribute"]},
+                {"slot": "trajectory_collect", "plugin": "dsh"},
+            ],
+        }
+    )
+    assert intent.executor == "dsh"
+    assert len(intent.extension_selects) == 2
+    assert intent.extension_selects[0].plugin == "nooa"
+    assert intent.extension_selects[0].slots is None
+    assert intent.extension_selects[1].slots == (IMAGE_CONTRIBUTE,)
+    assert len(intent.extensions) == 1
+    assert intent.extensions[0].slot == TRAJECTORY_COLLECT
+    assert intent.extensions[0].plugin == "dsh"

--- a/tests/plugins/test_image_contribute_bake.py
+++ b/tests/plugins/test_image_contribute_bake.py
@@ -48,9 +48,15 @@ def test_bound_executor_ids() -> None:
 
 def test_apply_skips_first_party_only() -> None:
     lock = _lock_with_profiles([{"id": "s", "executor": "acp"}])
-    with patch(
-        "bora.application.plugin_ops.image_contribute_bake.collect_declares_for_lock",
-        return_value=[{"plugin": "acp"}],
+    with (
+        patch(
+            "bora.application.plugin_ops.image_contribute_bake.collect_declares_for_lock",
+            return_value=[{"plugin": "acp"}],
+        ),
+        patch(
+            "bora.application.plugin_ops.image_contribute_bake.selected_contribute_plugin_ids",
+            return_value=[],
+        ),
     ):
         out, meta = apply_image_contribute_bake(
             lock=lock, base_image=_base(), platform="linux/arm64"
@@ -68,6 +74,10 @@ def test_apply_fail_closed_when_bound_but_no_declare() -> None:
             "bora.application.plugin_ops.image_contribute_bake.collect_declares_for_lock",
             return_value=[],
         ),
+        patch(
+            "bora.application.plugin_ops.image_contribute_bake.selected_contribute_plugin_ids",
+            return_value=[],
+        ),
         pytest.raises(ImageContributeError) as ei,
     ):
         apply_image_contribute_bake(lock=lock, base_image=_base(), platform="linux/arm64")
@@ -82,6 +92,10 @@ def test_apply_fail_closed_when_not_installed() -> None:
         patch(
             "bora.application.plugin_ops.image_contribute_bake.collect_declares_for_lock",
             return_value=[{"plugin": "nooa"}],
+        ),
+        patch(
+            "bora.application.plugin_ops.image_contribute_bake.selected_contribute_plugin_ids",
+            return_value=["nooa"],
         ),
         patch(
             "bora.application.plugin_ops.image_contribute_bake._find_installed_plugin_root",
@@ -157,6 +171,10 @@ def test_apply_fail_closed_when_bake_file_missing(tmp_path: Path) -> None:
             return_value=[{"plugin": "nooa"}],
         ),
         patch(
+            "bora.application.plugin_ops.image_contribute_bake.selected_contribute_plugin_ids",
+            return_value=["nooa"],
+        ),
+        patch(
             "bora.application.plugin_ops.image_contribute_bake._find_installed_plugin_root",
             return_value=empty,
         ),
@@ -184,6 +202,10 @@ def test_apply_reuses_baked_tag_without_inspect_suffix(tmp_path: Path) -> None:
         patch(
             "bora.application.plugin_ops.image_contribute_bake.collect_declares_for_lock",
             return_value=[{"plugin": "nooa"}],
+        ),
+        patch(
+            "bora.application.plugin_ops.image_contribute_bake.selected_contribute_plugin_ids",
+            return_value=["nooa"],
         ),
         patch(
             "bora.application.plugin_ops.image_contribute_bake._find_installed_plugin_root",

--- a/tests/plugins/test_official_acp_image.py
+++ b/tests/plugins/test_official_acp_image.py
@@ -1,0 +1,179 @@
+"""First-party ACP reuses bora-attempt:l1; extra Dockerfile layers still build."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import patch
+
+from bora.adapters.provider_docker.images import is_official_base_noop_dockerfile
+from bora.adapters.provider_docker.types import DockerImageLock
+from bora.application.plugin_ops.image_contribute_bake import (
+    apply_image_contribute_bake,
+    baked_image_tag,
+    plugin_id_for_image_tag,
+    should_reuse_official_attempt_image,
+)
+from bora.config.model import LockedTaskConfig
+
+
+def _lock(profiles: list[dict[str, Any]]) -> LockedTaskConfig:
+    return cast(LockedTaskConfig, SimpleNamespace(agent_profiles=profiles))
+
+
+def _base() -> DockerImageLock:
+    return DockerImageLock(
+        kind="docker-attempt",
+        platform="linux/arm64",
+        image_tag="bora-attempt:l1",
+        image_digest="sha256:official",
+        build_input_digest="sha256:official-in",
+    )
+
+
+def test_noop_dockerfile_detection() -> None:
+    assert is_official_base_noop_dockerfile("FROM bora-attempt:l1\n")
+    assert is_official_base_noop_dockerfile("# comment\nFROM bora-attempt:l1 AS base\n")
+    assert not is_official_base_noop_dockerfile("FROM bora-attempt:l1\nCOPY x /x\n")
+    assert not is_official_base_noop_dockerfile("FROM bora-attempt:l1\nRUN true\n")
+    assert not is_official_base_noop_dockerfile("FROM other:latest\n")
+
+
+def test_reuse_official_acp_from_only() -> None:
+    lock = _lock([{"id": "s", "executor": "acp", "options": {"entry": "pi"}}])
+    with patch(
+        "bora.application.plugin_ops.image_contribute_bake.selected_contribute_plugin_ids",
+        return_value=[],
+    ):
+        assert should_reuse_official_attempt_image(lock, "FROM bora-attempt:l1\n") is True
+
+
+def test_copy_or_run_still_builds_package_tag() -> None:
+    lock = _lock([{"id": "s", "executor": "acp", "options": {"entry": "pi"}}])
+    with patch(
+        "bora.application.plugin_ops.image_contribute_bake.selected_contribute_plugin_ids",
+        return_value=[],
+    ):
+        assert (
+            should_reuse_official_attempt_image(
+                lock, "FROM bora-attempt:l1\nCOPY environment/tool.sh /bin/tool\n"
+            )
+            is False
+        )
+        assert (
+            should_reuse_official_attempt_image(lock, "FROM bora-attempt:l1\nRUN true\n") is False
+        )
+
+
+def test_external_executor_does_not_reuse() -> None:
+    lock = _lock([{"id": "s", "executor": "dsh"}])
+    with patch(
+        "bora.application.plugin_ops.image_contribute_bake.selected_contribute_plugin_ids",
+        return_value=["dsh"],
+    ):
+        assert should_reuse_official_attempt_image(lock, "FROM bora-attempt:l1\n") is False
+
+
+def test_selected_bake_does_not_reuse() -> None:
+    lock = _lock(
+        [
+            {
+                "id": "s",
+                "executor": "acp",
+                "options": {"entry": "pi"},
+                "extensions": [{"plugin": "dsh", "slots": ["image_contribute"]}],
+            }
+        ]
+    )
+    with patch(
+        "bora.application.plugin_ops.image_contribute_bake.selected_contribute_plugin_ids",
+        return_value=["dsh"],
+    ):
+        assert should_reuse_official_attempt_image(lock, "FROM bora-attempt:l1\n") is False
+
+
+def test_apply_acp_only_does_not_bake_installed_declares() -> None:
+    lock = _lock([{"id": "s", "executor": "acp", "options": {"entry": "pi"}}])
+    with (
+        patch(
+            "bora.application.plugin_ops.image_contribute_bake.collect_declares_for_lock",
+            return_value=[{"plugin": "acp"}],
+        ),
+        patch(
+            "bora.application.plugin_ops.image_contribute_bake.selected_contribute_plugin_ids",
+            return_value=[],
+        ),
+    ):
+        out, meta = apply_image_contribute_bake(
+            lock=lock, base_image=_base(), platform="linux/arm64"
+        )
+    assert out.image_tag == "bora-attempt:l1"
+    assert meta["status"] == "skipped"
+    assert meta["baked"] == []
+
+
+def test_prepare_reuses_official_tag_without_buildx(
+    tmp_path,
+    monkeypatch,  # type: ignore[no-untyped-def]
+) -> None:
+    import bora.application.attempt.extension_hooks as hooks
+    import bora.application.attempt.run_l1_prepare as prep
+    import bora.application.plugin_ops.image_contribute_bake as bake
+    from bora.application.attempt.run_l1_prepare import prepare_l1_runtime
+    from bora.runtime.identity import IdentityFactory
+
+    (tmp_path / "environment").mkdir()
+    (tmp_path / "environment" / "Dockerfile").write_text("FROM bora-attempt:l1\n", encoding="utf-8")
+    official = _base()
+
+    class FakeDocker:
+        def __init__(self, *, image_lock_path):  # type: ignore[no-untyped-def]
+            del image_lock_path
+
+        def prepare(self, attempt, **_kwargs):  # type: ignore[no-untyped-def]
+            from bora.adapters.provider_docker.types import DockerRuntime
+
+            return DockerRuntime(
+                attempt=attempt,
+                image_lock=official,
+                workdir_host=tmp_path / "work",
+            )
+
+    def _must_not_build(**_kwargs: object) -> DockerImageLock:
+        raise AssertionError("must not build package image")
+
+    monkeypatch.setattr(prep, "ensure_base_image", lambda _cwd: official)
+    monkeypatch.setattr(prep, "build_package_image", _must_not_build)
+    monkeypatch.setattr(prep, "ensure_image_lock", lambda _cwd: tmp_path / "lock.json")
+    monkeypatch.setattr(prep, "DockerProvider", FakeDocker)
+    monkeypatch.setattr(hooks, "hook_prepare", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        bake, "apply_image_contribute_bake", lambda **kw: (kw["base_image"], {"status": "skipped"})
+    )
+    monkeypatch.setattr(bake, "should_reuse_official_attempt_image", lambda *_a, **_k: True)
+
+    factory = IdentityFactory()
+    run = factory.new_run()
+    trial = factory.new_trial(run, "sha256:" + "a" * 64)
+    lock = SimpleNamespace(
+        digest="sha256:" + "a" * 64,
+        task_id="terminal-jsonl-agg",
+        provider={"kind": "docker", "dockerfile": "environment/Dockerfile"},
+        agent_profiles=[{"id": "s", "executor": "acp", "options": {"entry": "pi"}}],
+    )
+    _docker, runtime, meta = prepare_l1_runtime(
+        tmp_path,
+        lock,
+        tmp_path / "run",
+        attempt=factory.new_attempt(trial),
+    )
+    assert runtime.image_lock is not None
+    assert runtime.image_lock.image_tag == "bora-attempt:l1"
+    assert meta["image_tag"] == "bora-attempt:l1"
+
+
+def test_namespaced_plugin_id_in_bake_tag() -> None:
+    assert plugin_id_for_image_tag("acme/nooa") == "acme--nooa"
+    tag = baked_image_tag(_base(), "acme/nooa", "d" * 24)
+    assert tag.startswith("bora-attempt:l1-acme--nooa-")
+    assert "/" not in tag.split(":", 1)[1]

--- a/tests/plugins/test_plugin_identity.py
+++ b/tests/plugins/test_plugin_identity.py
@@ -212,7 +212,8 @@ def test_official_org_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
     from services.registry.official import is_official_upload_org, official_orgs
 
     monkeypatch.delenv("BORA_OFFICIAL_ORGS", raising=False)
-    assert "Official" in official_orgs()
+    assert "official" in official_orgs()
+    assert is_official_upload_org("official") is True
     assert is_official_upload_org("Official") is True
     assert is_official_upload_org("acme") is False
     monkeypatch.setenv("BORA_OFFICIAL_ORGS", "Acme, Labs")

--- a/tests/plugins/test_plugin_identity.py
+++ b/tests/plugins/test_plugin_identity.py
@@ -1,0 +1,187 @@
+"""plugin_id identity: local short ids vs Hub org/name."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bora.config.errors import ConfigError
+from bora.plugins.manifest import (
+    PluginManifestError,
+    hub_plugin_package_id,
+    normalize_plugin_id,
+    parse_manifest_mapping,
+    split_plugin_id,
+)
+
+
+def test_normalize_short_and_namespaced() -> None:
+    assert normalize_plugin_id("nooa") == "nooa"
+    assert normalize_plugin_id("sample-echo") == "sample-echo"
+    assert normalize_plugin_id("acme/nooa") == "acme/nooa"
+    assert normalize_plugin_id("Official/acp") == "Official/acp"
+    assert split_plugin_id("acme/nooa") == ("acme", "nooa")
+    assert split_plugin_id("dsh") == (None, "dsh")
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["org.name", "acme//nooa", "acme/nooa/extra", "-bad", "acme/", "/nooa", ""],
+)
+def test_normalize_rejects_invalid(raw: str) -> None:
+    with pytest.raises(PluginManifestError) as ei:
+        normalize_plugin_id(raw)
+    assert ei.value.kind in {"plugin_id_invalid", "plugin_manifest_invalid"}
+
+
+def test_parse_manifest_keeps_short_id() -> None:
+    manifest = parse_manifest_mapping(
+        {
+            "format": "bora.plugin/1",
+            "plugin_id": "dsh",
+            "version": "0.1.0",
+            "slots": {"provide": [{"id": "executor", "entry": "pkg:fn"}]},
+        }
+    )
+    assert manifest.plugin_id == "dsh"
+
+
+def test_hub_publish_concatenates_short_id() -> None:
+    assert hub_plugin_package_id("nooa", org="Official") == "Official/nooa"
+    assert hub_plugin_package_id("sample-echo", org="test") == "test/sample-echo"
+
+
+def test_hub_publish_namespaced_must_match_org() -> None:
+    assert hub_plugin_package_id("test/sample-echo", org="test") == "test/sample-echo"
+    with pytest.raises(PluginManifestError) as mismatch:
+        hub_plugin_package_id("other/sample-echo", org="test")
+    assert mismatch.value.kind == "plugin_org_mismatch"
+
+
+def test_publish_command_rejects_org_mismatch(tmp_path: Path) -> None:
+    from bora.application.plugin_ops.plugin_publish import PluginPublishCommand
+
+    root = tmp_path / "plug"
+    root.mkdir()
+    (root / "plugin.yaml").write_text(
+        "format: bora.plugin/1\nplugin_id: acme/echo\nversion: 0.0.1\n",
+        encoding="utf-8",
+    )
+    cmd = PluginPublishCommand(client_factory=lambda **_k: None)
+    with pytest.raises(ConfigError) as ei:
+        cmd.publish_plugin(root, org="other")
+    assert ei.value.error_code == "plugin_org_mismatch"
+
+
+def test_publish_command_concatenates_short_id(tmp_path: Path) -> None:
+    from bora.application.plugin_ops.plugin_publish import PluginPublishCommand
+
+    class _Client:
+        def publish(self, **kwargs):  # type: ignore[no-untyped-def]
+            return type(
+                "Info",
+                (),
+                {
+                    "database_id": kwargs["database_id"],
+                    "version": kwargs["version"],
+                    "visibility": kwargs["visibility"],
+                    "package_digest": kwargs["package_digest"],
+                    "blob_digest": kwargs["blob_digest"],
+                    "size": kwargs["size"],
+                    "media_type": kwargs["media_type"],
+                    "org_id": kwargs["org_id"],
+                },
+            )()
+
+    root = tmp_path / "plug"
+    root.mkdir()
+    (root / "plugin.yaml").write_text(
+        "format: bora.plugin/1\nplugin_id: sample-echo\nversion: 0.0.1\n",
+        encoding="utf-8",
+    )
+    cmd = PluginPublishCommand(client_factory=lambda **_k: _Client())
+    summary = cmd.publish_plugin(root, org="Official")
+    assert summary["package_id"] == "Official/sample-echo"
+    assert summary["plugin_id"] == "sample-echo"
+    assert summary["ref"] == "Official/sample-echo@0.0.1"
+
+
+def test_path_install_keeps_short_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("BORA_HOME", str(home))
+    from bora.plugins.store import install_from_path, list_installed, uninstall
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "plugin.yaml").write_text(
+        "format: bora.plugin/1\nplugin_id: nooa\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+    (src / "readme.txt").write_text("hi\n", encoding="utf-8")
+    entry = install_from_path(src)
+    assert entry.plugin_id == "nooa"
+    assert entry.digest.startswith("sha256:")
+    assert (home / "plugins" / "nooa" / "0.1.0" / "plugin.yaml").is_file()
+    assert list_installed()[0].plugin_id == "nooa"
+    assert uninstall("nooa") is True
+    assert list_installed() == []
+
+
+def test_hub_install_records_namespaced_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("BORA_HOME", str(home))
+    from bora.plugins.store import install_from_path, list_installed
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "plugin.yaml").write_text(
+        "format: bora.plugin/1\nplugin_id: nooa\nversion: 0.1.0\n"
+        "slots:\n  provide:\n    - id: executor\n      entry: missing:fn\n",
+        encoding="utf-8",
+    )
+    entry = install_from_path(src, plugin_id="Official/nooa")
+    assert entry.plugin_id == "Official/nooa"
+    assert entry.version == "0.1.0"
+    assert entry.digest.startswith("sha256:")
+    assert (home / "plugins" / "Official" / "nooa" / "0.1.0" / "plugin.yaml").is_file()
+    assert list_installed()[0].plugin_id == "Official/nooa"
+
+
+def test_hub_install_registers_index_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("BORA_HOME", str(home))
+    from bora.plugins import bootstrap as boot
+    from bora.plugins.bootstrap import bootstrap_registry
+    from bora.plugins.registry import ExtensionRegistry, reset_global_registry
+    from bora.plugins.slots import EXECUTOR
+    from bora.plugins.store import install_from_path
+
+    fixture = Path(__file__).resolve().parents[1] / "fixtures" / "plugins" / "sample-echo"
+    install_from_path(fixture, plugin_id="Official/sample-echo")
+    boot._BOOTSTRAPPED = False  # type: ignore[attr-defined]
+    reset_global_registry()
+    reg = ExtensionRegistry()
+    bootstrap_registry(reg)
+    assert "Official/sample-echo" in reg.plugins_for_slot(EXECUTOR)
+    assert "sample-echo" not in reg.plugins_for_slot(EXECUTOR)
+
+
+def test_official_org_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    from services.registry.official import is_official_upload_org, official_orgs
+
+    monkeypatch.delenv("BORA_OFFICIAL_ORGS", raising=False)
+    assert "Official" in official_orgs()
+    assert is_official_upload_org("Official") is True
+    assert is_official_upload_org("acme") is False
+    monkeypatch.setenv("BORA_OFFICIAL_ORGS", "Acme, Labs")
+    assert official_orgs() == frozenset({"Acme", "Labs"})
+    assert is_official_upload_org("Acme") is True
+    assert is_official_upload_org("Official") is False

--- a/tests/plugins/test_plugin_identity.py
+++ b/tests/plugins/test_plugin_identity.py
@@ -174,6 +174,40 @@ def test_hub_install_registers_index_id(
     assert "sample-echo" not in reg.plugins_for_slot(EXECUTOR)
 
 
+def test_release_dict_marks_official_from_allowlist() -> None:
+    from bora.registry.plugin_package import PLUGIN_MEDIA_TYPE
+    from services.registry.store import ReleaseRow, release_to_dict
+
+    official = release_to_dict(
+        ReleaseRow(
+            database_id="Official/nooa",
+            version="0.1.0",
+            visibility="public",
+            package_digest="sha256:a",
+            blob_digest="sha256:b",
+            size=1,
+            media_type=PLUGIN_MEDIA_TYPE,
+            created_at=0.0,
+            org_id="Official",
+        )
+    )
+    other = release_to_dict(
+        ReleaseRow(
+            database_id="acme/nooa",
+            version="0.1.0",
+            visibility="public",
+            package_digest="sha256:a",
+            blob_digest="sha256:b",
+            size=1,
+            media_type=PLUGIN_MEDIA_TYPE,
+            created_at=0.0,
+            org_id="acme",
+        )
+    )
+    assert official["official"] is True
+    assert other["official"] is False
+
+
 def test_official_org_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
     from services.registry.official import is_official_upload_org, official_orgs
 

--- a/tests/plugins/test_plugin_identity.py
+++ b/tests/plugins/test_plugin_identity.py
@@ -129,9 +129,7 @@ def test_path_install_keeps_short_id(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert list_installed() == []
 
 
-def test_hub_install_records_namespaced_id(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_hub_install_records_namespaced_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("BORA_HOME", str(home))
@@ -152,9 +150,7 @@ def test_hub_install_records_namespaced_id(
     assert list_installed()[0].plugin_id == "Official/nooa"
 
 
-def test_hub_install_registers_index_id(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_hub_install_registers_index_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("BORA_HOME", str(home))
@@ -175,8 +171,9 @@ def test_hub_install_registers_index_id(
 
 
 def test_release_dict_marks_official_from_allowlist() -> None:
-    from bora.registry.plugin_package import PLUGIN_MEDIA_TYPE
     from services.registry.store import ReleaseRow, release_to_dict
+
+    from bora.registry.plugin_package import PLUGIN_MEDIA_TYPE
 
     official = release_to_dict(
         ReleaseRow(

--- a/tests/plugins/test_registry_resolve.py
+++ b/tests/plugins/test_registry_resolve.py
@@ -11,7 +11,7 @@ from bora.plugins.defaults import register_defaults
 from bora.plugins.errors import ExtensionPluginNotFoundError, UnknownExtensionSlotError
 from bora.plugins.lock_bind import extension_graph_to_lock
 from bora.plugins.middleware import run_chain
-from bora.plugins.protocol import BindingIntent, ExplicitBinding
+from bora.plugins.protocol import BindingIntent, ExplicitBinding, ExtensionSelect
 from bora.plugins.registry import ExtensionRegistry
 from bora.plugins.resolve import resolve
 from bora.plugins.slots import BEFORE_AGENT_INVOKE, EXECUTOR
@@ -104,7 +104,16 @@ def test_multi_chain_order_lower_priority_number_first() -> None:
 
     make("late", 100)
     make("early", 10)
-    graph = resolve(BindingIntent(profile_id="s"), reg)
+    graph = resolve(
+        BindingIntent(
+            profile_id="s",
+            extension_selects=[
+                ExtensionSelect(plugin="late"),
+                ExtensionSelect(plugin="early"),
+            ],
+        ),
+        reg,
+    )
     result = asyncio.run(run_chain(graph, BEFORE_AGENT_INVOKE, "prompt"))
     assert result == "prompt"
     assert order[0] == "enter:early"

--- a/tests/plugins/test_slot_wiring_agent_bookends.py
+++ b/tests/plugins/test_slot_wiring_agent_bookends.py
@@ -100,7 +100,14 @@ def _svc_with_spies() -> tuple[ParentAgentService, _FakeExecutor, list[str]]:
     reg.on(BEFORE_AGENT_INVOKE, "spy", rewrite_prompt, priority=10, source="test")
 
     svc = ParentAgentService(
-        profiles=[{"id": "p1", "executor": "fake", "model": "m"}],
+        profiles=[
+            {
+                "id": "p1",
+                "executor": "fake",
+                "model": "m",
+                "extensions": [{"plugin": "spy"}],
+            }
+        ],
         agent_invocation_limit=5,
         attempt_id="att_test",
         offline_env="",
@@ -145,7 +152,14 @@ def test_open_hook_fail_closed_no_half_open_session() -> None:
 
     reg.on(BEFORE_AGENT_OPEN, "spy", boom, priority=10, source="test")
     svc = ParentAgentService(
-        profiles=[{"id": "p1", "executor": "fake", "model": "m"}],
+        profiles=[
+            {
+                "id": "p1",
+                "executor": "fake",
+                "model": "m",
+                "extensions": [{"plugin": "spy"}],
+            }
+        ],
         agent_invocation_limit=2,
         attempt_id="att_fail",
         offline_env="",

--- a/tests/plugins/test_slot_wiring_env.py
+++ b/tests/plugins/test_slot_wiring_env.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 from bora.application.attempt import extension_hooks as hooks
 from bora.environment.manager import EnvironmentManager
 from bora.plugins.defaults import register_defaults
-from bora.plugins.protocol import BindingIntent
+from bora.plugins.protocol import BindingIntent, ExtensionSelect
 from bora.plugins.registry import ExtensionRegistry
 from bora.plugins.resolve import resolve
 from bora.plugins.slots import ENV_ACTION, ENV_INJECT, ENV_PREPARE_COMMANDS, ENV_TEARDOWN_COMMANDS
@@ -55,7 +55,14 @@ def test_env_prepare_handler_does_real_work_and_rewrites_handoff(tmp_path: Path)
     reg.on(ENV_PREPARE_COMMANDS, "spy-env", after_prepare, priority=10, source="test")
     reg.on(ENV_INJECT, "spy-env", inject, priority=10, source="test")
     reg.on(ENV_TEARDOWN_COMMANDS, "spy-env", teardown, priority=10, source="test")
-    graph = resolve(BindingIntent(profile_id="p"), reg, materialize=True)
+    graph = resolve(
+        BindingIntent(
+            profile_id="p",
+            extension_selects=[ExtensionSelect(plugin="spy-env")],
+        ),
+        reg,
+        materialize=True,
+    )
 
     lock = _lock()
     handoff = {"ok": True, "resource": "postgresql"}
@@ -117,7 +124,14 @@ def test_env_action_provide_materializes() -> None:
         return AllowAll()
 
     reg.provide(ENV_ACTION, "gate-plugin", factory, priority=10, source="test", is_factory=True)
-    graph = resolve(BindingIntent(profile_id="p"), reg, materialize=True)
+    graph = resolve(
+        BindingIntent(
+            profile_id="p",
+            extension_selects=[ExtensionSelect(plugin="gate-plugin")],
+        ),
+        reg,
+        materialize=True,
+    )
     lock = _lock()
     with patch.object(hooks, "graph_for_lock", return_value=graph):
         spi = hooks.hook_env_action(lock, {"op": "prepare"})

--- a/tests/plugins/test_slot_wiring_eval.py
+++ b/tests/plugins/test_slot_wiring_eval.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 from bora.application.attempt import extension_hooks as hooks
 from bora.plugins.defaults import register_defaults
 from bora.plugins.lock_bind import extension_graph_to_lock
-from bora.plugins.protocol import BindingIntent
+from bora.plugins.protocol import BindingIntent, ExtensionSelect
 from bora.plugins.registry import ExtensionRegistry
 from bora.plugins.resolve import resolve
 from bora.plugins.slots import EVALUATION_INPUT_CONTRIBUTE, EVALUATION_RUNTIME, SCORE_POSTPROCESS
@@ -48,7 +48,11 @@ def test_evaluation_input_and_score_postprocess_rewrite() -> None:
 
     reg.on(EVALUATION_INPUT_CONTRIBUTE, "spy", ein, priority=10, source="test")
     reg.on(SCORE_POSTPROCESS, "spy", spp, priority=10, source="test")
-    graph = resolve(BindingIntent(profile_id="p"), reg, materialize=True)
+    graph = resolve(
+        BindingIntent(profile_id="p", extension_selects=[ExtensionSelect(plugin="spy")]),
+        reg,
+        materialize=True,
+    )
 
     lock = _lock()
     with patch.object(hooks, "graph_for_lock", return_value=graph):
@@ -74,7 +78,14 @@ def test_l3_bindings_appear_in_lock_fragment() -> None:
         return await nxt(value)
 
     reg.on(SCORE_POSTPROCESS, "score-spy", spp, priority=50, source="test")
-    graph = resolve(BindingIntent(profile_id="solver"), reg, materialize=False)
+    graph = resolve(
+        BindingIntent(
+            profile_id="solver",
+            extension_selects=[ExtensionSelect(plugin="score-spy")],
+        ),
+        reg,
+        materialize=False,
+    )
     frag = extension_graph_to_lock(graph)
     assert SCORE_POSTPROCESS in frag
     assert frag[SCORE_POSTPROCESS]["kind"] == "on"

--- a/tests/plugins/test_slot_wiring_trajectory.py
+++ b/tests/plugins/test_slot_wiring_trajectory.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from bora.plugins.defaults import register_defaults
-from bora.plugins.protocol import BindingIntent
+from bora.plugins.protocol import BindingIntent, ExtensionSelect
 from bora.plugins.registry import ExtensionRegistry
 from bora.plugins.resolve import resolve
 from bora.plugins.slots import (
@@ -86,7 +86,11 @@ def test_trajectory_chain_enriches_metadata_and_evidence_extra(tmp_path: Path) -
     reg.on(EVIDENCE_EXTRA, "spy", extras, priority=10, source="test")
     # trajectory_seal provide stays on default marker
 
-    graph = resolve(BindingIntent(profile_id="p"), reg, materialize=True)
+    graph = resolve(
+        BindingIntent(profile_id="p", extension_selects=[ExtensionSelect(plugin="spy")]),
+        reg,
+        materialize=True,
+    )
     inv_dir = tmp_path / "inv_001"
     inv_dir.mkdir()
     handle = _FakeHandle(inv_dir)
@@ -150,7 +154,11 @@ def test_trajectory_rewrite_on_collect_changes_prompt_written(tmp_path: Path) ->
         return out
 
     reg.on(TRAJECTORY_COLLECT, "spy", collect, priority=10, source="test")
-    graph = resolve(BindingIntent(profile_id="p"), reg, materialize=True)
+    graph = resolve(
+        BindingIntent(profile_id="p", extension_selects=[ExtensionSelect(plugin="spy")]),
+        reg,
+        materialize=True,
+    )
     inv_dir = tmp_path / "inv_002"
     inv_dir.mkdir()
     handle = _FakeHandle(inv_dir)

--- a/tests/registry/test_plugin_package_e2e.py
+++ b/tests/registry/test_plugin_package_e2e.py
@@ -109,6 +109,9 @@ def test_publish_plugin_preview_and_install(
     plugin_items = listed.get("items") or []
     assert any(i.get("database_id") == summary["package_id"] for i in plugin_items)
     assert all(i.get("package_kind") == "plugin" for i in plugin_items)
+    echo_row = next(i for i in plugin_items if i.get("database_id") == summary["package_id"])
+    assert echo_row.get("official") is False
+    assert echo_row.get("org_id") == TEST_ORG
     db_req = urllib.request.Request(
         registry_server["url"] + "/v1/packages?package_kind=database",
         headers={"Authorization": f"Bearer {registry_server['token']}"},
@@ -121,7 +124,9 @@ def test_publish_plugin_preview_and_install(
 
     installed = install_plugin_from_registry(ref)
     assert installed["ok"] is True
-    assert installed["plugin_id"] == "sample-echo"
+    assert installed["plugin_id"] == f"{TEST_ORG}/sample-echo"
+    assert installed["version"] == summary["version"]
+    assert installed["digest"].startswith("sha256:")
     assert (home / "plugins" / "index.json").is_file()
 
 

--- a/tests/registry/test_registry_org_share.py
+++ b/tests/registry/test_registry_org_share.py
@@ -71,6 +71,34 @@ def test_org_create_list_and_publish_requires_org(
     assert meta.org_id == "acme"
 
 
+def test_owner_can_patch_org_and_package_display_name(
+    registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    url = registry_server["url"]
+    boot = RegistryClient(url, token=registry_server["token"])
+    boot.create_org(name="lab", display_name="lab")
+    patched = boot.patch_org("lab", display_name="My Lab")
+    assert patched["display_name"] == "My Lab"
+    assert patched["org_id"] == "lab"
+
+    write_credentials(url=url, token=registry_server["token"], path=tmp_path / "c")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BORA_REGISTRY_URL", url)
+    monkeypatch.setenv("BORA_REGISTRY_TOKEN", registry_server["token"])
+    from bora.application.composition import build_plugin_commands
+
+    plugin = REPO / "tests/fixtures/plugins/sample-echo"
+    summary = build_plugin_commands().publish_plugin(plugin, public=True, org="lab")
+    labeled = boot.patch_package_display_name(summary["package_id"], display_name="Echo probe")
+    assert labeled["display_name"] == "Echo probe"
+    via_prefix = boot.patch_package_display_name(
+        summary["package_id"], display_name="lab/Echo probe"
+    )
+    assert via_prefix["display_name"] == "Echo probe"
+    with pytest.raises(RegistryError):
+        boot.patch_package_display_name(summary["package_id"], display_name="other/Echo")
+
+
 def test_private_package_visible_to_org_member_only(
     registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/website/content/docs/run/plugins.en.mdx
+++ b/website/content/docs/run/plugins.en.mdx
@@ -30,10 +30,17 @@ uv run bora plugin uninstall nooa
 bindings:
   solver:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:JsonlAggAgent"
       method: "run"
 ```
+
+`executor:` selects `provide(executor)` only — it does **not** bake or attach
+other `on:` slots. Add `extensions` on the same role when L1 needs bake /
+trajectory collect (short ids match a path install). ACP-only profiles omit
+`extensions`.
 
 Use an alternate profiles file at run time without changing Database ACP defaults:
 
@@ -63,9 +70,10 @@ fenced; bash stays local. This is not a BORA isolation claim.
 | **profiles bind** | Job selects that executor |
 | **L1 Ready** | `image_contribute` bake during prepare; execute in-container |
 
-A successful install does **not** imply the L1 isolated path is ready. Docker L1 tasks
-need a successful bake before the container worker runs (for example nooa or dsh
-in-container).
+A successful install does **not** imply the L1 isolated path is ready. Docker L1
+tasks need this profile's `extensions` to select `image_contribute` and a
+successful bake before the container worker runs (for example nooa or dsh
+in-container). Installed plugins that are not listed stay off the Attempt image.
 
 ## Relation to ACP
 

--- a/website/content/docs/run/plugins.mdx
+++ b/website/content/docs/run/plugins.mdx
@@ -29,10 +29,14 @@ uv run bora plugin uninstall nooa
 bindings:
   solver:
     executor: nooa
+    extensions:
+      - plugin: nooa
     options:
       agent: "lib.agents:JsonlAggAgent"
       method: "run"
 ```
+
+`executor:` 只选 `provide(executor)`，**不**自动 bake 或挂上其它 `on:`。L1 需要 bake / 轨迹收集时，在同一 role 下写 `extensions`（短 id 与路径安装一致）。纯 ACP profile 省略 `extensions`。
 
 运行时用备用 profiles 文件切换，不必改 Database 默认 ACP 配置：
 
@@ -61,8 +65,10 @@ uv run bora run examples/journeys --task terminal-jsonl-agg \
 | **profiles 绑定** | Job 选择该 executor |
 | **L1 Ready** | `image_contribute` 在 prepare 时 bake 进 Attempt 镜像；容器内执行 |
 
-有 install 成功 **不等于** L1 隔离路径已就绪。Docker L1 任务需 bake 成功后，才在
-容器内调用 worker（例如 nooa / dsh 的 in-container 路径）。
+有 install 成功 **不等于** L1 隔离路径已就绪。Docker L1 任务需该 profile 的
+`extensions` 选中 `image_contribute` 并 bake 成功后，才在容器内调用 worker
+（例如 nooa / dsh 的 in-container 路径）。已安装但未写入 `extensions` 的插件
+不会进 Attempt 镜像。
 
 ## 与 ACP 的关系
 


### PR DESCRIPTION
## Summary

- `profiles.extensions` is the only way installed plugins join MULTI slots. `executor:` no longer bakes or attaches collect.
- First-party ACP + FROM-only package Dockerfile reuses `bora-attempt:l1` (no extra `bora-pkg` tag).
- Local path install / lock / run keep short ids (`acp`, `nooa`, `dsh`). Hub publish concatenates `--org`; Hub install records `org/name`.
- Official chip is Registry display policy: default org slug `official` (`BORA_OFFICIAL_ORGS` on the Registry process). Hub shows a verified check, not a PLUGIN chip.
- Org and plugin owners can edit display names in Hub. Plugin display is the name leaf only (`org/` stays locked).

Closes #113

## Test plan

- [x] `bora lock examples/journeys --task terminal-jsonl-agg` — ACP contribute has no installed dsh/nooa
- [x] `bora lock … --profiles examples/journeys/profiles.dsh.yaml` — dsh contribute selected, nooa off
- [x] Live L1: `bora run examples/journeys --task terminal-jsonl-agg --profiles examples/journeys/profiles.dsh.yaml` — PASS, `baked=['dsh']`
- [x] Local CI-equivalent: python-core (610 passed), python-registry (101 passed), hub lint+build, website build
- [x] Hub: official check on `official/sample-echo`; owner edit org/plugin display name; plugin header shows `@id` without digest