### PR TITLE
feat(registry): public concurrency and whole-object streaming

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -158,6 +158,7 @@ BORA/
 │   ├── dataset.py             # draft 槽常量、task 集指纹、suite 完备谓词
 │   ├── sql_adapter.py         # sqlite/postgres 只 connect / placeholder / row-map
 │   ├── store.py               # 一份 MetadataStore + 薄 Postgres 适配
+│   ├── blob_io.py / spool.py  # 整包 put/open 走 Path；上传 spool 后再校验
 │   └── routes.py              # ROUTES 必须声明 access；skip_auth 仅 access=none
 ├── examples/                  # 见 examples/README.md
 │   ├── journeys/              # case-class：env / multiagent / tau2 / terminal（+ profiles.nooa / profiles.dsh[.read-only]）

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -148,7 +148,11 @@ BORA/
 │   ├── viewer/                # 本地 `bora view` SPA（Jobs → Trial；非 Registry）
 │   └── hub/                   # Registry Dataset / Plugin / Home / Leaderboard SPA
 ├── services/registry/         # 独立 HTTP：Route.access + _dispatch 强制策略
-│   ├── app.py                 # Handler 是 HTTP adapter（读 body → *Service → JSON）
+│   ├── app.py                 # 启动 / 后端选择；stdlib Handler 是薄 HTTP adapter
+│   ├── http_api.py            # Route.access + *Service → HttpResult（stdlib 与 ASGI 共用）
+│   ├── asgi.py                # Starlette/uvicorn 管；不持有 ACL
+│   ├── backend.py             # 公网 fail-closed：Postgres + S3；--local 才 SQLite
+│   ├── upload_slots.py        # 进程内 in-flight upload 上限
 │   ├── auth_service.py / package_service.py / result_service.py / org_service.py
 │   ├── queries.py             # 唯一 SQL / schema 文本
 │   ├── dataset.py             # draft 槽常量、task 集指纹、suite 完备谓词

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dev = [
 registry = [
     "psycopg[binary]>=3.2.0",
     "boto3>=1.35.0",
+    "starlette>=0.41.0",
+    "uvicorn>=0.32.0",
 ]
 nooa = [
     "httpx[socks]>=0.28.1",

--- a/services/registry/.env.example
+++ b/services/registry/.env.example
@@ -14,6 +14,11 @@ BORA_REGISTRY_S3_REGION=us-east-1
 BORA_REGISTRY_HOST=127.0.0.1
 BORA_REGISTRY_PORT=8700
 
+# Public process model (ignored by --local unless --workers is set)
+# BORA_REGISTRY_WORKERS=4
+# BORA_REGISTRY_UPLOAD_SLOTS=4
+# Proxy body limit must match the application cap (64 MiB).
+
 # Comma-separated GitHub logins allowed to bora login (required for OAuth)
 BORA_GITHUB_LOGIN_ALLOWLIST=
 

--- a/services/registry/.env.example
+++ b/services/registry/.env.example
@@ -17,7 +17,7 @@ BORA_REGISTRY_PORT=8700
 # Public process model (ignored by --local unless --workers is set)
 # BORA_REGISTRY_WORKERS=4
 # BORA_REGISTRY_UPLOAD_SLOTS=4
-# Proxy body limit must match the application cap (64 MiB).
+# Proxy body limit must match the application cap (512 MiB).
 
 # Comma-separated GitHub logins allowed to bora login (required for OAuth)
 BORA_GITHUB_LOGIN_ALLOWLIST=

--- a/services/registry/Caddyfile
+++ b/services/registry/Caddyfile
@@ -2,7 +2,7 @@
 # Do not expose the Python process on the public internet.
 #
 # Align client_max_body / request_body with the application cap
-# (BORA_REGISTRY_MAX_UPLOAD, default 64 MiB until streaming lands).
+# (512 MiB after whole-object streaming).
 # In-flight uploads: workers × BORA_REGISTRY_UPLOAD_SLOTS.
 
 {
@@ -18,6 +18,6 @@
 		}
 	}
 	request_body {
-		max_size 64MB
+		max_size 512MB
 	}
 }

--- a/services/registry/Caddyfile
+++ b/services/registry/Caddyfile
@@ -1,0 +1,23 @@
+# Example reverse proxy in front of Registry workers.
+# Do not expose the Python process on the public internet.
+#
+# Align client_max_body / request_body with the application cap
+# (BORA_REGISTRY_MAX_UPLOAD, default 64 MiB until streaming lands).
+# In-flight uploads: workers × BORA_REGISTRY_UPLOAD_SLOTS.
+
+{
+	# optional
+}
+
+:443 {
+	reverse_proxy 127.0.0.1:8700 {
+		flush_interval -1
+		transport http {
+			read_timeout 15m
+			write_timeout 15m
+		}
+	}
+	request_body {
+		max_size 64MB
+	}
+}

--- a/services/registry/README.md
+++ b/services/registry/README.md
@@ -40,7 +40,7 @@ connection limits on nginx or Caddy, then proxy to uvicorn workers.
 
 | Knob | Where | Same number |
 | --- | --- | --- |
-| Body limit | Proxy `client_max_body_size` / Caddy `request_body.max_size` | Application `MAX_UPLOAD_BYTES` (64 MiB) |
+| Body limit | Proxy `client_max_body_size` / Caddy `request_body.max_size` | Application `MAX_UPLOAD_BYTES` (512 MiB) |
 | In-flight uploads | Proxy concurrent-request cap (optional) | `workers × BORA_REGISTRY_UPLOAD_SLOTS` |
 | Workers | `--workers` / `BORA_REGISTRY_WORKERS` (default 2 in public mode) | One process per worker; each has its own slot pool |
 
@@ -55,7 +55,7 @@ uv run --extra registry python -m services.registry.app --host 127.0.0.1 --port 
 Example Caddyfile: [`Caddyfile`](Caddyfile). nginx equivalent:
 
 ```nginx
-client_max_body_size 64m;
+client_max_body_size 512m;
 proxy_read_timeout 900s;
 proxy_send_timeout 900s;
 location / {

--- a/services/registry/README.md
+++ b/services/registry/README.md
@@ -23,6 +23,10 @@ uv run --extra registry python -m services.registry.app --host 127.0.0.1 --port 
 Public mode **refuses to start** without `BORA_REGISTRY_DATABASE_URL` and
 `BORA_REGISTRY_S3_ENDPOINT`. There is no silent SQLite fallback.
 
+Whole-object publish/upload on the ASGI pipe streams the multipart body to a
+spool file (hash/validate from disk, then BlobStore put). JSON bodies stay
+small. Proxy `client_max_body_size` must still match `MAX_UPLOAD_BYTES`.
+
 ## Zero-dep / tests
 
 ```bash

--- a/services/registry/README.md
+++ b/services/registry/README.md
@@ -15,13 +15,13 @@ cp services/registry/.env.example services/registry/.env
 # set BORA_GITHUB_CLIENT_ID / BORA_GITHUB_CLIENT_SECRET for bora login
 
 uv sync --extra registry
+# Public start is fail-closed: Postgres + S3 env must be set (see .env.example).
 uv run --extra registry python -m services.registry.app --host 127.0.0.1 --port 8700
 # stderr prints bootstrap token once — or use bora login after OAuth is configured
 ```
 
-When `BORA_REGISTRY_DATABASE_URL` and `BORA_REGISTRY_S3_ENDPOINT` are set (via
-`.env` or the environment), the service uses **Postgres + S3**. Otherwise it
-falls back to SQLite + filesystem under `--data-dir`.
+Public mode **refuses to start** without `BORA_REGISTRY_DATABASE_URL` and
+`BORA_REGISTRY_S3_ENDPOINT`. There is no silent SQLite fallback.
 
 ## Zero-dep / tests
 
@@ -29,6 +29,42 @@ falls back to SQLite + filesystem under `--data-dir`.
 python -m services.registry.app --local --host 127.0.0.1 --port 8700
 # or --memory-blob for tests
 ```
+
+`--local` / `--memory-blob` are the only SQLite paths. They are for
+dev and tests, not a public Hub.
+
+## Public deploy (proxy + workers)
+
+Do **not** put the Python port on the public internet. Terminate TLS and
+connection limits on nginx or Caddy, then proxy to uvicorn workers.
+
+| Knob | Where | Same number |
+| --- | --- | --- |
+| Body limit | Proxy `client_max_body_size` / Caddy `request_body.max_size` | Application `MAX_UPLOAD_BYTES` (64 MiB) |
+| In-flight uploads | Proxy concurrent-request cap (optional) | `workers × BORA_REGISTRY_UPLOAD_SLOTS` |
+| Workers | `--workers` / `BORA_REGISTRY_WORKERS` (default 2 in public mode) | One process per worker; each has its own slot pool |
+
+```bash
+export BORA_REGISTRY_WORKERS=4
+export BORA_REGISTRY_UPLOAD_SLOTS=4
+# 4 × 4 = 16 in-flight uploads across the process group
+uv run --extra registry python -m services.registry.app --host 127.0.0.1 --port 8700
+# or: uvicorn services.registry.asgi:app_factory --factory --host 127.0.0.1 --port 8700 --workers 4
+```
+
+Example Caddyfile: [`Caddyfile`](Caddyfile). nginx equivalent:
+
+```nginx
+client_max_body_size 64m;
+proxy_read_timeout 900s;
+proxy_send_timeout 900s;
+location / {
+    proxy_pass http://127.0.0.1:8700;
+}
+```
+
+Replace / blob GC under several workers is Postgres-authoritative. Do not run
+public mode on SQLite.
 
 ## CLI
 
@@ -123,7 +159,7 @@ Set `BORA_REGISTRY_CORS_ORIGIN` (default `*` when unset) so a browser Hub on
 another origin can call `/v1/*` with `Authorization`. Local Hub dev usually
 proxies via Vite (`apps/hub`) and does not need CORS.
 
-### Package files API (Hub S2 / #38)
+### Package files API
 
 Browse published package contents **without** downloading the whole tar to the browser:
 
@@ -146,7 +182,7 @@ optional `?package_kind=database|plugin` (Hub plugin marketplace).
 - Private unauthorized → **404** (not 403)
 - Server indexes tar on first access (process LRU by digest); does not change upload format
 
-### Organizations + ACL (design #52)
+### Organizations + ACL
 
 | Surface | Ownership | Private read | Delete / set-visibility / replace |
 | --- | --- | --- | --- |
@@ -216,9 +252,9 @@ files (no `..`, 2 MiB cap, **413** when larger):
 Row fields: `database_id`, `database_version`, `pass_rate`, `mean_score`, `metrics`,
 `task_refs`, optional `agent_label` / `model_label`, `exit_code`, and optional
 config-comparability projection (`config_fingerprint`, `config_homogeneous`,
-`actors_summary`) written at suite-run time (#42) — **not** invented at upload.
+`actors_summary`) written at suite-run time — **not** invented at upload.
 **No suite-level PASS** is stored or accepted (client keys `pass` / `verdict` / `suite_pass` → 400).
-Leaderboard (#40) should refuse comparable ranking when `config_homogeneous` is
+Leaderboard should refuse comparable ranking when `config_homogeneous` is
 false; missing fingerprint on legacy rows degrades to labels-only.
 
 Result archives keep layout `.bora/runs/<run_id>/…` so download extracts into a

--- a/services/registry/app.py
+++ b/services/registry/app.py
@@ -49,15 +49,12 @@ Blob GC: delete meta first; drop blob only when digest has zero remaining refs.
 from __future__ import annotations
 
 import argparse
-import json
 import os
-import re
 import secrets
 import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs, unquote, urlparse
 
 # Allow `python -m services.registry.app` from repo root.
 _REPO = Path(__file__).resolve().parents[2]
@@ -72,8 +69,7 @@ from services.registry.backend import (  # noqa: E402
     require_public_backend,
 )
 from services.registry.envload import load_env_file  # noqa: E402
-from services.registry.errors import RegistryAppError  # noqa: E402
-from services.registry.routes import match_route  # noqa: E402
+from services.registry.http_api import RegistryHttpApi, write_http_result  # noqa: E402
 from services.registry.store import (  # noqa: E402
     ADMIN_SCOPES,
     FilesystemBlobStore,
@@ -83,7 +79,6 @@ from services.registry.store import (  # noqa: E402
     PostgresTokenStore,
     S3BlobStore,
     SqliteTokenStore,
-    TokenInfo,
 )
 from services.registry.upload_slots import (  # noqa: E402
     UploadSlotPool,
@@ -94,6 +89,11 @@ from bora.registry.media_types import (  # noqa: E402
     ATTEMPT_RESULT_MEDIA_TYPE as RESULT_MEDIA_TYPE,
 )
 from bora.registry.media_types import SUITE_RESULT_MEDIA_TYPE  # noqa: E402
+
+__all__ = [
+    "RESULT_MEDIA_TYPE",
+    "SUITE_RESULT_MEDIA_TYPE",
+]
 
 MAX_UPLOAD_BYTES = 64 * 1024 * 1024  # 64 MiB hard top for v1
 
@@ -141,78 +141,16 @@ class RegistryState:
         self.max_upload = max_upload
 
 
-def _cors_headers(handler: BaseHTTPRequestHandler) -> None:
-    """Optional CORS for Hub SPA (different origin). Env: BORA_REGISTRY_CORS_ORIGIN.
-
-    Default ``*`` for local Hub; set a concrete origin in production. Never
-    reflects credentials into logs.
-    """
-    origin = (os.environ.get("BORA_REGISTRY_CORS_ORIGIN") or "*").strip() or "*"
-    handler.send_header("Access-Control-Allow-Origin", origin)
-    handler.send_header("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept")
-    handler.send_header("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
-    if origin != "*":
-        handler.send_header("Vary", "Origin")
-
-
-def _json_response(handler: BaseHTTPRequestHandler, status: int, payload: dict[str, Any]) -> None:
-    body = json.dumps(payload, sort_keys=True).encode("utf-8")
-    handler.send_response(status)
-    handler.send_header("Content-Type", "application/json")
-    handler.send_header("Content-Length", str(len(body)))
-    _cors_headers(handler)
-    handler.end_headers()
-    handler.wfile.write(body)
-
-
-def _app_error(handler: BaseHTTPRequestHandler, exc: RegistryAppError) -> None:
-    _json_response(handler, exc.http_status, exc.payload())
-
-
-def _bearer(handler: BaseHTTPRequestHandler) -> str | None:
-    auth = handler.headers.get("Authorization") or ""
-    if auth.lower().startswith("bearer "):
-        return auth[7:].strip() or None
-    return None
-
-
 def _parse_multipart(body: bytes, content_type: str) -> dict[str, bytes]:
-    """Parse multipart/form-data without corrupting binary parts.
+    """Compatibility alias for tests that import the stdlib parser."""
+    from services.registry.http_api import parse_multipart
 
-    Only strip framing CRLF at the part boundary — never rstrip the payload
-    (gzip archives may legitimately end in 0x0d / 0x0a).
-    """
-    m = re.search(r"boundary=([^;]+)", content_type)
-    if not m:
-        raise ValueError("missing multipart boundary")
-    boundary = m.group(1).strip().encode()
-    parts = body.split(b"--" + boundary)
-    out: dict[str, bytes] = {}
-    for part in parts:
-        if part in (b"", b"--\r\n", b"--", b"\r\n", b"--\r\n", b""):
-            continue
-        if part.startswith(b"--"):
-            continue
-        if part.startswith(b"\r\n"):
-            part = part[2:]
-        # Final boundary part may end with "--" after optional CRLF.
-        if part.endswith(b"--"):
-            part = part[:-2]
-        if part.endswith(b"\r\n"):
-            part = part[:-2]
-        header_blob, sep, data = part.partition(b"\r\n\r\n")
-        if not sep:
-            continue
-        headers = header_blob.decode("utf-8", errors="replace")
-        name_m = re.search(r'name="([^"]+)"', headers)
-        if not name_m:
-            continue
-        # Framing already removed above; keep payload bytes intact.
-        out[name_m.group(1)] = data
-    return out
+    return parse_multipart(body, content_type)
 
 
 def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
+    api = RegistryHttpApi(state)
+
     class Handler(BaseHTTPRequestHandler):
         protocol_version = "HTTP/1.1"
 
@@ -221,34 +159,31 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             sys.stderr.write(f"{self.address_string()} - {fmt % args}\n")
 
         def do_OPTIONS(self) -> None:  # noqa: N802
-            # CORS preflight for Hub SPA (browser Authorization header).
-            self.send_response(204)
-            _cors_headers(self)
-            self.send_header("Content-Length", "0")
-            self.end_headers()
+            self._write_result(
+                api.dispatch(
+                    method="OPTIONS",
+                    path=self.path,
+                    headers=self.headers,
+                    body=self.rfile,
+                )
+            )
 
         def _dispatch(self, method: str) -> None:
-            parsed = urlparse(self.path)
-            path = unquote(parsed.path)
-            qs = parse_qs(parsed.query)
-            matched = match_route(method, path)
-            if matched is None:
-                _json_response(self, 404, {"error": "not_found", "message": "unknown path"})
-                return
-            route, kwargs = matched
-            handler = getattr(self, f"_{route.name}")
-            token = _bearer(self)
-            auth = state.auth.auth_for(token)
-            denied = state.access.enforce_route_access(route.access, auth, kwargs=kwargs)
-            if denied is not None:
-                status, body = denied
-                _json_response(self, status, body)
-                return
-            if route.access != "none":
-                kwargs["auth"] = auth
-            if route.pass_qs:
-                kwargs["qs"] = qs
-            handler(**kwargs)
+            try:
+                length = int(self.headers.get("Content-Length") or "0")
+            except ValueError:
+                length = 0
+            result = api.dispatch(
+                method=method,
+                path=self.path,
+                headers=self.headers,
+                body=self.rfile,
+                content_length=length,
+            )
+            self._write_result(result)
+
+        def _write_result(self, result: Any) -> None:
+            write_http_result(self, result)
 
         def do_GET(self) -> None:  # noqa: N802
             self._dispatch("GET")
@@ -261,729 +196,6 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
 
         def do_PATCH(self) -> None:  # noqa: N802
             self._dispatch("PATCH")
-
-        def _health(self) -> None:
-            _json_response(self, 200, {"ok": True, "service": "bora-registry"})
-
-        # ---- OAuth -------------------------------------------------------
-
-        def _auth_web_start(self) -> None:
-            body = self._read_json_body()
-            if body is None:
-                return
-            try:
-                payload = state.auth.web_start(
-                    redirect_uri=str(body.get("redirect_uri") or "").strip()
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _auth_web_callback(self) -> None:
-            body = self._read_json_body()
-            if body is None:
-                return
-            try:
-                payload = state.auth.web_callback(
-                    code=str(body.get("code") or "").strip(),
-                    state=str(body.get("state") or "").strip(),
-                    redirect_uri=str(body.get("redirect_uri") or "").strip(),
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _auth_device_code(self) -> None:
-            try:
-                payload = state.auth.device_code()
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _auth_device_poll(self) -> None:
-            body = self._read_json_body()
-            if body is None:
-                return
-            try:
-                status, payload = state.auth.device_poll(
-                    device_code=str(body.get("device_code") or "")
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, status, payload)
-
-        # ---- packages ----------------------------------------------------
-
-        def _publish_package(self, *, auth: TokenInfo) -> None:
-            try:
-                with state.upload_slots.hold():
-                    length = int(self.headers.get("Content-Length") or "0")
-                    if length <= 0 or length > state.max_upload:
-                        _json_response(
-                            self,
-                            413,
-                            {
-                                "error": "payload_too_large",
-                                "message": f"max {state.max_upload} bytes",
-                            },
-                        )
-                        return
-                    body = self.rfile.read(length)
-                    ctype = self.headers.get("Content-Type") or ""
-                    try:
-                        parts = _parse_multipart(body, ctype)
-                        meta = json.loads(parts["metadata"].decode("utf-8"))
-                        archive = parts["archive"]
-                    except (KeyError, ValueError, json.JSONDecodeError) as exc:
-                        _json_response(
-                            self,
-                            400,
-                            {"error": "invalid_request", "message": f"bad multipart: {exc}"},
-                        )
-                        return
-                    payload = state.packages.publish(meta=meta, archive=archive, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 201, payload)
-
-        def _release_draft(self, *, database_id: str, auth: TokenInfo) -> None:
-            body = self._read_json_body()
-            if body is None:
-                body = {}
-            try:
-                payload = state.packages.release_draft(
-                    database_id=database_id,
-                    auth=auth,
-                    visibility=str(body.get("visibility") or "") or None,
-                    replace=bool(body.get("replace")),
-                    version=str(body.get("version") or "") or None,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 201, payload)
-
-        def _list_packages(self, *, auth: TokenInfo, qs: dict[str, list[str]]) -> None:
-            try:
-                mine_raw = (qs.get("mine") or [""])[0]
-                payload = state.packages.list_packages(
-                    auth=auth,
-                    prefix=(qs.get("database_id_prefix") or [None])[0],
-                    visibility=(qs.get("visibility") or [None])[0],
-                    version=(qs.get("version") or [None])[0],
-                    package_kind=(qs.get("package_kind") or [None])[0],
-                    mine=str(mine_raw).strip().lower() in {"1", "true", "yes"},
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _list_package_versions(self, *, database_id: str, auth: TokenInfo) -> None:
-            try:
-                payload = state.packages.list_versions(database_id=database_id, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _serve_meta(
-            self,
-            *,
-            database_id: str,
-            version: str | None,
-            package_digest: str | None,
-            auth: TokenInfo,
-        ) -> None:
-            try:
-                payload = state.packages.serve_meta(
-                    database_id=database_id,
-                    version=version,
-                    package_digest=package_digest,
-                    auth=auth,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _serve_content(
-            self,
-            *,
-            database_id: str,
-            package_digest: str,
-            auth: TokenInfo,
-        ) -> None:
-            try:
-                data, row = state.packages.serve_content(
-                    database_id=database_id,
-                    package_digest=package_digest,
-                    auth=auth,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            self.send_response(200)
-            self.send_header("Content-Type", "application/octet-stream")
-            self.send_header("Content-Length", str(len(data)))
-            self.send_header("X-Bora-Blob-Digest", row.blob_digest)
-            self.end_headers()
-            self.wfile.write(data)
-
-        def _serve_package_files_list(
-            self,
-            *,
-            database_id: str,
-            auth: TokenInfo,
-            package_digest: str | None = None,
-            version: str | None = None,
-        ) -> None:
-            try:
-                payload = state.packages.list_files(
-                    database_id=database_id,
-                    auth=auth,
-                    package_digest=package_digest,
-                    version=version,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _serve_package_file(
-            self,
-            *,
-            database_id: str,
-            file_path: str,
-            auth: TokenInfo,
-            package_digest: str | None = None,
-            version: str | None = None,
-        ) -> None:
-            try:
-                payload = state.packages.read_file(
-                    database_id=database_id,
-                    file_path=file_path,
-                    auth=auth,
-                    package_digest=package_digest,
-                    version=version,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _read_multipart_archive(self) -> tuple[dict[str, Any], bytes] | None:
-            length = int(self.headers.get("Content-Length") or "0")
-            if length <= 0 or length > state.max_upload:
-                _json_response(
-                    self,
-                    413,
-                    {"error": "payload_too_large", "message": f"max {state.max_upload} bytes"},
-                )
-                return None
-            body = self.rfile.read(length)
-            ctype = self.headers.get("Content-Type") or ""
-            try:
-                parts = _parse_multipart(body, ctype)
-                meta = json.loads(parts["metadata"].decode("utf-8"))
-                archive = parts["archive"]
-            except (KeyError, ValueError, json.JSONDecodeError) as exc:
-                _json_response(
-                    self,
-                    400,
-                    {"error": "invalid_request", "message": f"bad multipart: {exc}"},
-                )
-                return None
-            return meta, archive
-
-        def _read_json_body(self) -> dict[str, Any] | None:
-            length = int(self.headers.get("Content-Length") or "0")
-            raw = self.rfile.read(length) if length > 0 else b"{}"
-            try:
-                body = json.loads(raw.decode("utf-8") or "{}")
-            except json.JSONDecodeError:
-                _json_response(self, 400, {"error": "invalid_request", "message": "bad JSON"})
-                return None
-            if not isinstance(body, dict):
-                _json_response(self, 400, {"error": "invalid_request", "message": "bad JSON"})
-                return None
-            return body
-
-        # ---- results -----------------------------------------------------
-
-        def _upload_attempt(self, *, auth: TokenInfo) -> None:
-            try:
-                with state.upload_slots.hold():
-                    parsed = self._read_multipart_archive()
-                    if parsed is None:
-                        return
-                    meta, archive = parsed
-                    payload = state.results.upload_attempt(meta=meta, archive=archive, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 201, payload)
-
-        def _list_attempts(self, *, auth: TokenInfo, qs: dict[str, list[str]]) -> None:
-            try:
-                payload = state.results.list_attempts(
-                    auth=auth,
-                    database_id=(qs.get("database_id") or [None])[0],
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _serve_attempt_meta(self, *, run_id: str, auth: TokenInfo) -> None:
-            try:
-                payload = state.results.serve_attempt_meta(run_id=run_id, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _serve_attempt_content(self, *, run_id: str, auth: TokenInfo) -> None:
-            try:
-                data, row = state.results.serve_attempt_content(run_id=run_id, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            self.send_response(200)
-            self.send_header("Content-Type", "application/octet-stream")
-            self.send_header("Content-Length", str(len(data)))
-            self.send_header("X-Bora-Blob-Digest", row.blob_digest)
-            self.send_header("X-Bora-Media-Type", RESULT_MEDIA_TYPE)
-            self.end_headers()
-            self.wfile.write(data)
-
-        def _serve_attempt_files_list(self, *, run_id: str, auth: TokenInfo) -> None:
-            try:
-                payload = state.results.list_attempt_files(run_id=run_id, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _serve_attempt_file(self, *, run_id: str, file_path: str, auth: TokenInfo) -> None:
-            try:
-                payload = state.results.read_attempt_file(
-                    run_id=run_id, file_path=file_path, auth=auth
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _upload_suite(self, *, auth: TokenInfo) -> None:
-            try:
-                with state.upload_slots.hold():
-                    parsed = self._read_multipart_archive()
-                    if parsed is None:
-                        return
-                    meta, archive = parsed
-                    payload = state.results.upload_suite(meta=meta, archive=archive, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 201, payload)
-
-        def _list_suites(self, *, auth: TokenInfo, qs: dict[str, list[str]]) -> None:
-            try:
-                board_raw = (qs.get("board") or [""])[0]
-                payload = state.results.list_suites(
-                    auth=auth,
-                    database_id=(qs.get("database_id") or [None])[0],
-                    board=str(board_raw).strip().lower() in {"1", "true", "yes"},
-                    uploaded_by=(qs.get("uploaded_by") or [None])[0],
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _serve_suite_meta(self, *, suite_run_id: str, auth: TokenInfo) -> None:
-            try:
-                payload = state.results.serve_suite_meta(suite_run_id=suite_run_id, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _serve_suite_content(self, *, suite_run_id: str, auth: TokenInfo) -> None:
-            try:
-                data, row = state.results.serve_suite_content(suite_run_id=suite_run_id, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            self.send_response(200)
-            self.send_header("Content-Type", "application/octet-stream")
-            self.send_header("Content-Length", str(len(data)))
-            self.send_header("X-Bora-Blob-Digest", row.blob_digest)
-            self.send_header("X-Bora-Media-Type", SUITE_RESULT_MEDIA_TYPE)
-            self.end_headers()
-            self.wfile.write(data)
-
-        # ---- users -------------------------------------------------------
-
-        def _get_user(self, *, user_id: str) -> None:
-            try:
-                payload = state.users.get_public(user_id)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        # ---- org ---------------------------------------------------------
-
-        def _create_org(self, *, auth: TokenInfo) -> None:
-            body = self._read_json_body()
-            if body is None:
-                return
-            try:
-                payload = state.orgs.create(
-                    name=str(body.get("name") or ""),
-                    display_name=str(body.get("display_name") or ""),
-                    is_claimable=bool(body.get("is_claimable", False)),
-                    auth=auth,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 201, payload)
-
-        def _list_orgs(self, *, auth: TokenInfo) -> None:
-            try:
-                payload = state.orgs.list_for_user(auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _get_org(self, *, org_id: str, auth: TokenInfo) -> None:
-            try:
-                payload = state.orgs.get_public(org_id=org_id, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _patch_org(self, *, org_id: str, auth: TokenInfo) -> None:
-            body = self._read_json_body()
-            if body is None:
-                return
-            try:
-                payload = state.orgs.patch(
-                    org_id=org_id,
-                    display_name=body.get("display_name"),
-                    auth=auth,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _patch_package_display_name(self, *, database_id: str, auth: TokenInfo) -> None:
-            body = self._read_json_body()
-            if body is None:
-                return
-            try:
-                payload = state.packages.patch_display_name(
-                    database_id=database_id,
-                    display_name=body.get("display_name"),
-                    auth=auth,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _claim_org(self, *, org_id: str, auth: TokenInfo) -> None:
-            try:
-                payload = state.orgs.claim(org_id=org_id, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _create_invite_key(self, *, org_id: str, auth: TokenInfo) -> None:
-            body = self._read_json_body()
-            if body is None:
-                return
-            try:
-                payload = state.orgs.create_invite(
-                    org_id=org_id,
-                    max_uses=body.get("max_uses"),
-                    expires_at=body.get("expires_at"),
-                    expires_in_days=body.get("expires_in_days"),
-                    auth=auth,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 201, payload)
-
-        def _list_invite_keys(self, *, org_id: str, auth: TokenInfo) -> None:
-            try:
-                payload = state.orgs.list_invites(org_id=org_id, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _revoke_invite_key(self, *, org_id: str, key_id: str, auth: TokenInfo) -> None:
-            try:
-                payload = state.orgs.revoke_invite(org_id=org_id, key_id=key_id, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _join_org_with_invite(self, *, auth: TokenInfo) -> None:
-            body = self._read_json_body()
-            if body is None:
-                return
-            try:
-                payload = state.orgs.join(
-                    invite_key=str(body.get("invite_key") or ""),
-                    auth=auth,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _list_org_members(self, *, org_id: str, auth: TokenInfo) -> None:
-            try:
-                payload = state.orgs.list_members(org_id=org_id, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _add_org_member(self, *, org_id: str, auth: TokenInfo) -> None:
-            body = self._read_json_body()
-            if body is None:
-                return
-            try:
-                payload = state.orgs.add_member(
-                    org_id=org_id,
-                    user_id=str(body.get("user_id") or ""),
-                    role=str(body.get("role") or "member"),
-                    auth=auth,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 201, payload)
-
-        def _remove_org_member(self, *, org_id: str, user_id: str, auth: TokenInfo) -> None:
-            try:
-                payload = state.orgs.remove_member(org_id=org_id, user_id=user_id, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _patch_org_member(self, *, org_id: str, user_id: str, auth: TokenInfo) -> None:
-            body = self._read_json_body()
-            if body is None:
-                return
-            try:
-                payload = state.orgs.set_member_role(
-                    org_id=org_id,
-                    user_id=user_id,
-                    role=str(body.get("role") or ""),
-                    auth=auth,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _transfer_org(self, *, org_id: str, auth: TokenInfo) -> None:
-            body = self._read_json_body()
-            if body is None:
-                return
-            try:
-                payload = state.orgs.transfer(
-                    org_id=org_id,
-                    user_id=str(body.get("user_id") or ""),
-                    auth=auth,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _leave_org(self, *, org_id: str, auth: TokenInfo) -> None:
-            try:
-                payload = state.orgs.leave(org_id=org_id, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _delete_org(self, *, org_id: str, auth: TokenInfo) -> None:
-            try:
-                payload = state.orgs.delete(org_id=org_id, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        # ---- result shares -----------------------------------------------
-
-        def _list_result_shares(self, *, result_kind: str, result_id: str, auth: TokenInfo) -> None:
-            try:
-                payload = state.results.list_shares(
-                    result_kind=result_kind, result_id=result_id, auth=auth
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _add_result_share(self, *, result_kind: str, result_id: str, auth: TokenInfo) -> None:
-            body = self._read_json_body()
-            if body is None:
-                return
-            try:
-                payload = state.results.add_share(
-                    result_kind=result_kind,
-                    result_id=result_id,
-                    target_type=str(body.get("target_type") or ""),
-                    target_id=str(body.get("target_id") or ""),
-                    auth=auth,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 201, payload)
-
-        def _remove_result_share(
-            self, *, result_kind: str, result_id: str, auth: TokenInfo
-        ) -> None:
-            body = self._read_json_body()
-            if body is None:
-                return
-            try:
-                payload = state.results.remove_share(
-                    result_kind=result_kind,
-                    result_id=result_id,
-                    target_type=str(body.get("target_type") or ""),
-                    target_id=str(body.get("target_id") or ""),
-                    auth=auth,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _delete_attempt(self, *, run_id: str, auth: TokenInfo) -> None:
-            try:
-                payload = state.results.delete_attempt(run_id=run_id, auth=auth)
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _delete_suite(
-            self, *, suite_run_id: str, auth: TokenInfo, qs: dict[str, list[str]]
-        ) -> None:
-            with_attempts = (qs.get("with_attempts") or ["0"])[0] in {
-                "1",
-                "true",
-                "yes",
-            }
-            try:
-                payload = state.results.delete_suite(
-                    suite_run_id=suite_run_id,
-                    with_attempts=with_attempts,
-                    auth=auth,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _patch_visibility_body(self) -> str | None:
-            body = self._read_json_body()
-            if body is None:
-                return None
-            visibility = str(body.get("visibility") or "").strip()
-            if visibility not in {"public", "private"}:
-                _json_response(
-                    self,
-                    400,
-                    {
-                        "error": "invalid_request",
-                        "message": "visibility must be public or private",
-                    },
-                )
-                return None
-            return visibility
-
-        def _patch_attempt(self, *, run_id: str, auth: TokenInfo) -> None:
-            visibility = self._patch_visibility_body()
-            if visibility is None:
-                return
-            try:
-                payload = state.results.patch_attempt(
-                    run_id=run_id, visibility=visibility, auth=auth
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _patch_suite(self, *, suite_run_id: str, auth: TokenInfo) -> None:
-            visibility = self._patch_visibility_body()
-            if visibility is None:
-                return
-            try:
-                payload = state.results.patch_suite(
-                    suite_run_id=suite_run_id, visibility=visibility, auth=auth
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _delete_package_release(
-            self, *, database_id: str, version: str, auth: TokenInfo
-        ) -> None:
-            try:
-                payload = state.packages.delete_release(
-                    database_id=database_id, version=version, auth=auth
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
-
-        def _patch_package_release(
-            self, *, database_id: str, version: str, auth: TokenInfo
-        ) -> None:
-            visibility = self._patch_visibility_body()
-            if visibility is None:
-                return
-            try:
-                payload = state.packages.patch_visibility(
-                    database_id=database_id,
-                    version=version,
-                    visibility=visibility,
-                    auth=auth,
-                )
-            except RegistryAppError as exc:
-                _app_error(self, exc)
-                return
-            _json_response(self, 200, payload)
 
     return Handler
 
@@ -1096,6 +308,12 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Force SQLite+filesystem even if Postgres/S3 env is set",
     )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=int(os.environ.get("BORA_REGISTRY_WORKERS") or "0"),
+        help="ASGI worker count (uvicorn). 0 = stdlib ThreadingHTTPServer (dev)",
+    )
     args = parser.parse_args(argv)
 
     if args.local or args.memory_blob:
@@ -1121,12 +339,32 @@ def main(argv: list[str] | None = None) -> int:
             sys.stderr.write(f"registry backend init failed: {exc}\n")
             return 1
 
-    handler = make_handler(state)
-    server = ThreadingHTTPServer((args.host, args.port), handler)
+    workers = max(0, int(args.workers))
+    public = not (args.local or args.memory_blob)
+    if public and workers <= 0:
+        workers = int(os.environ.get("BORA_REGISTRY_WORKERS") or "2")
     sys.stderr.write(
-        f"bora-registry listening on http://{args.host}:{args.port} backend={backend}\n"
+        f"bora-registry listening on http://{args.host}:{args.port} "
+        f"backend={backend} workers={workers or 1} http="
+        f"{'asgi' if workers > 0 else 'stdlib'}\n"
         f"bootstrap token (store in ~/.bora/credentials; not logged elsewhere): {token}\n"
     )
+    if workers > 0:
+        from services.registry.asgi import serve_uvicorn
+
+        return serve_uvicorn(
+            state,
+            host=args.host,
+            port=args.port,
+            workers=workers,
+            token=token,
+            local=args.local or args.memory_blob,
+            memory_blob=args.memory_blob,
+            data_dir=str(args.data_dir),
+            bootstrap_token=args.bootstrap_token,
+        )
+    handler = make_handler(state)
+    server = ThreadingHTTPServer((args.host, args.port), handler)
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/services/registry/app.py
+++ b/services/registry/app.py
@@ -52,6 +52,7 @@ import argparse
 import os
 import secrets
 import sys
+import tempfile
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
@@ -95,7 +96,7 @@ __all__ = [
     "SUITE_RESULT_MEDIA_TYPE",
 ]
 
-MAX_UPLOAD_BYTES = 64 * 1024 * 1024  # 64 MiB hard top for v1
+MAX_UPLOAD_BYTES = 512 * 1024 * 1024  # 512 MiB after whole-object streaming
 
 
 class RegistryState:
@@ -139,6 +140,8 @@ class RegistryState:
         self.orgs = OrgService(meta, self.access)
         self.users = UserService(meta)
         self.max_upload = max_upload
+        self.spool_dir = Path(tempfile.gettempdir()) / "bora-registry-spool"
+        self.spool_dir.mkdir(parents=True, exist_ok=True)
 
 
 def _parse_multipart(body: bytes, content_type: str) -> dict[str, bytes]:

--- a/services/registry/app.py
+++ b/services/registry/app.py
@@ -67,6 +67,10 @@ if str(_REPO) not in sys.path:
     sys.path.insert(0, str(_REPO))
 
 from services.registry.access import AccessPolicy  # noqa: E402
+from services.registry.backend import (  # noqa: E402
+    PublicBackendError,
+    require_public_backend,
+)
 from services.registry.envload import load_env_file  # noqa: E402
 from services.registry.errors import RegistryAppError  # noqa: E402
 from services.registry.routes import match_route  # noqa: E402
@@ -80,6 +84,10 @@ from services.registry.store import (  # noqa: E402
     S3BlobStore,
     SqliteTokenStore,
     TokenInfo,
+)
+from services.registry.upload_slots import (  # noqa: E402
+    UploadSlotPool,
+    slots_from_env,
 )
 
 from bora.registry.media_types import (  # noqa: E402
@@ -101,11 +109,18 @@ class RegistryState:
         github_client_id: str | None = None,
         github_client_secret: str | None = None,
         github_login_allowlist: frozenset[str] | None = None,
+        upload_slots: int | UploadSlotPool | None = None,
     ) -> None:
         self.meta = meta
         self.blobs = blobs
         self.tokens = tokens
         self.access = AccessPolicy(meta=meta)
+        if isinstance(upload_slots, UploadSlotPool):
+            self.upload_slots = upload_slots
+        else:
+            self.upload_slots = UploadSlotPool(
+                slots_from_env() if upload_slots is None else upload_slots
+            )
         from services.registry.auth_service import AuthService
         from services.registry.org_service import OrgService
         from services.registry.package_service import PackageService
@@ -304,29 +319,33 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
         # ---- packages ----------------------------------------------------
 
         def _publish_package(self, *, auth: TokenInfo) -> None:
-            length = int(self.headers.get("Content-Length") or "0")
-            if length <= 0 or length > state.max_upload:
-                _json_response(
-                    self,
-                    413,
-                    {"error": "payload_too_large", "message": f"max {state.max_upload} bytes"},
-                )
-                return
-            body = self.rfile.read(length)
-            ctype = self.headers.get("Content-Type") or ""
             try:
-                parts = _parse_multipart(body, ctype)
-                meta = json.loads(parts["metadata"].decode("utf-8"))
-                archive = parts["archive"]
-            except (KeyError, ValueError, json.JSONDecodeError) as exc:
-                _json_response(
-                    self,
-                    400,
-                    {"error": "invalid_request", "message": f"bad multipart: {exc}"},
-                )
-                return
-            try:
-                payload = state.packages.publish(meta=meta, archive=archive, auth=auth)
+                with state.upload_slots.hold():
+                    length = int(self.headers.get("Content-Length") or "0")
+                    if length <= 0 or length > state.max_upload:
+                        _json_response(
+                            self,
+                            413,
+                            {
+                                "error": "payload_too_large",
+                                "message": f"max {state.max_upload} bytes",
+                            },
+                        )
+                        return
+                    body = self.rfile.read(length)
+                    ctype = self.headers.get("Content-Type") or ""
+                    try:
+                        parts = _parse_multipart(body, ctype)
+                        meta = json.loads(parts["metadata"].decode("utf-8"))
+                        archive = parts["archive"]
+                    except (KeyError, ValueError, json.JSONDecodeError) as exc:
+                        _json_response(
+                            self,
+                            400,
+                            {"error": "invalid_request", "message": f"bad multipart: {exc}"},
+                        )
+                        return
+                    payload = state.packages.publish(meta=meta, archive=archive, auth=auth)
             except RegistryAppError as exc:
                 _app_error(self, exc)
                 return
@@ -498,12 +517,13 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
         # ---- results -----------------------------------------------------
 
         def _upload_attempt(self, *, auth: TokenInfo) -> None:
-            parsed = self._read_multipart_archive()
-            if parsed is None:
-                return
-            meta, archive = parsed
             try:
-                payload = state.results.upload_attempt(meta=meta, archive=archive, auth=auth)
+                with state.upload_slots.hold():
+                    parsed = self._read_multipart_archive()
+                    if parsed is None:
+                        return
+                    meta, archive = parsed
+                    payload = state.results.upload_attempt(meta=meta, archive=archive, auth=auth)
             except RegistryAppError as exc:
                 _app_error(self, exc)
                 return
@@ -561,12 +581,13 @@ def make_handler(state: RegistryState) -> type[BaseHTTPRequestHandler]:
             _json_response(self, 200, payload)
 
         def _upload_suite(self, *, auth: TokenInfo) -> None:
-            parsed = self._read_multipart_archive()
-            if parsed is None:
-                return
-            meta, archive = parsed
             try:
-                payload = state.results.upload_suite(meta=meta, archive=archive, auth=auth)
+                with state.upload_slots.hold():
+                    parsed = self._read_multipart_archive()
+                    if parsed is None:
+                        return
+                    meta, archive = parsed
+                    payload = state.results.upload_suite(meta=meta, archive=archive, auth=auth)
             except RegistryAppError as exc:
                 _app_error(self, exc)
                 return
@@ -1002,20 +1023,22 @@ def build_state_from_env(
     *,
     bootstrap_token: str | None = None,
     force_local: bool = False,
+    memory_blob: bool = False,
 ) -> tuple[RegistryState, str]:
-    """Prefer Postgres + S3 when env is set; else SQLite/fs under data dir."""
+    """Public path is Postgres + S3. Local/test path is explicit."""
     load_env_file()
-    database_url = os.environ.get("BORA_REGISTRY_DATABASE_URL")
-    s3_endpoint = os.environ.get("BORA_REGISTRY_S3_ENDPOINT")
-    if force_local or not database_url or not s3_endpoint:
+    if force_local:
         data_dir = (
             Path(os.environ.get("BORA_REGISTRY_DATA_DIR") or ".bora/registry-data")
             .expanduser()
             .resolve()
         )
         data_dir.mkdir(parents=True, exist_ok=True)
-        return build_default_state(data_dir, bootstrap_token=bootstrap_token)
+        return build_default_state(
+            data_dir, bootstrap_token=bootstrap_token, memory_blob=memory_blob
+        )
 
+    database_url, s3_endpoint = require_public_backend()
     meta = PostgresMetadataStore(database_url)
     tokens = PostgresTokenStore(database_url)
     blobs = S3BlobStore(
@@ -1090,9 +1113,10 @@ def main(argv: list[str] | None = None) -> int:
                 bootstrap_token=args.bootstrap_token,
                 force_local=False,
             )
-            database_url = os.environ.get("BORA_REGISTRY_DATABASE_URL")
-            s3_endpoint = os.environ.get("BORA_REGISTRY_S3_ENDPOINT")
-            backend = "postgres+s3" if database_url and s3_endpoint else "sqlite+filesystem"
+            backend = "postgres+s3"
+        except PublicBackendError as exc:
+            sys.stderr.write(f"registry public start refused: {exc}\n")
+            return 2
         except Exception as exc:  # noqa: BLE001
             sys.stderr.write(f"registry backend init failed: {exc}\n")
             return 1

--- a/services/registry/asgi.py
+++ b/services/registry/asgi.py
@@ -6,12 +6,16 @@ only terminates HTTP and fans out workers. FastAPI / OpenAPI are out of scope.
 
 from __future__ import annotations
 
+import asyncio
 import io
 import os
+import shutil
 import sys
+import tempfile
+from pathlib import Path
 from typing import Any
 
-from services.registry.http_api import RegistryHttpApi
+from services.registry.http_api import RegistryHttpApi, json_result
 
 
 def build_asgi_app(state: Any) -> Any:
@@ -23,19 +27,89 @@ def build_asgi_app(state: Any) -> Any:
 
     api = RegistryHttpApi(state)
 
+    async def _spool_multipart(request: Request) -> tuple[Path, int] | Any:
+        try:
+            declared = int(request.headers.get("content-length") or "0")
+        except ValueError:
+            declared = 0
+        if declared <= 0 or declared > state.max_upload:
+            return json_result(
+                413,
+                {
+                    "error": "payload_too_large",
+                    "message": f"max {state.max_upload} bytes",
+                },
+            )
+        parent = getattr(state, "spool_dir", None)
+        root = (
+            parent
+            if isinstance(parent, Path)
+            else Path(tempfile.gettempdir()) / "bora-registry-spool"
+        )
+        root.mkdir(parents=True, exist_ok=True)
+        work = Path(tempfile.mkdtemp(prefix="bora-asgi-", dir=str(root)))
+        dest = work / "body.spool"
+        written = 0
+        try:
+            with dest.open("wb") as out:
+                async for chunk in request.stream():
+                    written += len(chunk)
+                    if written > state.max_upload:
+                        raise OSError("payload_too_large")
+                    out.write(chunk)
+        except OSError:
+            shutil.rmtree(work, ignore_errors=True)
+            return json_result(
+                413,
+                {
+                    "error": "payload_too_large",
+                    "message": f"max {state.max_upload} bytes",
+                },
+            )
+        return dest, written
+
     async def endpoint(request: Request) -> Response:
-        body = await request.body()
         header_map = {k.decode("latin1"): v.decode("latin1") for k, v in request.scope["headers"]}
         target = request.url.path
         if request.url.query:
             target = f"{target}?{request.url.query}"
-        result = api.dispatch(
-            method=request.method,
-            path=target,
-            headers=header_map,
-            body=io.BytesIO(body),
-            content_length=len(body),
-        )
+        ctype = header_map.get("content-type", "")
+        spool: Path | None = None
+        body_fh: Any = None
+        try:
+            if (
+                request.method in {"POST", "PUT", "PATCH"}
+                and "multipart/form-data" in ctype.lower()
+            ):
+                spooled = await _spool_multipart(request)
+                if not isinstance(spooled, tuple):
+                    result = spooled
+                else:
+                    spool, written = spooled
+                    body_fh = spool.open("rb")
+                    result = await asyncio.to_thread(
+                        api.dispatch,
+                        method=request.method,
+                        path=target,
+                        headers=header_map,
+                        body=body_fh,
+                        content_length=written,
+                    )
+            else:
+                raw = await request.body()
+                result = await asyncio.to_thread(
+                    api.dispatch,
+                    method=request.method,
+                    path=target,
+                    headers=header_map,
+                    body=io.BytesIO(raw),
+                    content_length=len(raw),
+                )
+        finally:
+            if body_fh is not None:
+                body_fh.close()
+            if spool is not None:
+                shutil.rmtree(spool.parent, ignore_errors=True)
         headers = dict(result.headers)
         if result.stream is not None:
 

--- a/services/registry/asgi.py
+++ b/services/registry/asgi.py
@@ -111,17 +111,18 @@ def build_asgi_app(state: Any) -> Any:
             if spool is not None:
                 shutil.rmtree(spool.parent, ignore_errors=True)
         headers = dict(result.headers)
-        if result.stream is not None:
+        stream = result.stream
+        if stream is not None:
 
             def _iter() -> Any:
                 try:
                     while True:
-                        chunk = result.stream.read(64 * 1024)
+                        chunk = stream.read(64 * 1024)
                         if not chunk:
                             break
                         yield chunk
                 finally:
-                    result.stream.close()
+                    stream.close()
 
             return StreamingResponse(
                 _iter(),

--- a/services/registry/asgi.py
+++ b/services/registry/asgi.py
@@ -1,0 +1,155 @@
+"""Starlette/uvicorn HTTP pipe for the Registry.
+
+ACL and routing stay in ``Route.access`` + ``RegistryHttpApi``. This module
+only terminates HTTP and fans out workers. FastAPI / OpenAPI are out of scope.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+from typing import Any
+
+from services.registry.http_api import RegistryHttpApi
+
+
+def build_asgi_app(state: Any) -> Any:
+    """Return a Starlette app bound to an already-built ``RegistryState``."""
+    from starlette.applications import Starlette
+    from starlette.requests import Request
+    from starlette.responses import Response, StreamingResponse
+    from starlette.routing import Route
+
+    api = RegistryHttpApi(state)
+
+    async def endpoint(request: Request) -> Response:
+        body = await request.body()
+        header_map = {k.decode("latin1"): v.decode("latin1") for k, v in request.scope["headers"]}
+        target = request.url.path
+        if request.url.query:
+            target = f"{target}?{request.url.query}"
+        result = api.dispatch(
+            method=request.method,
+            path=target,
+            headers=header_map,
+            body=io.BytesIO(body),
+            content_length=len(body),
+        )
+        headers = dict(result.headers)
+        if result.stream is not None:
+
+            def _iter() -> Any:
+                try:
+                    while True:
+                        chunk = result.stream.read(64 * 1024)
+                        if not chunk:
+                            break
+                        yield chunk
+                finally:
+                    result.stream.close()
+
+            return StreamingResponse(
+                _iter(),
+                status_code=result.status,
+                headers=headers,
+                media_type=headers.pop("Content-Type", "application/octet-stream"),
+            )
+        media = headers.pop("Content-Type", "application/json")
+        return Response(
+            content=result.body,
+            status_code=result.status,
+            headers=headers,
+            media_type=media,
+        )
+
+    async def endpoint_any(request: Request) -> Response:
+        return await endpoint(request)
+
+    return Starlette(
+        routes=[
+            Route(
+                "/{path:path}",
+                endpoint=endpoint_any,
+                methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+            ),
+            Route(
+                "/", endpoint=endpoint_any, methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"]
+            ),
+        ]
+    )
+
+
+def app_factory() -> Any:
+    """Uvicorn ``--factory`` entry: rebuild state per worker from env."""
+    from services.registry.app import build_state_from_env
+    from services.registry.envload import load_env_file
+
+    load_env_file()
+    force_local = (os.environ.get("BORA_REGISTRY_FORCE_LOCAL") or "").strip() in {
+        "1",
+        "true",
+        "yes",
+    }
+    memory_blob = (os.environ.get("BORA_REGISTRY_MEMORY_BLOB") or "").strip() in {
+        "1",
+        "true",
+        "yes",
+    }
+    state, token = build_state_from_env(
+        bootstrap_token=os.environ.get("BORA_REGISTRY_BOOTSTRAP_TOKEN"),
+        force_local=force_local or memory_blob,
+        memory_blob=memory_blob,
+    )
+    # One line per worker so operators can see the token without stdout dumps.
+    if token and not os.environ.get("BORA_REGISTRY_BOOTSTRAP_TOKEN"):
+        sys.stderr.write(f"worker bootstrap token: {token}\n")
+    return build_asgi_app(state)
+
+
+def serve_uvicorn(
+    state: Any,
+    *,
+    host: str,
+    port: int,
+    workers: int,
+    token: str,
+    local: bool,
+    memory_blob: bool,
+    data_dir: str,
+    bootstrap_token: str | None,
+) -> int:
+    """Run uvicorn. Workers > 1 rebuild state via ``app_factory``."""
+    try:
+        import uvicorn
+    except ImportError as exc:
+        raise RuntimeError(
+            "uvicorn required for --workers; install with: uv sync --extra registry"
+        ) from exc
+
+    if bootstrap_token:
+        os.environ["BORA_REGISTRY_BOOTSTRAP_TOKEN"] = bootstrap_token
+    elif token:
+        os.environ.setdefault("BORA_REGISTRY_BOOTSTRAP_TOKEN", token)
+    os.environ["BORA_REGISTRY_DATA_DIR"] = data_dir
+    if local:
+        os.environ["BORA_REGISTRY_FORCE_LOCAL"] = "1"
+    if memory_blob:
+        os.environ["BORA_REGISTRY_MEMORY_BLOB"] = "1"
+
+    config_kw: dict[str, Any] = {
+        "host": host,
+        "port": port,
+        "log_level": "warning",
+    }
+    if workers <= 1:
+        app = build_asgi_app(state)
+        uvicorn.run(app, **config_kw)
+        return 0
+    uvicorn.run(
+        "services.registry.asgi:app_factory",
+        factory=True,
+        workers=workers,
+        **config_kw,
+    )
+    return 0

--- a/services/registry/backend.py
+++ b/services/registry/backend.py
@@ -1,0 +1,37 @@
+"""Public vs local Registry backend selection.
+
+Public start is fail-closed: Postgres URL + S3 endpoint are required.
+``--local`` / ``--memory-blob`` remain the only SQLite / in-process paths.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+class PublicBackendError(RuntimeError):
+    """Raised when a public start is missing required backends."""
+
+
+def postgres_url() -> str:
+    return (os.environ.get("BORA_REGISTRY_DATABASE_URL") or "").strip()
+
+
+def s3_endpoint() -> str:
+    return (os.environ.get("BORA_REGISTRY_S3_ENDPOINT") or "").strip()
+
+
+def public_env_ready() -> bool:
+    return bool(postgres_url() and s3_endpoint())
+
+
+def require_public_backend() -> tuple[str, str]:
+    """Return ``(database_url, s3_endpoint)`` or raise ``PublicBackendError``."""
+    database_url = postgres_url()
+    endpoint = s3_endpoint()
+    if not database_url or not endpoint:
+        raise PublicBackendError(
+            "public registry start requires BORA_REGISTRY_DATABASE_URL and "
+            "BORA_REGISTRY_S3_ENDPOINT; use --local or --memory-blob for dev/test"
+        )
+    return database_url, endpoint

--- a/services/registry/blob_io.py
+++ b/services/registry/blob_io.py
@@ -1,0 +1,40 @@
+"""File-oriented blob helpers. Production put/open paths take a Path or fileobj."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any, BinaryIO
+
+
+def sha256_file(path: Path, *, chunk: int = 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        while True:
+            block = fh.read(chunk)
+            if not block:
+                break
+            digest.update(block)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def copy_fileobj(src: BinaryIO, dest: Path, *, chunk: int = 1024 * 1024) -> int:
+    written = 0
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with dest.open("wb") as out:
+        while True:
+            block = src.read(chunk)
+            if not block:
+                break
+            out.write(block)
+            written += len(block)
+    return written
+
+
+def read_blob(blobs: Any, blob_digest: str, *, prefix: str) -> bytes | None:
+    """Load one object for preview / list_files (not the whole-object HTTP path)."""
+    fh = blobs.open(blob_digest, prefix=prefix)
+    if fh is None:
+        return None
+    with fh:
+        return fh.read()

--- a/services/registry/http_api.py
+++ b/services/registry/http_api.py
@@ -11,14 +11,17 @@ import json
 import os
 import re
 import shutil
+import tempfile
 from collections.abc import Mapping
 from contextvars import ContextVar
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, BinaryIO
 from urllib.parse import parse_qs, unquote, urlparse
 
 from services.registry.errors import RegistryAppError
 from services.registry.routes import match_route
+from services.registry.spool import extract_multipart_archive, spool_body
 from services.registry.store import TokenInfo
 
 from bora.registry.media_types import (
@@ -71,14 +74,21 @@ def empty_result(status: int) -> HttpResult:
     return HttpResult(status, headers, body=b"")
 
 
-def octet_result(data: bytes, extra: Mapping[str, str]) -> HttpResult:
+def octet_result(
+    data: bytes | None,
+    extra: Mapping[str, str],
+    *,
+    stream: BinaryIO | None = None,
+    size: int | None = None,
+) -> HttpResult:
+    length = size if size is not None else (len(data) if data is not None else 0)
     headers = {
         "Content-Type": "application/octet-stream",
-        "Content-Length": str(len(data)),
+        "Content-Length": str(length),
         **dict(extra),
         **cors_headers(),
     }
-    return HttpResult(200, headers, body=data)
+    return HttpResult(200, headers, body=data or b"", stream=stream)
 
 
 def parse_multipart(body: bytes, content_type: str) -> dict[str, bytes]:
@@ -191,7 +201,14 @@ class RegistryHttpApi:
             return json_result(400, {"error": "invalid_request", "message": "bad JSON"})
         return parsed
 
-    def _read_multipart_archive(self) -> tuple[dict[str, Any], bytes] | HttpResult:
+    def _spool_dir(self) -> Path:
+        raw = getattr(self.state, "spool_dir", None)
+        if isinstance(raw, Path):
+            return raw
+        return Path(tempfile.gettempdir()) / "bora-registry-spool"
+
+    def _read_multipart_archive(self) -> tuple[dict[str, Any], Path, Path] | HttpResult:
+        """Return metadata, archive path, and the parent spool dir to delete later."""
         ctx = _ctx.get()
         length = ctx.content_length
         if length <= 0 or length > self.state.max_upload:
@@ -202,18 +219,29 @@ class RegistryHttpApi:
                     "message": f"max {self.state.max_upload} bytes",
                 },
             )
-        raw = ctx.body.read(length)
-        ctype = _header(ctx.headers, "Content-Type")
+        parent = self._spool_dir()
+        parent.mkdir(parents=True, exist_ok=True)
+        work = Path(tempfile.mkdtemp(prefix="bora-up-", dir=str(parent)))
         try:
-            parts = parse_multipart(raw, ctype)
-            meta = json.loads(parts["metadata"].decode("utf-8"))
-            archive = parts["archive"]
-        except (KeyError, ValueError, json.JSONDecodeError) as exc:
+            spool = spool_body(
+                ctx.body,
+                length=length,
+                max_bytes=self.state.max_upload,
+                dest_dir=work,
+            )
+            ctype = _header(ctx.headers, "Content-Type")
+            meta, archive = extract_multipart_archive(spool, ctype, work)
+            spool.unlink(missing_ok=True)
+            return meta, archive, work
+        except RegistryAppError as exc:
+            shutil.rmtree(work, ignore_errors=True)
+            return _caught(exc)
+        except (KeyError, ValueError, json.JSONDecodeError, OSError) as exc:
+            shutil.rmtree(work, ignore_errors=True)
             return json_result(
                 400,
                 {"error": "invalid_request", "message": f"bad multipart: {exc}"},
             )
-        return meta, archive
 
     def _visibility_body(self) -> str | HttpResult:
         body = self._read_json_body()
@@ -278,15 +306,19 @@ class RegistryHttpApi:
         return json_result(status, payload)
 
     def _publish_package(self, *, auth: TokenInfo) -> HttpResult:
+        work: Path | None = None
         try:
             with self.state.upload_slots.hold():
                 parsed = self._read_multipart_archive()
                 if isinstance(parsed, HttpResult):
                     return parsed
-                meta, archive = parsed
+                meta, archive, work = parsed
                 payload = self.state.packages.publish(meta=meta, archive=archive, auth=auth)
         except RegistryAppError as exc:
             return _caught(exc)
+        finally:
+            if work is not None:
+                shutil.rmtree(work, ignore_errors=True)
         return json_result(201, payload)
 
     def _release_draft(self, *, database_id: str, auth: TokenInfo) -> HttpResult:
@@ -350,14 +382,19 @@ class RegistryHttpApi:
         self, *, database_id: str, package_digest: str, auth: TokenInfo
     ) -> HttpResult:
         try:
-            data, row = self.state.packages.serve_content(
+            fh, size, row = self.state.packages.serve_content(
                 database_id=database_id,
                 package_digest=package_digest,
                 auth=auth,
             )
         except RegistryAppError as exc:
             return _caught(exc)
-        return octet_result(data, {"X-Bora-Blob-Digest": row.blob_digest})
+        return octet_result(
+            None,
+            {"X-Bora-Blob-Digest": row.blob_digest},
+            stream=fh,
+            size=size,
+        )
 
     def _serve_package_files_list(
         self,
@@ -400,15 +437,19 @@ class RegistryHttpApi:
         return json_result(200, payload)
 
     def _upload_attempt(self, *, auth: TokenInfo) -> HttpResult:
+        work: Path | None = None
         try:
             with self.state.upload_slots.hold():
                 parsed = self._read_multipart_archive()
                 if isinstance(parsed, HttpResult):
                     return parsed
-                meta, archive = parsed
+                meta, archive, work = parsed
                 payload = self.state.results.upload_attempt(meta=meta, archive=archive, auth=auth)
         except RegistryAppError as exc:
             return _caught(exc)
+        finally:
+            if work is not None:
+                shutil.rmtree(work, ignore_errors=True)
         return json_result(201, payload)
 
     def _list_attempts(self, *, auth: TokenInfo, qs: dict[str, list[str]]) -> HttpResult:
@@ -430,15 +471,17 @@ class RegistryHttpApi:
 
     def _serve_attempt_content(self, *, run_id: str, auth: TokenInfo) -> HttpResult:
         try:
-            data, row = self.state.results.serve_attempt_content(run_id=run_id, auth=auth)
+            fh, size, row = self.state.results.serve_attempt_content(run_id=run_id, auth=auth)
         except RegistryAppError as exc:
             return _caught(exc)
         return octet_result(
-            data,
+            None,
             {
                 "X-Bora-Blob-Digest": row.blob_digest,
                 "X-Bora-Media-Type": RESULT_MEDIA_TYPE,
             },
+            stream=fh,
+            size=size,
         )
 
     def _serve_attempt_files_list(self, *, run_id: str, auth: TokenInfo) -> HttpResult:
@@ -458,15 +501,19 @@ class RegistryHttpApi:
         return json_result(200, payload)
 
     def _upload_suite(self, *, auth: TokenInfo) -> HttpResult:
+        work: Path | None = None
         try:
             with self.state.upload_slots.hold():
                 parsed = self._read_multipart_archive()
                 if isinstance(parsed, HttpResult):
                     return parsed
-                meta, archive = parsed
+                meta, archive, work = parsed
                 payload = self.state.results.upload_suite(meta=meta, archive=archive, auth=auth)
         except RegistryAppError as exc:
             return _caught(exc)
+        finally:
+            if work is not None:
+                shutil.rmtree(work, ignore_errors=True)
         return json_result(201, payload)
 
     def _list_suites(self, *, auth: TokenInfo, qs: dict[str, list[str]]) -> HttpResult:
@@ -491,15 +538,19 @@ class RegistryHttpApi:
 
     def _serve_suite_content(self, *, suite_run_id: str, auth: TokenInfo) -> HttpResult:
         try:
-            data, row = self.state.results.serve_suite_content(suite_run_id=suite_run_id, auth=auth)
+            fh, size, row = self.state.results.serve_suite_content(
+                suite_run_id=suite_run_id, auth=auth
+            )
         except RegistryAppError as exc:
             return _caught(exc)
         return octet_result(
-            data,
+            None,
             {
                 "X-Bora-Blob-Digest": row.blob_digest,
                 "X-Bora-Media-Type": SUITE_RESULT_MEDIA_TYPE,
             },
+            stream=fh,
+            size=size,
         )
 
     def _get_user(self, *, user_id: str) -> HttpResult:

--- a/services/registry/http_api.py
+++ b/services/registry/http_api.py
@@ -1,0 +1,823 @@
+"""HTTP-library-neutral Registry adapter.
+
+Reads a request, runs Route.access + *Service, returns an HttpResult.
+Stdlib Handler and the Starlette pipe both call this. ACL stays on
+``Route.access`` / ``AccessPolicy``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+from collections.abc import Mapping
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Any, BinaryIO
+from urllib.parse import parse_qs, unquote, urlparse
+
+from services.registry.errors import RegistryAppError
+from services.registry.routes import match_route
+from services.registry.store import TokenInfo
+
+from bora.registry.media_types import (
+    ATTEMPT_RESULT_MEDIA_TYPE as RESULT_MEDIA_TYPE,
+)
+from bora.registry.media_types import SUITE_RESULT_MEDIA_TYPE
+
+_ctx: ContextVar[RequestCtx] = ContextVar("registry_http_ctx")
+
+
+@dataclass(slots=True)
+class RequestCtx:
+    headers: Mapping[str, str]
+    body: BinaryIO
+    content_length: int
+
+
+@dataclass(slots=True)
+class HttpResult:
+    status: int
+    headers: dict[str, str] = field(default_factory=dict)
+    body: bytes = b""
+    stream: BinaryIO | None = None
+
+
+def cors_headers() -> dict[str, str]:
+    origin = (os.environ.get("BORA_REGISTRY_CORS_ORIGIN") or "*").strip() or "*"
+    out = {
+        "Access-Control-Allow-Origin": origin,
+        "Access-Control-Allow-Headers": "Authorization, Content-Type, Accept",
+        "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+    }
+    if origin != "*":
+        out["Vary"] = "Origin"
+    return out
+
+
+def json_result(status: int, payload: dict[str, Any]) -> HttpResult:
+    body = json.dumps(payload, sort_keys=True).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "Content-Length": str(len(body)),
+        **cors_headers(),
+    }
+    return HttpResult(status, headers, body=body)
+
+
+def empty_result(status: int) -> HttpResult:
+    headers = {"Content-Length": "0", **cors_headers()}
+    return HttpResult(status, headers, body=b"")
+
+
+def octet_result(data: bytes, extra: Mapping[str, str]) -> HttpResult:
+    headers = {
+        "Content-Type": "application/octet-stream",
+        "Content-Length": str(len(data)),
+        **dict(extra),
+        **cors_headers(),
+    }
+    return HttpResult(200, headers, body=data)
+
+
+def parse_multipart(body: bytes, content_type: str) -> dict[str, bytes]:
+    """Parse multipart/form-data without corrupting binary parts.
+
+    Only strip framing CRLF at the part boundary — never rstrip the payload
+    (gzip archives may legitimately end in 0x0d / 0x0a).
+    """
+    m = re.search(r"boundary=([^;]+)", content_type)
+    if not m:
+        raise ValueError("missing multipart boundary")
+    boundary = m.group(1).strip().encode()
+    parts = body.split(b"--" + boundary)
+    out: dict[str, bytes] = {}
+    for part in parts:
+        if part in (b"", b"--\r\n", b"--", b"\r\n"):
+            continue
+        if part.startswith(b"--"):
+            continue
+        if part.startswith(b"\r\n"):
+            part = part[2:]
+        if part.endswith(b"--"):
+            part = part[:-2]
+        if part.endswith(b"\r\n"):
+            part = part[:-2]
+        header_blob, sep, data = part.partition(b"\r\n\r\n")
+        if not sep:
+            continue
+        headers = header_blob.decode("utf-8", errors="replace")
+        name_m = re.search(r'name="([^"]+)"', headers)
+        if not name_m:
+            continue
+        out[name_m.group(1)] = data
+    return out
+
+
+def _header(headers: Mapping[str, str], name: str) -> str:
+    target = name.lower()
+    for key, value in headers.items():
+        if key.lower() == target:
+            return value
+    return ""
+
+
+def _bearer(headers: Mapping[str, str]) -> str | None:
+    auth = _header(headers, "Authorization")
+    if auth.lower().startswith("bearer "):
+        return auth[7:].strip() or None
+    return None
+
+
+def _caught(exc: RegistryAppError) -> HttpResult:
+    return json_result(exc.http_status, exc.payload())
+
+
+class RegistryHttpApi:
+    def __init__(self, state: Any) -> None:
+        self.state = state
+
+    def dispatch(
+        self,
+        *,
+        method: str,
+        path: str,
+        headers: Mapping[str, str],
+        body: BinaryIO,
+        content_length: int | None = None,
+    ) -> HttpResult:
+        if method == "OPTIONS":
+            return empty_result(204)
+        parsed = urlparse(path)
+        route_path = unquote(parsed.path)
+        qs = parse_qs(parsed.query)
+        matched = match_route(method, route_path)
+        if matched is None:
+            return json_result(404, {"error": "not_found", "message": "unknown path"})
+        route, kwargs = matched
+        token = _bearer(headers)
+        auth = self.state.auth.auth_for(token)
+        denied = self.state.access.enforce_route_access(route.access, auth, kwargs=kwargs)
+        if denied is not None:
+            status, payload = denied
+            return json_result(status, payload)
+        if route.access != "none":
+            kwargs["auth"] = auth
+        if route.pass_qs:
+            kwargs["qs"] = qs
+        length = content_length
+        if length is None:
+            raw_len = _header(headers, "Content-Length") or "0"
+            try:
+                length = int(raw_len)
+            except ValueError:
+                length = 0
+        token_ctx = _ctx.set(RequestCtx(headers=headers, body=body, content_length=length))
+        try:
+            handler = getattr(self, f"_{route.name}")
+            return handler(**kwargs)
+        finally:
+            _ctx.reset(token_ctx)
+
+    def _read_json_body(self) -> dict[str, Any] | HttpResult:
+        ctx = _ctx.get()
+        raw = ctx.body.read(ctx.content_length) if ctx.content_length > 0 else b"{}"
+        try:
+            parsed = json.loads(raw.decode("utf-8") or "{}")
+        except json.JSONDecodeError:
+            return json_result(400, {"error": "invalid_request", "message": "bad JSON"})
+        if not isinstance(parsed, dict):
+            return json_result(400, {"error": "invalid_request", "message": "bad JSON"})
+        return parsed
+
+    def _read_multipart_archive(self) -> tuple[dict[str, Any], bytes] | HttpResult:
+        ctx = _ctx.get()
+        length = ctx.content_length
+        if length <= 0 or length > self.state.max_upload:
+            return json_result(
+                413,
+                {
+                    "error": "payload_too_large",
+                    "message": f"max {self.state.max_upload} bytes",
+                },
+            )
+        raw = ctx.body.read(length)
+        ctype = _header(ctx.headers, "Content-Type")
+        try:
+            parts = parse_multipart(raw, ctype)
+            meta = json.loads(parts["metadata"].decode("utf-8"))
+            archive = parts["archive"]
+        except (KeyError, ValueError, json.JSONDecodeError) as exc:
+            return json_result(
+                400,
+                {"error": "invalid_request", "message": f"bad multipart: {exc}"},
+            )
+        return meta, archive
+
+    def _visibility_body(self) -> str | HttpResult:
+        body = self._read_json_body()
+        if isinstance(body, HttpResult):
+            return body
+        visibility = str(body.get("visibility") or "").strip()
+        if visibility not in {"public", "private"}:
+            return json_result(
+                400,
+                {
+                    "error": "invalid_request",
+                    "message": "visibility must be public or private",
+                },
+            )
+        return visibility
+
+    def _health(self) -> HttpResult:
+        return json_result(200, {"ok": True, "service": "bora-registry"})
+
+    def _auth_web_start(self) -> HttpResult:
+        body = self._read_json_body()
+        if isinstance(body, HttpResult):
+            return body
+        try:
+            payload = self.state.auth.web_start(
+                redirect_uri=str(body.get("redirect_uri") or "").strip()
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _auth_web_callback(self) -> HttpResult:
+        body = self._read_json_body()
+        if isinstance(body, HttpResult):
+            return body
+        try:
+            payload = self.state.auth.web_callback(
+                code=str(body.get("code") or "").strip(),
+                state=str(body.get("state") or "").strip(),
+                redirect_uri=str(body.get("redirect_uri") or "").strip(),
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _auth_device_code(self) -> HttpResult:
+        try:
+            return json_result(200, self.state.auth.device_code())
+        except RegistryAppError as exc:
+            return _caught(exc)
+
+    def _auth_device_poll(self) -> HttpResult:
+        body = self._read_json_body()
+        if isinstance(body, HttpResult):
+            return body
+        try:
+            status, payload = self.state.auth.device_poll(
+                device_code=str(body.get("device_code") or "")
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(status, payload)
+
+    def _publish_package(self, *, auth: TokenInfo) -> HttpResult:
+        try:
+            with self.state.upload_slots.hold():
+                parsed = self._read_multipart_archive()
+                if isinstance(parsed, HttpResult):
+                    return parsed
+                meta, archive = parsed
+                payload = self.state.packages.publish(meta=meta, archive=archive, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(201, payload)
+
+    def _release_draft(self, *, database_id: str, auth: TokenInfo) -> HttpResult:
+        body = self._read_json_body()
+        if isinstance(body, HttpResult):
+            return body
+        try:
+            payload = self.state.packages.release_draft(
+                database_id=database_id,
+                auth=auth,
+                visibility=str(body.get("visibility") or "") or None,
+                replace=bool(body.get("replace")),
+                version=str(body.get("version") or "") or None,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(201, payload)
+
+    def _list_packages(self, *, auth: TokenInfo, qs: dict[str, list[str]]) -> HttpResult:
+        try:
+            mine_raw = (qs.get("mine") or [""])[0]
+            payload = self.state.packages.list_packages(
+                auth=auth,
+                prefix=(qs.get("database_id_prefix") or [None])[0],
+                visibility=(qs.get("visibility") or [None])[0],
+                version=(qs.get("version") or [None])[0],
+                package_kind=(qs.get("package_kind") or [None])[0],
+                mine=str(mine_raw).strip().lower() in {"1", "true", "yes"},
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _list_package_versions(self, *, database_id: str, auth: TokenInfo) -> HttpResult:
+        try:
+            payload = self.state.packages.list_versions(database_id=database_id, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _serve_meta(
+        self,
+        *,
+        database_id: str,
+        version: str | None,
+        package_digest: str | None,
+        auth: TokenInfo,
+    ) -> HttpResult:
+        try:
+            payload = self.state.packages.serve_meta(
+                database_id=database_id,
+                version=version,
+                package_digest=package_digest,
+                auth=auth,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _serve_content(
+        self, *, database_id: str, package_digest: str, auth: TokenInfo
+    ) -> HttpResult:
+        try:
+            data, row = self.state.packages.serve_content(
+                database_id=database_id,
+                package_digest=package_digest,
+                auth=auth,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return octet_result(data, {"X-Bora-Blob-Digest": row.blob_digest})
+
+    def _serve_package_files_list(
+        self,
+        *,
+        database_id: str,
+        auth: TokenInfo,
+        package_digest: str | None = None,
+        version: str | None = None,
+    ) -> HttpResult:
+        try:
+            payload = self.state.packages.list_files(
+                database_id=database_id,
+                auth=auth,
+                package_digest=package_digest,
+                version=version,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _serve_package_file(
+        self,
+        *,
+        database_id: str,
+        file_path: str,
+        auth: TokenInfo,
+        package_digest: str | None = None,
+        version: str | None = None,
+    ) -> HttpResult:
+        try:
+            payload = self.state.packages.read_file(
+                database_id=database_id,
+                file_path=file_path,
+                auth=auth,
+                package_digest=package_digest,
+                version=version,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _upload_attempt(self, *, auth: TokenInfo) -> HttpResult:
+        try:
+            with self.state.upload_slots.hold():
+                parsed = self._read_multipart_archive()
+                if isinstance(parsed, HttpResult):
+                    return parsed
+                meta, archive = parsed
+                payload = self.state.results.upload_attempt(meta=meta, archive=archive, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(201, payload)
+
+    def _list_attempts(self, *, auth: TokenInfo, qs: dict[str, list[str]]) -> HttpResult:
+        try:
+            payload = self.state.results.list_attempts(
+                auth=auth,
+                database_id=(qs.get("database_id") or [None])[0],
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _serve_attempt_meta(self, *, run_id: str, auth: TokenInfo) -> HttpResult:
+        try:
+            payload = self.state.results.serve_attempt_meta(run_id=run_id, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _serve_attempt_content(self, *, run_id: str, auth: TokenInfo) -> HttpResult:
+        try:
+            data, row = self.state.results.serve_attempt_content(run_id=run_id, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return octet_result(
+            data,
+            {
+                "X-Bora-Blob-Digest": row.blob_digest,
+                "X-Bora-Media-Type": RESULT_MEDIA_TYPE,
+            },
+        )
+
+    def _serve_attempt_files_list(self, *, run_id: str, auth: TokenInfo) -> HttpResult:
+        try:
+            payload = self.state.results.list_attempt_files(run_id=run_id, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _serve_attempt_file(self, *, run_id: str, file_path: str, auth: TokenInfo) -> HttpResult:
+        try:
+            payload = self.state.results.read_attempt_file(
+                run_id=run_id, file_path=file_path, auth=auth
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _upload_suite(self, *, auth: TokenInfo) -> HttpResult:
+        try:
+            with self.state.upload_slots.hold():
+                parsed = self._read_multipart_archive()
+                if isinstance(parsed, HttpResult):
+                    return parsed
+                meta, archive = parsed
+                payload = self.state.results.upload_suite(meta=meta, archive=archive, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(201, payload)
+
+    def _list_suites(self, *, auth: TokenInfo, qs: dict[str, list[str]]) -> HttpResult:
+        try:
+            board_raw = (qs.get("board") or [""])[0]
+            payload = self.state.results.list_suites(
+                auth=auth,
+                database_id=(qs.get("database_id") or [None])[0],
+                board=str(board_raw).strip().lower() in {"1", "true", "yes"},
+                uploaded_by=(qs.get("uploaded_by") or [None])[0],
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _serve_suite_meta(self, *, suite_run_id: str, auth: TokenInfo) -> HttpResult:
+        try:
+            payload = self.state.results.serve_suite_meta(suite_run_id=suite_run_id, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _serve_suite_content(self, *, suite_run_id: str, auth: TokenInfo) -> HttpResult:
+        try:
+            data, row = self.state.results.serve_suite_content(suite_run_id=suite_run_id, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return octet_result(
+            data,
+            {
+                "X-Bora-Blob-Digest": row.blob_digest,
+                "X-Bora-Media-Type": SUITE_RESULT_MEDIA_TYPE,
+            },
+        )
+
+    def _get_user(self, *, user_id: str) -> HttpResult:
+        try:
+            payload = self.state.users.get_public(user_id)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _create_org(self, *, auth: TokenInfo) -> HttpResult:
+        body = self._read_json_body()
+        if isinstance(body, HttpResult):
+            return body
+        try:
+            payload = self.state.orgs.create(
+                name=str(body.get("name") or ""),
+                display_name=str(body.get("display_name") or ""),
+                is_claimable=bool(body.get("is_claimable", False)),
+                auth=auth,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(201, payload)
+
+    def _list_orgs(self, *, auth: TokenInfo) -> HttpResult:
+        try:
+            payload = self.state.orgs.list_for_user(auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _get_org(self, *, org_id: str, auth: TokenInfo) -> HttpResult:
+        try:
+            payload = self.state.orgs.get_public(org_id=org_id, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _patch_org(self, *, org_id: str, auth: TokenInfo) -> HttpResult:
+        body = self._read_json_body()
+        if isinstance(body, HttpResult):
+            return body
+        try:
+            payload = self.state.orgs.patch(
+                org_id=org_id,
+                display_name=body.get("display_name"),
+                auth=auth,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _patch_package_display_name(self, *, database_id: str, auth: TokenInfo) -> HttpResult:
+        body = self._read_json_body()
+        if isinstance(body, HttpResult):
+            return body
+        try:
+            payload = self.state.packages.patch_display_name(
+                database_id=database_id,
+                display_name=body.get("display_name"),
+                auth=auth,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _claim_org(self, *, org_id: str, auth: TokenInfo) -> HttpResult:
+        try:
+            payload = self.state.orgs.claim(org_id=org_id, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _create_invite_key(self, *, org_id: str, auth: TokenInfo) -> HttpResult:
+        body = self._read_json_body()
+        if isinstance(body, HttpResult):
+            return body
+        try:
+            payload = self.state.orgs.create_invite(
+                org_id=org_id,
+                max_uses=body.get("max_uses"),
+                expires_at=body.get("expires_at"),
+                expires_in_days=body.get("expires_in_days"),
+                auth=auth,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(201, payload)
+
+    def _list_invite_keys(self, *, org_id: str, auth: TokenInfo) -> HttpResult:
+        try:
+            payload = self.state.orgs.list_invites(org_id=org_id, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _revoke_invite_key(self, *, org_id: str, key_id: str, auth: TokenInfo) -> HttpResult:
+        try:
+            payload = self.state.orgs.revoke_invite(org_id=org_id, key_id=key_id, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _join_org_with_invite(self, *, auth: TokenInfo) -> HttpResult:
+        body = self._read_json_body()
+        if isinstance(body, HttpResult):
+            return body
+        try:
+            payload = self.state.orgs.join(
+                invite_key=str(body.get("invite_key") or ""),
+                auth=auth,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _list_org_members(self, *, org_id: str, auth: TokenInfo) -> HttpResult:
+        try:
+            payload = self.state.orgs.list_members(org_id=org_id, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _add_org_member(self, *, org_id: str, auth: TokenInfo) -> HttpResult:
+        body = self._read_json_body()
+        if isinstance(body, HttpResult):
+            return body
+        try:
+            payload = self.state.orgs.add_member(
+                org_id=org_id,
+                user_id=str(body.get("user_id") or ""),
+                role=str(body.get("role") or "member"),
+                auth=auth,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(201, payload)
+
+    def _remove_org_member(self, *, org_id: str, user_id: str, auth: TokenInfo) -> HttpResult:
+        try:
+            payload = self.state.orgs.remove_member(org_id=org_id, user_id=user_id, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _patch_org_member(self, *, org_id: str, user_id: str, auth: TokenInfo) -> HttpResult:
+        body = self._read_json_body()
+        if isinstance(body, HttpResult):
+            return body
+        try:
+            payload = self.state.orgs.set_member_role(
+                org_id=org_id,
+                user_id=user_id,
+                role=str(body.get("role") or ""),
+                auth=auth,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _transfer_org(self, *, org_id: str, auth: TokenInfo) -> HttpResult:
+        body = self._read_json_body()
+        if isinstance(body, HttpResult):
+            return body
+        try:
+            payload = self.state.orgs.transfer(
+                org_id=org_id,
+                user_id=str(body.get("user_id") or ""),
+                auth=auth,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _leave_org(self, *, org_id: str, auth: TokenInfo) -> HttpResult:
+        try:
+            payload = self.state.orgs.leave(org_id=org_id, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _delete_org(self, *, org_id: str, auth: TokenInfo) -> HttpResult:
+        try:
+            payload = self.state.orgs.delete(org_id=org_id, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _list_result_shares(
+        self, *, result_kind: str, result_id: str, auth: TokenInfo
+    ) -> HttpResult:
+        try:
+            payload = self.state.results.list_shares(
+                result_kind=result_kind, result_id=result_id, auth=auth
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _add_result_share(self, *, result_kind: str, result_id: str, auth: TokenInfo) -> HttpResult:
+        body = self._read_json_body()
+        if isinstance(body, HttpResult):
+            return body
+        try:
+            payload = self.state.results.add_share(
+                result_kind=result_kind,
+                result_id=result_id,
+                target_type=str(body.get("target_type") or ""),
+                target_id=str(body.get("target_id") or ""),
+                auth=auth,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(201, payload)
+
+    def _remove_result_share(
+        self, *, result_kind: str, result_id: str, auth: TokenInfo
+    ) -> HttpResult:
+        body = self._read_json_body()
+        if isinstance(body, HttpResult):
+            return body
+        try:
+            payload = self.state.results.remove_share(
+                result_kind=result_kind,
+                result_id=result_id,
+                target_type=str(body.get("target_type") or ""),
+                target_id=str(body.get("target_id") or ""),
+                auth=auth,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _delete_attempt(self, *, run_id: str, auth: TokenInfo) -> HttpResult:
+        try:
+            payload = self.state.results.delete_attempt(run_id=run_id, auth=auth)
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _delete_suite(
+        self, *, suite_run_id: str, auth: TokenInfo, qs: dict[str, list[str]]
+    ) -> HttpResult:
+        with_attempts = (qs.get("with_attempts") or ["0"])[0] in {"1", "true", "yes"}
+        try:
+            payload = self.state.results.delete_suite(
+                suite_run_id=suite_run_id,
+                with_attempts=with_attempts,
+                auth=auth,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _patch_attempt(self, *, run_id: str, auth: TokenInfo) -> HttpResult:
+        visibility = self._visibility_body()
+        if isinstance(visibility, HttpResult):
+            return visibility
+        try:
+            payload = self.state.results.patch_attempt(
+                run_id=run_id, visibility=visibility, auth=auth
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _patch_suite(self, *, suite_run_id: str, auth: TokenInfo) -> HttpResult:
+        visibility = self._visibility_body()
+        if isinstance(visibility, HttpResult):
+            return visibility
+        try:
+            payload = self.state.results.patch_suite(
+                suite_run_id=suite_run_id, visibility=visibility, auth=auth
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _delete_package_release(
+        self, *, database_id: str, version: str, auth: TokenInfo
+    ) -> HttpResult:
+        try:
+            payload = self.state.packages.delete_release(
+                database_id=database_id, version=version, auth=auth
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+    def _patch_package_release(
+        self, *, database_id: str, version: str, auth: TokenInfo
+    ) -> HttpResult:
+        visibility = self._visibility_body()
+        if isinstance(visibility, HttpResult):
+            return visibility
+        try:
+            payload = self.state.packages.patch_visibility(
+                database_id=database_id,
+                version=version,
+                visibility=visibility,
+                auth=auth,
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
+
+def write_http_result(handler: Any, result: HttpResult) -> None:
+    """Write ``HttpResult`` onto a ``BaseHTTPRequestHandler``."""
+    handler.send_response(result.status)
+    for key, value in result.headers.items():
+        handler.send_header(key, value)
+    handler.end_headers()
+    if result.stream is not None:
+        try:
+            shutil.copyfileobj(result.stream, handler.wfile)
+        finally:
+            result.stream.close()
+        return
+    if result.body:
+        handler.wfile.write(result.body)

--- a/services/registry/package_service.py
+++ b/services/registry/package_service.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import hashlib
 import tempfile
 from pathlib import Path
 from typing import Any
 
 from services.registry.access import AccessPolicy
+from services.registry.blob_io import read_blob, sha256_file
 from services.registry.dataset import DRAFT_SLOT, is_draft_version
 from services.registry.errors import RegistryAppError
 from services.registry.store import DraftRow, ReleaseRow, TokenInfo, now, release_to_dict
@@ -59,8 +59,9 @@ class PackageService:
     def can_manage(self, row: ReleaseRow, auth: TokenInfo) -> bool:
         return self.access.can_manage_package(row, auth)
 
-    def publish(self, *, meta: dict[str, Any], archive: bytes, auth: TokenInfo) -> dict[str, Any]:
-        if len(archive) > self.max_upload:
+    def publish(self, *, meta: dict[str, Any], archive: Path, auth: TokenInfo) -> dict[str, Any]:
+        size_on_disk = archive.stat().st_size
+        if size_on_disk > self.max_upload:
             raise RegistryAppError(
                 "payload_too_large",
                 f"max {self.max_upload} bytes",
@@ -75,7 +76,7 @@ class PackageService:
         slot = str(meta.get("slot") or "").strip().casefold()
         raw_org = str(meta.get("org_id") or meta.get("org") or "").strip()
         org_id = raw_org.casefold() if raw_org else None
-        size = int(meta.get("size") or len(archive))
+        size = int(meta.get("size") or size_on_disk)
         user_id = auth.user_id or ""
         if visibility not in {"private", "public"}:
             raise RegistryAppError("invalid_request", "bad visibility", http_status=400)
@@ -91,8 +92,8 @@ class PackageService:
                 "must be org member to publish under this org",
                 http_status=403,
             )
-        actual_blob = f"sha256:{hashlib.sha256(archive).hexdigest()}"
-        if actual_blob != blob_digest or size != len(archive):
+        actual_blob = sha256_file(archive)
+        if actual_blob != blob_digest or size != size_on_disk:
             raise RegistryAppError(
                 "digest_mismatch",
                 "blob digest or size mismatch",
@@ -147,9 +148,10 @@ class PackageService:
         return payload
 
     def upsert_draft(
-        self, *, meta: dict[str, Any], archive: bytes, auth: TokenInfo
+        self, *, meta: dict[str, Any], archive: Path, auth: TokenInfo
     ) -> dict[str, Any]:
-        if len(archive) > self.max_upload:
+        size_on_disk = archive.stat().st_size
+        if size_on_disk > self.max_upload:
             raise RegistryAppError(
                 "payload_too_large",
                 f"max {self.max_upload} bytes",
@@ -162,7 +164,7 @@ class PackageService:
         visibility = str(meta.get("visibility") or "private")
         raw_org = str(meta.get("org_id") or meta.get("org") or "").strip()
         org_id = raw_org.casefold() if raw_org else None
-        size = int(meta.get("size") or len(archive))
+        size = int(meta.get("size") or size_on_disk)
         user_id = auth.user_id or ""
         if not database_id:
             raise RegistryAppError("invalid_request", "database_id required", http_status=400)
@@ -186,8 +188,8 @@ class PackageService:
                 "dataset collaborator or first-upload org member required",
                 http_status=403,
             )
-        actual_blob = f"sha256:{hashlib.sha256(archive).hexdigest()}"
-        if actual_blob != blob_digest or size != len(archive):
+        actual_blob = sha256_file(archive)
+        if actual_blob != blob_digest or size != size_on_disk:
             raise RegistryAppError(
                 "digest_mismatch",
                 "blob digest or size mismatch",
@@ -234,7 +236,7 @@ class PackageService:
         draft = self.meta.get_draft(database_id)
         if draft is None or not self.access.can_release_draft(draft, auth):
             raise RegistryAppError("not_found", "draft not found", http_status=404)
-        archive = self.blobs.get(draft.blob_digest, prefix="packages")
+        archive = read_blob(self.blobs, draft.blob_digest, prefix="packages")
         if archive is None:
             raise RegistryAppError("not_found", "draft blob missing", http_status=404)
         rel_version = (version or "").strip() or self._version_from_archive(archive)
@@ -378,7 +380,7 @@ class PackageService:
             from bora.registry.plugin_package import PLUGIN_MEDIA_TYPE
 
             if row.media_type == PLUGIN_MEDIA_TYPE:
-                data = self.blobs.get(row.blob_digest, prefix="packages")
+                data = read_blob(self.blobs, row.blob_digest, prefix="packages")
                 payload["package_kind"] = "plugin"
                 if data is not None:
                     payload["plugin_preview"] = _plugin_preview_from_archive(data)
@@ -394,16 +396,17 @@ class PackageService:
         database_id: str,
         package_digest: str,
         auth: TokenInfo,
-    ) -> tuple[bytes, ReleaseRow]:
+    ) -> tuple[Any, int, ReleaseRow]:
         row = self._visible_release(
             database_id=database_id,
             auth=auth,
             package_digest=package_digest,
         )
-        data = self.blobs.get(row.blob_digest, prefix="packages")
-        if data is None:
+        size = self.blobs.size(row.blob_digest, prefix="packages")
+        fh = self.blobs.open(row.blob_digest, prefix="packages")
+        if fh is None or size is None:
             raise RegistryAppError("not_found", "blob missing", http_status=404)
-        return data, row
+        return fh, int(size), row
 
     def list_files(
         self,
@@ -421,7 +424,7 @@ class PackageService:
             package_digest=package_digest,
             version=version,
         )
-        archive = self.blobs.get(row.blob_digest, prefix="packages")
+        archive = read_blob(self.blobs, row.blob_digest, prefix="packages")
         if archive is None:
             raise RegistryAppError("not_found", "blob missing", http_status=404)
         try:
@@ -468,7 +471,7 @@ class PackageService:
             safe_path = normalize_package_path(file_path)
         except PackagePathError as exc:
             raise RegistryAppError("invalid_path", str(exc), http_status=400) from exc
-        archive = self.blobs.get(row.blob_digest, prefix="packages")
+        archive = read_blob(self.blobs, row.blob_digest, prefix="packages")
         if archive is None:
             raise RegistryAppError("not_found", "blob missing", http_status=404)
         try:
@@ -610,7 +613,7 @@ class PackageService:
 
     def _validate_archive(
         self,
-        archive: bytes,
+        archive: Path,
         *,
         package_kind: str,
         media_type: str,

--- a/services/registry/result_service.py
+++ b/services/registry/result_service.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import re
+from pathlib import Path
 from typing import Any
 
 from services.registry.access import AccessPolicy
+from services.registry.blob_io import read_blob, sha256_file
 from services.registry.dataset import (
     BOUND_DRAFT,
     BOUND_RELEASE,
@@ -38,8 +39,9 @@ _SECRET_PATTERNS = (
 )
 
 
-def _archive_looks_like_secret_leak(archive: bytes) -> bool:
-    sample = archive if len(archive) < 4_000_000 else archive[:4_000_000]
+def _archive_looks_like_secret_leak(archive: Path) -> bool:
+    with archive.open("rb") as fh:
+        sample = fh.read(4_000_000)
     return any(p.search(sample) for p in _SECRET_PATTERNS)
 
 
@@ -67,9 +69,10 @@ class ResultService:
         return self.access.can_manage_result(result_kind, result_id, auth, for_read=False)
 
     def upload_attempt(
-        self, *, meta: dict[str, Any], archive: bytes, auth: TokenInfo
+        self, *, meta: dict[str, Any], archive: Path, auth: TokenInfo
     ) -> dict[str, Any]:
-        if len(archive) > self.max_upload:
+        size_on_disk = archive.stat().st_size
+        if size_on_disk > self.max_upload:
             raise RegistryAppError(
                 "payload_too_large",
                 f"max {self.max_upload} bytes",
@@ -82,7 +85,7 @@ class ResultService:
         status = str(meta.get("status") or "")
         visibility = str(meta.get("visibility") or "private")
         blob_digest = str(meta.get("blob_digest") or "")
-        size = int(meta.get("size") or len(archive))
+        size = int(meta.get("size") or size_on_disk)
         suite_run_id = str(meta.get("suite_run_id") or "").strip()
         if not run_id or not database_id:
             raise RegistryAppError(
@@ -92,8 +95,8 @@ class ResultService:
             )
         if visibility not in {"private", "public"}:
             raise RegistryAppError("invalid_request", "bad visibility", http_status=400)
-        actual_blob = f"sha256:{hashlib.sha256(archive).hexdigest()}"
-        if actual_blob != blob_digest or size != len(archive):
+        actual_blob = sha256_file(archive)
+        if actual_blob != blob_digest or size != size_on_disk:
             raise RegistryAppError(
                 "digest_mismatch",
                 "blob digest or size mismatch",
@@ -162,18 +165,19 @@ class ResultService:
 
     def serve_attempt_content(
         self, *, run_id: str, auth: TokenInfo
-    ) -> tuple[bytes, AttemptResultRow]:
+    ) -> tuple[Any, int, AttemptResultRow]:
         row = self._require_visible_attempt(run_id, auth)
-        data = self.blobs.get(row.blob_digest, prefix="results")
-        if data is None:
+        size = self.blobs.size(row.blob_digest, prefix="results")
+        fh = self.blobs.open(row.blob_digest, prefix="results")
+        if fh is None or size is None:
             raise RegistryAppError("not_found", "blob missing", http_status=404)
-        return data, row
+        return fh, int(size), row
 
     def list_attempt_files(self, *, run_id: str, auth: TokenInfo) -> dict[str, Any]:
         from services.registry.package_files import get_or_build_index
 
         row = self._require_visible_attempt(run_id, auth)
-        archive = self.blobs.get(row.blob_digest, prefix="results")
+        archive = read_blob(self.blobs, row.blob_digest, prefix="results")
         if archive is None:
             raise RegistryAppError("not_found", "blob missing", http_status=404)
         try:
@@ -208,7 +212,7 @@ class ResultService:
             safe_path = normalize_package_path(file_path)
         except PackagePathError as exc:
             raise RegistryAppError("invalid_path", str(exc), http_status=400) from exc
-        archive = self.blobs.get(row.blob_digest, prefix="results")
+        archive = read_blob(self.blobs, row.blob_digest, prefix="results")
         if archive is None:
             raise RegistryAppError("not_found", "blob missing", http_status=404)
         try:
@@ -231,9 +235,10 @@ class ResultService:
         return file_payload(safe_path, data, size=size, truncated=truncated)
 
     def upload_suite(
-        self, *, meta: dict[str, Any], archive: bytes, auth: TokenInfo
+        self, *, meta: dict[str, Any], archive: Path, auth: TokenInfo
     ) -> dict[str, Any]:
-        if len(archive) > self.max_upload:
+        size_on_disk = archive.stat().st_size
+        if size_on_disk > self.max_upload:
             raise RegistryAppError(
                 "payload_too_large",
                 f"max {self.max_upload} bytes",
@@ -244,7 +249,7 @@ class ResultService:
         database_version = str(meta.get("database_version") or "")
         visibility = str(meta.get("visibility") or "private")
         blob_digest = str(meta.get("blob_digest") or "")
-        size = int(meta.get("size") or len(archive))
+        size = int(meta.get("size") or size_on_disk)
         if not suite_run_id or not database_id:
             raise RegistryAppError(
                 "invalid_request",
@@ -259,8 +264,8 @@ class ResultService:
                 "suite-level PASS/verdict fields are not accepted",
                 http_status=400,
             )
-        actual_blob = f"sha256:{hashlib.sha256(archive).hexdigest()}"
-        if actual_blob != blob_digest or size != len(archive):
+        actual_blob = sha256_file(archive)
+        if actual_blob != blob_digest or size != size_on_disk:
             raise RegistryAppError(
                 "digest_mismatch",
                 "blob digest or size mismatch",
@@ -406,12 +411,13 @@ class ResultService:
 
     def serve_suite_content(
         self, *, suite_run_id: str, auth: TokenInfo
-    ) -> tuple[bytes, SuiteResultRow]:
+    ) -> tuple[Any, int, SuiteResultRow]:
         row = self._require_visible_suite(suite_run_id, auth)
-        data = self.blobs.get(row.blob_digest, prefix="suite-results")
-        if data is None:
+        size = self.blobs.size(row.blob_digest, prefix="suite-results")
+        fh = self.blobs.open(row.blob_digest, prefix="suite-results")
+        if fh is None or size is None:
             raise RegistryAppError("not_found", "blob missing", http_status=404)
-        return data, row
+        return fh, int(size), row
 
     def list_shares(self, *, result_kind: str, result_id: str, auth: TokenInfo) -> dict[str, Any]:
         if not self.access.can_manage_result(result_kind, result_id, auth, for_read=True):
@@ -606,10 +612,10 @@ class ResultService:
         blob = None
         digest = ""
         if release is not None:
-            blob = self.blobs.get(release.blob_digest, prefix="packages")
+            blob = read_blob(self.blobs, release.blob_digest, prefix="packages")
             digest = release.package_digest
         elif draft is not None:
-            blob = self.blobs.get(draft.blob_digest, prefix="packages")
+            blob = read_blob(self.blobs, draft.blob_digest, prefix="packages")
             digest = draft.package_digest
         if blob is None:
             return kind, frozenset()

--- a/services/registry/spool.py
+++ b/services/registry/spool.py
@@ -1,0 +1,127 @@
+"""Length-capped upload spool and on-disk multipart split."""
+
+from __future__ import annotations
+
+import json
+import mmap
+import re
+import secrets
+from pathlib import Path
+from typing import Any, BinaryIO
+
+from services.registry.errors import RegistryAppError
+
+
+def spool_body(
+    body: BinaryIO,
+    *,
+    length: int,
+    max_bytes: int,
+    dest_dir: Path,
+) -> Path:
+    """Write at most *max_bytes* from *body* into a temp file. Hash is not required."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / f"upload-{secrets.token_hex(8)}.spool"
+    remaining = length
+    written = 0
+    try:
+        with dest.open("wb") as out:
+            while remaining > 0:
+                block = body.read(min(64 * 1024, remaining))
+                if not block:
+                    break
+                written += len(block)
+                if written > max_bytes:
+                    raise RegistryAppError(
+                        "payload_too_large",
+                        f"max {max_bytes} bytes",
+                        http_status=413,
+                    )
+                out.write(block)
+                remaining -= len(block)
+    except Exception:
+        dest.unlink(missing_ok=True)
+        raise
+    if written <= 0:
+        dest.unlink(missing_ok=True)
+        raise RegistryAppError(
+            "payload_too_large",
+            f"max {max_bytes} bytes",
+            http_status=413,
+        )
+    return dest
+
+
+def extract_multipart_archive(
+    spool: Path,
+    content_type: str,
+    dest_dir: Path,
+) -> tuple[dict[str, Any], Path]:
+    """Split a multipart spool into metadata JSON and an archive file."""
+    match = re.search(r"boundary=([^;]+)", content_type)
+    if not match:
+        raise ValueError("missing multipart boundary")
+    boundary = match.group(1).strip().encode()
+    marker = b"--" + boundary
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = dest_dir / f"archive-{secrets.token_hex(8)}.bin"
+    meta: dict[str, Any] | None = None
+    found_archive = False
+    with spool.open("rb") as fh:
+        mapped = mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ)
+        try:
+            positions = _marker_positions(mapped, marker)
+            for index, start in enumerate(positions):
+                payload_at = start + len(marker)
+                if payload_at + 2 <= len(mapped) and mapped[payload_at : payload_at + 2] == b"--":
+                    continue
+                if payload_at + 2 <= len(mapped) and mapped[payload_at : payload_at + 2] == b"\r\n":
+                    payload_at += 2
+                header_end = mapped.find(b"\r\n\r\n", payload_at)
+                if header_end < 0:
+                    continue
+                headers = mapped[payload_at:header_end].decode("utf-8", errors="replace")
+                name_m = re.search(r'name="([^"]+)"', headers)
+                if not name_m:
+                    continue
+                data_start = header_end + 4
+                data_end = positions[index + 1] if index + 1 < len(positions) else len(mapped)
+                # Strip the CRLF that precedes the next boundary.
+                if data_end >= 2 and mapped[data_end - 2 : data_end] == b"\r\n":
+                    data_end -= 2
+                name = name_m.group(1)
+                if name == "metadata":
+                    raw = bytes(mapped[data_start:data_end])
+                    meta = json.loads(raw.decode("utf-8"))
+                elif name == "archive":
+                    _copy_span(mapped, data_start, data_end, archive_path)
+                    found_archive = True
+        finally:
+            mapped.close()
+    if meta is None or not found_archive:
+        archive_path.unlink(missing_ok=True)
+        raise ValueError("metadata and archive parts required")
+    if not isinstance(meta, dict):
+        archive_path.unlink(missing_ok=True)
+        raise ValueError("metadata must be a JSON object")
+    return meta, archive_path
+
+
+def _marker_positions(mapped: mmap.mmap, marker: bytes) -> list[int]:
+    found: list[int] = []
+    cursor = 0
+    while True:
+        at = mapped.find(marker, cursor)
+        if at < 0:
+            return found
+        found.append(at)
+        cursor = at + len(marker)
+
+
+def _copy_span(mapped: mmap.mmap, start: int, end: int, dest: Path) -> None:
+    with dest.open("wb") as out:
+        cursor = start
+        while cursor < end:
+            block = mapped[cursor : min(cursor + 1024 * 1024, end)]
+            out.write(block)
+            cursor += len(block)

--- a/services/registry/sql_adapter.py
+++ b/services/registry/sql_adapter.py
@@ -68,7 +68,7 @@ class SqliteAdapter:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
 
     def connect(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+        conn = sqlite3.connect(str(self.db_path), check_same_thread=False, timeout=30.0)
         conn.row_factory = sqlite3.Row
         return conn
 

--- a/services/registry/store.py
+++ b/services/registry/store.py
@@ -201,7 +201,7 @@ class OrgInviteKeyRow:
 
 
 class MemoryBlobStore:
-    """Unit-test only blob backend."""
+    """Unit-test only blob backend (bytes adapter behind a Path/fileobj put)."""
 
     def __init__(self) -> None:
         self._data: dict[str, bytes] = {}
@@ -210,13 +210,26 @@ class MemoryBlobStore:
     def _key(self, blob_digest: str, prefix: str) -> str:
         return f"{prefix}/{blob_digest}"
 
-    def put_if_absent(self, blob_digest: str, data: bytes, *, prefix: str = "packages") -> None:
+    def put_if_absent(
+        self, blob_digest: str, source: Path | Any, *, prefix: str = "packages"
+    ) -> None:
+        payload = source.read_bytes() if isinstance(source, Path) else source.read()
         with self._lock:
-            self._data.setdefault(self._key(blob_digest, prefix), data)
+            self._data.setdefault(self._key(blob_digest, prefix), payload)
 
-    def get(self, blob_digest: str, *, prefix: str = "packages") -> bytes | None:
+    def open(self, blob_digest: str, *, prefix: str = "packages") -> Any:
+        import io
+
         with self._lock:
-            return self._data.get(self._key(blob_digest, prefix))
+            data = self._data.get(self._key(blob_digest, prefix))
+        if data is None:
+            return None
+        return io.BytesIO(data)
+
+    def size(self, blob_digest: str, *, prefix: str = "packages") -> int | None:
+        with self._lock:
+            data = self._data.get(self._key(blob_digest, prefix))
+        return None if data is None else len(data)
 
     def delete(self, blob_digest: str, *, prefix: str = "packages") -> bool:
         """Remove blob if present. Returns True when a key was deleted."""
@@ -235,20 +248,38 @@ class FilesystemBlobStore:
         key = blob_digest.replace(":", "_")
         return self.root / prefix / key
 
-    def put_if_absent(self, blob_digest: str, data: bytes, *, prefix: str = "packages") -> None:
+    def put_if_absent(
+        self, blob_digest: str, source: Path | Any, *, prefix: str = "packages"
+    ) -> None:
+        import shutil
+
         path = self._path(blob_digest, prefix)
         path.parent.mkdir(parents=True, exist_ok=True)
         if path.exists():
             return
-        tmp = path.with_suffix(".tmp")
-        tmp.write_bytes(data)
-        tmp.replace(path)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        try:
+            if isinstance(source, Path):
+                shutil.copyfile(source, tmp)
+            else:
+                with tmp.open("wb") as out:
+                    shutil.copyfileobj(source, out)
+            tmp.replace(path)
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
 
-    def get(self, blob_digest: str, *, prefix: str = "packages") -> bytes | None:
+    def open(self, blob_digest: str, *, prefix: str = "packages") -> Any:
         path = self._path(blob_digest, prefix)
         if not path.is_file():
             return None
-        return path.read_bytes()
+        return path.open("rb")
+
+    def size(self, blob_digest: str, *, prefix: str = "packages") -> int | None:
+        path = self._path(blob_digest, prefix)
+        if not path.is_file():
+            return None
+        return path.stat().st_size
 
     def delete(self, blob_digest: str, *, prefix: str = "packages") -> bool:
         path = self._path(blob_digest, prefix)
@@ -302,22 +333,35 @@ class S3BlobStore:
     def _object_key(self, blob_digest: str, prefix: str) -> str:
         return f"{prefix}/{blob_digest.replace(':', '_')}"
 
-    def put_if_absent(self, blob_digest: str, data: bytes, *, prefix: str = "packages") -> None:
+    def put_if_absent(
+        self, blob_digest: str, source: Path | Any, *, prefix: str = "packages"
+    ) -> None:
         key = self._object_key(blob_digest, prefix)
         try:
             self._client.head_object(Bucket=self.bucket, Key=key)
             return
         except self._ClientError:
             pass
-        self._client.put_object(Bucket=self.bucket, Key=key, Body=data)
+        if isinstance(source, Path):
+            self._client.upload_file(str(source), self.bucket, key)
+            return
+        self._client.upload_fileobj(source, self.bucket, key)
 
-    def get(self, blob_digest: str, *, prefix: str = "packages") -> bytes | None:
+    def open(self, blob_digest: str, *, prefix: str = "packages") -> Any:
         key = self._object_key(blob_digest, prefix)
         try:
             resp = self._client.get_object(Bucket=self.bucket, Key=key)
         except self._ClientError:
             return None
-        return bytes(resp["Body"].read())
+        return resp["Body"]
+
+    def size(self, blob_digest: str, *, prefix: str = "packages") -> int | None:
+        key = self._object_key(blob_digest, prefix)
+        try:
+            resp = self._client.head_object(Bucket=self.bucket, Key=key)
+        except self._ClientError:
+            return None
+        return int(resp["ContentLength"])
 
     def delete(self, blob_digest: str, *, prefix: str = "packages") -> bool:
         key = self._object_key(blob_digest, prefix)

--- a/services/registry/upload_slots.py
+++ b/services/registry/upload_slots.py
@@ -1,0 +1,54 @@
+"""In-flight upload cap (per process).
+
+Public deploy: workers × this limit is the process-side ceiling. Put the
+same number (or smaller) on the reverse proxy so disk / NIC cannot fill.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from services.registry.errors import RegistryAppError
+
+DEFAULT_UPLOAD_SLOTS = 4
+
+
+def slots_from_env(*, default: int = DEFAULT_UPLOAD_SLOTS) -> int:
+    raw = (os.environ.get("BORA_REGISTRY_UPLOAD_SLOTS") or "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return max(1, value)
+
+
+class UploadSlotPool:
+    """Non-blocking semaphore. Exhaustion is 429, not a queue."""
+
+    def __init__(self, limit: int = DEFAULT_UPLOAD_SLOTS) -> None:
+        self.limit = max(1, int(limit))
+        self._sem = threading.BoundedSemaphore(self.limit)
+
+    def try_acquire(self) -> bool:
+        return self._sem.acquire(blocking=False)
+
+    def release(self) -> None:
+        self._sem.release()
+
+    @contextmanager
+    def hold(self) -> Iterator[None]:
+        if not self.try_acquire():
+            raise RegistryAppError(
+                "too_many_uploads",
+                f"in-flight upload limit {self.limit} reached",
+                http_status=429,
+            )
+        try:
+            yield
+        finally:
+            self.release()

--- a/src/bora/application/plugin_ops/plugin_install_remote.py
+++ b/src/bora/application/plugin_ops/plugin_install_remote.py
@@ -53,8 +53,11 @@ class PluginInstallCommand:
                     f"release is not a plugin (media_type={meta.media_type})",
                     location=locator,
                 )
-            archive = client.fetch_content(
-                database_id=package_id, package_digest=meta.package_digest
+            archive_path = Path(tempfile.mkdtemp(prefix="bora-plugin-dl-")) / "plugin.tar.gz"
+            client.fetch_content(
+                database_id=package_id,
+                package_digest=meta.package_digest,
+                dest=archive_path,
             )
         except RegistryError as exc:
             raise ConfigError(exc.code, exc.message, location="registry") from exc
@@ -62,7 +65,8 @@ class PluginInstallCommand:
         with tempfile.TemporaryDirectory(prefix="bora-plugin-") as tmp:
             extract_dir = Path(tmp) / "pkg"
             extract_dir.mkdir()
-            extract_archive(archive, extract_dir)
+            extract_archive(archive_path, extract_dir)
+            archive_path.unlink(missing_ok=True)
             entry = install_from_path(extract_dir, plugin_id=package_id)
         return {
             "ok": True,

--- a/src/bora/application/plugin_ops/plugin_publish.py
+++ b/src/bora/application/plugin_ops/plugin_publish.py
@@ -52,27 +52,32 @@ class PluginPublishCommand:
 
         package_digest = compute_plugin_digest(root)
         archive, blob_digest, size = build_plugin_archive(root)
+        import tempfile
+
+        visibility = "public" if public else "private"
         client = self._client_factory(
             registry_url=registry_url,
             token=token,
             require_token=True,
         )
-        visibility = "public" if public else "private"
-        try:
-            info = client.publish(
-                database_id=package_id,
-                version=manifest.version,
-                package_digest=package_digest,
-                blob_digest=blob_digest,
-                size=size,
-                media_type=PLUGIN_MEDIA_TYPE,
-                visibility=visibility,
-                archive=archive,
-                org_id=org_id,
-                package_kind="plugin",
-            )
-        except RegistryError as exc:
-            raise ConfigError(exc.code, exc.message, location="registry") from exc
+        with tempfile.TemporaryDirectory(prefix="bora-plug-") as tmp:
+            archive_path = Path(tmp) / "plugin.tar.gz"
+            archive_path.write_bytes(archive)
+            try:
+                info = client.publish(
+                    database_id=package_id,
+                    version=manifest.version,
+                    package_digest=package_digest,
+                    blob_digest=blob_digest,
+                    size=size,
+                    media_type=PLUGIN_MEDIA_TYPE,
+                    visibility=visibility,
+                    archive=archive_path,
+                    org_id=org_id,
+                    package_kind="plugin",
+                )
+            except RegistryError as exc:
+                raise ConfigError(exc.code, exc.message, location="registry") from exc
 
         return {
             "ok": True,

--- a/src/bora/application/registry_ops/publish_command.py
+++ b/src/bora/application/registry_ops/publish_command.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from bora.config.database import load_database_manifest
 from bora.config.errors import ConfigError
-from bora.registry.archive import MEDIA_TYPE, build_archive
+from bora.registry.archive import MEDIA_TYPE, write_archive
 from bora.registry.client import RegistryError
 from bora.registry.digest import compute_package_digest
 
@@ -40,12 +40,6 @@ class PublishCommand:
             raise
 
         package_digest = compute_package_digest(root)
-        archive, blob_digest, size = build_archive(root)
-        client = self._client_factory(
-            registry_url=registry_url,
-            token=token,
-            require_token=True,
-        )
         visibility = "public" if public else "private"
         org_id = (org or "").strip()
         if not org_id:
@@ -54,22 +48,32 @@ class PublishCommand:
                 "publish requires --org (package must belong to an organization)",
                 location="registry",
             )
-        try:
-            info = client.publish(
-                database_id=manifest.database_id,
-                version=manifest.version,
-                package_digest=package_digest,
-                blob_digest=blob_digest,
-                size=size,
-                media_type=MEDIA_TYPE,
-                visibility=visibility,
-                archive=archive,
-                org_id=org_id,
-                replace=replace,
-                slot="draft" if draft else None,
+        import tempfile
+
+        with tempfile.TemporaryDirectory(prefix="bora-pub-") as tmp:
+            archive_path = Path(tmp) / "package.tar.gz"
+            blob_digest, size = write_archive(root, archive_path)
+            client = self._client_factory(
+                registry_url=registry_url,
+                token=token,
+                require_token=True,
             )
-        except RegistryError as exc:
-            raise ConfigError(exc.code, exc.message, location="registry") from exc
+            try:
+                info = client.publish(
+                    database_id=manifest.database_id,
+                    version=manifest.version,
+                    package_digest=package_digest,
+                    blob_digest=blob_digest,
+                    size=size,
+                    media_type=MEDIA_TYPE,
+                    visibility=visibility,
+                    archive=archive_path,
+                    org_id=org_id,
+                    replace=replace,
+                    slot="draft" if draft else None,
+                )
+            except RegistryError as exc:
+                raise ConfigError(exc.code, exc.message, location="registry") from exc
 
         out: dict[str, Any] = {
             "ok": True,

--- a/src/bora/application/registry_ops/results_command.py
+++ b/src/bora/application/registry_ops/results_command.py
@@ -217,7 +217,7 @@ class ResultsCommands:
             raise ConfigError("invalid_package", str(exc), location=str(root)) from exc
 
         run_dir = resolve_attempt_run_dir(root, run_id)
-        archive, blob_digest, size = build_attempt_archive(run_dir, run_id=run_id)
+        archive_bytes, blob_digest, size = build_attempt_archive(run_dir, run_id=run_id)
         meta = _read_run_meta(run_dir)
         task_id = str(meta.get("task_id") or "")
         lock_digest = str(meta.get("lock_digest") or meta.get("digest") or "")
@@ -227,36 +227,41 @@ class ResultsCommands:
         client = self._client_factory(
             registry_url=registry_url, require_token=True, accept_results_url=True
         )
-        try:
-            info = client.upload_attempt(
-                run_id=run_id,
-                database_id=database_id,
-                task_id=task_id,
-                lock_digest=lock_digest,
-                status=status,
-                visibility="public" if public else "private",
-                blob_digest=blob_digest,
-                size=size,
-                archive=archive,
-                suite_run_id=suite_link,
-                replace=replace,
-            )
-        except RegistryError as exc:
-            if allow_existing and (
-                exc.code == "conflict" or (exc.status == 409) or "already exists" in exc.message
-            ):
-                return {
-                    "ok": True,
-                    "already_exists": True,
-                    "run_id": run_id,
-                    "database_id": database_id,
-                    "blob_digest": blob_digest,
-                    "size": size,
-                    "visibility": "public" if public else "private",
-                    "status": status,
-                    "suite_run_id": suite_link,
-                }
-            raise ConfigError(exc.code, exc.message, location="registry") from exc
+        import tempfile
+
+        with tempfile.TemporaryDirectory(prefix="bora-att-") as tmp:
+            archive = Path(tmp) / "attempt.tar.gz"
+            archive.write_bytes(archive_bytes)
+            try:
+                info = client.upload_attempt(
+                    run_id=run_id,
+                    database_id=database_id,
+                    task_id=task_id,
+                    lock_digest=lock_digest,
+                    status=status,
+                    visibility="public" if public else "private",
+                    blob_digest=blob_digest,
+                    size=size,
+                    archive=archive,
+                    suite_run_id=suite_link,
+                    replace=replace,
+                )
+            except RegistryError as exc:
+                if allow_existing and (
+                    exc.code == "conflict" or (exc.status == 409) or "already exists" in exc.message
+                ):
+                    return {
+                        "ok": True,
+                        "already_exists": True,
+                        "run_id": run_id,
+                        "database_id": database_id,
+                        "blob_digest": blob_digest,
+                        "size": size,
+                        "visibility": "public" if public else "private",
+                        "status": status,
+                        "suite_run_id": suite_link,
+                    }
+                raise ConfigError(exc.code, exc.message, location="registry") from exc
 
         out: dict[str, Any] = {
             "ok": True,
@@ -289,12 +294,14 @@ class ResultsCommands:
         )
         try:
             meta = client.get_attempt(run_id)
-            archive = client.fetch_attempt_content(run_id)
+            dest = out_dir.expanduser().resolve(strict=False)
+            archive_path = dest / f"{run_id}.tar.gz"
+            client.fetch_attempt_content(run_id, dest=archive_path)
         except RegistryError as exc:
             raise ConfigError(exc.code, exc.message, location="registry") from exc
 
-        dest = out_dir.expanduser().resolve(strict=False)
-        run_path = extract_attempt_archive(archive, dest)
+        run_path = extract_attempt_archive(archive_path, dest)
+        archive_path.unlink(missing_ok=True)
         return {
             "ok": True,
             "run_id": run_id,
@@ -387,40 +394,45 @@ class ResultsCommands:
                     location=str(default_runs_root(root)),
                 )
 
-        archive, blob_digest, size = build_suite_archive(suite_dir, suite_run_id=suite_run_id)
+        archive_bytes, blob_digest, size = build_suite_archive(suite_dir, suite_run_id=suite_run_id)
         config_proj = _config_fields_from_summary(summary)
         client = self._client_factory(
             registry_url=registry_url, require_token=True, accept_results_url=True
         )
-        try:
-            info = client.upload_suite(
-                suite_run_id=suite_run_id,
-                database_id=database_id,
-                database_version=database_version,
-                visibility="public" if public else "private",
-                pass_rate=pass_rate,
-                mean_score=mean_score,
-                metrics=dict(metrics),
-                task_refs=list(task_refs),
-                agent_label=agent_label or str(summary.get("agent_label") or ""),
-                model_label=model_label or str(summary.get("model_label") or ""),
-                exit_code=exit_code,
-                blob_digest=blob_digest,
-                size=size,
-                archive=archive,
-                config_fingerprint=config_proj.get("config_fingerprint"),
-                config_homogeneous=config_proj.get("config_homogeneous"),
-                actors_summary=list(config_proj.get("actors_summary") or []),
-                job_overlay=config_proj.get("job_overlay")
-                if isinstance(config_proj.get("job_overlay"), dict)
-                else None,
-                plugins=list(config_proj.get("plugins") or [])
-                if isinstance(config_proj.get("plugins"), list)
-                else None,
-                replace=replace,
-            )
-        except RegistryError as exc:
-            raise ConfigError(exc.code, exc.message, location="registry") from exc
+        import tempfile
+
+        with tempfile.TemporaryDirectory(prefix="bora-suite-") as tmp:
+            archive = Path(tmp) / "suite.tar.gz"
+            archive.write_bytes(archive_bytes)
+            try:
+                info = client.upload_suite(
+                    suite_run_id=suite_run_id,
+                    database_id=database_id,
+                    database_version=database_version,
+                    visibility="public" if public else "private",
+                    pass_rate=pass_rate,
+                    mean_score=mean_score,
+                    metrics=dict(metrics),
+                    task_refs=list(task_refs),
+                    agent_label=agent_label or str(summary.get("agent_label") or ""),
+                    model_label=model_label or str(summary.get("model_label") or ""),
+                    exit_code=exit_code,
+                    blob_digest=blob_digest,
+                    size=size,
+                    archive=archive,
+                    config_fingerprint=config_proj.get("config_fingerprint"),
+                    config_homogeneous=config_proj.get("config_homogeneous"),
+                    actors_summary=list(config_proj.get("actors_summary") or []),
+                    job_overlay=config_proj.get("job_overlay")
+                    if isinstance(config_proj.get("job_overlay"), dict)
+                    else None,
+                    plugins=list(config_proj.get("plugins") or [])
+                    if isinstance(config_proj.get("plugins"), list)
+                    else None,
+                    replace=replace,
+                )
+            except RegistryError as exc:
+                raise ConfigError(exc.code, exc.message, location="registry") from exc
 
         out: dict[str, Any] = {
             "ok": True,
@@ -522,12 +534,14 @@ class ResultsCommands:
 
         result: dict[str, Any] = {"ok": True, "source": "registry", **meta}
         if out_dir is not None:
+            dest = out_dir.expanduser().resolve(strict=False)
+            archive_path = dest / f"{suite_run_id}.tar.gz"
             try:
-                archive = client.fetch_suite_content(suite_run_id)
+                client.fetch_suite_content(suite_run_id, dest=archive_path)
             except RegistryError as exc:
                 raise ConfigError(exc.code, exc.message, location="registry") from exc
-            dest = out_dir.expanduser().resolve(strict=False)
-            suite_path = extract_suite_archive(archive, dest)
+            suite_path = extract_suite_archive(archive_path, dest)
+            archive_path.unlink(missing_ok=True)
             result["out"] = str(suite_path)
             # #59: materialize job_overlay as profiles.yaml next to extract when present.
             overlay = meta.get("job_overlay")

--- a/src/bora/registry/archive.py
+++ b/src/bora/registry/archive.py
@@ -16,6 +16,7 @@ import hashlib
 import io
 import tarfile
 from pathlib import Path
+from typing import Any
 
 from bora.config.database import member_paths_for_digest
 from bora.registry.media_types import DATABASE_MEDIA_TYPE
@@ -23,61 +24,94 @@ from bora.registry.media_types import DATABASE_MEDIA_TYPE
 MEDIA_TYPE = DATABASE_MEDIA_TYPE
 
 
-def build_archive(database_root: Path) -> tuple[bytes, str, int]:
-    """Return ``(archive_bytes, blob_digest, size)`` for *database_root*."""
+def write_archive(database_root: Path, dest: Path) -> tuple[str, int]:
+    """Write a deterministic tar.gz to *dest*. Return ``(blob_digest, size)``."""
     root = database_root.expanduser().resolve(strict=False)
     paths = member_paths_for_digest(root)
-    buf = io.BytesIO()
-    # Build uncompressed tar first for stable gzip of fixed payload.
-    tar_buf = io.BytesIO()
-    with tarfile.open(fileobj=tar_buf, mode="w", format=tarfile.PAX_FORMAT) as tar:
-        # Ensure parent dirs are present deterministically.
-        seen_dirs: set[str] = set()
-        for rel in paths:
-            parts = Path(rel).parts
-            for i in range(1, len(parts)):
-                d = "/".join(parts[:i])
-                if d in seen_dirs:
-                    continue
-                seen_dirs.add(d)
-                info = tarfile.TarInfo(name=d)
-                info.type = tarfile.DIRTYPE
+    dest = dest.expanduser().resolve(strict=False)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tar_tmp = dest.with_name(dest.name + ".tar.tmp")
+    try:
+        with tarfile.open(name=tar_tmp, mode="w", format=tarfile.PAX_FORMAT) as tar:
+            seen_dirs: set[str] = set()
+            for rel in paths:
+                parts = Path(rel).parts
+                for i in range(1, len(parts)):
+                    d = "/".join(parts[:i])
+                    if d in seen_dirs:
+                        continue
+                    seen_dirs.add(d)
+                    info = tarfile.TarInfo(name=d)
+                    info.type = tarfile.DIRTYPE
+                    info.mtime = 0
+                    info.uid = 0
+                    info.gid = 0
+                    info.uname = ""
+                    info.gname = ""
+                    info.mode = 0o755
+                    tar.addfile(info)
+                abs_path = root / rel
+                data = abs_path.read_bytes()
+                info = tarfile.TarInfo(name=rel)
+                info.size = len(data)
                 info.mtime = 0
                 info.uid = 0
                 info.gid = 0
                 info.uname = ""
                 info.gname = ""
-                info.mode = 0o755
-                tar.addfile(info)
-            abs_path = root / rel
-            data = abs_path.read_bytes()
-            info = tarfile.TarInfo(name=rel)
-            info.size = len(data)
-            info.mtime = 0
-            info.uid = 0
-            info.gid = 0
-            info.uname = ""
-            info.gname = ""
-            info.mode = 0o644
-            tar.addfile(info, io.BytesIO(data))
-    raw_tar = tar_buf.getvalue()
-    with gzip.GzipFile(fileobj=buf, mode="wb", mtime=0, compresslevel=9) as gz:
-        gz.write(raw_tar)
-    archive = buf.getvalue()
-    digest = f"sha256:{hashlib.sha256(archive).hexdigest()}"
-    return archive, digest, len(archive)
+                info.mode = 0o644
+                tar.addfile(info, io.BytesIO(data))
+        with (
+            dest.open("wb") as out,
+            gzip.GzipFile(fileobj=out, mode="wb", mtime=0, compresslevel=9) as gz,
+            tar_tmp.open("rb") as inf,
+        ):
+            while True:
+                block = inf.read(1024 * 1024)
+                if not block:
+                    break
+                gz.write(block)
+    finally:
+        tar_tmp.unlink(missing_ok=True)
+    digest = hashlib.sha256()
+    with dest.open("rb") as fh:
+        while True:
+            block = fh.read(1024 * 1024)
+            if not block:
+                break
+            digest.update(block)
+    return f"sha256:{digest.hexdigest()}", dest.stat().st_size
 
 
-def extract_archive(archive: bytes, dest_root: Path) -> None:
+def build_archive(database_root: Path) -> tuple[bytes, str, int]:
+    """Return ``(archive_bytes, blob_digest, size)`` for small fixtures/tests."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory(prefix="bora-arch-") as tmp:
+        dest = Path(tmp) / "pkg.tar.gz"
+        digest, size = write_archive(database_root, dest)
+        return dest.read_bytes(), digest, size
+
+
+def extract_archive(archive: bytes | Path, dest_root: Path) -> None:
     """Extract archive into *dest_root* (must not already exist as non-empty)."""
     dest_root = dest_root.expanduser().resolve(strict=False)
     dest_root.mkdir(parents=True, exist_ok=True)
-    with (
-        gzip.GzipFile(fileobj=io.BytesIO(archive), mode="rb") as gz,
-        tarfile.open(fileobj=gz, mode="r:") as tar,
-    ):
-        # Python 3.12+ filter= for path safety when available.
-        try:
-            tar.extractall(path=dest_root, filter="data")  # type: ignore[call-arg]
-        except TypeError:
-            tar.extractall(path=dest_root)  # noqa: S202 — trusted registry bytes after digest
+    closer: Any = None
+    if isinstance(archive, Path):
+        fileobj: Any = archive.open("rb")
+        closer = fileobj
+    else:
+        fileobj = io.BytesIO(archive)
+    try:
+        with (
+            gzip.GzipFile(fileobj=fileobj, mode="rb") as gz,
+            tarfile.open(fileobj=gz, mode="r:") as tar,
+        ):
+            try:
+                tar.extractall(path=dest_root, filter="data")  # type: ignore[call-arg]
+            except TypeError:
+                tar.extractall(path=dest_root)  # noqa: S202 — trusted registry bytes after digest
+    finally:
+        if closer is not None:
+            closer.close()

--- a/src/bora/registry/cache.py
+++ b/src/bora/registry/cache.py
@@ -52,14 +52,21 @@ class PackageCache:
         *,
         database_id: str,
         package_digest: str,
-        archive: bytes,
+        archive: Path,
         expected_blob_digest: str | None = None,
     ) -> Path:
         """Extract archive into a temp dir, verify packageDigest, then atomic rename."""
         import hashlib
 
         if expected_blob_digest is not None:
-            actual = f"sha256:{hashlib.sha256(archive).hexdigest()}"
+            digest = hashlib.sha256()
+            with archive.open("rb") as fh:
+                while True:
+                    block = fh.read(1024 * 1024)
+                    if not block:
+                        break
+                    digest.update(block)
+            actual = f"sha256:{digest.hexdigest()}"
             if actual != expected_blob_digest:
                 msg = f"blob digest mismatch: expected {expected_blob_digest}, got {actual}"
                 raise ValueError(msg)

--- a/src/bora/registry/client.py
+++ b/src/bora/registry/client.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+import shutil
+import tempfile
 import urllib.error
 import urllib.request
+from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
@@ -42,7 +45,7 @@ class RegistryClient:
         method: str,
         path: str,
         *,
-        body: bytes | None = None,
+        body: bytes | Any | None = None,
         headers: dict[str, str] | None = None,
         auth: bool = True,
     ) -> tuple[int, bytes, dict[str, str]]:
@@ -74,6 +77,81 @@ class RegistryClient:
                 f"cannot reach registry: {exc.reason}",
             ) from exc
 
+    def _put_multipart(
+        self,
+        path: str,
+        *,
+        meta: dict[str, Any],
+        archive: Path,
+        filename: str,
+        boundary_prefix: str,
+    ) -> tuple[int, bytes, dict[str, str]]:
+        import secrets as _secrets
+
+        boundary = f"{boundary_prefix}-{_secrets.token_hex(12)}"
+        header = (
+            f"--{boundary}\r\n"
+            'Content-Disposition: form-data; name="metadata"\r\n'
+            "Content-Type: application/json\r\n\r\n"
+        ).encode()
+        mid = (
+            f"\r\n--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="archive"; filename="{filename}"\r\n'
+            "Content-Type: application/octet-stream\r\n\r\n"
+        ).encode()
+        tail = f"\r\n--{boundary}--\r\n".encode()
+        meta_bytes = json.dumps(meta, sort_keys=True).encode()
+        with tempfile.NamedTemporaryFile(prefix="bora-mp-", suffix=".http", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+        try:
+            with tmp_path.open("wb") as out, archive.open("rb") as inf:
+                out.write(header)
+                out.write(meta_bytes)
+                out.write(mid)
+                shutil.copyfileobj(inf, out)
+                out.write(tail)
+            size = tmp_path.stat().st_size
+            headers = self._headers(
+                content_type=f"multipart/form-data; boundary={boundary}",
+                auth=True,
+            )
+            headers["Content-Length"] = str(size)
+            with tmp_path.open("rb") as body:
+                return self._request("POST", path, body=body, headers=headers)  # type: ignore[arg-type]
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def _download_to(self, path: str, dest: Path) -> Path:
+        dest = dest.expanduser()
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        tmp = dest.with_name(dest.name + ".part")
+        url = f"{self.base_url}{path}"
+        req = urllib.request.Request(url, method="GET", headers=self._headers(auth=True))
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp, tmp.open("wb") as out:  # noqa: S310
+                shutil.copyfileobj(resp, out)
+        except urllib.error.HTTPError as exc:
+            tmp.unlink(missing_ok=True)
+            raw = exc.read() if exc.fp else b""
+            try:
+                payload = json.loads(raw.decode("utf-8")) if raw else {}
+            except json.JSONDecodeError:
+                payload = {}
+            code = str(payload.get("error") or "registry_http_error")
+            msg = str(payload.get("message") or exc.reason or "HTTP error")
+            raise RegistryError(code, msg, status=int(exc.code)) from exc
+        except urllib.error.URLError as exc:
+            tmp.unlink(missing_ok=True)
+            raise RegistryError(
+                "registry_unavailable",
+                f"cannot reach registry: {exc.reason}",
+            ) from exc
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
+        tmp.replace(dest)
+        return dest
+
     def health(self) -> dict[str, Any]:
         status, raw, _ = self._request("GET", "/health", auth=False)
         if status != 200:
@@ -90,7 +168,7 @@ class RegistryClient:
         size: int,
         media_type: str,
         visibility: str,
-        archive: bytes,
+        archive: Path,
         org_id: str,
         replace: bool = False,
         package_kind: str = "database",
@@ -111,26 +189,13 @@ class RegistryClient:
             meta["replace"] = True
         if slot:
             meta["slot"] = slot
-        import secrets as _secrets
-
-        boundary = f"bora-{_secrets.token_hex(12)}"
-        body = b""
-        body += f"--{boundary}\r\n".encode()
-        body += b'Content-Disposition: form-data; name="metadata"\r\n'
-        body += b"Content-Type: application/json\r\n\r\n"
-        body += json.dumps(meta, sort_keys=True).encode("utf-8")
-        body += b"\r\n"
-        body += f"--{boundary}\r\n".encode()
-        body += b'Content-Disposition: form-data; name="archive"; filename="package.tar.gz"\r\n'
-        body += b"Content-Type: application/octet-stream\r\n\r\n"
-        body += archive
-        body += b"\r\n"
-        body += f"--{boundary}--\r\n".encode()
-        headers = self._headers(
-            content_type=f"multipart/form-data; boundary={boundary}",
-            auth=True,
+        status, raw, _ = self._put_multipart(
+            "/v1/packages",
+            meta=meta,
+            archive=archive,
+            filename="package.tar.gz",
+            boundary_prefix="bora",
         )
-        status, raw, _ = self._request("POST", "/v1/packages", body=body, headers=headers)
         if status not in {200, 201}:
             raise RegistryError("publish_failed", f"unexpected status {status}", status=status)
         data = json.loads(raw.decode("utf-8"))
@@ -183,15 +248,12 @@ class RegistryClient:
         data = json.loads(raw.decode("utf-8"))
         return ReleaseInfo.from_payload(data)
 
-    def fetch_content(self, *, database_id: str, package_digest: str) -> bytes:
+    def fetch_content(self, *, database_id: str, package_digest: str, dest: Path) -> Path:
         path = (
             f"/v1/packages/{quote(database_id, safe='/')}"
             f"/by-digest/{quote(package_digest, safe=':')}/content"
         )
-        status, raw, _ = self._request("GET", path, auth=True)
-        if status != 200:
-            raise RegistryError("not_found", f"content not found ({status})", status=status)
-        return raw
+        return self._download_to(path, dest)
 
     def list_package_files(
         self,
@@ -319,7 +381,7 @@ class RegistryClient:
         visibility: str,
         blob_digest: str,
         size: int,
-        archive: bytes,
+        archive: Path,
         suite_run_id: str | None = None,
         replace: bool = False,
     ) -> dict[str, Any]:
@@ -337,27 +399,12 @@ class RegistryClient:
             meta["suite_run_id"] = suite_run_id
         if replace:
             meta["replace"] = True
-        import secrets as _secrets
-
-        boundary = f"bora-result-{_secrets.token_hex(12)}"
-        body = b""
-        body += f"--{boundary}\r\n".encode()
-        body += b'Content-Disposition: form-data; name="metadata"\r\n'
-        body += b"Content-Type: application/json\r\n\r\n"
-        body += json.dumps(meta, sort_keys=True).encode("utf-8")
-        body += b"\r\n"
-        body += f"--{boundary}\r\n".encode()
-        body += b'Content-Disposition: form-data; name="archive"; filename="attempt.tar.gz"\r\n'
-        body += b"Content-Type: application/octet-stream\r\n\r\n"
-        body += archive
-        body += b"\r\n"
-        body += f"--{boundary}--\r\n".encode()
-        headers = self._headers(
-            content_type=f"multipart/form-data; boundary={boundary}",
-            auth=True,
-        )
-        http_status, raw, _ = self._request(
-            "POST", "/v1/results/attempts", body=body, headers=headers
+        http_status, raw, _ = self._put_multipart(
+            "/v1/results/attempts",
+            meta=meta,
+            archive=archive,
+            filename="attempt.tar.gz",
+            boundary_prefix="bora-result",
         )
         if http_status not in {200, 201}:
             raise RegistryError(
@@ -372,12 +419,9 @@ class RegistryClient:
             raise RegistryError("not_found", f"attempt not found ({status})", status=status)
         return json.loads(raw.decode("utf-8"))
 
-    def fetch_attempt_content(self, run_id: str) -> bytes:
+    def fetch_attempt_content(self, run_id: str, dest: Path) -> Path:
         path = f"/v1/results/attempts/{quote(run_id, safe='')}/content"
-        status, raw, _ = self._request("GET", path, auth=True)
-        if status != 200:
-            raise RegistryError("not_found", f"content not found ({status})", status=status)
-        return raw
+        return self._download_to(path, dest)
 
     def list_attempts(self, *, database_id: str | None = None) -> list[dict[str, Any]]:
         from urllib.parse import urlencode
@@ -410,7 +454,7 @@ class RegistryClient:
         exit_code: int,
         blob_digest: str,
         size: int,
-        archive: bytes,
+        archive: Path,
         config_fingerprint: str | None = None,
         config_homogeneous: bool | None = None,
         actors_summary: list[dict[str, Any]] | None = None,
@@ -447,27 +491,12 @@ class RegistryClient:
             meta["job_overlay"] = job_overlay
         if isinstance(plugins, list) and plugins:
             meta["plugins"] = plugins
-        import secrets as _secrets
-
-        boundary = f"bora-suite-{_secrets.token_hex(12)}"
-        body = b""
-        body += f"--{boundary}\r\n".encode()
-        body += b'Content-Disposition: form-data; name="metadata"\r\n'
-        body += b"Content-Type: application/json\r\n\r\n"
-        body += json.dumps(meta, sort_keys=True).encode("utf-8")
-        body += b"\r\n"
-        body += f"--{boundary}\r\n".encode()
-        body += b'Content-Disposition: form-data; name="archive"; filename="suite.tar.gz"\r\n'
-        body += b"Content-Type: application/octet-stream\r\n\r\n"
-        body += archive
-        body += b"\r\n"
-        body += f"--{boundary}--\r\n".encode()
-        headers = self._headers(
-            content_type=f"multipart/form-data; boundary={boundary}",
-            auth=True,
-        )
-        http_status, raw, _ = self._request(
-            "POST", "/v1/results/suites", body=body, headers=headers
+        http_status, raw, _ = self._put_multipart(
+            "/v1/results/suites",
+            meta=meta,
+            archive=archive,
+            filename="suite.tar.gz",
+            boundary_prefix="bora-suite",
         )
         if http_status not in {200, 201}:
             raise RegistryError(
@@ -482,12 +511,9 @@ class RegistryClient:
             raise RegistryError("not_found", f"suite not found ({status})", status=status)
         return json.loads(raw.decode("utf-8"))
 
-    def fetch_suite_content(self, suite_run_id: str) -> bytes:
+    def fetch_suite_content(self, suite_run_id: str, dest: Path) -> Path:
         path = f"/v1/results/suites/{quote(suite_run_id, safe='')}/content"
-        status, raw, _ = self._request("GET", path, auth=True)
-        if status != 200:
-            raise RegistryError("not_found", f"content not found ({status})", status=status)
-        return raw
+        return self._download_to(path, dest)
 
     def list_suites(
         self, *, database_id: str | None = None, board: bool = False

--- a/src/bora/registry/resolve.py
+++ b/src/bora/registry/resolve.py
@@ -64,15 +64,21 @@ def resolve_database_root(
         hit = pkg_cache.lookup(meta.database_id, meta.package_digest)
         if hit is not None:
             return hit
-        archive = reg_client.fetch_content(
-            database_id=meta.database_id, package_digest=meta.package_digest
-        )
-        return pkg_cache.publish_atomic(
-            database_id=meta.database_id,
-            package_digest=meta.package_digest,
-            archive=archive,
-            expected_blob_digest=meta.blob_digest,
-        )
+        import tempfile
+
+        with tempfile.TemporaryDirectory(prefix="bora-fetch-") as tmp:
+            dest = Path(tmp) / "package.tar.gz"
+            reg_client.fetch_content(
+                database_id=meta.database_id,
+                package_digest=meta.package_digest,
+                dest=dest,
+            )
+            return pkg_cache.publish_atomic(
+                database_id=meta.database_id,
+                package_digest=meta.package_digest,
+                archive=dest,
+                expected_blob_digest=meta.blob_digest,
+            )
     except RegistryError as exc:
         # Offline: digest ref may still hit cache (already checked); version cannot.
         if exc.code == "registry_unavailable" and ref.kind == "digest" and ref.package_digest:

--- a/src/bora/registry/results_archive.py
+++ b/src/bora/registry/results_archive.py
@@ -14,6 +14,7 @@ import hashlib
 import io
 import tarfile
 from pathlib import Path
+from typing import Any
 
 from bora.registry.media_types import ATTEMPT_RESULT_MEDIA_TYPE, SUITE_RESULT_MEDIA_TYPE
 
@@ -52,18 +53,29 @@ def build_attempt_archive(run_dir: Path, *, run_id: str) -> tuple[bytes, str, in
     return _pack_tree(members)
 
 
-def extract_attempt_archive(archive: bytes, dest_root: Path) -> Path:
+def extract_attempt_archive(archive: bytes | Path, dest_root: Path) -> Path:
     """Extract into *dest_root*; return path to ``.bora/runs/<run_id>`` if found."""
     dest = dest_root.expanduser().resolve(strict=False)
     dest.mkdir(parents=True, exist_ok=True)
-    with (
-        gzip.GzipFile(fileobj=io.BytesIO(archive), mode="rb") as gz,
-        tarfile.open(fileobj=gz, mode="r:") as tar,
-    ):
-        try:
-            tar.extractall(path=dest, filter="data")  # type: ignore[call-arg]
-        except TypeError:
-            tar.extractall(path=dest)
+    closer = None
+    fileobj: Any
+    if isinstance(archive, Path):
+        fileobj = archive.open("rb")
+        closer = fileobj
+    else:
+        fileobj = io.BytesIO(archive)
+    try:
+        with (
+            gzip.GzipFile(fileobj=fileobj, mode="rb") as gz,
+            tarfile.open(fileobj=gz, mode="r:") as tar,
+        ):
+            try:
+                tar.extractall(path=dest, filter="data")  # type: ignore[call-arg]
+            except TypeError:
+                tar.extractall(path=dest)
+    finally:
+        if closer is not None:
+            closer.close()
     from bora.evidence.locators import default_runs_root
 
     runs = default_runs_root(dest)
@@ -139,18 +151,29 @@ def build_suite_archive(suite_dir: Path, *, suite_run_id: str) -> tuple[bytes, s
     return _pack_tree(members)
 
 
-def extract_suite_archive(archive: bytes, dest_root: Path) -> Path:
+def extract_suite_archive(archive: bytes | Path, dest_root: Path) -> Path:
     """Extract suite bundle; return path to ``.bora/suite-runs/<id>`` if found."""
     dest = dest_root.expanduser().resolve(strict=False)
     dest.mkdir(parents=True, exist_ok=True)
-    with (
-        gzip.GzipFile(fileobj=io.BytesIO(archive), mode="rb") as gz,
-        tarfile.open(fileobj=gz, mode="r:") as tar,
-    ):
-        try:
-            tar.extractall(path=dest, filter="data")  # type: ignore[call-arg]
-        except TypeError:
-            tar.extractall(path=dest)
+    closer = None
+    fileobj: Any
+    if isinstance(archive, Path):
+        fileobj = archive.open("rb")
+        closer = fileobj
+    else:
+        fileobj = io.BytesIO(archive)
+    try:
+        with (
+            gzip.GzipFile(fileobj=fileobj, mode="rb") as gz,
+            tarfile.open(fileobj=gz, mode="r:") as tar,
+        ):
+            try:
+                tar.extractall(path=dest, filter="data")  # type: ignore[call-arg]
+            except TypeError:
+                tar.extractall(path=dest)
+    finally:
+        if closer is not None:
+            closer.close()
     suites = dest / ".bora" / "suite-runs"
     if suites.is_dir():
         children = [p for p in suites.iterdir() if p.is_dir()]

--- a/tests/architecture/test_attempt_seams.py
+++ b/tests/architecture/test_attempt_seams.py
@@ -127,9 +127,9 @@ def test_assemble_quota_object_is_shared_in_source() -> None:
 
 
 def test_handler_calls_all_domain_services() -> None:
-    app = (REPO / "services" / "registry" / "app.py").read_text(encoding="utf-8")
+    api = (REPO / "services" / "registry" / "http_api.py").read_text(encoding="utf-8")
     for needle in ("state.packages.", "state.results.", "state.orgs.", "state.auth."):
-        assert needle in app, needle
+        assert needle in api, needle
 
 
 def test_handler_methods_do_not_touch_store() -> None:
@@ -150,7 +150,7 @@ def test_handler_methods_do_not_touch_store() -> None:
 
 
 def test_bearer_is_only_used_by_dispatch() -> None:
-    text = (REPO / "services" / "registry" / "app.py").read_text(encoding="utf-8")
+    text = (REPO / "services" / "registry" / "http_api.py").read_text(encoding="utf-8")
     assert text.count("_bearer(") == 2
 
 

--- a/tests/registry/test_asgi_pipe.py
+++ b/tests/registry/test_asgi_pipe.py
@@ -166,6 +166,8 @@ def test_uvicorn_workers_health_not_starved(tmp_path: Path) -> None:
         client.create_org(name="test", display_name="Test")
         archive, blob_digest, size = build_archive(FIXTURE)
         digest = compute_package_digest(FIXTURE)
+        archive_path = tmp_path / "pkg.tar.gz"
+        archive_path.write_bytes(archive)
 
         def _health() -> int:
             return int(client.health()["ok"] is True)
@@ -179,7 +181,7 @@ def test_uvicorn_workers_health_not_starved(tmp_path: Path) -> None:
                 size=size,
                 media_type=MEDIA_TYPE,
                 visibility="private",
-                archive=archive,
+                archive=archive_path,
                 org_id="test",
             )
             return int(info.database_id == "test/publish-min")

--- a/tests/registry/test_asgi_pipe.py
+++ b/tests/registry/test_asgi_pipe.py
@@ -92,6 +92,13 @@ def test_asgi_health_and_json(tmp_path: Path) -> None:
     assert "items" in payload
 
 
+def test_asgi_multipart_uses_stream_not_full_body() -> None:
+    src = Path(__file__).resolve().parents[2] / "services" / "registry" / "asgi.py"
+    text = src.read_text(encoding="utf-8")
+    assert "request.stream()" in text
+    assert "multipart/form-data" in text
+
+
 def test_http_api_matches_asgi_health(tmp_path: Path) -> None:
     state, _token = build_default_state(tmp_path / "d", bootstrap_token="t", memory_blob=True)
     api = RegistryHttpApi(state)

--- a/tests/registry/test_asgi_pipe.py
+++ b/tests/registry/test_asgi_pipe.py
@@ -1,0 +1,201 @@
+"""ASGI pipe shares Route.access + *Service; workers do not starve health."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import pytest
+from services.registry.app import build_default_state
+from services.registry.asgi import build_asgi_app
+from services.registry.http_api import RegistryHttpApi
+
+from bora.registry.archive import MEDIA_TYPE, build_archive
+from bora.registry.client import RegistryClient
+from bora.registry.digest import compute_package_digest
+
+REPO = Path(__file__).resolve().parents[2]
+FIXTURE = REPO / "tests" / "fixtures" / "databases" / "publish-min"
+
+
+def _asgi_call(
+    app: object,
+    method: str,
+    path: str,
+    *,
+    headers: dict[str, str] | None = None,
+    body: bytes = b"",
+) -> tuple[int, bytes]:
+    header_list = [
+        (k.lower().encode("latin1"), v.encode("latin1")) for k, v in (headers or {}).items()
+    ]
+    if body and not any(k == b"content-length" for k, _ in header_list):
+        header_list.append((b"content-length", str(len(body)).encode("latin1")))
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": b"",
+        "headers": header_list,
+        "client": ("127.0.0.1", 12345),
+        "server": ("127.0.0.1", 80),
+    }
+    messages: list[dict[str, object]] = []
+    sent = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal sent
+        if sent:
+            return {"type": "http.disconnect"}
+        sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    import asyncio
+
+    asyncio.run(app(scope, receive, send))  # type: ignore[operator]
+    start = next(m for m in messages if m["type"] == "http.response.start")
+    chunks = [m["body"] for m in messages if m["type"] == "http.response.body"]
+    raw = b"".join(c if isinstance(c, bytes) else b"" for c in chunks)
+    return int(start["status"]), raw  # type: ignore[arg-type]
+
+
+def test_asgi_health_and_json(tmp_path: Path) -> None:
+    state, token = build_default_state(tmp_path / "data", bootstrap_token="asgi", memory_blob=True)
+    app = build_asgi_app(state)
+    status, raw = _asgi_call(app, "GET", "/health")
+    assert status == 200
+    assert json.loads(raw.decode())["ok"] is True
+    status, raw = _asgi_call(
+        app,
+        "GET",
+        "/v1/orgs",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert status == 200
+    payload = json.loads(raw.decode())
+    assert "items" in payload
+
+
+def test_http_api_matches_asgi_health(tmp_path: Path) -> None:
+    state, _token = build_default_state(tmp_path / "d", bootstrap_token="t", memory_blob=True)
+    api = RegistryHttpApi(state)
+    result = api.dispatch(method="GET", path="/health", headers={}, body=io.BytesIO())
+    assert result.status == 200
+    assert json.loads(result.body.decode())["service"] == "bora-registry"
+
+
+def _free_port() -> int:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = int(sock.getsockname()[1])
+    sock.close()
+    return port
+
+
+def _wait_health(url: str, *, timeout: float = 15.0) -> None:
+    deadline = time.time() + timeout
+    last: Exception | None = None
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(f"{url}/health", timeout=1.0) as resp:  # noqa: S310
+                if int(resp.status) == 200:
+                    return
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            last = exc
+            time.sleep(0.15)
+    raise AssertionError(f"registry did not become healthy: {last}")
+
+
+@pytest.mark.skipif(
+    os.environ.get("BORA_SKIP_UVICORN_WORKERS") == "1",
+    reason="operator skipped multi-worker smoke",
+)
+def test_uvicorn_workers_health_not_starved(tmp_path: Path) -> None:
+    pytest.importorskip("uvicorn")
+    pytest.importorskip("starlette")
+    port = _free_port()
+    data = tmp_path / "reg"
+    data.mkdir()
+    env = os.environ.copy()
+    env["BORA_REGISTRY_FORCE_LOCAL"] = "1"
+    env["BORA_REGISTRY_DATA_DIR"] = str(data)
+    env["BORA_REGISTRY_BOOTSTRAP_TOKEN"] = "worker-token"
+    env["BORA_REGISTRY_WORKERS"] = "2"
+    proc = subprocess.Popen(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "services.registry.app",
+            "--local",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--data-dir",
+            str(data),
+            "--bootstrap-token",
+            "worker-token",
+            "--workers",
+            "2",
+        ],
+        cwd=str(REPO),
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    url = f"http://127.0.0.1:{port}"
+    try:
+        _wait_health(url)
+        client = RegistryClient(url, token="worker-token")
+        client.create_org(name="test", display_name="Test")
+        archive, blob_digest, size = build_archive(FIXTURE)
+        digest = compute_package_digest(FIXTURE)
+
+        def _health() -> int:
+            return int(client.health()["ok"] is True)
+
+        def _publish() -> int:
+            info = client.publish(
+                database_id="test/publish-min",
+                version="0.1.0",
+                package_digest=digest,
+                blob_digest=blob_digest,
+                size=size,
+                media_type=MEDIA_TYPE,
+                visibility="private",
+                archive=archive,
+                org_id="test",
+            )
+            return int(info.database_id == "test/publish-min")
+
+        with ThreadPoolExecutor(max_workers=6) as pool:
+            futs = [pool.submit(_health) for _ in range(8)]
+            futs.append(pool.submit(_publish))
+            futs.extend(pool.submit(_health) for _ in range(8))
+            results = [f.result(timeout=30) for f in as_completed(futs, timeout=40)]
+        assert all(results)
+        listed = client.list_packages()
+        assert any(item.database_id == "test/publish-min" for item in listed)
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=8)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=4)

--- a/tests/registry/test_blob_stream.py
+++ b/tests/registry/test_blob_stream.py
@@ -1,0 +1,105 @@
+"""Whole-object blob put/open is Path/fileobj, not bytes-only."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from services.registry.blob_io import read_blob, sha256_file
+from services.registry.spool import extract_multipart_archive, spool_body
+from services.registry.store import FilesystemBlobStore, MemoryBlobStore
+
+
+def test_filesystem_put_tmp_rename_and_open(tmp_path: Path) -> None:
+    store = FilesystemBlobStore(tmp_path / "blobs")
+    src = tmp_path / "src.bin"
+    payload = b"hello-stream" * 1000
+    src.write_bytes(payload)
+    digest = sha256_file(src)
+    store.put_if_absent(digest, src, prefix="packages")
+    assert store.size(digest, prefix="packages") == len(payload)
+    with store.open(digest, prefix="packages") as fh:
+        assert fh.read() == payload
+    # second put is a no-op
+    src.write_bytes(b"changed")
+    store.put_if_absent(digest, src, prefix="packages")
+    assert read_blob(store, digest, prefix="packages") == payload
+
+
+def test_memory_put_from_path(tmp_path: Path) -> None:
+    store = MemoryBlobStore()
+    src = tmp_path / "m.bin"
+    src.write_bytes(b"mem")
+    store.put_if_absent("sha256:x", src, prefix="results")
+    assert store.size("sha256:x", prefix="results") == 3
+    assert read_blob(store, "sha256:x", prefix="results") == b"mem"
+
+
+def test_s3_stub_uses_upload_fileobj(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    class _Client:
+        def head_object(self, **kwargs: object) -> None:
+            raise KeyError("missing")
+
+        def upload_file(self, filename: str, bucket: str, key: str) -> None:
+            calls.append(f"file:{filename}")
+            Path(filename).read_bytes()
+
+        def upload_fileobj(self, fileobj: object, bucket: str, key: str) -> None:
+            calls.append("fileobj")
+
+        def get_object(self, **kwargs: object) -> dict[str, object]:
+            raise KeyError("missing")
+
+        def head_bucket(self, **kwargs: object) -> None:
+            return None
+
+        def create_bucket(self, **kwargs: object) -> None:
+            return None
+
+        def delete_object(self, **kwargs: object) -> None:
+            return None
+
+    from services.registry.store import S3BlobStore
+
+    store = object.__new__(S3BlobStore)
+    store.bucket = "bora"
+    store._ClientError = KeyError
+    store._client = _Client()
+    src = tmp_path / "s3.bin"
+    src.write_bytes(b"abc")
+    store.put_if_absent("sha256:s3", src, prefix="packages")
+    assert calls == [f"file:{src}"]
+
+
+def test_spool_and_multipart_do_not_require_bytes_archive(tmp_path: Path) -> None:
+    archive = b"ARCHIVE-BYTES-NOT-IN-RAM-CONTRACT"
+    boundary = "bora-test"
+    meta = b'{"database_id":"a/b"}'
+    body = (
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="metadata"\r\n'
+        "Content-Type: application/json\r\n\r\n"
+    ).encode()
+    body += meta
+    body += (
+        f"\r\n--{boundary}\r\n"
+        'Content-Disposition: form-data; name="archive"; filename="p.tar.gz"\r\n'
+        "Content-Type: application/octet-stream\r\n\r\n"
+    ).encode()
+    body += archive
+    body += f"\r\n--{boundary}--\r\n".encode()
+    spool = spool_body(
+        __import__("io").BytesIO(body),
+        length=len(body),
+        max_bytes=1024 * 1024,
+        dest_dir=tmp_path,
+    )
+    parsed_meta, archive_path = extract_multipart_archive(
+        spool,
+        f"multipart/form-data; boundary={boundary}",
+        tmp_path,
+    )
+    assert parsed_meta["database_id"] == "a/b"
+    assert archive_path.read_bytes() == archive
+    assert archive_path.is_file()

--- a/tests/registry/test_blob_stream.py
+++ b/tests/registry/test_blob_stream.py
@@ -64,8 +64,8 @@ def test_s3_stub_uses_upload_fileobj(tmp_path: Path) -> None:
 
     store = object.__new__(S3BlobStore)
     store.bucket = "bora"
-    store._ClientError = KeyError
-    store._client = _Client()
+    store._ClientError = KeyError  # type: ignore[assignment]
+    store._client = _Client()  # type: ignore[assignment]
     src = tmp_path / "s3.bin"
     src.write_bytes(b"abc")
     store.put_if_absent("sha256:s3", src, prefix="packages")

--- a/tests/registry/test_package_service.py
+++ b/tests/registry/test_package_service.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from services.registry.access import AccessPolicy
+from services.registry.blob_io import read_blob
 from services.registry.errors import RegistryAppError
 from services.registry.package_service import PackageService
 from services.registry.store import (
@@ -27,8 +28,10 @@ def _service(tmp_path: Path) -> PackageService:
     return PackageService(meta, blobs, AccessPolicy(meta=meta), max_upload=64 * 1024 * 1024)
 
 
-def _meta_archive() -> tuple[dict[str, object], bytes]:
+def _meta_archive(tmp_path: Path) -> tuple[dict[str, object], Path, bytes]:
     archive, blob_digest, size = build_archive(FIXTURE)
+    path = tmp_path / "pkg.tar.gz"
+    path.write_bytes(archive)
     return (
         {
             "database_id": "test/publish-min",
@@ -40,13 +43,14 @@ def _meta_archive() -> tuple[dict[str, object], bytes]:
             "org_id": "acme",
             "size": size,
         },
+        path,
         archive,
     )
 
 
 def test_publish_missing_org(tmp_path: Path) -> None:
     svc = _service(tmp_path)
-    meta, archive = _meta_archive()
+    meta, archive, _raw = _meta_archive(tmp_path)
     auth = TokenInfo(scopes=frozenset({"registry:publish"}), user_id="alice")
     with pytest.raises(RegistryAppError) as ei:
         svc.publish(meta=meta, archive=archive, auth=auth)
@@ -57,7 +61,7 @@ def test_publish_missing_org(tmp_path: Path) -> None:
 def test_publish_requires_membership(tmp_path: Path) -> None:
     svc = _service(tmp_path)
     svc.meta.create_org(name="acme", owner_user_id="owner", display_name="Acme")
-    meta, archive = _meta_archive()
+    meta, archive, _raw = _meta_archive(tmp_path)
     auth = TokenInfo(scopes=frozenset({"registry:publish"}), user_id="alice")
     with pytest.raises(RegistryAppError) as ei:
         svc.publish(meta=meta, archive=archive, auth=auth)
@@ -68,7 +72,7 @@ def test_publish_requires_membership(tmp_path: Path) -> None:
 def test_publish_happy_path(tmp_path: Path) -> None:
     svc = _service(tmp_path)
     svc.meta.create_org(name="acme", owner_user_id="alice", display_name="Acme")
-    meta, archive = _meta_archive()
+    meta, archive, _raw = _meta_archive(tmp_path)
     auth = TokenInfo(scopes=frozenset({"registry:publish"}), user_id="alice")
     payload = svc.publish(meta=meta, archive=archive, auth=auth)
     assert payload["database_id"] == "test/publish-min"
@@ -76,7 +80,7 @@ def test_publish_happy_path(tmp_path: Path) -> None:
     assert payload.get("uploaded_by") == "alice"
     row = svc.get("test/publish-min", "0.1.0")
     assert row is not None
-    assert svc.blobs.get(row.blob_digest, prefix="packages") == archive
+    assert read_blob(svc.blobs, row.blob_digest, prefix="packages") == _raw
     mine = svc.list_packages(
         auth=auth,
         prefix=None,
@@ -101,7 +105,7 @@ def test_publish_happy_path(tmp_path: Path) -> None:
 def test_draft_overwrite_and_entitled_list(tmp_path: Path) -> None:
     svc = _service(tmp_path)
     svc.meta.create_org(name="acme", owner_user_id="alice", display_name="Acme")
-    meta, archive = _meta_archive()
+    meta, archive, _raw = _meta_archive(tmp_path)
     meta["slot"] = "draft"
     alice = TokenInfo(scopes=frozenset({"registry:publish"}), user_id="alice")
     first = svc.publish(meta=meta, archive=archive, auth=alice)
@@ -124,7 +128,7 @@ def test_draft_overwrite_and_entitled_list(tmp_path: Path) -> None:
 def test_draft_hidden_from_non_entitled_get(tmp_path: Path) -> None:
     svc = _service(tmp_path)
     svc.meta.create_org(name="acme", owner_user_id="alice", display_name="Acme")
-    meta, archive = _meta_archive()
+    meta, archive, _raw = _meta_archive(tmp_path)
     meta["slot"] = "draft"
     alice = TokenInfo(scopes=frozenset({"registry:publish"}), user_id="alice")
     svc.publish(meta=meta, archive=archive, auth=alice)
@@ -142,7 +146,7 @@ def test_draft_hidden_from_non_entitled_get(tmp_path: Path) -> None:
 def test_release_draft_creates_durable_version(tmp_path: Path) -> None:
     svc = _service(tmp_path)
     svc.meta.create_org(name="acme", owner_user_id="alice", display_name="Acme")
-    meta, archive = _meta_archive()
+    meta, archive, _raw = _meta_archive(tmp_path)
     meta["slot"] = "draft"
     alice = TokenInfo(scopes=frozenset({"registry:publish"}), user_id="alice")
     svc.publish(meta=meta, archive=archive, auth=alice)
@@ -158,7 +162,7 @@ def test_collaborator_cannot_release(tmp_path: Path) -> None:
     svc = _service(tmp_path)
     svc.meta.create_org(name="acme", owner_user_id="alice", display_name="Acme")
     svc.meta.add_member("acme", "bob", role="member")
-    meta, archive = _meta_archive()
+    meta, archive, _raw = _meta_archive(tmp_path)
     meta["slot"] = "draft"
     alice = TokenInfo(scopes=frozenset({"registry:publish"}), user_id="alice")
     svc.publish(meta=meta, archive=archive, auth=alice)
@@ -172,7 +176,7 @@ def test_collaborator_cannot_release(tmp_path: Path) -> None:
 def test_reserved_version_draft_rejected_on_release_publish(tmp_path: Path) -> None:
     svc = _service(tmp_path)
     svc.meta.create_org(name="acme", owner_user_id="alice", display_name="Acme")
-    meta, archive = _meta_archive()
+    meta, archive, _raw = _meta_archive(tmp_path)
     meta["version"] = "draft"
     # Without slot, version=draft still takes the draft path (reserved).
     alice = TokenInfo(scopes=frozenset({"registry:publish"}), user_id="alice")
@@ -184,7 +188,7 @@ def test_reserved_version_draft_rejected_on_release_publish(tmp_path: Path) -> N
 def test_anon_sees_public_release_not_draft(tmp_path: Path) -> None:
     svc = _service(tmp_path)
     svc.meta.create_org(name="acme", owner_user_id="alice", display_name="Acme")
-    meta, archive = _meta_archive()
+    meta, archive, _raw = _meta_archive(tmp_path)
     meta["slot"] = "draft"
     alice = TokenInfo(scopes=frozenset({"registry:publish"}), user_id="alice")
     svc.publish(meta=meta, archive=archive, auth=alice)
@@ -220,7 +224,7 @@ def test_org_member_can_read_draft(tmp_path: Path) -> None:
     svc = _service(tmp_path)
     svc.meta.create_org(name="acme", owner_user_id="alice", display_name="Acme")
     svc.meta.add_member("acme", "carol", role="member")
-    meta, archive = _meta_archive()
+    meta, archive, _raw = _meta_archive(tmp_path)
     meta["slot"] = "draft"
     alice = TokenInfo(scopes=frozenset({"registry:publish"}), user_id="alice")
     svc.publish(meta=meta, archive=archive, auth=alice)
@@ -239,7 +243,7 @@ def test_org_member_can_read_draft(tmp_path: Path) -> None:
 def test_draft_first_upload_requires_org_membership(tmp_path: Path) -> None:
     svc = _service(tmp_path)
     svc.meta.create_org(name="acme", owner_user_id="alice", display_name="Acme")
-    meta, archive = _meta_archive()
+    meta, archive, _raw = _meta_archive(tmp_path)
     meta["slot"] = "draft"
     bob = TokenInfo(scopes=frozenset({"registry:publish"}), user_id="bob")
     with pytest.raises(RegistryAppError) as ei:

--- a/tests/registry/test_plugin_package_e2e.py
+++ b/tests/registry/test_plugin_package_e2e.py
@@ -144,6 +144,8 @@ def test_reject_database_as_plugin(
     db = REPO / "tests" / "fixtures" / "databases" / "publish-min"
     archive, blob_digest, size = build_archive(db)
     package_digest = compute_package_digest(db)
+    archive_path = tmp_path / "not-plugin.tar.gz"
+    archive_path.write_bytes(archive)
     client = RegistryClient(registry_server["url"], token=registry_server["token"])
     with pytest.raises(RegistryError) as ei:
         client.publish(
@@ -154,7 +156,7 @@ def test_reject_database_as_plugin(
             size=size,
             media_type=PLUGIN_MEDIA_TYPE,
             visibility="private",
-            archive=archive,
+            archive=archive_path,
             org_id=TEST_ORG,
             package_kind="plugin",
         )

--- a/tests/registry/test_public_start.py
+++ b/tests/registry/test_public_start.py
@@ -1,0 +1,62 @@
+"""Public Registry start is fail-closed without Postgres + S3."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from services.registry.app import build_default_state, build_state_from_env
+from services.registry.backend import (
+    PublicBackendError,
+    public_env_ready,
+    require_public_backend,
+)
+
+
+def test_require_public_backend_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BORA_REGISTRY_DATABASE_URL", raising=False)
+    monkeypatch.delenv("BORA_REGISTRY_S3_ENDPOINT", raising=False)
+    assert public_env_ready() is False
+    with pytest.raises(PublicBackendError, match="BORA_REGISTRY_DATABASE_URL"):
+        require_public_backend()
+
+
+def test_require_public_backend_partial(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BORA_REGISTRY_DATABASE_URL", "postgresql://bora:bora@127.0.0.1/x")
+    monkeypatch.delenv("BORA_REGISTRY_S3_ENDPOINT", raising=False)
+    with pytest.raises(PublicBackendError, match="S3"):
+        require_public_backend()
+
+
+def test_require_public_backend_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BORA_REGISTRY_DATABASE_URL", "postgresql://bora:bora@127.0.0.1/x")
+    monkeypatch.setenv("BORA_REGISTRY_S3_ENDPOINT", "http://127.0.0.1:9000")
+    assert public_env_ready() is True
+    url, endpoint = require_public_backend()
+    assert url.startswith("postgresql://")
+    assert endpoint.startswith("http://")
+
+
+def test_build_state_from_env_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BORA_REGISTRY_DATABASE_URL", raising=False)
+    monkeypatch.delenv("BORA_REGISTRY_S3_ENDPOINT", raising=False)
+    monkeypatch.setenv("BORA_REGISTRY_DATA_DIR", str(tmp_path / "data"))
+    with pytest.raises(PublicBackendError):
+        build_state_from_env(force_local=False, bootstrap_token="t")
+
+
+def test_build_state_from_env_force_local(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BORA_REGISTRY_DATA_DIR", str(tmp_path / "data"))
+    state, token = build_state_from_env(
+        force_local=True, bootstrap_token="local-token", memory_blob=True
+    )
+    assert token == "local-token"
+    assert state.max_upload > 0
+    health_auth = state.auth.auth_for("local-token")
+    assert "admin" in health_auth.scopes
+
+
+def test_local_default_state_still_works(tmp_path: Path) -> None:
+    state, token = build_default_state(tmp_path / "data", bootstrap_token="boot", memory_blob=True)
+    assert token == "boot"
+    assert state.upload_slots.limit >= 1

--- a/tests/registry/test_registry_package_files.py
+++ b/tests/registry/test_registry_package_files.py
@@ -199,7 +199,7 @@ def test_oversize_file_raises_when_truncate_disabled() -> None:
 
 
 def test_oversize_http_returns_truncated_preview(
-    registry_server, monkeypatch: pytest.MonkeyPatch
+    registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Inject a large blob; Hub preview gets a truncated head (not 413)."""
     summary = _publish_public(registry_server, monkeypatch)
@@ -209,7 +209,9 @@ def test_oversize_http_returns_truncated_preview(
     big = b"z" * (MAX_FILE_BYTES + 50)
     archive = _gzip_tar_with_file("huge.txt", big)
     # Overwrite package blob (memory store)
-    state.blobs.put_if_absent(row.blob_digest + "-unused", b"x", prefix="packages")
+    unused = tmp_path / "unused.bin"
+    unused.write_bytes(b"x")
+    state.blobs.put_if_absent(row.blob_digest + "-unused", unused, prefix="packages")
     # Force replace in memory store
     key = f"packages/{row.blob_digest}"
     if hasattr(state.blobs, "_data"):

--- a/tests/registry/test_route_policy.py
+++ b/tests/registry/test_route_policy.py
@@ -48,7 +48,7 @@ def test_skip_auth_is_derived_from_access() -> None:
 def test_bearer_helper_is_only_used_by_dispatch() -> None:
     from pathlib import Path
 
-    text = (Path(__file__).resolve().parents[2] / "services" / "registry" / "app.py").read_text(
-        encoding="utf-8"
-    )
+    text = (
+        Path(__file__).resolve().parents[2] / "services" / "registry" / "http_api.py"
+    ).read_text(encoding="utf-8")
     assert text.count("_bearer(") == 2

--- a/tests/registry/test_suite_completeness.py
+++ b/tests/registry/test_suite_completeness.py
@@ -26,7 +26,13 @@ def _services(tmp_path: Path) -> tuple[PackageService, ResultService]:
     return packages, results
 
 
-def _publish_release(packages: PackageService) -> None:
+def _as_path(tmp_path: Path, data: bytes, name: str = "blob.bin") -> Path:
+    path = tmp_path / name
+    path.write_bytes(data)
+    return path
+
+
+def _publish_release(packages: PackageService, tmp_path: Path) -> None:
     archive, blob_digest, size = build_archive(FIXTURE)
     packages.meta.create_org(name="acme", owner_user_id="alice", display_name="Acme")
     auth = TokenInfo(scopes=frozenset({"registry:publish"}), user_id="alice")
@@ -41,17 +47,18 @@ def _publish_release(packages: PackageService) -> None:
             "org_id": "acme",
             "size": size,
         },
-        archive=archive,
+        archive=_as_path(tmp_path, archive, "release.tar.gz"),
         auth=auth,
     )
 
 
 def _suite_meta(
+    tmp_path: Path,
     *,
     suite_run_id: str,
     task_refs: list[dict[str, object]],
     version: str = "0.1.0",
-) -> tuple[dict[str, object], bytes]:
+) -> tuple[dict[str, object], Path]:
     archive = b"suite-archive"
     import hashlib
 
@@ -69,15 +76,16 @@ def _suite_meta(
             "metrics": {"n_tasks": len(task_refs)},
             "task_refs": task_refs,
         },
-        archive,
+        _as_path(tmp_path, archive, f"{suite_run_id}.bin"),
     )
 
 
 def test_fail_on_all_tasks_is_complete_and_on_board(tmp_path: Path) -> None:
     packages, results = _services(tmp_path)
-    _publish_release(packages)
+    _publish_release(packages, tmp_path)
     auth = TokenInfo(scopes=frozenset({"results:upload"}), user_id="alice")
     meta, archive = _suite_meta(
+        tmp_path,
         suite_run_id="suite_fail_all",
         task_refs=[{"task_id": "hello", "status": "FAIL", "score": 0.0}],
     )
@@ -90,9 +98,10 @@ def test_fail_on_all_tasks_is_complete_and_on_board(tmp_path: Path) -> None:
 
 def test_missing_task_is_incomplete_hidden_from_board(tmp_path: Path) -> None:
     packages, results = _services(tmp_path)
-    _publish_release(packages)
+    _publish_release(packages, tmp_path)
     auth = TokenInfo(scopes=frozenset({"results:upload"}), user_id="alice")
     meta, archive = _suite_meta(
+        tmp_path,
         suite_run_id="suite_missing",
         task_refs=[],
     )
@@ -121,10 +130,11 @@ def test_draft_bound_suite_stays_off_public_board(tmp_path: Path) -> None:
             "size": size,
             "slot": "draft",
         },
-        archive=archive,
+        archive=_as_path(tmp_path, archive, "draft.tar.gz"),
         auth=alice,
     )
     meta, sarch = _suite_meta(
+        tmp_path,
         suite_run_id="suite_draft",
         version="0.1.0",
         task_refs=[{"task_id": "hello", "status": "PASS", "score": 1.0}],
@@ -140,10 +150,11 @@ def test_draft_bound_suite_stays_off_public_board(tmp_path: Path) -> None:
 
 def test_suite_plugins_and_uploaded_by_me_filter(tmp_path: Path) -> None:
     packages, results = _services(tmp_path)
-    _publish_release(packages)
+    _publish_release(packages, tmp_path)
     alice = TokenInfo(scopes=frozenset({"results:upload"}), user_id="alice")
     bob = TokenInfo(scopes=frozenset({"results:upload"}), user_id="bob")
     meta, archive = _suite_meta(
+        tmp_path,
         suite_run_id="suite_alice",
         task_refs=[{"task_id": "hello", "status": "PASS", "score": 1.0}],
     )
@@ -157,6 +168,7 @@ def test_suite_plugins_and_uploaded_by_me_filter(tmp_path: Path) -> None:
     payload = results.upload_suite(meta=meta, archive=archive, auth=alice)
     assert payload["plugins"] == [{"plugin_id": "nooa", "version": "0.1.0"}]
     meta_b, arch_b = _suite_meta(
+        tmp_path,
         suite_run_id="suite_bob",
         task_refs=[{"task_id": "hello", "status": "FAIL", "score": 0.0}],
     )
@@ -173,9 +185,10 @@ def test_suite_plugins_and_uploaded_by_me_filter(tmp_path: Path) -> None:
 
 def test_later_draft_task_does_not_drop_old_release_run(tmp_path: Path) -> None:
     packages, results = _services(tmp_path)
-    _publish_release(packages)
+    _publish_release(packages, tmp_path)
     auth = TokenInfo(scopes=frozenset({"registry:publish", "results:upload"}), user_id="alice")
     meta, archive = _suite_meta(
+        tmp_path,
         suite_run_id="suite_release",
         task_refs=[{"task_id": "hello", "status": "PASS", "score": 1.0}],
     )
@@ -207,7 +220,7 @@ def test_later_draft_task_does_not_drop_old_release_run(tmp_path: Path) -> None:
             "size": size,
             "slot": "draft",
         },
-        archive=pkg,
+        archive=_as_path(tmp_path, pkg, "wider.tar.gz"),
         auth=auth,
     )
     board = results.list_suites(auth=auth, database_id="test/publish-min", board=True)
@@ -216,6 +229,7 @@ def test_later_draft_task_does_not_drop_old_release_run(tmp_path: Path) -> None:
     assert board["items"][0]["bound_kind"] == "release"
 
     draft_meta, draft_arch = _suite_meta(
+        tmp_path,
         suite_run_id="suite_new_draft",
         version="draft",
         task_refs=[{"task_id": "hello", "status": "PASS", "score": 1.0}],
@@ -244,11 +258,12 @@ def test_non_entitled_uploader_cannot_bind_private_draft(tmp_path: Path) -> None
             "size": size,
             "slot": "draft",
         },
-        archive=archive,
+        archive=_as_path(tmp_path, archive, "priv-draft.tar.gz"),
         auth=alice,
     )
     bob = TokenInfo(scopes=frozenset({"results:upload"}), user_id="bob")
     meta, sarch = _suite_meta(
+        tmp_path,
         suite_run_id="suite_stranger",
         version="draft",
         task_refs=[{"task_id": "hello", "status": "PASS", "score": 1.0}],
@@ -259,6 +274,7 @@ def test_non_entitled_uploader_cannot_bind_private_draft(tmp_path: Path) -> None
     assert "task_set_digest" not in payload
 
     fallback_meta, fallback_arch = _suite_meta(
+        tmp_path,
         suite_run_id="suite_stranger_fallback",
         version="0.1.0",
         task_refs=[{"task_id": "hello", "status": "PASS", "score": 1.0}],

--- a/tests/registry/test_upload_slots.py
+++ b/tests/registry/test_upload_slots.py
@@ -39,6 +39,8 @@ def test_http_429_when_slot_held(tmp_path: Path) -> None:
         client = RegistryClient(url, token=token)
         assert client.health()["ok"] is True
         with state.upload_slots.hold():
+            bogus = tmp_path / "nope.bin"
+            bogus.write_bytes(b"nope")
             with pytest.raises(RegistryError) as ei:
                 client.publish(
                     database_id="test/publish-min",
@@ -48,7 +50,7 @@ def test_http_429_when_slot_held(tmp_path: Path) -> None:
                     size=4,
                     media_type="application/vnd.bora.database.v1.tar+gzip",
                     visibility="private",
-                    archive=b"nope",
+                    archive=bogus,
                     org_id="test",
                 )
             assert ei.value.status == 429

--- a/tests/registry/test_upload_slots.py
+++ b/tests/registry/test_upload_slots.py
@@ -1,0 +1,57 @@
+"""In-flight upload cap: 429 when slots are exhausted."""
+
+from __future__ import annotations
+
+import threading
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+from services.registry.app import build_default_state, make_handler
+from services.registry.errors import RegistryAppError
+from services.registry.upload_slots import UploadSlotPool
+
+from bora.registry.client import RegistryClient, RegistryError
+
+
+def test_pool_hold_and_exhaust() -> None:
+    pool = UploadSlotPool(1)
+    with pool.hold():
+        with pytest.raises(RegistryAppError) as ei, pool.hold():
+            raise AssertionError("must not enter")
+        assert ei.value.error == "too_many_uploads"
+        assert ei.value.http_status == 429
+    with pool.hold():
+        pass
+
+
+def test_http_429_when_slot_held(tmp_path: Path) -> None:
+    state, token = build_default_state(
+        tmp_path / "data", bootstrap_token="slot-token", memory_blob=True
+    )
+    state.upload_slots = UploadSlotPool(1)
+    handler = make_handler(state)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}"
+        client = RegistryClient(url, token=token)
+        assert client.health()["ok"] is True
+        with state.upload_slots.hold():
+            with pytest.raises(RegistryError) as ei:
+                client.publish(
+                    database_id="test/publish-min",
+                    version="0.1.0",
+                    package_digest="sha256:" + "ab" * 32,
+                    blob_digest="sha256:" + "cd" * 32,
+                    size=4,
+                    media_type="application/vnd.bora.database.v1.tar+gzip",
+                    visibility="private",
+                    archive=b"nope",
+                    org_id="test",
+                )
+            assert ei.value.status == 429
+            assert ei.value.code == "too_many_uploads"
+    finally:
+        server.shutdown()

--- a/uv.lock
+++ b/uv.lock
@@ -203,6 +203,8 @@ nooa = [
 registry = [
     { name = "boto3" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "starlette" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -227,7 +229,9 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
     { name = "socksio", marker = "extra == 'nooa'", specifier = ">=1.0.0" },
+    { name = "starlette", marker = "extra == 'registry'", specifier = ">=0.41.0" },
     { name = "typer", specifier = ">=0.16.0" },
+    { name = "uvicorn", marker = "extra == 'registry'", specifier = ">=0.32.0" },
 ]
 provides-extras = ["dev", "dsh", "nooa", "registry"]
 
@@ -1896,6 +1900,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
 name = "tiktoken"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2033,6 +2050,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.52.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/28/64ca011edf31c715b4fad359c587ea52391aaffa125065695590241ff617/uvicorn-0.52.3.tar.gz", hash = "sha256:18857b9e6579300be55c91c0a1cfd37d9a2cf0cabea33b88275f199eb73b8b58", size = 100621, upload-time = "2026-08-13T16:50:02.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/2b/ebd108734a8204c6b4b93c681c9a38c5273b3ccd5d129fee4ffc1d97772c/uvicorn-0.52.3-py3-none-any.whl", hash = "sha256:116af2710dbf47c80f463cd20ee4884b6662f4c9f227d797ddc7279d2fcc2c7c", size = 79859, upload-time = "2026-08-13T16:50:01.323Z" },
 ]
 
 [[package]]

--- a/website/content/docs/share/registry.en.mdx
+++ b/website/content/docs/share/registry.en.mdx
@@ -8,7 +8,7 @@ It is **not** the local Viewer and **not** BORA Core.
 
 ## Flow
 
-1. Start it per [`services/registry/README.md`](https://github.com/ZJU-REAL/BORA/blob/main/services/registry/README.md)
+1. Start it per [`services/registry/README.md`](https://github.com/ZJU-REAL/BORA/blob/main/services/registry/README.md). Public mode needs Postgres + S3 behind a reverse proxy — do not expose the Python port. Use `--local` only for development
 2. After CLI login: create an org. Upload a Dataset draft with `bora publish --draft`; an owner promotes it with `bora release`. Direct `bora publish` still creates a release. Upload suite / Attempt results as needed
 3. Share private results with an org or user when you want
 4. Browse in [Hub](/docs/share/hub); Hub uses browser OAuth, CLI uses Device Flow

--- a/website/content/docs/share/registry.mdx
+++ b/website/content/docs/share/registry.mdx
@@ -8,7 +8,7 @@ Registry 是独立的 HTTP 服务：发包、管组织、存结果、登录。
 
 ## 怎么用
 
-1. 按仓库 [`services/registry/README.md`](https://github.com/ZJU-REAL/BORA/blob/main/services/registry/README.md) 启动服务
+1. 按仓库 [`services/registry/README.md`](https://github.com/ZJU-REAL/BORA/blob/main/services/registry/README.md) 启动服务。公网必须走 Postgres + S3，前面加反向代理，不要把 Python 端口直接暴露出去；本机开发用 `--local`
 2. CLI 登录后创建组织。Dataset 用 `bora publish --draft` 覆盖当前工作树，owner 再用 `bora release` 固化为不可变版本；也可直接 `bora publish` 发 release。按需上传 suite / Attempt 结果
 3. 私有结果可以分享给某个组织或用户
 4. 用浏览器打开 [Hub](/docs/share/hub) 浏览；Hub 走浏览器 OAuth，CLI 走 Device Flow


### PR DESCRIPTION
Closes #98.

Two Registry layers on one branch (issue asked for separate PRs; this draft delivers both so Hub public mode is not half-shipped).

## A — public concurrency
- Public start is fail-closed without `BORA_REGISTRY_DATABASE_URL` + `BORA_REGISTRY_S3_ENDPOINT` (exit 2).
- `--local` / `--memory-blob` stay the only SQLite paths.
- HTTP adapter extracted (`http_api.py`); stdlib Handler and Starlette/uvicorn share `Route.access` + `*Service`.
- Public default is uvicorn workers; `--local` without `--workers` stays `ThreadingHTTPServer`.
- Per-process upload slots return 429; runbook documents `workers × BORA_REGISTRY_UPLOAD_SLOTS` and proxy body limit.

## B — whole-object streaming
- BlobStore `put_if_absent` / `open` / `size` take Path or fileobj on Memory, FS, and S3.
- Upload: length-capped spool → multipart split on disk → validate → commit; spool deleted afterwards.
- ASGI multipart uses `request.stream()` into a spool (not `await request.body()`), then dispatch on a worker thread.
- Download is a streamed response with `Content-Length`.
- CLI/client package PUT/GET copy through files. Cap raised to 512 MiB after the stream path landed.

## Docs
- `services/registry/README.md` public deploy checklist + Caddyfile.
- Website registry pages note Postgres+S3 + reverse proxy.
- No GitHub issue numbers on reader-facing pages.
- Evidence grades unchanged.

## Verified
- `uv run pytest tests/registry tests/architecture/test_attempt_seams.py` — 151 passed, 2 skipped.
- python-core ruff + pyright; architecture seam tests retargeted to `http_api.py`.
- `pnpm --dir website build`.
- Live `--local --workers 2`: health, fail-closed public start, `bora registry org-create`, `bora publish tests/fixtures/databases/publish-min`, streamed download size match, 20 concurrent health.

## Not run
- Real Postgres + RustFS/S3 soak.
- Multi-worker load beyond one small publish + health storm.
- RSS measurement of a 32–512 MiB body.
- Results CLI pack (`build_attempt_archive` / `build_suite_archive`) still builds bytes, then writes a temp file for the HTTP PUT.

## Follow-ups
- Path-only pack for attempt/suite archives.
- Delete blob if `put` succeeds and meta insert then 409s.
- S3 multipart abort on failed `upload_file`.