### PR TITLE
feat(suite): append a replacement attempt onto an existing suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ uv run bora run examples/core --max-concurrent-tasks 2
 uv run bora run examples/core -k 5 --max-concurrent-tasks 2
 # uv run bora run examples/core --task sdk-agent-session -k 5
 # uv run bora run examples/core --resume-suite <suite_run_id> --task sdk-agent-session -k 5
+# uv run bora run examples/core --resume-suite <suite_run_id> --task sdk-agent-session --replace-slot
 
 # Suite job control (optional --database for progress / cancel.requested)
 # uv run bora status <suite_run_id> --database examples/core

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,6 +65,7 @@ uv run bora run examples/core --max-concurrent-tasks 2
 uv run bora run examples/core -k 5 --max-concurrent-tasks 2
 # uv run bora run examples/core --task sdk-agent-session -k 5
 # uv run bora run examples/core --resume-suite <suite_run_id> --task sdk-agent-session -k 5
+# uv run bora run examples/core --resume-suite <suite_run_id> --task sdk-agent-session --replace-slot
 
 # suite job 控制（可选 --database 读进度 / 写 cancel）
 # uv run bora status <suite_run_id> --database examples/core

--- a/apps/hub/AGENTS.md
+++ b/apps/hub/AGENTS.md
@@ -9,3 +9,25 @@
 | Same stack as viewer (Vite/React/shadcn) | Second component library / marketing CSS |
 
 Registry API is the data plane. Token stays in browser storage only.
+
+## UI reuse (mandatory)
+
+Stack is Vite + React + Tailwind + **shadcn/ui** under `src/components/ui/`
+(`Select`, `DropdownMenu`, `Table`, `Button`, tooltip). Same family as Viewer.
+
+1. **Reuse a shipped control.** Version / filter / menu lists use
+   `@/components/ui/select` (see `VersionSwitcher`) or
+   `@/components/ui/dropdown-menu`. Do not invent a parallel widget.
+2. **No native chrome.** Product UI must not use raw `<select>`, `<option>`,
+   or unstyled `<button>` as the visible control. Radix/shadcn owns focus,
+   trigger, and list.
+3. **Operator labels, not digests.** Dropdown rows show a human label
+   (`versionLabel`, `patch N`) plus a date via `SelectItem` `trailing` /
+   `formatDay` / `formatDate`. `run_id`, sha256, and other identity strings
+   stay in the breadcrumb / mono heading, not in the list text.
+4. **Copy an existing pattern.** Package versions → `VersionSwitcher`. Slot
+   history on Attempt evidence → the same `Select` shape (label + trailing
+   time). Jobs filters in Viewer are the same `Select` primitive.
+
+New chrome requires a new `src/components/ui/` primitive first, used by both
+Hub and Viewer. Do not one-off style a native element.

--- a/apps/hub/src/components/trial/slot-history-select.tsx
+++ b/apps/hub/src/components/trial/slot-history-select.tsx
@@ -1,39 +1,73 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { formatDate } from "@/lib/utils";
+
 export type SlotHistoryEntry = {
   run_id?: string | null;
   status?: string | null;
+  started_at?: string | null;
+  replaced_at?: string | null;
 };
+
+function patchRows(
+  currentRunId: string,
+  previous: SlotHistoryEntry[] | undefined,
+  currentAt?: string | null,
+): Array<{ runId: string; patch: number; at: string | null }> {
+  const hist = (previous ?? []).filter((p): p is SlotHistoryEntry & { run_id: string } =>
+    Boolean(p.run_id && String(p.run_id).trim()),
+  );
+  const rows = hist.map((item, i) => ({
+    runId: String(item.run_id),
+    patch: i + 1,
+    at: item.started_at ?? null,
+  }));
+  rows.push({
+    runId: currentRunId,
+    patch: hist.length + 1,
+    at: currentAt ?? null,
+  });
+  return rows.reverse();
+}
 
 export function SlotHistorySelect({
   viewingRunId,
   currentRunId,
   previous,
+  currentAt,
   onSelect,
 }: {
   viewingRunId: string;
   currentRunId: string | null | undefined;
   previous: SlotHistoryEntry[] | undefined;
+  currentAt?: string | null;
   onSelect: (runId: string) => void;
 }) {
-  const items = previous?.filter((p) => p.run_id) ?? [];
-  if (!currentRunId || items.length === 0) return null;
+  if (!currentRunId) return null;
+  const rows = patchRows(currentRunId, previous, currentAt);
+  if (rows.length < 2) return null;
 
   return (
-    <label className="flex items-center gap-2 text-xs text-mute shrink-0">
-      <span>Version</span>
-      <select
-        className="max-w-[28ch] rounded-[6px] border border-hairline bg-canvas px-2 py-1 font-mono text-[12px] text-ink"
-        value={viewingRunId}
-        onChange={(e) => onSelect(e.target.value)}
-        aria-label="Slot version"
-      >
-        <option value={currentRunId}>current · {currentRunId}</option>
-        {[...items].reverse().map((item) => (
-          <option key={item.run_id!} value={item.run_id!}>
-            {item.status ? `${item.status} · ` : ""}
-            {item.run_id}
-          </option>
+    <Select value={viewingRunId} onValueChange={onSelect}>
+      <SelectTrigger aria-label="Slot version" className="min-w-0 w-auto font-mono">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent className="w-max min-w-0">
+        {rows.map((row) => (
+          <SelectItem
+            key={row.runId}
+            value={row.runId}
+            trailing={row.at ? formatDate(row.at) : undefined}
+          >
+            {`patch ${row.patch}`}
+          </SelectItem>
         ))}
-      </select>
-    </label>
+      </SelectContent>
+    </Select>
   );
 }

--- a/apps/hub/src/components/trial/slot-history-select.tsx
+++ b/apps/hub/src/components/trial/slot-history-select.tsx
@@ -1,0 +1,39 @@
+export type SlotHistoryEntry = {
+  run_id?: string | null;
+  status?: string | null;
+};
+
+export function SlotHistorySelect({
+  viewingRunId,
+  currentRunId,
+  previous,
+  onSelect,
+}: {
+  viewingRunId: string;
+  currentRunId: string | null | undefined;
+  previous: SlotHistoryEntry[] | undefined;
+  onSelect: (runId: string) => void;
+}) {
+  const items = previous?.filter((p) => p.run_id) ?? [];
+  if (!currentRunId || items.length === 0) return null;
+
+  return (
+    <label className="flex items-center gap-2 text-xs text-mute shrink-0">
+      <span>Version</span>
+      <select
+        className="max-w-[28ch] rounded-[6px] border border-hairline bg-canvas px-2 py-1 font-mono text-[12px] text-ink"
+        value={viewingRunId}
+        onChange={(e) => onSelect(e.target.value)}
+        aria-label="Slot version"
+      >
+        <option value={currentRunId}>current · {currentRunId}</option>
+        {[...items].reverse().map((item) => (
+          <option key={item.run_id!} value={item.run_id!}>
+            {item.status ? `${item.status} · ` : ""}
+            {item.run_id}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/apps/hub/src/components/trial/trial-header.tsx
+++ b/apps/hub/src/components/trial/trial-header.tsx
@@ -11,6 +11,7 @@ export function TrialHeader({
   taskId,
   trial,
   slotCurrentRunId,
+  slotCurrentStartedAt,
   slotPrevious,
   onSlotSelect,
 }: {
@@ -18,6 +19,7 @@ export function TrialHeader({
   taskId: string;
   trial: Trial | null;
   slotCurrentRunId?: string | null;
+  slotCurrentStartedAt?: string | null;
   slotPrevious?: SlotHistoryEntry[];
   onSlotSelect?: (id: string) => void;
 }) {
@@ -75,6 +77,7 @@ export function TrialHeader({
           viewingRunId={runId}
           currentRunId={slotCurrentRunId}
           previous={slotPrevious}
+          currentAt={slotCurrentStartedAt ?? trial?.started}
           onSelect={onSlotSelect}
         />
       ) : null}

--- a/apps/hub/src/components/trial/trial-header.tsx
+++ b/apps/hub/src/components/trial/trial-header.tsx
@@ -1,4 +1,8 @@
 import { HoverTip } from "@/components/hover-tip";
+import {
+  SlotHistorySelect,
+  type SlotHistoryEntry,
+} from "@/components/trial/slot-history-select";
 import type { Trial } from "@/lib/trial-types";
 
 /** Header without sibling nav (Hub has no local trial list siblings by default). */
@@ -6,10 +10,16 @@ export function TrialHeader({
   runId,
   taskId,
   trial,
+  slotCurrentRunId,
+  slotPrevious,
+  onSlotSelect,
 }: {
   runId: string;
   taskId: string;
   trial: Trial | null;
+  slotCurrentRunId?: string | null;
+  slotPrevious?: SlotHistoryEntry[];
+  onSlotSelect?: (id: string) => void;
 }) {
   return (
     <div className="flex flex-wrap items-start justify-between gap-3">
@@ -60,6 +70,14 @@ export function TrialHeader({
           ) : null}
         </p>
       </div>
+      {onSlotSelect ? (
+        <SlotHistorySelect
+          viewingRunId={runId}
+          currentRunId={slotCurrentRunId}
+          previous={slotPrevious}
+          onSelect={onSlotSelect}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/hub/src/lib/api.ts
+++ b/apps/hub/src/lib/api.ts
@@ -157,6 +157,14 @@ export type SuiteRow = {
     attempt_run_ids?: string[];
     /** True when full Attempt evidence archive is present on Registry (#43). */
     has_attempt_content?: boolean;
+    /** Superseded Attempts for this scoring slot (oldest first). */
+    previous?: Array<{
+      run_id?: string | null;
+      status?: string | null;
+      score?: number | null;
+      attempt_index?: number | null;
+      replaced_at?: string | null;
+    }>;
   }>;
   agent_label?: string;
   model_label?: string;

--- a/apps/hub/src/lib/api.ts
+++ b/apps/hub/src/lib/api.ts
@@ -163,6 +163,7 @@ export type SuiteRow = {
       status?: string | null;
       score?: number | null;
       attempt_index?: number | null;
+      started_at?: string | null;
       replaced_at?: string | null;
     }>;
   }>;

--- a/apps/hub/src/pages/AttemptEvidencePage.tsx
+++ b/apps/hub/src/pages/AttemptEvidencePage.tsx
@@ -9,8 +9,42 @@ import { OutcomeStrip } from "@/components/trial/outcome-strip";
 import { PhaseTimingBar } from "@/components/trial/phase-timing-bar";
 import { TrialHeader } from "@/components/trial/trial-header";
 import { useAttemptEvidence } from "@/hooks/use-attempt-evidence";
-import { decodeDatasetId, listSuites } from "@/lib/api";
+import {
+  decodeDatasetId,
+  decodeFileContent,
+  getAttemptFile,
+  listSuites,
+} from "@/lib/api";
+import { toArchivePath } from "@/lib/attempt-evidence";
 import { getToken } from "@/lib/auth";
+
+async function readAttemptStartedAt(
+  runId: string,
+  token: string | null,
+): Promise<string | null> {
+  for (const rel of ["summary.json", "result.json"]) {
+    try {
+      const file = await getAttemptFile(runId, toArchivePath(rel, runId), token);
+      const text = decodeFileContent(file);
+      if (!text) continue;
+      const data = JSON.parse(text) as {
+        started_at?: unknown;
+        started?: unknown;
+        phase_timing?: { started_at?: unknown };
+      };
+      for (const raw of [
+        data.started_at,
+        data.started,
+        data.phase_timing?.started_at,
+      ]) {
+        if (typeof raw === "string" && raw.trim()) return raw.trim();
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
 
 /**
  * Hub Jobs deep-link: uploaded Attempt evidence with viewer-parity IA
@@ -27,8 +61,16 @@ export function AttemptEvidencePage() {
   const token = getToken();
   const navigate = useNavigate();
   const [slotCurrentRunId, setSlotCurrentRunId] = useState<string | null>(null);
+  const [slotCurrentStartedAt, setSlotCurrentStartedAt] = useState<string | null>(
+    null,
+  );
   const [slotPrevious, setSlotPrevious] = useState<
-    Array<{ run_id?: string | null; status?: string | null }>
+    Array<{
+      run_id?: string | null;
+      status?: string | null;
+      started_at?: string | null;
+      replaced_at?: string | null;
+    }>
   >([]);
 
   const {
@@ -57,7 +99,7 @@ export function AttemptEvidencePage() {
     let cancelled = false;
     if (!datasetId || !taskId || !runId) return;
     listSuites(datasetId, token)
-      .then((suites) => {
+      .then(async (suites) => {
         if (cancelled) return;
         for (const suite of suites) {
           const hit = (suite.task_refs || []).find((ref) => ref.task_id === taskId);
@@ -69,16 +111,34 @@ export function AttemptEvidencePage() {
             ...prev.map((item) => item.run_id),
           ];
           if (!ids.includes(runId)) continue;
-          setSlotCurrentRunId(hit.run_id ?? null);
-          setSlotPrevious(prev);
+          const current = hit.run_id ?? null;
+          const [currentAt, ...prevTimes] = await Promise.all([
+            current ? readAttemptStartedAt(current, token) : Promise.resolve(null),
+            ...prev.map((item) =>
+              item.run_id
+                ? item.started_at || readAttemptStartedAt(item.run_id, token)
+                : Promise.resolve(null),
+            ),
+          ]);
+          if (cancelled) return;
+          setSlotCurrentRunId(current);
+          setSlotCurrentStartedAt(currentAt);
+          setSlotPrevious(
+            prev.map((item, i) => ({
+              ...item,
+              started_at: item.started_at || prevTimes[i] || null,
+            })),
+          );
           return;
         }
         setSlotCurrentRunId(null);
+        setSlotCurrentStartedAt(null);
         setSlotPrevious([]);
       })
       .catch(() => {
         if (!cancelled) {
           setSlotCurrentRunId(null);
+          setSlotCurrentStartedAt(null);
           setSlotPrevious([]);
         }
       });
@@ -111,6 +171,7 @@ export function AttemptEvidencePage() {
           taskId={taskId}
           trial={trial}
           slotCurrentRunId={slotCurrentRunId}
+          slotCurrentStartedAt={slotCurrentStartedAt}
           slotPrevious={slotPrevious}
           onSlotSelect={(id) => navigate(attemptHref(id))}
         />

--- a/apps/hub/src/pages/AttemptEvidencePage.tsx
+++ b/apps/hub/src/pages/AttemptEvidencePage.tsx
@@ -1,4 +1,5 @@
-import { Link, useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
 
 import { BreadcrumbNav } from "@/components/breadcrumb";
 import { CommandStrip } from "@/components/command-strip";
@@ -8,7 +9,7 @@ import { OutcomeStrip } from "@/components/trial/outcome-strip";
 import { PhaseTimingBar } from "@/components/trial/phase-timing-bar";
 import { TrialHeader } from "@/components/trial/trial-header";
 import { useAttemptEvidence } from "@/hooks/use-attempt-evidence";
-import { decodeDatasetId } from "@/lib/api";
+import { decodeDatasetId, listSuites } from "@/lib/api";
 import { getToken } from "@/lib/auth";
 
 /**
@@ -24,6 +25,11 @@ export function AttemptEvidencePage() {
   const taskId = decodeURIComponent(rawTask || "");
   const runId = decodeURIComponent(rawRun || "");
   const token = getToken();
+  const navigate = useNavigate();
+  const [slotCurrentRunId, setSlotCurrentRunId] = useState<string | null>(null);
+  const [slotPrevious, setSlotPrevious] = useState<
+    Array<{ run_id?: string | null; status?: string | null }>
+  >([]);
 
   const {
     trial,
@@ -47,7 +53,43 @@ export function AttemptEvidencePage() {
     fileLoading,
   } = useAttemptEvidence(runId, taskId, token);
 
+  useEffect(() => {
+    let cancelled = false;
+    if (!datasetId || !taskId || !runId) return;
+    listSuites(datasetId, token)
+      .then((suites) => {
+        if (cancelled) return;
+        for (const suite of suites) {
+          const hit = (suite.task_refs || []).find((ref) => ref.task_id === taskId);
+          if (!hit) continue;
+          const prev = hit.previous || [];
+          const ids = [
+            hit.run_id,
+            ...(hit.attempt_run_ids || []),
+            ...prev.map((item) => item.run_id),
+          ];
+          if (!ids.includes(runId)) continue;
+          setSlotCurrentRunId(hit.run_id ?? null);
+          setSlotPrevious(prev);
+          return;
+        }
+        setSlotCurrentRunId(null);
+        setSlotPrevious([]);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSlotCurrentRunId(null);
+          setSlotPrevious([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetId, taskId, runId, token]);
+
   const jobsHref = `/datasets/${encodeURIComponent(datasetId)}/tasks/${encodeURIComponent(taskId)}?tab=jobs`;
+  const attemptHref = (id: string) =>
+    `/datasets/${encodeURIComponent(datasetId)}/tasks/${encodeURIComponent(taskId)}/attempts/${encodeURIComponent(id)}`;
 
   return (
     <>
@@ -64,7 +106,14 @@ export function AttemptEvidencePage() {
           ]}
         />
 
-        <TrialHeader runId={runId} taskId={taskId} trial={trial} />
+        <TrialHeader
+          runId={runId}
+          taskId={taskId}
+          trial={trial}
+          slotCurrentRunId={slotCurrentRunId}
+          slotPrevious={slotPrevious}
+          onSlotSelect={(id) => navigate(attemptHref(id))}
+        />
 
         {runCommand ? <CommandStrip command={runCommand} /> : null}
 

--- a/apps/viewer/AGENTS.md
+++ b/apps/viewer/AGENTS.md
@@ -77,6 +77,23 @@ When UI conflicts with taste: **DESIGN.md wins**.
 7. Error / exception text uses the design-token error color.
 8. Prefer density of a results console, not an art gallery landing page.
 
+## UI reuse (mandatory)
+
+Same stack as Hub: shadcn/ui in `src/components/ui/`. **Reuse what is already
+shipped** (`Select` on Jobs filters, `DropdownMenu` on theme / row actions,
+`Table`, `Button`).
+
+1. Version / filter / action lists go through `@/components/ui/select` or
+   `@/components/ui/dropdown-menu`. Match Hub `VersionSwitcher` (label +
+   trailing date on `SelectItem`).
+2. **No native `<select>` / `<option>`** and no hand-rolled dropdown for
+   product chrome. If the primitive is missing a slot (e.g. `trailing`),
+   extend `src/components/ui/select.tsx` so Hub and Viewer stay aligned.
+3. Operator-facing list text is a short label plus time. Slot history:
+   `patch N` + `formatDate` / `formatDay`. Do **not** put `run_id` or sha256
+   in the trigger or the menu. Digests stay on the trial heading / breadcrumb.
+4. Do not add a second component library or a one-off styled native control.
+
 ## Backend contract
 
 Python API under `/api/*` (see `src/bora/viewer/`):
@@ -152,3 +169,5 @@ Dev: `bora view --dev` starts the API and tries to spawn Vite. If that cannot ru
 - Ignoring breadcrumb click-through
 - Unsortable tables when columns are metric-like
 - Shipping unbuilt `src/` only (always produce `dist/` for `bora view`)
+- Native `<select>` for a product list when shadcn `Select` already exists
+- Digest / `run_id` as the visible label in a version or filter menu

--- a/apps/viewer/src/components/trial/slot-history-select.tsx
+++ b/apps/viewer/src/components/trial/slot-history-select.tsx
@@ -1,39 +1,73 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { formatDate } from "@/lib/utils";
+
 export type SlotHistoryEntry = {
   run_id?: string | null;
   status?: string | null;
+  started_at?: string | null;
+  replaced_at?: string | null;
 };
+
+function patchRows(
+  currentRunId: string,
+  previous: SlotHistoryEntry[] | undefined,
+  currentAt?: string | null,
+): Array<{ runId: string; patch: number; at: string | null }> {
+  const hist = (previous ?? []).filter((p): p is SlotHistoryEntry & { run_id: string } =>
+    Boolean(p.run_id && String(p.run_id).trim()),
+  );
+  const rows = hist.map((item, i) => ({
+    runId: String(item.run_id),
+    patch: i + 1,
+    at: item.started_at ?? null,
+  }));
+  rows.push({
+    runId: currentRunId,
+    patch: hist.length + 1,
+    at: currentAt ?? null,
+  });
+  return rows.reverse();
+}
 
 export function SlotHistorySelect({
   viewingRunId,
   currentRunId,
   previous,
+  currentAt,
   onSelect,
 }: {
   viewingRunId: string;
   currentRunId: string | null | undefined;
   previous: SlotHistoryEntry[] | undefined;
+  currentAt?: string | null;
   onSelect: (runId: string) => void;
 }) {
-  const items = previous?.filter((p) => p.run_id) ?? [];
-  if (!currentRunId || items.length === 0) return null;
+  if (!currentRunId) return null;
+  const rows = patchRows(currentRunId, previous, currentAt);
+  if (rows.length < 2) return null;
 
   return (
-    <label className="flex items-center gap-2 text-xs text-mute shrink-0">
-      <span>Version</span>
-      <select
-        className="max-w-[28ch] rounded-[6px] border border-hairline bg-canvas px-2 py-1 font-mono text-[12px] text-ink"
-        value={viewingRunId}
-        onChange={(e) => onSelect(e.target.value)}
-        aria-label="Slot version"
-      >
-        <option value={currentRunId}>current · {currentRunId}</option>
-        {[...items].reverse().map((item) => (
-          <option key={item.run_id!} value={item.run_id!}>
-            {item.status ? `${item.status} · ` : ""}
-            {item.run_id}
-          </option>
+    <Select value={viewingRunId} onValueChange={onSelect}>
+      <SelectTrigger aria-label="Slot version" className="min-w-0 w-auto font-mono">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent className="w-max min-w-0">
+        {rows.map((row) => (
+          <SelectItem
+            key={row.runId}
+            value={row.runId}
+            trailing={row.at ? formatDate(row.at) : undefined}
+          >
+            {`patch ${row.patch}`}
+          </SelectItem>
         ))}
-      </select>
-    </label>
+      </SelectContent>
+    </Select>
   );
 }

--- a/apps/viewer/src/components/trial/slot-history-select.tsx
+++ b/apps/viewer/src/components/trial/slot-history-select.tsx
@@ -1,0 +1,39 @@
+export type SlotHistoryEntry = {
+  run_id?: string | null;
+  status?: string | null;
+};
+
+export function SlotHistorySelect({
+  viewingRunId,
+  currentRunId,
+  previous,
+  onSelect,
+}: {
+  viewingRunId: string;
+  currentRunId: string | null | undefined;
+  previous: SlotHistoryEntry[] | undefined;
+  onSelect: (runId: string) => void;
+}) {
+  const items = previous?.filter((p) => p.run_id) ?? [];
+  if (!currentRunId || items.length === 0) return null;
+
+  return (
+    <label className="flex items-center gap-2 text-xs text-mute shrink-0">
+      <span>Version</span>
+      <select
+        className="max-w-[28ch] rounded-[6px] border border-hairline bg-canvas px-2 py-1 font-mono text-[12px] text-ink"
+        value={viewingRunId}
+        onChange={(e) => onSelect(e.target.value)}
+        aria-label="Slot version"
+      >
+        <option value={currentRunId}>current · {currentRunId}</option>
+        {[...items].reverse().map((item) => (
+          <option key={item.run_id!} value={item.run_id!}>
+            {item.status ? `${item.status} · ` : ""}
+            {item.run_id}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/apps/viewer/src/components/trial/trial-header.tsx
+++ b/apps/viewer/src/components/trial/trial-header.tsx
@@ -1,6 +1,10 @@
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
 import { HoverTip } from "@/components/hover-tip";
+import {
+  SlotHistorySelect,
+  type SlotHistoryEntry,
+} from "@/components/trial/slot-history-select";
 import { Button } from "@/components/ui/button";
 import type { Trial } from "@/lib/api";
 
@@ -11,6 +15,9 @@ export function TrialHeader({
   prevId,
   nextId,
   onSibling,
+  slotCurrentRunId,
+  slotPrevious,
+  onSlotSelect,
 }: {
   runId: string;
   taskId: string;
@@ -18,6 +25,9 @@ export function TrialHeader({
   prevId: string | null;
   nextId: string | null;
   onSibling: (id: string | null) => void;
+  slotCurrentRunId?: string | null;
+  slotPrevious?: SlotHistoryEntry[];
+  onSlotSelect?: (id: string) => void;
 }) {
   return (
     <div className="flex flex-wrap items-start justify-between gap-3">
@@ -69,7 +79,15 @@ export function TrialHeader({
           ) : null}
         </p>
       </div>
-      <div className="flex items-center gap-1 shrink-0">
+      <div className="flex items-center gap-2 shrink-0">
+        {onSlotSelect ? (
+          <SlotHistorySelect
+            viewingRunId={runId}
+            currentRunId={slotCurrentRunId}
+            previous={slotPrevious}
+            onSelect={onSlotSelect}
+          />
+        ) : null}
         <Button
           type="button"
           variant="outline"

--- a/apps/viewer/src/components/trial/trial-header.tsx
+++ b/apps/viewer/src/components/trial/trial-header.tsx
@@ -16,6 +16,7 @@ export function TrialHeader({
   nextId,
   onSibling,
   slotCurrentRunId,
+  slotCurrentStartedAt,
   slotPrevious,
   onSlotSelect,
 }: {
@@ -26,6 +27,7 @@ export function TrialHeader({
   nextId: string | null;
   onSibling: (id: string | null) => void;
   slotCurrentRunId?: string | null;
+  slotCurrentStartedAt?: string | null;
   slotPrevious?: SlotHistoryEntry[];
   onSlotSelect?: (id: string) => void;
 }) {
@@ -85,6 +87,7 @@ export function TrialHeader({
             viewingRunId={runId}
             currentRunId={slotCurrentRunId}
             previous={slotPrevious}
+            currentAt={slotCurrentStartedAt ?? trial?.started}
             onSelect={onSlotSelect}
           />
         ) : null}

--- a/apps/viewer/src/components/ui/select.tsx
+++ b/apps/viewer/src/components/ui/select.tsx
@@ -49,8 +49,10 @@ SelectContent.displayName = SelectPrimitive.Content.displayName;
 
 export const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & {
+    trailing?: React.ReactNode;
+  }
+>(({ className, children, trailing, ...props }, ref) => (
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
@@ -65,6 +67,11 @@ export const SelectItem = React.forwardRef<
       </SelectPrimitive.ItemIndicator>
     </span>
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    {trailing != null && trailing !== "" ? (
+      <span className="ml-auto shrink-0 pl-4 text-right text-xs tabular whitespace-nowrap text-mute">
+        {trailing}
+      </span>
+    ) : null}
   </SelectPrimitive.Item>
 ));
 SelectItem.displayName = SelectPrimitive.Item.displayName;

--- a/apps/viewer/src/hooks/use-trial-detail.ts
+++ b/apps/viewer/src/hooks/use-trial-detail.ts
@@ -26,6 +26,10 @@ export function useTrialDetail(jobId: string, taskId: string, runId: string) {
   const [runCommand, setRunCommand] = useState("");
   const [prevId, setPrevId] = useState<string | null>(null);
   const [nextId, setNextId] = useState<string | null>(null);
+  const [slotCurrentRunId, setSlotCurrentRunId] = useState<string | null>(null);
+  const [slotPrevious, setSlotPrevious] = useState<
+    Array<{ run_id?: string | null; status?: string | null }>
+  >([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<TabId | null>(null);
@@ -68,6 +72,8 @@ export function useTrialDetail(jobId: string, taskId: string, runId: string) {
         setRunCommand(data.run_command || "");
         setPrevId(data.prev_run_id || null);
         setNextId(data.next_run_id || null);
+        setSlotCurrentRunId(data.slot_current_run_id || null);
+        setSlotPrevious(data.slot_previous || []);
         setError(null);
         const tabs = (data.trial.available_tabs || []).map(normalizeTabId) as TabId[];
         const first = FIRST_TAB_ORDER.find((t) => tabs.includes(t)) || null;
@@ -173,6 +179,8 @@ export function useTrialDetail(jobId: string, taskId: string, runId: string) {
     runCommand,
     prevId,
     nextId,
+    slotCurrentRunId,
+    slotPrevious,
     error,
     loading,
     activeTab,

--- a/apps/viewer/src/hooks/use-trial-detail.ts
+++ b/apps/viewer/src/hooks/use-trial-detail.ts
@@ -27,8 +27,16 @@ export function useTrialDetail(jobId: string, taskId: string, runId: string) {
   const [prevId, setPrevId] = useState<string | null>(null);
   const [nextId, setNextId] = useState<string | null>(null);
   const [slotCurrentRunId, setSlotCurrentRunId] = useState<string | null>(null);
+  const [slotCurrentStartedAt, setSlotCurrentStartedAt] = useState<string | null>(
+    null,
+  );
   const [slotPrevious, setSlotPrevious] = useState<
-    Array<{ run_id?: string | null; status?: string | null }>
+    Array<{
+      run_id?: string | null;
+      status?: string | null;
+      started_at?: string | null;
+      replaced_at?: string | null;
+    }>
   >([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -73,6 +81,7 @@ export function useTrialDetail(jobId: string, taskId: string, runId: string) {
         setPrevId(data.prev_run_id || null);
         setNextId(data.next_run_id || null);
         setSlotCurrentRunId(data.slot_current_run_id || null);
+        setSlotCurrentStartedAt(data.slot_current_started_at || null);
         setSlotPrevious(data.slot_previous || []);
         setError(null);
         const tabs = (data.trial.available_tabs || []).map(normalizeTabId) as TabId[];
@@ -180,6 +189,7 @@ export function useTrialDetail(jobId: string, taskId: string, runId: string) {
     prevId,
     nextId,
     slotCurrentRunId,
+    slotCurrentStartedAt,
     slotPrevious,
     error,
     loading,

--- a/apps/viewer/src/lib/api.ts
+++ b/apps/viewer/src/lib/api.ts
@@ -44,6 +44,7 @@ export type TaskRow = {
     status?: string | null;
     score?: number | null;
     attempt_index?: number | null;
+    started_at?: string | null;
     replaced_at?: string | null;
   }>;
 };
@@ -290,11 +291,13 @@ export function fetchTrial(jobId: string, taskId: string, runId: string) {
     next_run_id?: string | null;
     sibling_run_ids?: string[];
     slot_current_run_id?: string | null;
+    slot_current_started_at?: string | null;
     slot_previous?: Array<{
       run_id?: string | null;
       status?: string | null;
       score?: number | null;
       attempt_index?: number | null;
+      started_at?: string | null;
       replaced_at?: string | null;
     }>;
     commands?: Record<string, string>;

--- a/apps/viewer/src/lib/api.ts
+++ b/apps/viewer/src/lib/api.ts
@@ -39,6 +39,13 @@ export type TaskRow = {
   duration?: string | null;
   n?: number | null;
   attempt_run_ids?: string[];
+  previous?: Array<{
+    run_id?: string | null;
+    status?: string | null;
+    score?: number | null;
+    attempt_index?: number | null;
+    replaced_at?: string | null;
+  }>;
 };
 
 export type Trial = {
@@ -282,6 +289,14 @@ export function fetchTrial(jobId: string, taskId: string, runId: string) {
     prev_run_id?: string | null;
     next_run_id?: string | null;
     sibling_run_ids?: string[];
+    slot_current_run_id?: string | null;
+    slot_previous?: Array<{
+      run_id?: string | null;
+      status?: string | null;
+      score?: number | null;
+      attempt_index?: number | null;
+      replaced_at?: string | null;
+    }>;
     commands?: Record<string, string>;
     run_command?: string;
     breadcrumb: Breadcrumb[];

--- a/apps/viewer/src/pages/TrialDetailPage.tsx
+++ b/apps/viewer/src/pages/TrialDetailPage.tsx
@@ -29,6 +29,8 @@ export function TrialDetailPage() {
     runCommand,
     prevId,
     nextId,
+    slotCurrentRunId,
+    slotPrevious,
     error,
     loading,
     activeTab,
@@ -77,6 +79,9 @@ export function TrialDetailPage() {
           prevId={prevId}
           nextId={nextId}
           onSibling={goSibling}
+          slotCurrentRunId={slotCurrentRunId}
+          slotPrevious={slotPrevious}
+          onSlotSelect={goSibling}
         />
 
         {runCommand ? <CommandStrip command={runCommand} /> : null}

--- a/apps/viewer/src/pages/TrialDetailPage.tsx
+++ b/apps/viewer/src/pages/TrialDetailPage.tsx
@@ -30,6 +30,7 @@ export function TrialDetailPage() {
     prevId,
     nextId,
     slotCurrentRunId,
+    slotCurrentStartedAt,
     slotPrevious,
     error,
     loading,
@@ -80,6 +81,7 @@ export function TrialDetailPage() {
           nextId={nextId}
           onSibling={goSibling}
           slotCurrentRunId={slotCurrentRunId}
+          slotCurrentStartedAt={slotCurrentStartedAt}
           slotPrevious={slotPrevious}
           onSlotSelect={goSibling}
         />

--- a/docs/design/02-task-package-and-config.md
+++ b/docs/design/02-task-package-and-config.md
@@ -665,9 +665,9 @@ bora lock|run <path|ref> --task <id>      # ref 经 verified cache 后走 Databa
 | | Suite run | Campaign | Always-k |
 | --- | --- | --- | --- |
 | 轴 | 同一 Database 的 **task_id** | 同一 task 的 **parameter matrix** | 每 task **k 次独立 Attempt** |
-| CLI | `bora run <database> [--task] [--max-concurrent-tasks N] [-k N] [--resume-suite id]` | `bora campaign … --matrix` | 同上 `-k` / `--n-attempts`（**非** matrix） |
+| CLI | `bora run <database> [--task] [--max-concurrent-tasks N] [-k N] [--resume-suite id] [--replace-slot]` | `bora campaign … --matrix` | 同上 `-k` / `--n-attempts`（**非** matrix） |
 | PASS | **仅** per-task evaluator；无 suite PASS | 每 variant 独立 Trial PASS | 仍仅 per-Attempt evaluator；job 再算 pass@k |
-| 失败 | 默认可 `bora cancel suite_…` 停新 unit | 既有 campaign 策略 | 补跑只追加 Attempt |
+| 失败 | 默认可 `bora cancel suite_…` 停新 unit | 既有 campaign 策略 | 默认补跑只追加；`--replace-slot` 点名重跑一格 finished 槽 |
 
 Summary 写在 Database 根：`.bora/suite-runs/<suite_run_id>/summary.json`（另有 `progress.json`；cancel 可写 `cancel.requested`）。
 
@@ -694,7 +694,8 @@ Suite summary 含 `metrics` 对象（`bora.suite.summary/1` 附加字段），�
 ```
 
 **禁止** suite-level PASS 字段作为最终权威；PASS 仅 per-task evaluator。`exit_code` 与 `counts` 仍是操作者退出/计数语义，不是榜单 PASS。  
-pass@k / pass^k **不是** package 身份 / `config_fingerprint` 键；不同 k 的 job 可并列展示，身份仍是 agent×model 绑定。
+pass@k / pass^k **不是** package 身份 / `config_fingerprint` 键；不同 k 的 job 可并列展示，身份仍是 agent×model 绑定。  
+点名换槽后指标**只**按现行指针重算；`task_refs[].previous[]` 是审计链（见 [05-runtime/campaign-suite.md](05-runtime/campaign-suite.md) 与 [12](12-hub-dataset-and-leaderboard.md)）。
 
 ### Suite/job 结果上传（Registry）
 
@@ -703,11 +704,12 @@ pass@k / pass^k **不是** package 身份 / `config_fingerprint` 键；不同 k 
 | CLI | 语义 |
 | --- | --- |
 | `bora results upload-suite <db> --suite-run <id>` | 上传聚合分 + `task_refs` + summary 归档；上传前本地 **ensure/recompute** k 指标 |
-| `bora results get-suite <id>` / `list-suites` | Registry 查询（`metrics` 原样返回，**不剥除** pass@k） |
+| `bora results upload-suite … --task T --run <run_id>` | 向**已有** suite 行 PATCH 一槽现行指针（新 Attempt 须已上传）；**不是**整行 `--replace` |
+| `bora results get-suite <id>` / `list-suites` | Registry 查询（`metrics` 原样返回，**不剥除** pass@k；`task_refs` 可含 `previous[]`） |
 | `… --local <db>` | 不启 Registry，回落本机 `.bora/suite-runs/` |
 
-API：`POST/GET /v1/results/suites`（可见性与 attempt 一致：public / `results:read`）。  
+API：`POST/GET /v1/results/suites`（可见性与 attempt 一致：public / `results:read`）；换槽为对已有 `suite_run_id` 的 PATCH（一槽现行 + `previous[]`）。  
 `GET …/suites?board=1` 只返回完备且 `bound_kind=release` 的行；Jobs 列表不加该过滤。  
-响应含 `pass_rate`、`mean_score`、`metrics`（含 `pass_at_k` / `pass_power_k` 若有）、`task_refs`（可含 `n`/`c`/`attempt_run_ids`）、`complete` / `bound_kind`；**不**接受/存储 suite PASS。  
+响应含 `pass_rate`、`mean_score`、`metrics`（含 `pass_at_k` / `pass_power_k` 若有）、`task_refs`（可含 `n`/`c`/`attempt_run_ids`/`previous[]`）、`complete` / `bound_kind` / 可选 `amended`；**不**接受/存储 suite PASS。  
 一等列仍是 `pass_rate` / `mean_score`；k 指标读 `metrics` 即可（无需额外 first-class 列也可展示）。
 

--- a/docs/design/05-runtime/campaign-suite.md
+++ b/docs/design/05-runtime/campaign-suite.md
@@ -74,7 +74,7 @@ Summary / suite-run 布局见 [02-task-package-and-config.md](../02-task-package
 
 落盘（`bora.suite.summary/1`）：
 
-- `attempts[]` 只含**现行**样本（每槽一行）。被换下的现行行收成瘦快照推进该槽 `previous[]`（`run_id` / `status` / `score` / `attempt_index` / `replaced_at`）；旧行若已有 `previous[]` 则前缀保留。
+- `attempts[]` 只含**现行**样本（每槽一行）。被换下的现行行收成瘦快照推进该槽 `previous[]`（`run_id` / `status` / `score` / `attempt_index` / `started_at` / `replaced_at`）；旧行若已有 `previous[]` 则前缀保留。`started_at` 是该 Attempt 自己的开始时间；`replaced_at` 只记录指针何时挪走。
 - `task_refs[]` 的 `run_id` / `attempt_run_ids` 只列现行；另带该 task 各槽的 `previous[]`（无历史则省略）。
 - 任一槽被换过：`amended: true`（审计；**不**取消 Public Leaderboard 资格）。完备性仍按现行指针：PASS / FAIL / ERROR 都算「有 result」。
 

--- a/docs/design/05-runtime/campaign-suite.md
+++ b/docs/design/05-runtime/campaign-suite.md
@@ -48,14 +48,41 @@ Variant 是 Config Core 的显式输入。它不会成为 Task Package 内第二
 
 - **Always-k**：范围内每 task 固定产出 k 个独立 Attempt（并列或链均可；**不许**改旧 Attempt）。
 - **pass@k**：无偏估计（Harbor）；**pass^k**：\((c/n)^k\)；suite / dataset 分 = 各 task 指标的 **mean**（样本不够的 task 不进该 k 分母）。
-- **补跑**：`--resume-suite` 跳过**真实跑完**的 `(task_id, attempt_index)`，**追加** Attempt 后重算 metrics；suite **cancel 占位**（未真正执行）在 resume 时会**重跑**（避免永久压低 pass@k / pass^k），并清除 `cancel.requested`。
+- **补跑**：`--resume-suite` **默认**跳过**真实跑完**的 `(task_id, attempt_index)`（PASS / FAIL / **ERROR** 一律算 finished），**追加**缺失 index 后重算 metrics；suite **cancel 占位**（未真正执行）在 resume 时会**重跑**（避免永久压低 pass@k / pass^k），并清除 `cancel.requested`。
+- **点名换槽**：`--resume-suite --task T --replace-slot`（Always-k 再加 `--attempt-index i`，默认 `i=0`）只重跑**被点名**的 finished 槽。无 `--replace-slot` 时行为与上一条相同。这是操作者写路径，**不是** Harbor 式自动重试。
 - **进度 / 取消**：suite `progress.json`；`bora status|cancel <suite_run_id>`（可选 `--database`；id 默认为 8 hex）。
 - **阶段耗时**：Attempt `phase_timing`（prepare / run / evaluate / cleanup），服务进度与 Viewer/Hub Timing 条；不替代 PASS。
 
 Summary / suite-run 布局见 [02-task-package-and-config.md](../02-task-package-and-config.md)（Database Registry 与 Suite 轴）。
 
+## 点名换槽（finished slot replace）
+
+操作者可以把**已结束** suite 上的一格换成新 Attempt，**同一** `suite_run_id`，旧 Attempt 只进审计链。
+
+| 项 | 契约 |
+| --- | --- |
+| 谁可被换 | **任意** status（ERROR / FAIL / PASS）。操作者点名 task（Always-k 再点 `attempt_index`）。不自动重试。 |
+| Attempt 身份 | **永远**新 `run_id`。不改旧 `result.json` / score / identity，不删旧 evidence 树。 |
+| Suite 身份 | **同一** `suite_run_id`。 |
+| 槽键 | `k=1`：一 task 一条链。Always-k：一格 `(task_id, attempt_index)`，k 分母仍是 k。 |
+| 历史形状 | 每评分槽 **现行指针 + `previous[]`**（oldest → newest superseded）。v1 **没有**整份 `summary.json` 快照版本。 |
+| 公布指标 | 只按**现行指针**重算 `pass_rate` / `mean_score` / `pass@k` / `pass^k`。`previous[]` 不进分母。 |
+| 绑定 | 新 Attempt 必须与该 suite 同一 Database / 同一 `config_fingerprint` / job overlay 家族。换 profile 当补丁 → 拒绝。 |
+| 拒绝 | suite 仍在跑（`progress.json` 未结束）或存在 `cancel.requested`；缺本地新 `run_id`；`run_id` 属于别的 suite；指纹不一致。 |
+| 写路径 | 本地 CLI + Registry API。Hub / Viewer **只读**链（默认现行）。 |
+| 与 `--replace` | `bora results upload-suite --replace` 仍是**整行 blob 覆盖、不留历史**。换槽**不得**静默走那条路径。 |
+
+落盘（`bora.suite.summary/1`）：
+
+- `attempts[]` 只含**现行**样本（每槽一行）。被换下的现行行收成瘦快照推进该槽 `previous[]`（`run_id` / `status` / `score` / `attempt_index` / `replaced_at`）；旧行若已有 `previous[]` 则前缀保留。
+- `task_refs[]` 的 `run_id` / `attempt_run_ids` 只列现行；另带该 task 各槽的 `previous[]`（无历史则省略）。
+- 任一槽被换过：`amended: true`（审计；**不**取消 Public Leaderboard 资格）。完备性仍按现行指针：PASS / FAIL / ERROR 都算「有 result」。
+
+Registry：PATCH 一条已存在的 suite 行，接收**已上传**的新 Attempt，改该槽现行指针，旧 blob **不删**。`GET` 返回现行 + `previous[]`。所有权与今日 suite 上传 / `--replace` 相同。
+
 ## 多 Attempt / 重试（设计契约）
 
-- 重试、矩阵单元、Always-k 样本、取消后的再跑 → **新 Attempt identity**；
+- 重试、矩阵单元、Always-k 样本、取消后的再跑、**点名换槽** → **新 Attempt identity**；
 - 不静默改写旧 Attempt 的 score 或 identity；
-- multi-attempt 编排细节（并行度、k、resume）属 Application / CLI job 参数面；稳定不变量见 [lifecycle.md](lifecycle.md)。
+- 换槽只改 suite 现行指针与指标，不改 PASS 权威（仍是独立 evaluator）；
+- multi-attempt 编排细节（并行度、k、resume、replace-slot）属 Application / CLI job 参数面；稳定不变量见 [lifecycle.md](lifecycle.md)。

--- a/docs/design/12-hub-dataset-and-leaderboard.md
+++ b/docs/design/12-hub-dataset-and-leaderboard.md
@@ -66,6 +66,8 @@ task 集指纹在上传时从绑定版本的包归档提取并落库。之后改
 - 缺行或无 status 且无 score → incomplete
 - `n_attempts` 不对齐 **不**取消资格
 - Complete **不是** suite PASS；指标仍是观测值
+- 点名换槽后的 suite **仍按现行指针**判定完备；`previous[]` 不参与完备、也不进 `pass_rate` / `mean_score` / `pass@k` / `pass^k`
+- `amended: true` 只作审计。**不得**仅因某槽被换过就把该行踢出 Public Leaderboard
 
 | 表面 | 谁出现 |
 | --- | --- |
@@ -73,6 +75,20 @@ task 集指纹在上传时从绑定版本的包归档提取并落库。之后改
 | Task Jobs | 调用者可见的全部 suite（含 incomplete、draft-bound） |
 
 过滤在 Registry list API（`board=1`），不靠 SPA 藏行作为唯一门。
+
+### Suite `task_refs`：现行指针与槽历史
+
+每个评分槽一条链：`run_id`（及 Always-k 的 `attempt_run_ids`）是**现行** Attempt；被换下的现行收进该槽 `previous[]`（oldest → newest superseded）。v1 没有整份 suite 快照版本。
+
+| 字段 | 语义 |
+| --- | --- |
+| `run_id` / `attempt_run_ids` | 现行样本。Hub / Viewer 默认打开这些。 |
+| `previous[]` | 该槽被换下的 Attempt 瘦记录（`run_id`、`status`、`score`、`attempt_index`、`replaced_at`）。无历史则省略。 |
+| `status` / `score` / `n` / `c` | **只**由现行样本计算。 |
+
+Hub / Viewer 打开 suite 题 / run 时默认现行。操作者可从版本列表选一个 `previous[].run_id` 只读打开该 Attempt 证据。**没有** GUI 写（上传 / 换槽 / 回滚整份 suite）。
+
+写路径只在 CLI + Registry：本地 `--resume-suite --replace-slot` 之后，上传**新** Attempt 并对已有 `suite_run_id` PATCH 一槽。`upload-suite --replace` 仍是整行覆盖、不留 `previous[]`，换槽不得走它。旧 Attempt blob 保留，直到独立的 delete。
 
 ## Leaderboard 行展开：profiles | plugin
 

--- a/docs/design/12-hub-dataset-and-leaderboard.md
+++ b/docs/design/12-hub-dataset-and-leaderboard.md
@@ -83,10 +83,10 @@ task 集指纹在上传时从绑定版本的包归档提取并落库。之后改
 | 字段 | 语义 |
 | --- | --- |
 | `run_id` / `attempt_run_ids` | 现行样本。Hub / Viewer 默认打开这些。 |
-| `previous[]` | 该槽被换下的 Attempt 瘦记录（`run_id`、`status`、`score`、`attempt_index`、`replaced_at`）。无历史则省略。 |
+| `previous[]` | 该槽被换下的 Attempt 瘦记录（`run_id`、`status`、`score`、`attempt_index`、`started_at`、`replaced_at`）。无历史则省略。`started_at` 是该 Attempt 的开始时间，不是 suite 换槽时刻。 |
 | `status` / `score` / `n` / `c` | **只**由现行样本计算。 |
 
-Hub / Viewer 打开 suite 题 / run 时默认现行。操作者可从版本列表选一个 `previous[].run_id` 只读打开该 Attempt 证据。**没有** GUI 写（上传 / 换槽 / 回滚整份 suite）。
+Hub / Viewer 打开 suite 题 / run 时默认现行。操作者用同一套 shadcn `Select` 只读切版本：列表文案是 `patch N` + 该 Attempt 的开始时间，**不**把 `run_id` / digest 写进菜单。内部仍按 `run_id` 打开证据。**没有** GUI 写（上传 / 换槽 / 回滚整份 suite）。
 
 写路径只在 CLI + Registry：本地 `--resume-suite --replace-slot` 之后，上传**新** Attempt 并对已有 `suite_run_id` PATCH 一槽。`upload-suite --replace` 仍是整行覆盖、不留 `previous[]`，换槽不得走它。旧 Attempt blob 保留，直到独立的 delete。
 

--- a/plugins/miniswe/src/miniswe_plugin/factory.py
+++ b/plugins/miniswe/src/miniswe_plugin/factory.py
@@ -191,6 +191,7 @@ class MinisweExecutorSPI:
         self.cmd_timeout = _as_positive_int(opts.get("cmd_timeout"), name="cmd_timeout", default=30)
         self.session_id = f"bora-{self.profile_id or 'solver'}-{uuid.uuid4().hex[:12]}"
         self._placement: Any | None = None
+        self.execution_location = "host"
         self._ready = False
 
     @staticmethod

--- a/services/registry/README.md
+++ b/services/registry/README.md
@@ -117,6 +117,8 @@ uv run bora results upload-suite <database> --suite-run <suite_run_id> [--public
 # Optional: also pack each task's Attempt tree (Hub can open Job detail)
 uv run bora results upload-suite <database> --suite-run <suite_run_id> --with-attempts
 # uv run bora results upload-suite … --suite-run <id> --replace
+# Patch one slot (current + previous[]); not whole-row --replace:
+# uv run bora results upload-suite … --suite-run <id> --task <task_id> [--run <run_id>]
 uv run bora results get-suite <suite_run_id> [--out /tmp/restored-suite]
 uv run bora results list-suites [--database-id <id>]
 # Suite delete keeps attempts by default; optional cascade:
@@ -215,12 +217,14 @@ Publish may be done by any org **member**; destructive package ops require **own
 | PATCH | `/v1/results/attempts/{run_id}` body `{ "visibility" }` |
 | DELETE | `/v1/results/suites/{id}[?with_attempts=1]` (uploader; cascade optional) |
 | PATCH | `/v1/results/suites/{id}` body `{ "visibility" }` |
+| POST | `/v1/results/suites/{id}/slots` (uploader; one new Attempt + `previous[]`; not `--replace`) |
 | GET/POST/DELETE | `/v1/results/attempts\|suites/{id}/shares` |
 
 **Replace policy:** same `database_id@version` / `run_id` / `suite_run_id` defaults
 to **409 conflict**. Explicit `replace: true` (CLI `--replace`) deletes the prior
 row then inserts: blob, digests, metrics/labels, and visibility from the new
-upload. No silent overwrite.
+upload. No silent overwrite. Slot append (`POST …/slots` / `upload-suite --task`)
+updates current + `previous[]` in place and never deletes old Attempt blobs.
 
 **Blob GC:** meta (+ result shares) deleted first; blob object removed only when
 no remaining row references that digest (packages / attempt / suite prefixes

--- a/services/registry/http_api.py
+++ b/services/registry/http_api.py
@@ -516,6 +516,18 @@ class RegistryHttpApi:
                 shutil.rmtree(work, ignore_errors=True)
         return json_result(201, payload)
 
+    def _append_suite_slot(self, *, suite_run_id: str, auth: TokenInfo) -> HttpResult:
+        body = self._read_json_body()
+        if isinstance(body, HttpResult):
+            return body
+        try:
+            payload = self.state.results.append_suite_slot(
+                suite_run_id=suite_run_id, body=body, auth=auth
+            )
+        except RegistryAppError as exc:
+            return _caught(exc)
+        return json_result(200, payload)
+
     def _list_suites(self, *, auth: TokenInfo, qs: dict[str, list[str]]) -> HttpResult:
         try:
             board_raw = (qs.get("board") or [""])[0]

--- a/services/registry/protocols.py
+++ b/services/registry/protocols.py
@@ -87,6 +87,18 @@ class MetadataStoreProtocol(Protocol):
 
     def set_attempt_visibility(self, run_id: str, visibility: str) -> AttemptResultRow: ...
 
+    def update_suite_slot(
+        self,
+        suite_run_id: str,
+        *,
+        pass_rate: float,
+        mean_score: float,
+        metrics_json: str,
+        tasks_json: str,
+        exit_code: int,
+        complete: bool,
+    ) -> SuiteResultRow: ...
+
     def set_suite_visibility(self, suite_run_id: str, visibility: str) -> SuiteResultRow: ...
 
     def list_attempts_for_suite(self, suite_run_id: str) -> list[AttemptResultRow]: ...

--- a/services/registry/queries.py
+++ b/services/registry/queries.py
@@ -342,6 +342,12 @@ UPDATE_ATTEMPT_VISIBILITY = "UPDATE attempt_results SET visibility=? WHERE run_i
 DELETE_SUITE_SHARES = "DELETE FROM result_shares WHERE result_kind='suite' AND result_id=?"
 DELETE_SUITE = "DELETE FROM suite_results WHERE suite_run_id=?"
 UPDATE_SUITE_VISIBILITY = "UPDATE suite_results SET visibility=? WHERE suite_run_id=?"
+UPDATE_SUITE_SLOT = """
+UPDATE suite_results SET
+    pass_rate=?, mean_score=?, metrics_json=?, tasks_json=?,
+    exit_code=?, complete=?
+WHERE suite_run_id=?
+"""
 SELECT_ATTEMPTS_FOR_SUITE = (
     "SELECT * FROM attempt_results WHERE suite_run_id=? ORDER BY created_at DESC"
 )

--- a/services/registry/result_service.py
+++ b/services/registry/result_service.py
@@ -56,16 +56,20 @@ def _previous_run_ids(ref: dict[str, Any]) -> set[str]:
     return out
 
 
-def _outgoing_slot_run_id(ref: dict[str, Any], attempt_index: int) -> str:
-    ids = ref.get("attempt_run_ids")
-    if isinstance(ids, list) and 0 <= attempt_index < len(ids):
-        raw = ids[attempt_index]
-        if raw is not None and str(raw).strip():
-            return str(raw).strip()
+def _current_run_ids(ref: dict[str, Any]) -> set[str]:
+    out: set[str] = set()
     rid = ref.get("run_id")
-    if attempt_index == 0 and rid is not None:
-        return str(rid).strip()
-    return ""
+    if rid is not None and str(rid).strip():
+        out.add(str(rid).strip())
+    extra = ref.get("attempt_run_ids")
+    if isinstance(extra, list):
+        for item in extra:
+            if item is None:
+                continue
+            text = str(item).strip()
+            if text:
+                out.add(text)
+    return out
 
 
 def _archive_looks_like_secret_leak(archive: Path) -> bool:
@@ -529,9 +533,9 @@ class ResultService:
                     old_hit = raw
                     break
         if isinstance(old_hit, dict):
-            outgoing = _outgoing_slot_run_id(old_hit, attempt_index)
+            dropped = _current_run_ids(old_hit) - _current_run_ids(hit)
             prev_ids = _previous_run_ids(hit)
-            if outgoing and outgoing != new_run_id and outgoing not in prev_ids:
+            if dropped and not dropped <= prev_ids:
                 raise RegistryAppError(
                     "invalid_request",
                     "previous[] must keep the outgoing current",

--- a/services/registry/result_service.py
+++ b/services/registry/result_service.py
@@ -39,6 +39,35 @@ _SECRET_PATTERNS = (
 )
 
 
+def _previous_run_ids(ref: dict[str, Any]) -> set[str]:
+    raw = ref.get("previous")
+    if not isinstance(raw, list):
+        return set()
+    out: set[str] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        rid = item.get("run_id")
+        if rid is None:
+            continue
+        text = str(rid).strip()
+        if text:
+            out.add(text)
+    return out
+
+
+def _outgoing_slot_run_id(ref: dict[str, Any], attempt_index: int) -> str:
+    ids = ref.get("attempt_run_ids")
+    if isinstance(ids, list) and 0 <= attempt_index < len(ids):
+        raw = ids[attempt_index]
+        if raw is not None and str(raw).strip():
+            return str(raw).strip()
+    rid = ref.get("run_id")
+    if attempt_index == 0 and rid is not None:
+        return str(rid).strip()
+    return ""
+
+
 def _archive_looks_like_secret_leak(archive: Path) -> bool:
     with archive.open("rb") as fh:
         sample = fh.read(4_000_000)
@@ -380,6 +409,163 @@ class ResultService:
         payload = suite_to_dict(row)
         if existing is not None and replace:
             payload["replaced"] = True
+        return payload
+
+    def append_suite_slot(
+        self, *, suite_run_id: str, body: dict[str, Any], auth: TokenInfo
+    ) -> dict[str, Any]:
+        """Point one scoring slot at a new uploaded Attempt; keep previous[] + old blobs."""
+        if body.get("replace") is not None:
+            raise RegistryAppError(
+                "invalid_request",
+                "slot append must not use replace",
+                http_status=400,
+            )
+        existing = self.meta.get_suite(suite_run_id)
+        if existing is None:
+            raise RegistryAppError("not_found", "suite not found", http_status=404)
+        if not (
+            AccessPolicy.is_admin(auth.scopes)
+            or (auth.user_id and existing.uploaded_by == auth.user_id)
+        ):
+            raise RegistryAppError("not_found", "suite not found", http_status=404)
+        if "pass" in body or "verdict" in body or body.get("suite_pass") is not None:
+            raise RegistryAppError(
+                "invalid_request",
+                "suite-level PASS/verdict fields are not accepted",
+                http_status=400,
+            )
+        task_id = str(body.get("task_id") or "").strip()
+        new_run_id = str(body.get("run_id") or "").strip()
+        if not task_id or not new_run_id:
+            raise RegistryAppError(
+                "invalid_request",
+                "task_id and run_id required",
+                http_status=400,
+            )
+        try:
+            attempt_index = int(body.get("attempt_index") or 0)
+        except (TypeError, ValueError) as exc:
+            raise RegistryAppError(
+                "invalid_request",
+                "attempt_index must be an integer ≥ 0",
+                http_status=400,
+            ) from exc
+        if attempt_index < 0:
+            raise RegistryAppError(
+                "invalid_request",
+                "attempt_index must be an integer ≥ 0",
+                http_status=400,
+            )
+        attempt = self.meta.get_attempt(new_run_id)
+        if attempt is None:
+            raise RegistryAppError(
+                "invalid_request",
+                "run_id is missing",
+                http_status=400,
+            )
+        if attempt.suite_run_id and attempt.suite_run_id != suite_run_id:
+            raise RegistryAppError(
+                "invalid_request",
+                "run_id belongs to another suite",
+                http_status=400,
+            )
+        if attempt.database_id and attempt.database_id != existing.database_id:
+            raise RegistryAppError(
+                "invalid_request",
+                "run_id database_id does not match the suite",
+                http_status=400,
+            )
+        incoming_fp = str(body.get("config_fingerprint") or "").strip()
+        try:
+            stored_cfg = json.loads(existing.config_json or "{}")
+        except (json.JSONDecodeError, TypeError):
+            stored_cfg = {}
+        stored_fp = ""
+        if isinstance(stored_cfg, dict):
+            stored_fp = str(stored_cfg.get("config_fingerprint") or "").strip()
+        if incoming_fp and stored_fp and incoming_fp != stored_fp:
+            raise RegistryAppError(
+                "invalid_request",
+                "replace-slot requires the same config_fingerprint / job overlay",
+                http_status=400,
+            )
+        task_refs = body.get("task_refs")
+        if not isinstance(task_refs, list) or not task_refs:
+            raise RegistryAppError(
+                "invalid_request",
+                "task_refs required",
+                http_status=400,
+            )
+        hit: dict[str, Any] | None = None
+        for raw in task_refs:
+            if isinstance(raw, dict) and str(raw.get("task_id") or "") == task_id:
+                hit = raw
+                break
+        if hit is None:
+            raise RegistryAppError(
+                "invalid_request",
+                f"task_refs missing task {task_id}",
+                http_status=400,
+            )
+        current_ids = {str(hit.get("run_id") or "").strip()}
+        extra_ids = hit.get("attempt_run_ids")
+        if isinstance(extra_ids, list):
+            current_ids.update(str(x).strip() for x in extra_ids if x is not None)
+        if new_run_id not in current_ids:
+            raise RegistryAppError(
+                "invalid_request",
+                "task_refs current pointer must be the new run_id",
+                http_status=400,
+            )
+        try:
+            old_refs = json.loads(existing.tasks_json)
+        except (json.JSONDecodeError, TypeError):
+            old_refs = []
+        old_hit = None
+        if isinstance(old_refs, list):
+            for raw in old_refs:
+                if isinstance(raw, dict) and str(raw.get("task_id") or "") == task_id:
+                    old_hit = raw
+                    break
+        if isinstance(old_hit, dict):
+            outgoing = _outgoing_slot_run_id(old_hit, attempt_index)
+            prev_ids = _previous_run_ids(hit)
+            if outgoing and outgoing != new_run_id and outgoing not in prev_ids:
+                raise RegistryAppError(
+                    "invalid_request",
+                    "previous[] must keep the outgoing current",
+                    http_status=400,
+                )
+        metrics: dict[str, Any] = body["metrics"] if isinstance(body.get("metrics"), dict) else {}
+        try:
+            pass_rate = float(body.get("pass_rate", metrics.get("pass_rate", 0.0)))
+            mean_score = float(body.get("mean_score", metrics.get("mean_score", 0.0)))
+        except (TypeError, ValueError) as exc:
+            raise RegistryAppError(
+                "invalid_request",
+                "pass_rate/mean_score must be numeric",
+                http_status=400,
+            ) from exc
+        try:
+            exit_code = int(body.get("exit_code", existing.exit_code))
+        except (TypeError, ValueError):
+            exit_code = existing.exit_code
+        _bound_kind, bound_ids = self._bound_task_ids(
+            existing.database_id, existing.database_version, auth=auth
+        )
+        complete = suite_is_complete(bound_task_ids=bound_ids, task_refs=task_refs)
+        row = self.meta.update_suite_slot(
+            suite_run_id,
+            pass_rate=pass_rate,
+            mean_score=mean_score,
+            metrics_json=json.dumps(metrics, sort_keys=True),
+            tasks_json=json.dumps(task_refs, sort_keys=True),
+            exit_code=exit_code,
+            complete=complete,
+        )
+        payload = suite_to_dict(row)
+        payload["amended"] = True
         return payload
 
     def list_suites(

--- a/services/registry/routes.py
+++ b/services/registry/routes.py
@@ -273,6 +273,13 @@ ROUTES: tuple[Route, ...] = (
     Route("POST", "upload_suite", access="results_upload", exact="/v1/results/suites"),
     Route(
         "POST",
+        "append_suite_slot",
+        access="results_upload",
+        pattern=r"/v1/results/suites/([^/]+)/slots",
+        groups=("suite_run_id",),
+    ),
+    Route(
+        "POST",
         "add_result_share",
         access="result_manage",
         pattern=r"/v1/results/attempts/([^/]+)/shares",

--- a/services/registry/store.py
+++ b/services/registry/store.py
@@ -769,6 +769,40 @@ class MetadataStore(MetadataStoreProtocol):
             conn.commit()
         return row
 
+    def update_suite_slot(
+        self,
+        suite_run_id: str,
+        *,
+        pass_rate: float,
+        mean_score: float,
+        metrics_json: str,
+        tasks_json: str,
+        exit_code: int,
+        complete: bool,
+    ) -> SuiteResultRow:
+        """In-place slot append. Keeps created_at, owner, visibility, shares, blob."""
+        row = self.get_suite(suite_run_id)
+        if row is None:
+            raise LookupError("suite not found")
+        with self._connect() as conn:
+            self._exec(
+                conn,
+                Q.UPDATE_SUITE_SLOT,
+                (
+                    pass_rate,
+                    mean_score,
+                    metrics_json,
+                    tasks_json,
+                    exit_code,
+                    1 if complete else 0,
+                    suite_run_id,
+                ),
+            )
+            conn.commit()
+        updated = self.get_suite(suite_run_id)
+        assert updated is not None
+        return updated
+
     def set_suite_visibility(self, suite_run_id: str, visibility: str) -> SuiteResultRow:
         if visibility not in {"public", "private"}:
             raise ValueError("bad visibility")
@@ -1890,6 +1924,11 @@ def suite_to_dict(
         plugins = cfg.get("plugins")
         if isinstance(plugins, list) and plugins:
             out["plugins"] = plugins
+    if any(
+        isinstance(ref, dict) and isinstance(ref.get("previous"), list) and ref["previous"]
+        for ref in task_refs
+    ):
+        out["amended"] = True
     return out
 
 

--- a/skills/bora-cli/SKILL.md
+++ b/skills/bora-cli/SKILL.md
@@ -43,13 +43,15 @@ uv run bora --help
 | `bora run <package> --task <id>`                              | One foreground Attempt                                                                             |
 | `bora run <package> [-k N] [--max-concurrent-tasks N]`        | Suite / Always-k job (`-k` = `--n-attempts`; CLI only)                                             |
 | `bora run … --resume-suite <id> [--task id] -k N`             | Append Attempts into existing suite job; recompute pass@k / pass^k                                 |
+| `bora run … --resume-suite <id> --task T --replace-slot`      | Re-run one finished slot; new Attempt; old row stays in `previous[]`                               |
 | `bora run … --keep-workspace`                                 | L1 only: retain host `l1-work/` after cleanup (default: delete; Docker volumes still go)           |
 | `bora run ... --set '/bindings/solver/options/entry="pi"'`    | Job binding override (entry/model)                                                                 |
 | `bora campaign <package> --task <id> --matrix ...`            | Serial matrix (`/parameters/*` or `/bindings/<role>/…`); ≠ Always-k                                |
 | `bora evidence <logs-path> --out <dir>`                       | Sealed trajectory export (no score change)                                                         |
 | `bora results upload-suite …`                                 | Suite aggregates → Registry; recompute pass@k if missing; job_overlay                              |
 | `bora results upload-suite … --with-attempts`                 | Also upload attempt dirs from task_refs.attempt_run_ids / run_id                                   |
-| `bora results upload\|upload-suite … --replace`               | Owner overwrite same run_id / suite_run_id (default 409)                                           |
+| `bora results upload-suite … --task T [--run]`                | Patch one slot onto an already-uploaded suite (not whole-row `--replace`)                          |
+| `bora results upload\|upload-suite … --replace`               | Owner overwrite same run_id / suite_run_id (default 409); no history                               |
 | `bora results delete\|set-visibility … --kind attempt\|suite` | Owner delete (`--yes`) or flip visibility after upload                                             |
 | `bora results share\|unshare …`                               | Grant / revoke private result access (owner only)                                                  |
 | `bora results export-profiles <suite_run_id> --out …`         | Rehydrate job binding as profiles.yaml (locators only)                                             |
@@ -149,7 +151,7 @@ Value after `=` is JSON (strings need quotes):
 | Path                         | Content                                                                                      |
 | ---------------------------- | -------------------------------------------------------------------------------------------- |
 | `summary.json` → `metrics`   | `pass_rate`, `mean_score`, `pass_at_k`, `pass_power_k`, `n_attempts`, `k_values`, `per_task` |
-| `summary.json` → `task_refs` | May include `n`, `c`, `attempt_run_ids` (multi-attempt audit / upload)                       |
+| `summary.json` → `task_refs` | May include `n`, `c`, `attempt_run_ids`, `previous[]` (current + superseded)                 |
 | `progress.json`              | Multi-unit progress                                                                          |
 | Attempt `result.json`        | May include `phase_timing` (prepare/run/evaluate/cleanup)                                    |
 

--- a/skills/bora-cli/references/commands.md
+++ b/skills/bora-cli/references/commands.md
@@ -50,7 +50,11 @@ Stdout JSON (high level):
 - **`--max-concurrent-tasks`**: speeds wall time only; does not change k or PASS.
 - **`--resume-suite <suite_run_id>`**: skip finished `(task_id, attempt_index)`
   (PASS/FAIL/**ERROR** all count as finished), append missing Attempts, recompute
-  metrics. Retrying an ERROR needs a **new** suite, not resume of that index.
+  metrics. Cancel placeholders are retried.
+- **`--replace-slot`** (with `--resume-suite` and `--task`): re-run that finished
+  slot even if PASS / FAIL / ERROR. Writes a new `run_id`; old current moves to
+  `previous[]`. Always-k uses `--attempt-index` (default 0). Same
+  `config_fingerprint` required. In-progress / `cancel.requested` refuse.
 - **`--keep-workspace`** (L1 / `provider.kind: docker` only): retain host
   `.bora/runs/<run_id>/l1-work/` after cleanup for local debug. **Default off** —
   Runtime deletes `l1-work` after container cleanup. Docker volumes and env
@@ -111,13 +115,16 @@ Stdout JSON (high level):
   `k_values` / `per_task` when recoverable from `attempts[]` or task `n`/`c`
   (Hub does **not** recompute live).
 - Contract: `metrics.pass_at_k["<k>"] = { value, n_tasks, incomplete_tasks }` (k string keys).
-- `task_refs` may carry `n`, `c`, `attempt_run_ids` for multi-attempt audit.
+- `task_refs` may carry `n`, `c`, `attempt_run_ids`, and `previous[]` (superseded current).
 - **`--with-attempts`:** packs `.bora/runs/<run_id>/` for each id in
   `attempt_run_ids` (preferred) or primary `run_id`; missing dirs fail closed.
   Sets `task_refs[].has_attempt_content` so Hub Task Jobs can open Attempt detail.
 - **`--agent` / `--model`:** optional Leaderboard labels (else derived from suite summary).
 - **`--replace`:** owner overwrite of same `suite_run_id` (default remains 409);
-  with `--with-attempts`, linked attempts also replace.
+  with `--with-attempts`, linked attempts also replace. **No** `previous[]`.
+- **`--task` / `--run`:** append one local slot onto an already-uploaded suite
+  (upload the new Attempt, then PATCH current + `previous[]`). Must not combine
+  with `--replace`.
 - Registry stores full `metrics` blob (no strip). pass@k is **not**
   `config_fingerprint` / job identity.
 - Hub Leaderboard: **Public** lists **complete, release-bound suite** rows (`board=1`); optional

--- a/skills/bora-cli/references/failures.md
+++ b/skills/bora-cli/references/failures.md
@@ -12,7 +12,7 @@
 | ACP entry not ready | `bora executors -v` → that `entry_id` `host_ready` / install pin; no invoke-time `npm i` |
 | PASS without real model | Forbidden — do not use fixtures as public proof |
 | Trajectory empty | Non-empty `agent_profiles` + harness `Agent.session`/`invoke`. Plugin L1 with no tools: worker import / collect — `$bora-plugin` |
-| Resume skipped an ERROR | `--resume-suite` skips finished `(task_id, attempt_index)` including ERROR. New suite to retry. |
+| Resume skipped an ERROR | Default `--resume-suite` skips finished PASS / FAIL / ERROR. Use `--replace-slot --task T` on the same suite. |
 | Export fails `unsealed_invocation` | Attempt still running or metadata not terminal |
 | Export fails `secret_residual` | Fix source evidence; do not strip secrets by hand in export dir |
 | Docker L1 ERROR | Docker daemon, image build, network/creds projection; read `l1.json` / agent meta under logs |

--- a/src/bora/application/attempt/run_l1_evaluator.py
+++ b/src/bora/application/attempt/run_l1_evaluator.py
@@ -14,7 +14,6 @@ from bora.config.eval_placement import (
     WORKDIR_ENV,
     WORKDIR_PATH,
     EvalPlacement,
-    resolve_eval_placement,
 )
 
 

--- a/src/bora/application/attempt/run_l1_phases.py
+++ b/src/bora/application/attempt/run_l1_phases.py
@@ -508,8 +508,7 @@ def bind_l1_result(ctx: AttemptStageContext) -> None:
         agent_invocations=ctx.inv_count,
         evidence_path=locator,
         error_phase=None
-        if isinstance(eval_raw, dict)
-        and eval_raw.get("status") in {"PASS", "FAIL", "ERROR"}
+        if isinstance(eval_raw, dict) and eval_raw.get("status") in {"PASS", "FAIL", "ERROR"}
         else "evaluation",
         logs=locator,
     )

--- a/src/bora/application/local_jobs/delete_job.py
+++ b/src/bora/application/local_jobs/delete_job.py
@@ -100,16 +100,31 @@ def _collect_referenced_run_ids(summary: dict[str, Any]) -> list[str]:
             if isinstance(extra, list):
                 for item in extra:
                     _add(item)
+            prev = ref.get("previous")
+            if isinstance(prev, list):
+                for item in prev:
+                    if isinstance(item, dict):
+                        _add(item.get("run_id"))
     tasks = summary.get("tasks")
     if isinstance(tasks, list):
         for task in tasks:
             if isinstance(task, dict):
                 _add(task.get("run_id"))
+                prev = task.get("previous")
+                if isinstance(prev, list):
+                    for item in prev:
+                        if isinstance(item, dict):
+                            _add(item.get("run_id"))
     attempts = summary.get("attempts")
     if isinstance(attempts, list):
         for attempt in attempts:
             if isinstance(attempt, dict):
                 _add(attempt.get("run_id"))
+                prev = attempt.get("previous")
+                if isinstance(prev, list):
+                    for item in prev:
+                        if isinstance(item, dict):
+                            _add(item.get("run_id"))
     return ids
 
 

--- a/src/bora/application/registry_ops/results_command.py
+++ b/src/bora/application/registry_ops/results_command.py
@@ -504,6 +504,140 @@ class ResultsCommands:
                 out["task_refs"] = enriched_refs
         return out
 
+    def append_suite_slot_result(
+        self,
+        database_root: Path,
+        *,
+        suite_run_id: str,
+        task_id: str,
+        run_id: str | None = None,
+        attempt_index: int = 0,
+        public: bool = False,
+        with_attempts: bool = False,
+        registry_url: str | None = None,
+    ) -> dict[str, Any]:
+        """Upload one new Attempt and PATCH that slot onto an existing suite.
+
+        Does **not** call whole-row ``upload_suite --replace``. Old Attempt blobs
+        stay. ``task_refs`` come from the local summary (current + previous[]).
+        """
+        root = database_root.expanduser().resolve(strict=False)
+        suite_dir = _resolve_suite_dir(root, suite_run_id)
+        summary = _load_suite_summary(suite_dir)
+        metrics, task_refs = _suite_metrics_and_refs(summary)
+        tid = task_id.strip()
+        hit: dict[str, Any] | None = None
+        for ref in task_refs:
+            if str(ref.get("task_id") or "") == tid:
+                hit = ref
+                break
+        if hit is None:
+            raise ConfigError(
+                "suite_replace_slot_missing",
+                f"local suite has no task_ref for {tid}",
+                location="--task",
+            )
+        current = (run_id or "").strip()
+        if not current:
+            ids = hit.get("attempt_run_ids")
+            if isinstance(ids, list) and 0 <= attempt_index < len(ids):
+                current = str(ids[attempt_index] or "").strip()
+            if not current:
+                current = str(hit.get("run_id") or "").strip()
+        if not current:
+            raise ConfigError(
+                "suite_replace_slot_missing",
+                f"no current run_id for {tid}[{attempt_index}]",
+                location="--run",
+            )
+        current_ids = {str(hit.get("run_id") or "").strip()}
+        extra = hit.get("attempt_run_ids")
+        if isinstance(extra, list):
+            current_ids.update(str(x).strip() for x in extra if x is not None)
+        if current not in current_ids:
+            raise ConfigError(
+                "invalid_request",
+                "--run must be the local current pointer for that slot",
+                location="--run",
+            )
+        resolve_attempt_run_dir(root, current)
+
+        upload_ids = [current]
+        if with_attempts:
+            prev = hit.get("previous")
+            if isinstance(prev, list):
+                for item in prev:
+                    if not isinstance(item, dict):
+                        continue
+                    rid = str(item.get("run_id") or "").strip()
+                    if rid and rid not in upload_ids:
+                        try:
+                            resolve_attempt_run_dir(root, rid)
+                        except ConfigError:
+                            continue
+                        upload_ids.append(rid)
+
+        attempt_uploads: list[dict[str, Any]] = []
+        for rid in upload_ids:
+            attempt_uploads.append(
+                self.upload_attempt_result(
+                    root,
+                    run_id=rid,
+                    public=public,
+                    suite_run_id=suite_run_id,
+                    registry_url=registry_url,
+                    allow_existing=True,
+                    replace=False,
+                )
+            )
+
+        try:
+            pass_rate = float(metrics.get("pass_rate", 0.0))
+            mean_score = float(metrics.get("mean_score", 0.0))
+        except (TypeError, ValueError):
+            pass_rate = 0.0
+            mean_score = 0.0
+        try:
+            exit_code = int(summary.get("exit_code", 0))
+        except (TypeError, ValueError):
+            exit_code = 0
+        config_proj = _config_fields_from_summary(summary)
+        client = self._client_factory(
+            registry_url=registry_url, require_token=True, accept_results_url=True
+        )
+        try:
+            info = client.append_suite_slot(
+                suite_run_id=suite_run_id,
+                task_id=tid,
+                run_id=current,
+                attempt_index=attempt_index,
+                task_refs=list(task_refs),
+                metrics=dict(metrics),
+                pass_rate=pass_rate,
+                mean_score=mean_score,
+                exit_code=exit_code,
+                config_fingerprint=config_proj.get("config_fingerprint"),
+            )
+        except RegistryError as exc:
+            raise ConfigError(exc.code, exc.message, location="registry") from exc
+
+        out: dict[str, Any] = {
+            "ok": True,
+            "appended": True,
+            "suite_run_id": info.get("suite_run_id", suite_run_id),
+            "task_id": tid,
+            "run_id": current,
+            "attempt_index": attempt_index,
+            "pass_rate": info.get("pass_rate", pass_rate),
+            "mean_score": info.get("mean_score", mean_score),
+            "metrics": info.get("metrics", metrics),
+            "task_refs": info.get("task_refs", task_refs),
+            "amended": True,
+            "note": info.get("note", "per-task evaluator verdicts only; no suite-level PASS"),
+            "attempts": attempt_uploads,
+        }
+        return out
+
     def get_suite_result(
         self,
         suite_run_id: str,

--- a/src/bora/application/registry_ops/results_command.py
+++ b/src/bora/application/registry_ops/results_command.py
@@ -539,9 +539,22 @@ class ResultsCommands:
             )
         current = (run_id or "").strip()
         if not current:
-            ids = hit.get("attempt_run_ids")
-            if isinstance(ids, list) and 0 <= attempt_index < len(ids):
-                current = str(ids[attempt_index] or "").strip()
+            for raw in summary.get("attempts") or []:
+                if not isinstance(raw, dict):
+                    continue
+                if str(raw.get("task_id") or "") != tid:
+                    continue
+                idx = raw.get("attempt_index")
+                if not isinstance(idx, int) or isinstance(idx, bool):
+                    idx = 0
+                if idx != attempt_index:
+                    continue
+                current = str(raw.get("run_id") or "").strip()
+                break
+            if not current:
+                ids = hit.get("attempt_run_ids")
+                if isinstance(ids, list) and 0 <= attempt_index < len(ids):
+                    current = str(ids[attempt_index] or "").strip()
             if not current:
                 current = str(hit.get("run_id") or "").strip()
         if not current:

--- a/src/bora/application/suite/suite_metrics.py
+++ b/src/bora/application/suite/suite_metrics.py
@@ -102,6 +102,53 @@ def aggregate_task_metrics(task_rows: Sequence[Mapping[str, Any]]) -> dict[str, 
     }
 
 
+def slot_key(row: Mapping[str, Any]) -> tuple[str, int]:
+    """Scoring-slot identity: ``(task_id, attempt_index)`` (missing index → 0)."""
+    tid = str(row.get("task_id") or "")
+    idx = row.get("attempt_index")
+    if not isinstance(idx, int) or isinstance(idx, bool):
+        idx = 0
+    return tid, idx
+
+
+def previous_entry(row: Mapping[str, Any], *, replaced_at: str) -> dict[str, Any]:
+    """Slim superseded snapshot. Old Attempt identity/score stay immutable."""
+    _tid, idx = slot_key(row)
+    return {
+        "run_id": row.get("run_id"),
+        "status": _normalize_status(row.get("status")) or None,
+        "score": _numeric_score_or_none(row.get("score")),
+        "attempt_index": idx,
+        "replaced_at": replaced_at,
+    }
+
+
+def extend_slot_previous(old_row: Mapping[str, Any], *, replaced_at: str) -> list[dict[str, Any]]:
+    """Oldest → newest superseded: keep prior chain, then the outgoing current."""
+    chain: list[dict[str, Any]] = []
+    raw = old_row.get("previous")
+    if isinstance(raw, list):
+        for item in raw:
+            if isinstance(item, Mapping):
+                chain.append(dict(item))
+    chain.append(previous_entry(old_row, replaced_at=replaced_at))
+    return chain
+
+
+def previous_from_attempts(attempt_rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Flatten per-slot ``previous[]`` in attempt_index order."""
+    ordered = sorted(attempt_rows, key=lambda r: slot_key(r)[1])
+    out: list[dict[str, Any]] = []
+    for row in ordered:
+        raw = row.get("previous")
+        if not isinstance(raw, list):
+            continue
+        for item in raw:
+            if isinstance(item, Mapping):
+                out.append(dict(item))
+    return out
+
+
 def task_refs_for_summary(
     task_rows: Sequence[Mapping[str, Any]],
     *,
@@ -111,7 +158,8 @@ def task_refs_for_summary(
 
     When *attempts* is provided (or a task row nests ``attempts``), each ref
     may include ``n``, ``c``, and ``attempt_run_ids`` for multi-attempt audit
-    and ``--with-attempts`` upload completeness (#60 A3).
+    and ``--with-attempts`` upload completeness (#60 A3). ``previous[]`` is the
+    superseded chain (audit only; not in metrics).
     """
     by_task: dict[str, list[Mapping[str, Any]]] = {}
     if attempts is not None:
@@ -171,6 +219,13 @@ def task_refs_for_summary(
             # Prefer primary run_id when missing: PASS attempt, else first.
             if not ref.get("run_id"):
                 ref["run_id"] = attempt_run_ids[0]
+        history = previous_from_attempts(nested_rows)
+        if not history:
+            raw_prev = row.get("previous")
+            if isinstance(raw_prev, list):
+                history = [dict(item) for item in raw_prev if isinstance(item, Mapping)]
+        if history:
+            ref["previous"] = history
         refs.append(ref)
     return refs
 
@@ -727,6 +782,11 @@ def ensure_suite_task_refs(
                     if not ref.get("attempt_run_ids") and isinstance(prior_ids, list):
                         ref["attempt_run_ids"] = [
                             str(x).strip() for x in prior_ids if x is not None and str(x).strip()
+                        ]
+                    prior_prev = prior.get("previous")
+                    if not ref.get("previous") and isinstance(prior_prev, list):
+                        ref["previous"] = [
+                            dict(item) for item in prior_prev if isinstance(item, Mapping)
                         ]
             return rebuilt
 

--- a/src/bora/application/suite/suite_metrics.py
+++ b/src/bora/application/suite/suite_metrics.py
@@ -111,16 +111,34 @@ def slot_key(row: Mapping[str, Any]) -> tuple[str, int]:
     return tid, idx
 
 
+def attempt_started_at(row: Mapping[str, Any]) -> str | None:
+    """Per-Attempt start, not suite replace time."""
+    for key in ("started_at", "started"):
+        raw = row.get(key)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+    timing = row.get("phase_timing")
+    if isinstance(timing, Mapping):
+        raw = timing.get("started_at")
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+    return None
+
+
 def previous_entry(row: Mapping[str, Any], *, replaced_at: str) -> dict[str, Any]:
     """Slim superseded snapshot. Old Attempt identity/score stay immutable."""
     _tid, idx = slot_key(row)
-    return {
+    out: dict[str, Any] = {
         "run_id": row.get("run_id"),
         "status": _normalize_status(row.get("status")) or None,
         "score": _numeric_score_or_none(row.get("score")),
         "attempt_index": idx,
         "replaced_at": replaced_at,
     }
+    started = attempt_started_at(row)
+    if started:
+        out["started_at"] = started
+    return out
 
 
 def extend_slot_previous(old_row: Mapping[str, Any], *, replaced_at: str) -> list[dict[str, Any]]:

--- a/src/bora/application/suite/suite_metrics.py
+++ b/src/bora/application/suite/suite_metrics.py
@@ -187,6 +187,7 @@ def task_refs_for_summary(
             nested_rows = list(by_task[tid])
 
         if nested_rows:
+            nested_rows = sorted(nested_rows, key=lambda r: slot_key(r)[1])
             n_from, c_from = count_passes(nested_rows)
             if n_val is None:
                 n_val = n_from

--- a/src/bora/application/suite/suite_run.py
+++ b/src/bora/application/suite/suite_run.py
@@ -23,7 +23,9 @@ from bora.application.composition import build_run_task
 from bora.application.suite.suite_config_fingerprint import collect_suite_config
 from bora.application.suite.suite_metrics import (
     aggregate_k_metrics,
+    extend_slot_previous,
     flatten_legacy_tasks_as_attempts,
+    slot_key,
     task_refs_for_summary,
 )
 from bora.config.database import list_tasks, load_database_manifest
@@ -237,6 +239,11 @@ def _is_cancelled_placeholder(row: Mapping[str, Any]) -> bool:
     return str(row.get("error") or "") == "suite_cancelled"
 
 
+_FINISHED_PROGRESS = frozenset(
+    {"complete", "completed", "finished", "done", "cancelled", "canceled"}
+)
+
+
 def _existing_attempt_keys(attempts: list[dict[str, Any]]) -> set[tuple[str, int]]:
     """Keys of finished attempts that resume must **not** re-run.
 
@@ -248,14 +255,34 @@ def _existing_attempt_keys(attempts: list[dict[str, Any]]) -> set[tuple[str, int
     for row in attempts:
         if _is_cancelled_placeholder(row):
             continue
-        tid = str(row.get("task_id") or "")
-        idx = row.get("attempt_index")
+        tid, idx = slot_key(row)
         if not tid:
             continue
-        if not isinstance(idx, int) or isinstance(idx, bool):
-            idx = 0
         keys.add((tid, idx))
     return keys
+
+
+def suite_is_settled(database_root: Path, suite_run_id: str) -> bool:
+    """True when the suite is not in-flight and has no pending cancel request."""
+    if is_suite_cancel_requested(database_root, suite_run_id):
+        return False
+    progress_path = (
+        database_root.expanduser().resolve(strict=False)
+        / ".bora"
+        / "suite-runs"
+        / suite_run_id
+        / "progress.json"
+    )
+    if not progress_path.is_file():
+        return True
+    try:
+        data = json.loads(progress_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    status = str(data.get("status") or "").strip().lower()
+    return status in _FINISHED_PROGRESS
 
 
 async def _run_one(
@@ -559,6 +586,8 @@ def _build_summary(
     plugins = config_fields.get("plugins")
     if isinstance(plugins, list) and plugins:
         summary["plugins"] = plugins
+    if any(isinstance(a.get("previous"), list) and a["previous"] for a in attempts):
+        summary["amended"] = True
     return summary
 
 
@@ -576,6 +605,50 @@ def _write_summary(plan: SuitePlan, summary: dict[str, Any]) -> dict[str, Any]:
     return summary
 
 
+def _assert_replace_slots(
+    plan: SuitePlan,
+    existing: list[dict[str, Any]],
+    old_summary: Mapping[str, Any],
+    replace: set[tuple[str, int]],
+    overrides: dict[str, Any] | None,
+    profiles_path: Path | str | None,
+) -> None:
+    """Fail closed: named slot must exist; binding family must match the suite."""
+    finished = _existing_attempt_keys(existing)
+    planned = set(plan.task_ids)
+    for tid, idx in sorted(replace):
+        if tid not in planned:
+            raise ConfigError(
+                "suite_replace_slot_missing",
+                f"replace-slot task is not in this resume filter: {tid}",
+                location="--task",
+            )
+        if (tid, idx) not in finished:
+            raise ConfigError(
+                "suite_replace_slot_missing",
+                f"no finished slot {tid}[{idx}] to replace",
+                location="--replace-slot",
+            )
+    old_fp = old_summary.get("config_fingerprint")
+    if not isinstance(old_fp, str) or not old_fp.strip():
+        return
+    fp_rows = [{"task_id": a.get("task_id"), "run_id": a.get("run_id")} for a in existing]
+    new_cfg = collect_suite_config(
+        plan.database_root,
+        fp_rows,
+        overrides=overrides,
+        task_ids=list(plan.task_ids),
+        profiles_path=profiles_path,
+    )
+    new_fp = new_cfg.get("config_fingerprint")
+    if str(new_fp or "") != old_fp:
+        raise ConfigError(
+            "suite_replace_fingerprint_mismatch",
+            "replace-slot requires the same config_fingerprint / job overlay",
+            location="--profiles",
+        )
+
+
 async def execute_suite_run(
     plan: SuitePlan,
     *,
@@ -583,6 +656,7 @@ async def execute_suite_run(
     run_fn: Callable[..., Awaitable[tuple[int, Any, dict[str, Any]]]] | None = None,
     profiles_path: Path | str | None = None,
     resume: bool = False,
+    replace_slots: set[tuple[str, int]] | None = None,
     on_progress: ProgressCallback | None = None,
     keep_workspace: bool = False,
 ) -> dict[str, Any]:
@@ -594,31 +668,61 @@ async def execute_suite_run(
     Real finished attempt rows are never rewritten; cancel placeholders are
     dropped when their slot is re-executed.
 
+    ``replace_slots`` (named finished slots only) re-runs those keys even when
+    they already have a real result. The outgoing current is pushed onto that
+    slot's ``previous[]``; metrics use the new current only.
+
     Cancel (#47 D4): if ``suite-runs/<id>/cancel.requested`` appears, no new units
     start; in-flight units finish; remaining planned units get cancelled rows.
-    Resume clears a prior cancel request so scheduling can proceed.
+    Resume without replace-slot clears a prior cancel request so scheduling can
+    proceed. Replace-slot refuses an unsettled suite.
     """
     reset_inflight_metrics()
     runner = run_fn or build_run_task()
     suite_dir_for(plan).mkdir(parents=True, exist_ok=True)
 
+    replace = {(str(t), int(i)) for t, i in (replace_slots or set()) if str(t)}
+    if replace and not resume:
+        raise ConfigError(
+            "suite_replace_requires_resume",
+            "replace-slot requires --resume-suite",
+            location="--replace-slot",
+        )
+
     existing: list[dict[str, Any]] = []
+    old_summary: dict[str, Any] | None = None
     if resume:
-        # Allow re-scheduling after a previous cancel.
-        clear_suite_cancel(plan.database_root, plan.suite_run_id)
-        old = load_suite_summary(plan.database_root, plan.suite_run_id)
-        raw_attempts = old.get("attempts")
+        if replace:
+            if not suite_is_settled(plan.database_root, plan.suite_run_id):
+                raise ConfigError(
+                    "suite_in_progress",
+                    "cannot replace a slot while the suite is in progress "
+                    "or cancel.requested is set",
+                    location=str(suite_dir_for(plan)),
+                )
+        else:
+            # Allow re-scheduling after a previous cancel.
+            clear_suite_cancel(plan.database_root, plan.suite_run_id)
+        old_summary = load_suite_summary(plan.database_root, plan.suite_run_id)
+        raw_attempts = old_summary.get("attempts")
         if isinstance(raw_attempts, list) and raw_attempts:
             existing = [dict(a) for a in raw_attempts if isinstance(a, Mapping)]
         else:
-            legacy_tasks = old.get("tasks")
+            legacy_tasks = old_summary.get("tasks")
             if isinstance(legacy_tasks, list):
                 existing = flatten_legacy_tasks_as_attempts(
                     [t for t in legacy_tasks if isinstance(t, Mapping)]
                 )
+        if replace:
+            _assert_replace_slots(plan, existing, old_summary, replace, overrides, profiles_path)
 
     done_keys = _existing_attempt_keys(existing)
+    if replace:
+        done_keys -= replace
     units = planned_units(plan)
+    for slot in replace:
+        if slot[0] in plan.task_ids and slot not in units:
+            units.append(slot)
     todo = [(tid, idx) for tid, idx in units if (tid, idx) not in done_keys]
     total_units = max(len(units), len(todo) + len(done_keys & set(units)))
     # Progress: completed existing + in-flight bookkeeping.
@@ -773,6 +877,15 @@ async def execute_suite_run(
             completed_count += 1
     if skipped_cancelled:
         new_results.extend(skipped_cancelled)
+
+    if replace and new_results:
+        replaced_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        outgoing = {slot_key(row): row for row in existing if slot_key(row) in replace}
+        for row in new_results:
+            old_row = outgoing.get(slot_key(row))
+            if old_row is None:
+                continue
+            row["previous"] = extend_slot_previous(old_row, replaced_at=replaced_at)
 
     # Merge: keep real finished rows; drop cancel placeholders for slots we
     # re-ran (or re-cancelled). Never mutate real finished attempt payloads.

--- a/src/bora/cli/README.md
+++ b/src/bora/cli/README.md
@@ -134,6 +134,8 @@ uv run bora run examples/core -k 5 --max-concurrent-tasks 2
 uv run bora run examples/core --task sdk-agent-session -k 5
 # Resume / top-up: skip real finished units; re-run suite-cancel placeholders; recompute pass@k
 # uv run bora run examples/core --resume-suite <suite_run_id> --task sdk-agent-session -k 5
+# Replace one finished slot (new Attempt; old current → previous[]):
+# uv run bora run examples/core --resume-suite <suite_run_id> --task sdk-agent-session --replace-slot
 
 # Allowlisted --set (JSON Pointer = JSON value)
 uv run bora lock examples/core --task config-minimal --set /parameters/seed=7
@@ -312,7 +314,7 @@ After `bora run <database>` (full suite or Always-k), summary lives at
 | `metrics.pass_at_k["<k>"]` | `{ value, n_tasks, incomplete_tasks }` (k as string key) |
 | `metrics.pass_power_k["<k>"]` | same |
 | `metrics.n_attempts` / `k_values` / `per_task` | job sample budget, k list, per-task n/c audit |
-| `task_refs[]` | `task_id`, `status`, `score`, `run_id`; multi-attempt may add `n`, `c`, `attempt_run_ids` |
+| `task_refs[]` | `task_id`, `status`, `score`, `run_id`; multi-attempt may add `n`, `c`, `attempt_run_ids`; replaced slots add `previous[]` |
 
 `upload-suite` **recomputes** missing k maps locally from `attempts[]` or task
 `n`/`c` before POST. Registry stores the full `metrics` blob (no strip).
@@ -326,8 +328,10 @@ uv run bora results upload-suite /path/to/database --suite-run <suite_run_id> \
 # Optional full Attempt evidence (Hub Jobs deep-link / evidence browser):
 uv run bora results upload-suite /path/to/database --suite-run <suite_run_id> \
   --with-attempts
-# Owner overwrite of same suite_run_id (default is 409):
+# Owner overwrite of same suite_run_id (default is 409; no history):
 # uv run bora results upload-suite … --suite-run <id> --replace
+# Patch one slot onto an already-uploaded suite (new Attempt + previous[]):
+# uv run bora results upload-suite … --suite-run <id> --task <task_id> [--run <run_id>] --with-attempts
 # Or backfill one run later:
 uv run bora results upload /path/to/database --run <run_id>
 uv run bora results list-suites --database-id test/suite-min

--- a/src/bora/cli/cmd_campaign_run.py
+++ b/src/bora/cli/cmd_campaign_run.py
@@ -114,7 +114,28 @@ def register(app: typer.Typer) -> None:
                 help=(
                     "Resume an existing suite_run_id under .bora/suite-runs/. "
                     "Skips finished (task_id, attempt_index) units, appends new Attempts, "
-                    "recomputes pass@k / pass^k. Combine with --task to top up one task."
+                    "recomputes pass@k / pass^k. Combine with --task to top up one task. "
+                    "With --replace-slot, re-run one named finished slot instead."
+                ),
+            ),
+        ] = None,
+        replace_slot: Annotated[
+            bool,
+            typer.Option(
+                "--replace-slot",
+                help=(
+                    "With --resume-suite and --task: re-run that finished slot "
+                    "(PASS / FAIL / ERROR). Writes a new run_id; old row stays on "
+                    "disk and in previous[]. Metrics use the new current only."
+                ),
+            ),
+        ] = False,
+        attempt_index: Annotated[
+            int | None,
+            typer.Option(
+                "--attempt-index",
+                help=(
+                    "Always-k slot to replace (0-based). Default 0. Only valid with --replace-slot."
                 ),
             ),
         ] = None,
@@ -229,6 +250,35 @@ def register(app: typer.Typer) -> None:
 
             k = n_attempts if n_attempts is not None else 1
             resume_id = resume_suite.strip() if resume_suite and str(resume_suite).strip() else None
+            task_id = task.strip() if task and str(task).strip() else None
+            replace_keys: set[tuple[str, int]] | None = None
+            if replace_slot:
+                if resume_id is None:
+                    raise ConfigError(
+                        "suite_replace_requires_resume",
+                        "replace-slot requires --resume-suite",
+                        location="--replace-slot",
+                    )
+                if not task_id:
+                    raise ConfigError(
+                        "suite_replace_requires_task",
+                        "replace-slot requires --task",
+                        location="--replace-slot",
+                    )
+                idx = 0 if attempt_index is None else attempt_index
+                if not isinstance(idx, int) or isinstance(idx, bool) or idx < 0:
+                    raise ConfigError(
+                        "invalid_override",
+                        "attempt-index must be an integer ≥ 0",
+                        location="--attempt-index",
+                    )
+                replace_keys = {(task_id, idx)}
+            elif attempt_index is not None:
+                raise ConfigError(
+                    "invalid_override",
+                    "--attempt-index is only valid with --replace-slot",
+                    location="--attempt-index",
+                )
 
             # Full suite when --task omitted; single task when provided.
             plan = plan_suite_run(
@@ -340,6 +390,7 @@ def register(app: typer.Typer) -> None:
                     overrides=overrides or None,
                     profiles_path=profiles,
                     resume=resume_id is not None,
+                    replace_slots=replace_keys,
                     on_progress=_progress,
                     keep_workspace=keep_workspace,
                 )

--- a/src/bora/cli/cmd_results.py
+++ b/src/bora/cli/cmd_results.py
@@ -161,6 +161,30 @@ def register(app: typer.Typer) -> None:
                 help="Overwrite same suite_run_id if you own it (default: conflict 409).",
             ),
         ] = False,
+        task: Annotated[
+            str | None,
+            typer.Option(
+                "--task",
+                help=(
+                    "Append one local slot onto an already-uploaded suite "
+                    "(current + previous[]). Not whole-row --replace."
+                ),
+            ),
+        ] = None,
+        run: Annotated[
+            str | None,
+            typer.Option(
+                "--run",
+                help="Attempt run_id to attach (default: local current for --task).",
+            ),
+        ] = None,
+        attempt_index: Annotated[
+            int,
+            typer.Option(
+                "--attempt-index",
+                help="Always-k slot index to append (default 0). Only with --task.",
+            ),
+        ] = 0,
         registry_url: Annotated[
             str | None,
             typer.Option("--registry-url", help="Override registry / results URL."),
@@ -169,20 +193,51 @@ def register(app: typer.Typer) -> None:
         """Upload a suite/job result row (metrics + task refs; no suite PASS)."""
         from bora.application.composition import build_results_commands
 
-        upload_suite_result = build_results_commands().upload_suite_result
+        cmds = build_results_commands()
         from bora.config.errors import ConfigError
 
         try:
-            summary = upload_suite_result(
-                database,
-                suite_run_id=suite_run,
-                public=public,
-                agent_label=agent,
-                model_label=model,
-                with_attempts=with_attempts,
-                replace=replace,
-                registry_url=registry_url,
-            )
+            task_id = task.strip() if task and str(task).strip() else None
+            if task_id:
+                if replace:
+                    raise ConfigError(
+                        "invalid_request",
+                        "slot append must not use --replace",
+                        location="--replace",
+                    )
+                if attempt_index < 0:
+                    raise ConfigError(
+                        "invalid_override",
+                        "attempt-index must be an integer ≥ 0",
+                        location="--attempt-index",
+                    )
+                summary = cmds.append_suite_slot_result(
+                    database,
+                    suite_run_id=suite_run,
+                    task_id=task_id,
+                    run_id=run,
+                    attempt_index=attempt_index,
+                    public=public,
+                    with_attempts=with_attempts,
+                    registry_url=registry_url,
+                )
+            else:
+                if run:
+                    raise ConfigError(
+                        "invalid_request",
+                        "--run requires --task (slot append)",
+                        location="--run",
+                    )
+                summary = cmds.upload_suite_result(
+                    database,
+                    suite_run_id=suite_run,
+                    public=public,
+                    agent_label=agent,
+                    model_label=model,
+                    with_attempts=with_attempts,
+                    replace=replace,
+                    registry_url=registry_url,
+                )
         except ConfigError as exc:
             typer.echo(str(exc), err=True)
             raise typer.Exit(code=2) from exc

--- a/src/bora/registry/client.py
+++ b/src/bora/registry/client.py
@@ -504,6 +504,49 @@ class RegistryClient:
             )
         return json.loads(raw.decode("utf-8"))
 
+    def append_suite_slot(
+        self,
+        *,
+        suite_run_id: str,
+        task_id: str,
+        run_id: str,
+        task_refs: list[dict[str, Any]],
+        metrics: dict[str, Any],
+        attempt_index: int = 0,
+        pass_rate: float | None = None,
+        mean_score: float | None = None,
+        exit_code: int | None = None,
+        config_fingerprint: str | None = None,
+    ) -> dict[str, Any]:
+        """PATCH one scoring slot onto an existing suite. Never uses --replace."""
+        body: dict[str, Any] = {
+            "task_id": task_id,
+            "run_id": run_id,
+            "attempt_index": attempt_index,
+            "task_refs": task_refs,
+            "metrics": metrics,
+        }
+        if pass_rate is not None:
+            body["pass_rate"] = pass_rate
+        if mean_score is not None:
+            body["mean_score"] = mean_score
+        if exit_code is not None:
+            body["exit_code"] = exit_code
+        if config_fingerprint:
+            body["config_fingerprint"] = config_fingerprint
+        raw_body = json.dumps(body, sort_keys=True).encode("utf-8")
+        path = f"/v1/results/suites/{quote(suite_run_id, safe='')}/slots"
+        status, raw, _ = self._request(
+            "POST",
+            path,
+            body=raw_body,
+            headers=self._headers(content_type="application/json", auth=True),
+            auth=True,
+        )
+        if status != 200:
+            raise RegistryError("upload_failed", f"unexpected status {status}", status=status)
+        return json.loads(raw.decode("utf-8"))
+
     def get_suite(self, suite_run_id: str) -> dict[str, Any]:
         path = f"/v1/results/suites/{quote(suite_run_id, safe='')}"
         status, raw, _ = self._request("GET", path, auth=True)

--- a/src/bora/viewer/jobs.py
+++ b/src/bora/viewer/jobs.py
@@ -123,6 +123,23 @@ def _attempts_for_task(summary: dict[str, Any], task_id: str) -> list[dict[str, 
     return []
 
 
+def _previous_entries(
+    ref: dict[str, Any], attempt_rows: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    raw = ref.get("previous")
+    if isinstance(raw, list) and raw:
+        return [dict(item) for item in raw if isinstance(item, dict)]
+    out: list[dict[str, Any]] = []
+    for row in attempt_rows:
+        nested = row.get("previous")
+        if not isinstance(nested, list):
+            continue
+        for item in nested:
+            if isinstance(item, dict):
+                out.append(dict(item))
+    return out
+
+
 def _job_row(summary: dict[str, Any], *, suite_dir: Path, database_root: Path) -> dict[str, Any]:
     metrics = _ensure_metrics(summary)
     refs = _ensure_task_refs(summary)
@@ -460,6 +477,7 @@ def get_job(database_root: Path, job_id: str) -> dict[str, Any]:
         n_val = full.get("n") if full.get("n") is not None else ref.get("n")
         if n_val is None:
             n_val = len(attempt_run_ids) or None
+        previous = _previous_entries(ref, attempt_rows)
         task_rows.append(
             {
                 "task_id": tid,
@@ -469,6 +487,7 @@ def get_job(database_root: Path, job_id: str) -> dict[str, Any]:
                 if attempt_run_ids
                 else full.get("run_id") or ref.get("run_id"),
                 "attempt_run_ids": attempt_run_ids,
+                "previous": previous,
                 "attempts": attempt_rows,
                 "error": full.get("error"),
                 "exit_code": full.get("exit_code"),

--- a/src/bora/viewer/jobs.py
+++ b/src/bora/viewer/jobs.py
@@ -19,7 +19,13 @@ from bora.application.suite import (
 )
 from bora.config.database import load_database_manifest
 from bora.config.errors import ConfigError
-from bora.evidence.locators import default_runs_root, default_suite_runs_root, safe_id_segment
+from bora.application.suite.suite_metrics import attempt_started_at
+from bora.evidence.locators import (
+    default_runs_root,
+    default_suite_runs_root,
+    resolve_evidence_root,
+    safe_id_segment,
+)
 from bora.viewer.browse import commands_for
 
 
@@ -123,21 +129,58 @@ def _attempts_for_task(summary: dict[str, Any], task_id: str) -> list[dict[str, 
     return []
 
 
+def _started_from_run_dir(database_root: Path, run_id: str) -> str | None:
+    try:
+        rid = safe_id_segment(run_id, field="run_id")
+        evidence = resolve_evidence_root(database_root, rid, require_task_match=False)
+    except ConfigError:
+        return None
+    for name in ("summary.json", "result.json"):
+        path = evidence / name
+        if not path.is_file():
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if isinstance(data, dict):
+            started = attempt_started_at(data)
+            if started:
+                return started
+    return None
+
+
 def _previous_entries(
-    ref: dict[str, Any], attempt_rows: list[dict[str, Any]]
+    ref: dict[str, Any],
+    attempt_rows: list[dict[str, Any]],
+    *,
+    database_root: Path | None = None,
 ) -> list[dict[str, Any]]:
     raw = ref.get("previous")
+    items: list[dict[str, Any]]
     if isinstance(raw, list) and raw:
-        return [dict(item) for item in raw if isinstance(item, dict)]
-    out: list[dict[str, Any]] = []
-    for row in attempt_rows:
-        nested = row.get("previous")
-        if not isinstance(nested, list):
+        items = [dict(item) for item in raw if isinstance(item, dict)]
+    else:
+        items = []
+        for row in attempt_rows:
+            nested = row.get("previous")
+            if not isinstance(nested, list):
+                continue
+            for item in nested:
+                if isinstance(item, dict):
+                    items.append(dict(item))
+    if database_root is None:
+        return items
+    for item in items:
+        if item.get("started_at"):
             continue
-        for item in nested:
-            if isinstance(item, dict):
-                out.append(dict(item))
-    return out
+        rid = str(item.get("run_id") or "").strip()
+        if not rid:
+            continue
+        started = _started_from_run_dir(database_root, rid)
+        if started:
+            item["started_at"] = started
+    return items
 
 
 def _job_row(summary: dict[str, Any], *, suite_dir: Path, database_root: Path) -> dict[str, Any]:
@@ -477,7 +520,7 @@ def get_job(database_root: Path, job_id: str) -> dict[str, Any]:
         n_val = full.get("n") if full.get("n") is not None else ref.get("n")
         if n_val is None:
             n_val = len(attempt_run_ids) or None
-        previous = _previous_entries(ref, attempt_rows)
+        previous = _previous_entries(ref, attempt_rows, database_root=root)
         task_rows.append(
             {
                 "task_id": tid,

--- a/src/bora/viewer/jobs.py
+++ b/src/bora/viewer/jobs.py
@@ -476,9 +476,7 @@ def list_jobs(database_root: Path) -> dict[str, Any]:
                 continue
             progress = _load_progress(child)
             if progress is not None:
-                items.append(
-                    _in_progress_suite_row(progress, suite_dir=child, database_root=root)
-                )
+                items.append(_in_progress_suite_row(progress, suite_dir=child, database_root=root))
 
     claimed = _referenced_run_ids(root, items) | _suite_run_ids(items)
     for run_id, evidence in _iter_attempt_dirs(root):
@@ -611,7 +609,8 @@ def _get_in_progress_suite_job(
     root: Path, *, suite_dir: Path, progress: dict[str, Any]
 ) -> dict[str, Any]:
     job = _in_progress_suite_row(progress, suite_dir=suite_dir, database_root=root)
-    running = progress.get("running") if isinstance(progress.get("running"), list) else []
+    raw_running = progress.get("running")
+    running: list[Any] = raw_running if isinstance(raw_running, list) else []
     task_rows: list[dict[str, Any]] = []
     for item in running:
         if not isinstance(item, dict):

--- a/src/bora/viewer/trials/meta.py
+++ b/src/bora/viewer/trials/meta.py
@@ -201,10 +201,30 @@ def get_trial(
         if isinstance(item, dict)
     }:
         sibling_ids.insert(0, rid)
+    from bora.application.suite.suite_metrics import attempt_started_at
+    from bora.viewer.jobs import _started_from_run_dir
+
     slot_previous = [
         dict(item) for item in (suite_row.get("previous") or []) if isinstance(item, dict)
     ]
+    for item in slot_previous:
+        if item.get("started_at"):
+            continue
+        prev_id = str(item.get("run_id") or "").strip()
+        if prev_id:
+            started = _started_from_run_dir(root, prev_id)
+            if started:
+                item["started_at"] = started
     slot_current = str(suite_row.get("run_id") or "") or (sibling_ids[0] if sibling_ids else rid)
+    slot_current_started = None
+    for attempt in suite_row.get("attempts") or []:
+        if isinstance(attempt, dict) and str(attempt.get("run_id") or "") == slot_current:
+            slot_current_started = attempt_started_at(attempt)
+            break
+    if not slot_current_started:
+        slot_current_started = attempt_started_at(suite_row)
+    if not slot_current_started and slot_current:
+        slot_current_started = _started_from_run_dir(root, slot_current)
     try:
         idx = sibling_ids.index(rid)
     except ValueError:
@@ -223,6 +243,7 @@ def get_trial(
         "next_run_id": next_id,
         "sibling_run_ids": sibling_ids,
         "slot_current_run_id": slot_current,
+        "slot_current_started_at": slot_current_started,
         "slot_previous": slot_previous,
         "commands": cmds,
         "run_command": cmds.get("run_task") or cmds.get("run_suite"),

--- a/src/bora/viewer/trials/meta.py
+++ b/src/bora/viewer/trials/meta.py
@@ -135,7 +135,13 @@ def get_trial(
             if isinstance(extra, list)
             else set()
         )
-        if str(row.get("run_id") or "") != rid and rid not in extra_ids:
+        prev_ids: set[str] = set()
+        raw_prev = row.get("previous")
+        if isinstance(raw_prev, list):
+            for item in raw_prev:
+                if isinstance(item, dict) and item.get("run_id"):
+                    prev_ids.add(str(item["run_id"]).strip())
+        if str(row.get("run_id") or "") != rid and rid not in extra_ids and rid not in prev_ids:
             continue
         suite_row = dict(row)
         for attempt in row.get("attempts") or []:
@@ -189,8 +195,16 @@ def get_trial(
 
     listed = list_task_trials(root, job_id, task_id)
     sibling_ids = [str(t.get("run_id")) for t in listed["trials"] if t.get("run_id")]
-    if rid not in sibling_ids:
+    if rid not in sibling_ids and rid not in {
+        str(item.get("run_id") or "").strip()
+        for item in (suite_row.get("previous") or [])
+        if isinstance(item, dict)
+    }:
         sibling_ids.insert(0, rid)
+    slot_previous = [
+        dict(item) for item in (suite_row.get("previous") or []) if isinstance(item, dict)
+    ]
+    slot_current = str(suite_row.get("run_id") or "") or (sibling_ids[0] if sibling_ids else rid)
     try:
         idx = sibling_ids.index(rid)
     except ValueError:
@@ -208,6 +222,8 @@ def get_trial(
         "prev_run_id": prev_id,
         "next_run_id": next_id,
         "sibling_run_ids": sibling_ids,
+        "slot_current_run_id": slot_current,
+        "slot_previous": slot_previous,
         "commands": cmds,
         "run_command": cmds.get("run_task") or cmds.get("run_suite"),
         "breadcrumb": [

--- a/tests/acceptance/test_suite_run_cli.py
+++ b/tests/acceptance/test_suite_run_cli.py
@@ -63,3 +63,13 @@ def test_unknown_task_suite_cli() -> None:
     r = _bora("run", str(SUITE), "--task", "missing-task")
     assert r.returncode == 2
     assert "unknown_task" in r.stderr
+
+
+def test_replace_slot_requires_resume_and_task() -> None:
+    r = _bora("run", str(SUITE), "--task", "alpha", "--replace-slot")
+    assert r.returncode == 2
+    assert "suite_replace_requires_resume" in r.stderr
+
+    r2 = _bora("run", str(SUITE), "--resume-suite", "deadbeef", "--replace-slot")
+    assert r2.returncode == 2
+    assert "suite_replace_requires_task" in r2.stderr

--- a/tests/application/test_suite_replace_slot.py
+++ b/tests/application/test_suite_replace_slot.py
@@ -1,0 +1,229 @@
+"""Named-slot replace on a finished suite: new Attempt + previous[] history."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from bora.application.suite.suite_metrics import (
+    extend_slot_previous,
+    previous_from_attempts,
+    task_refs_for_summary,
+)
+from bora.application.suite.suite_run import (
+    execute_suite_run,
+    plan_suite_run,
+    request_suite_cancel,
+    suite_dir_for,
+)
+from bora.config.errors import ConfigError
+
+REPO = Path(__file__).resolve().parents[2]
+SUITE = REPO / "tests" / "fixtures" / "databases" / "suite-min"
+
+
+def _runner(status: str = "PASS", score: float | None = 1.0, *, prefix: str = "cur"):
+    n = {"n": 0}
+
+    async def run(root, task_id, *, overrides=None, profiles_path=None, **kwargs):  # noqa: ANN001
+        n["n"] += 1
+        run_id = f"sha256_dead_run_{prefix}_{task_id}_{n['n']}"
+        abs_run = Path(root) / ".bora" / "runs" / run_id
+        abs_run.mkdir(parents=True, exist_ok=True)
+        st = status
+        sc = score
+        code = 0 if st == "PASS" else (1 if st == "FAIL" else 2)
+        result = SimpleNamespace(status=st, score=sc, evidence_path=str(abs_run), logs=str(abs_run))
+        return code, result, {"digest": f"sha256:{run_id}", "run_dir": str(abs_run)}
+
+    run.calls = n  # type: ignore[attr-defined]
+    return run
+
+
+def test_extend_previous_oldest_to_newest() -> None:
+    first = {
+        "task_id": "alpha",
+        "attempt_index": 0,
+        "run_id": "old",
+        "status": "ERROR",
+        "score": None,
+        "previous": [
+            {
+                "run_id": "older",
+                "status": "FAIL",
+                "score": 0.0,
+                "attempt_index": 0,
+                "replaced_at": "t0",
+            }
+        ],
+    }
+    chain = extend_slot_previous(first, replaced_at="t1")
+    assert [e["run_id"] for e in chain] == ["older", "old"]
+    assert chain[-1]["replaced_at"] == "t1"
+    assert chain[-1]["status"] == "ERROR"
+
+
+def test_task_refs_copy_previous_from_attempts() -> None:
+    refs = task_refs_for_summary(
+        [{"task_id": "alpha", "status": "PASS", "score": 1.0, "run_id": "new"}],
+        attempts=[
+            {
+                "task_id": "alpha",
+                "attempt_index": 0,
+                "run_id": "new",
+                "status": "PASS",
+                "score": 1.0,
+                "previous": [
+                    {
+                        "run_id": "old",
+                        "status": "ERROR",
+                        "score": None,
+                        "attempt_index": 0,
+                        "replaced_at": "t",
+                    }
+                ],
+            }
+        ],
+    )
+    assert refs[0]["run_id"] == "new"
+    assert refs[0]["previous"][0]["run_id"] == "old"
+    assert previous_from_attempts([]) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status,score", [("ERROR", None), ("FAIL", 0.0), ("PASS", 1.0)])
+async def test_replace_slot_reruns_finished_and_keeps_history(
+    status: str, score: float | None
+) -> None:
+    plan = plan_suite_run(SUITE, task_id="alpha", n_attempts=1)
+    first = await execute_suite_run(plan, run_fn=_runner(status, score, prefix="old"))
+    old_id = first["attempts"][0]["run_id"]
+    assert first["attempts"][0]["status"] == status
+    old_dir = Path(plan.database_root) / ".bora" / "runs" / old_id
+    assert old_dir.is_dir()
+
+    plan2 = plan_suite_run(SUITE, task_id="alpha", n_attempts=1, suite_run_id=first["suite_run_id"])
+    second = await execute_suite_run(
+        plan2,
+        run_fn=_runner("PASS", 1.0, prefix="new"),
+        resume=True,
+        replace_slots={("alpha", 0)},
+    )
+    assert second["resumed"] is True
+    assert second["amended"] is True
+    assert second["new_attempts"] == 1
+    assert len(second["attempts"]) == 1
+    cur = second["attempts"][0]
+    assert cur["run_id"] != old_id
+    assert cur["status"] == "PASS"
+    assert cur["previous"][0]["run_id"] == old_id
+    assert cur["previous"][0]["status"] == status
+    assert old_dir.is_dir()
+    refs = {r["task_id"]: r for r in second["task_refs"]}
+    assert refs["alpha"]["run_id"] == cur["run_id"]
+    assert refs["alpha"]["previous"][0]["run_id"] == old_id
+    assert second["metrics"]["n_pass"] == 1
+    disk = json.loads(Path(second["summary_path"]).read_text(encoding="utf-8"))
+    assert disk["amended"] is True
+    assert disk["attempts"][0]["previous"][0]["run_id"] == old_id
+
+
+@pytest.mark.asyncio
+async def test_resume_without_replace_skips_finished_error() -> None:
+    plan = plan_suite_run(SUITE, task_id="alpha", n_attempts=1)
+    first = await execute_suite_run(plan, run_fn=_runner("ERROR", None, prefix="err"))
+    old_id = first["attempts"][0]["run_id"]
+    plan2 = plan_suite_run(SUITE, task_id="alpha", n_attempts=1, suite_run_id=first["suite_run_id"])
+    runner = _runner("PASS", 1.0, prefix="skip")
+    second = await execute_suite_run(plan2, run_fn=runner, resume=True)
+    assert runner.calls["n"] == 0  # type: ignore[attr-defined]
+    assert second["new_attempts"] == 0
+    assert second["attempts"][0]["run_id"] == old_id
+    assert "amended" not in second
+
+
+@pytest.mark.asyncio
+async def test_replace_one_always_k_index_leaves_siblings() -> None:
+    plan = plan_suite_run(SUITE, task_id="alpha", n_attempts=3, max_concurrent_tasks=1)
+    first = await execute_suite_run(plan, run_fn=_runner("FAIL", 0.0, prefix="k"))
+    by_idx = {a["attempt_index"]: a["run_id"] for a in first["attempts"]}
+    assert first["metrics"]["n_pass"] == 0
+
+    plan2 = plan_suite_run(
+        SUITE,
+        task_id="alpha",
+        n_attempts=3,
+        suite_run_id=first["suite_run_id"],
+    )
+    second = await execute_suite_run(
+        plan2,
+        run_fn=_runner("PASS", 1.0, prefix="rep"),
+        resume=True,
+        replace_slots={("alpha", 1)},
+    )
+    cur = {a["attempt_index"]: a for a in second["attempts"]}
+    assert set(cur) == {0, 1, 2}
+    assert cur[0]["run_id"] == by_idx[0]
+    assert cur[2]["run_id"] == by_idx[2]
+    assert cur[1]["run_id"] != by_idx[1]
+    assert cur[1]["status"] == "PASS"
+    assert "previous" not in cur[0]
+    assert cur[1]["previous"][0]["run_id"] == by_idx[1]
+    assert second["metrics"]["n_pass"] == 1
+    # pass@1 uses current 3 samples (1 pass).
+    assert second["metrics"]["pass_at_k"]["1"]["value"] == pytest.approx(1 / 3)
+
+
+@pytest.mark.asyncio
+async def test_replace_refuses_in_progress_and_missing_slot() -> None:
+    plan = plan_suite_run(SUITE, task_id="alpha", n_attempts=1)
+    first = await execute_suite_run(plan, run_fn=_runner("ERROR", None, prefix="blk"))
+    suite_id = first["suite_run_id"]
+    plan2 = plan_suite_run(SUITE, task_id="alpha", n_attempts=1, suite_run_id=suite_id)
+
+    request_suite_cancel(plan.database_root, suite_id)
+    with pytest.raises(ConfigError, match="in progress"):
+        await execute_suite_run(
+            plan2,
+            run_fn=_runner("PASS", 1.0, prefix="no"),
+            resume=True,
+            replace_slots={("alpha", 0)},
+        )
+    (suite_dir_for(plan2) / "cancel.requested").unlink()
+
+    with pytest.raises(ConfigError, match="no finished slot"):
+        await execute_suite_run(
+            plan2,
+            run_fn=_runner("PASS", 1.0, prefix="no"),
+            resume=True,
+            replace_slots={("alpha", 3)},
+        )
+
+    with pytest.raises(ConfigError, match="replace-slot requires"):
+        await execute_suite_run(
+            plan,
+            run_fn=_runner("PASS", 1.0, prefix="no"),
+            replace_slots={("alpha", 0)},
+        )
+
+
+@pytest.mark.asyncio
+async def test_replace_refuses_fingerprint_mismatch() -> None:
+    plan = plan_suite_run(SUITE, task_id="alpha", n_attempts=1)
+    first = await execute_suite_run(plan, run_fn=_runner("ERROR", None, prefix="fp"))
+    path = Path(first["summary_path"])
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    doc["config_fingerprint"] = "sha256:not-the-real-fingerprint"
+    path.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+
+    plan2 = plan_suite_run(SUITE, task_id="alpha", n_attempts=1, suite_run_id=first["suite_run_id"])
+    with pytest.raises(ConfigError, match="config_fingerprint"):
+        await execute_suite_run(
+            plan2,
+            run_fn=_runner("PASS", 1.0, prefix="no"),
+            resume=True,
+            replace_slots={("alpha", 0)},
+        )

--- a/tests/application/test_suite_replace_slot.py
+++ b/tests/application/test_suite_replace_slot.py
@@ -175,6 +175,12 @@ async def test_replace_one_always_k_index_leaves_siblings() -> None:
     assert second["metrics"]["n_pass"] == 1
     # pass@1 uses current 3 samples (1 pass).
     assert second["metrics"]["pass_at_k"]["1"]["value"] == pytest.approx(1 / 3)
+    refs = {r["task_id"]: r for r in second["task_refs"]}
+    assert refs["alpha"]["attempt_run_ids"] == [
+        cur[0]["run_id"],
+        cur[1]["run_id"],
+        cur[2]["run_id"],
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/application/test_upload_suite_slot.py
+++ b/tests/application/test_upload_suite_slot.py
@@ -1,0 +1,116 @@
+"""CLI/application slot append uploads one run without --replace."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from bora.application.registry_ops.results_command import ResultsCommands
+from bora.config.errors import ConfigError
+
+
+def _seed(db: Path, *, suite_id: str = "suite1") -> None:
+    (db / "bora.yaml").write_text(
+        "format: bora.database/1\ndatabase_id: test/db\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+    suite_dir = db / ".bora" / "suite-runs" / suite_id
+    suite_dir.mkdir(parents=True)
+    suite_dir.joinpath("summary.json").write_text(
+        """{
+  "schema": "bora.suite.summary/1",
+  "suite_run_id": "suite1",
+  "database_id": "test/db",
+  "database_version": "0.1.0",
+  "exit_code": 0,
+  "config_fingerprint": "sha256:fp",
+  "amended": true,
+  "attempts": [
+    {
+      "task_id": "hello",
+      "attempt_index": 0,
+      "status": "PASS",
+      "score": 1.0,
+      "run_id": "newrun",
+      "previous": [
+        {"run_id": "oldrun", "status": "ERROR", "score": null, "attempt_index": 0}
+      ]
+    }
+  ],
+  "tasks": [{"task_id": "hello", "status": "PASS", "score": 1.0, "run_id": "newrun"}],
+  "task_refs": [
+    {
+      "task_id": "hello",
+      "status": "PASS",
+      "score": 1.0,
+      "run_id": "newrun",
+      "previous": [
+        {"run_id": "oldrun", "status": "ERROR", "score": null, "attempt_index": 0}
+      ]
+    }
+  ],
+  "metrics": {
+    "pass_rate": 1.0,
+    "mean_score": 1.0,
+    "n_tasks": 1,
+    "n_pass": 1,
+    "n_fail": 0,
+    "n_error": 0,
+    "missing_score_as": 0.0
+  }
+}
+""",
+        encoding="utf-8",
+    )
+    for rid in ("newrun", "oldrun"):
+        run_dir = db / ".bora" / "runs" / rid
+        run_dir.mkdir(parents=True)
+        run_dir.joinpath("result.json").write_text(
+            f'{{"status": "PASS", "task_id": "hello", "run_id": "{rid}"}}\n',
+            encoding="utf-8",
+        )
+
+
+def test_append_slot_uploads_attempt_and_patches_suite(tmp_path: Path) -> None:
+    db = tmp_path / "db"
+    db.mkdir()
+    _seed(db)
+    captured: dict[str, Any] = {}
+    mock = MagicMock()
+    mock.upload_attempt.return_value = {"run_id": "newrun", "ok": True}
+    mock.append_suite_slot.side_effect = lambda **kw: (
+        captured.update(kw)
+        or {
+            "suite_run_id": kw["suite_run_id"],
+            "task_refs": kw["task_refs"],
+            "metrics": kw["metrics"],
+            "pass_rate": 1.0,
+            "mean_score": 1.0,
+            "amended": True,
+            "note": "per-task evaluator verdicts only; no suite-level PASS",
+        }
+    )
+    cmds = ResultsCommands(client_factory=lambda **_kw: mock)
+    out = cmds.append_suite_slot_result(db, suite_run_id="suite1", task_id="hello")
+    assert out["appended"] is True
+    assert out["run_id"] == "newrun"
+    assert captured["run_id"] == "newrun"
+    assert captured["task_id"] == "hello"
+    assert captured["task_refs"][0]["previous"][0]["run_id"] == "oldrun"
+    mock.upload_suite.assert_not_called()
+    mock.upload_attempt.assert_called()
+    assert mock.upload_attempt.call_args.kwargs.get("replace") is False
+
+
+def test_append_slot_refuses_foreign_run(tmp_path: Path) -> None:
+    db = tmp_path / "db"
+    db.mkdir()
+    _seed(db)
+    (db / ".bora" / "runs" / "other").mkdir(parents=True)
+    (db / ".bora" / "runs" / "other" / "result.json").write_text("{}\n", encoding="utf-8")
+    cmds = ResultsCommands(client_factory=lambda **_kw: MagicMock())
+    with pytest.raises(ConfigError, match="current pointer"):
+        cmds.append_suite_slot_result(db, suite_run_id="suite1", task_id="hello", run_id="other")

--- a/tests/application/test_upload_suite_slot.py
+++ b/tests/application/test_upload_suite_slot.py
@@ -105,6 +105,64 @@ def test_append_slot_uploads_attempt_and_patches_suite(tmp_path: Path) -> None:
     assert mock.upload_attempt.call_args.kwargs.get("replace") is False
 
 
+def test_append_slot_resolves_always_k_index_from_attempts(tmp_path: Path) -> None:
+    db = tmp_path / "dbk"
+    db.mkdir()
+    (db / "bora.yaml").write_text(
+        "format: bora.database/1\ndatabase_id: test/db\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+    suite_dir = db / ".bora" / "suite-runs" / "suitek"
+    suite_dir.mkdir(parents=True)
+    suite_dir.joinpath("summary.json").write_text(
+        """{
+  "schema": "bora.suite.summary/1",
+  "suite_run_id": "suitek",
+  "database_id": "test/db",
+  "database_version": "0.1.0",
+  "exit_code": 0,
+  "attempts": [
+    {"task_id": "hello", "attempt_index": 0, "status": "FAIL", "run_id": "idx0"},
+    {"task_id": "hello", "attempt_index": 2, "status": "FAIL", "run_id": "idx2"},
+    {"task_id": "hello", "attempt_index": 1, "status": "PASS", "run_id": "idx1new",
+     "previous": [{"run_id": "idx1old", "status": "ERROR", "attempt_index": 1}]}
+  ],
+  "tasks": [{"task_id": "hello", "status": "PASS", "run_id": "idx1new", "n": 3, "c": 1}],
+  "task_refs": [{
+    "task_id": "hello",
+    "status": "PASS",
+    "run_id": "idx1new",
+    "attempt_run_ids": ["idx0", "idx2", "idx1new"],
+    "previous": [{"run_id": "idx1old", "status": "ERROR", "attempt_index": 1}]
+  }],
+  "metrics": {"pass_rate": 1.0, "mean_score": 1.0, "n_tasks": 1, "n_pass": 1}
+}
+""",
+        encoding="utf-8",
+    )
+    for rid in ("idx0", "idx2", "idx1new", "idx1old"):
+        run_dir = db / ".bora" / "runs" / rid
+        run_dir.mkdir(parents=True)
+        run_dir.joinpath("result.json").write_text("{}\n", encoding="utf-8")
+
+    captured: dict[str, Any] = {}
+    mock = MagicMock()
+    mock.upload_attempt.return_value = {"run_id": "idx1new", "ok": True}
+    mock.append_suite_slot.side_effect = lambda **kw: (
+        captured.update(kw)
+        or {
+            "suite_run_id": "suitek",
+            "task_refs": kw["task_refs"],
+            "metrics": kw["metrics"],
+        }
+    )
+    cmds = ResultsCommands(client_factory=lambda **_kw: mock)
+    out = cmds.append_suite_slot_result(db, suite_run_id="suitek", task_id="hello", attempt_index=1)
+    assert out["run_id"] == "idx1new"
+    assert captured["run_id"] == "idx1new"
+    assert captured["attempt_index"] == 1
+
+
 def test_append_slot_refuses_foreign_run(tmp_path: Path) -> None:
     db = tmp_path / "db"
     db.mkdir()

--- a/tests/plugins/test_miniswe_plugin.py
+++ b/tests/plugins/test_miniswe_plugin.py
@@ -46,6 +46,7 @@ def test_describe_and_bind_to_target() -> None:
     )
     assert isinstance(bound, MinisweExecutorSPI)
     assert bound.execution_location == "attempt-container"
+    assert bound._placement is not None
     assert bound._placement.container_id == "cid123"
 
 

--- a/tests/registry/test_suite_append_slot.py
+++ b/tests/registry/test_suite_append_slot.py
@@ -1,0 +1,240 @@
+"""Append one Attempt onto an existing suite row (not whole-row --replace)."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+from services.registry.access import AccessPolicy
+from services.registry.errors import RegistryAppError
+from services.registry.package_service import PackageService
+from services.registry.result_service import ResultService
+from services.registry.store import MemoryBlobStore, MetadataStore, TokenInfo
+
+from bora.registry.archive import MEDIA_TYPE, build_archive
+from bora.registry.digest import compute_package_digest
+
+REPO = Path(__file__).resolve().parents[2]
+FIXTURE = REPO / "tests" / "fixtures" / "databases" / "publish-min"
+
+
+def _services(tmp_path: Path) -> ResultService:
+    meta = MetadataStore(tmp_path / "meta.sqlite3")
+    blobs = MemoryBlobStore()
+    access = AccessPolicy(meta=meta)
+    packages = PackageService(meta, blobs, access, max_upload=64 * 1024 * 1024)
+    archive, blob_digest, size = build_archive(FIXTURE)
+    packages.meta.create_org(name="acme", owner_user_id="alice", display_name="Acme")
+    auth = TokenInfo(scopes=frozenset({"registry:publish"}), user_id="alice")
+    packages.publish(
+        meta={
+            "database_id": "test/publish-min",
+            "version": "0.1.0",
+            "package_digest": compute_package_digest(FIXTURE),
+            "blob_digest": blob_digest,
+            "media_type": MEDIA_TYPE,
+            "visibility": "public",
+            "org_id": "acme",
+            "size": size,
+        },
+        archive=_as_path(tmp_path, archive, "release.tar.gz"),
+        auth=auth,
+    )
+    return ResultService(meta, blobs, access, max_upload=64 * 1024 * 1024)
+
+
+def _as_path(tmp_path: Path, data: bytes, name: str) -> Path:
+    path = tmp_path / name
+    path.write_bytes(data)
+    return path
+
+
+def _blob(data: bytes) -> str:
+    return f"sha256:{hashlib.sha256(data).hexdigest()}"
+
+
+def _suite_archive(tmp_path: Path, suite_run_id: str) -> tuple[dict[str, object], Path]:
+    raw = b"suite-archive"
+    return (
+        {
+            "suite_run_id": suite_run_id,
+            "database_id": "test/publish-min",
+            "database_version": "0.1.0",
+            "visibility": "public",
+            "blob_digest": _blob(raw),
+            "size": len(raw),
+            "pass_rate": 0.0,
+            "mean_score": 0.0,
+            "exit_code": 2,
+            "metrics": {
+                "n_tasks": 1,
+                "n_pass": 0,
+                "n_error": 1,
+                "pass_rate": 0.0,
+                "mean_score": 0.0,
+            },
+            "task_refs": [
+                {"task_id": "hello", "status": "ERROR", "score": None, "run_id": "oldrun"}
+            ],
+            "config_fingerprint": "sha256:suite-fp",
+        },
+        _as_path(tmp_path, raw, f"{suite_run_id}.bin"),
+    )
+
+
+def _upload_attempt(
+    results: ResultService,
+    tmp_path: Path,
+    run_id: str,
+    *,
+    auth: TokenInfo,
+    status: str = "PASS",
+    suite_run_id: str = "",
+    database_id: str = "test/publish-min",
+) -> None:
+    raw = f"attempt-{run_id}".encode()
+    results.upload_attempt(
+        meta={
+            "run_id": run_id,
+            "database_id": database_id,
+            "task_id": "hello",
+            "lock_digest": "sha256:x",
+            "status": status,
+            "visibility": "public",
+            "blob_digest": _blob(raw),
+            "size": len(raw),
+            "suite_run_id": suite_run_id,
+        },
+        archive=_as_path(tmp_path, raw, f"{run_id}.bin"),
+        auth=auth,
+    )
+
+
+def test_append_slot_updates_metrics_and_keeps_old_attempt(tmp_path: Path) -> None:
+    results = _services(tmp_path)
+    auth = TokenInfo(scopes=frozenset({"results:upload"}), user_id="alice")
+    meta, archive = _suite_archive(tmp_path, "suite_slot")
+    results.upload_suite(meta=meta, archive=archive, auth=auth)
+    _upload_attempt(
+        results, tmp_path, "oldrun", auth=auth, status="ERROR", suite_run_id="suite_slot"
+    )
+    _upload_attempt(
+        results, tmp_path, "newrun", auth=auth, status="PASS", suite_run_id="suite_slot"
+    )
+
+    payload = results.append_suite_slot(
+        suite_run_id="suite_slot",
+        body={
+            "task_id": "hello",
+            "run_id": "newrun",
+            "attempt_index": 0,
+            "pass_rate": 1.0,
+            "mean_score": 1.0,
+            "exit_code": 0,
+            "metrics": {
+                "n_tasks": 1,
+                "n_pass": 1,
+                "n_error": 0,
+                "pass_rate": 1.0,
+                "mean_score": 1.0,
+            },
+            "task_refs": [
+                {
+                    "task_id": "hello",
+                    "status": "PASS",
+                    "score": 1.0,
+                    "run_id": "newrun",
+                    "previous": [
+                        {
+                            "run_id": "oldrun",
+                            "status": "ERROR",
+                            "score": None,
+                            "attempt_index": 0,
+                            "replaced_at": "t",
+                        }
+                    ],
+                }
+            ],
+            "config_fingerprint": "sha256:suite-fp",
+        },
+        auth=auth,
+    )
+    assert payload["amended"] is True
+    assert payload["pass_rate"] == 1.0
+    assert payload["complete"] is True
+    assert payload["task_refs"][0]["run_id"] == "newrun"
+    assert payload["task_refs"][0]["previous"][0]["run_id"] == "oldrun"
+    # Old row + blob still GET.
+    old = results.serve_attempt_meta(run_id="oldrun", auth=auth)
+    assert old["run_id"] == "oldrun"
+    assert old["status"] == "ERROR"
+    got = results.get_suite("suite_slot")
+    assert got is not None
+    assert got.created_at == results.get_suite("suite_slot").created_at
+
+
+def test_append_slot_refuses_replace_flag_and_missing_run(tmp_path: Path) -> None:
+    results = _services(tmp_path)
+    auth = TokenInfo(scopes=frozenset({"results:upload"}), user_id="alice")
+    meta, archive = _suite_archive(tmp_path, "suite_refuse")
+    results.upload_suite(meta=meta, archive=archive, auth=auth)
+
+    with pytest.raises(RegistryAppError, match="must not use replace"):
+        results.append_suite_slot(
+            suite_run_id="suite_refuse",
+            body={"replace": True, "task_id": "hello", "run_id": "x"},
+            auth=auth,
+        )
+    with pytest.raises(RegistryAppError, match="run_id is missing"):
+        results.append_suite_slot(
+            suite_run_id="suite_refuse",
+            body={
+                "task_id": "hello",
+                "run_id": "ghost",
+                "task_refs": [{"task_id": "hello", "run_id": "ghost", "status": "PASS"}],
+                "metrics": {},
+            },
+            auth=auth,
+        )
+
+
+def test_append_slot_refuses_foreign_run_and_fingerprint(tmp_path: Path) -> None:
+    results = _services(tmp_path)
+    auth = TokenInfo(scopes=frozenset({"results:upload"}), user_id="alice")
+    meta, archive = _suite_archive(tmp_path, "suite_a")
+    results.upload_suite(meta=meta, archive=archive, auth=auth)
+    _upload_attempt(results, tmp_path, "foreign", auth=auth, suite_run_id="other-suite")
+
+    with pytest.raises(RegistryAppError, match="another suite"):
+        results.append_suite_slot(
+            suite_run_id="suite_a",
+            body={
+                "task_id": "hello",
+                "run_id": "foreign",
+                "task_refs": [{"task_id": "hello", "run_id": "foreign", "status": "PASS"}],
+                "metrics": {},
+            },
+            auth=auth,
+        )
+
+    _upload_attempt(results, tmp_path, "newrun", auth=auth, suite_run_id="suite_a")
+    with pytest.raises(RegistryAppError, match="config_fingerprint"):
+        results.append_suite_slot(
+            suite_run_id="suite_a",
+            body={
+                "task_id": "hello",
+                "run_id": "newrun",
+                "config_fingerprint": "sha256:other",
+                "task_refs": [
+                    {
+                        "task_id": "hello",
+                        "run_id": "newrun",
+                        "status": "PASS",
+                        "previous": [{"run_id": "oldrun", "status": "ERROR"}],
+                    }
+                ],
+                "metrics": {},
+            },
+            auth=auth,
+        )

--- a/tests/registry/test_suite_append_slot.py
+++ b/tests/registry/test_suite_append_slot.py
@@ -219,6 +219,49 @@ def test_append_slot_refuses_foreign_run_and_fingerprint(tmp_path: Path) -> None
         )
 
     _upload_attempt(results, tmp_path, "newrun", auth=auth, suite_run_id="suite_a")
+    _upload_attempt(results, tmp_path, "id0", auth=auth, suite_run_id="suite_k")
+    _upload_attempt(results, tmp_path, "id2", auth=auth, suite_run_id="suite_k")
+    _upload_attempt(results, tmp_path, "id1new", auth=auth, suite_run_id="suite_k")
+    meta_k, archive_k = _suite_archive(tmp_path, "suite_k")
+    meta_k["task_refs"] = [
+        {
+            "task_id": "hello",
+            "status": "ERROR",
+            "run_id": "id0",
+            "attempt_run_ids": ["id0", "id2", "id1old"],
+        }
+    ]
+    results.upload_suite(meta=meta_k, archive=archive_k, auth=auth)
+    payload = results.append_suite_slot(
+        suite_run_id="suite_k",
+        body={
+            "task_id": "hello",
+            "run_id": "id1new",
+            "attempt_index": 1,
+            "config_fingerprint": "sha256:suite-fp",
+            "pass_rate": 0.0,
+            "mean_score": 0.0,
+            "metrics": {},
+            "task_refs": [
+                {
+                    "task_id": "hello",
+                    "status": "PASS",
+                    "run_id": "id1new",
+                    "attempt_run_ids": ["id0", "id1new", "id2"],
+                    "previous": [
+                        {
+                            "run_id": "id1old",
+                            "status": "ERROR",
+                            "attempt_index": 1,
+                        }
+                    ],
+                }
+            ],
+        },
+        auth=auth,
+    )
+    assert payload["task_refs"][0]["previous"][0]["run_id"] == "id1old"
+
     with pytest.raises(RegistryAppError, match="config_fingerprint"):
         results.append_suite_slot(
             suite_run_id="suite_a",

--- a/tests/viewer/test_local_job_delete.py
+++ b/tests/viewer/test_local_job_delete.py
@@ -146,6 +146,48 @@ def test_delete_suite_cascades_attempts(tmp_path: Path) -> None:
     assert not (db / ".bora" / "runs" / "run_a").exists()
 
 
+def test_delete_suite_cascades_previous_attempts(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = "suite_hist"
+    suite_dir = db / ".bora" / "suite-runs" / job_id
+    _write_json(
+        suite_dir / "summary.json",
+        {
+            "schema": "bora.suite.summary/1",
+            "suite_run_id": job_id,
+            "database_id": "test/suite-min",
+            "tasks": [{"task_id": "alpha", "status": "PASS", "run_id": "run_new"}],
+            "task_refs": [
+                {
+                    "task_id": "alpha",
+                    "status": "PASS",
+                    "run_id": "run_new",
+                    "previous": [{"run_id": "run_old", "status": "ERROR", "attempt_index": 0}],
+                }
+            ],
+            "attempts": [
+                {
+                    "task_id": "alpha",
+                    "run_id": "run_new",
+                    "previous": [{"run_id": "run_old", "status": "ERROR", "attempt_index": 0}],
+                }
+            ],
+            "metrics": {"n_tasks": 1, "n_pass": 1},
+        },
+    )
+    _seed_attempt(db, "run_new")
+    _seed_attempt(db, "run_old")
+    leftover = _seed_attempt(db, "run_other")
+    cmds = build_local_jobs_commands()
+    preview = cmds.preview_delete_job(db, job_id=job_id)
+    assert set(preview["cascade_run_ids"]) >= {"run_new", "run_old"}
+    inner = cmds.preview_delete_job(db, job_id="run_old")
+    assert inner["can_delete"] is False
+    cmds.delete_job(db, job_id=job_id, yes=True)
+    assert not (db / ".bora" / "runs" / "run_old").exists()
+    assert leftover.is_dir()
+
+
 def test_refuse_inner_attempt_delete(tmp_path: Path) -> None:
     db = _clean_db(tmp_path)
     _seed_suite(db)

--- a/tests/viewer/test_viewer_jobs.py
+++ b/tests/viewer/test_viewer_jobs.py
@@ -195,6 +195,7 @@ def test_job_task_exposes_attempt_run_ids_for_k(tmp_path: Path) -> None:
     row = detail["tasks"][0]
     assert row["attempt_run_ids"] == ["run_alpha_0", "run_alpha_1"]
     assert row["n"] == 2
+    assert row.get("previous") == []
 
     payload = jobs.get_job_task(db, job_id, "alpha")
     assert [t["run_id"] for t in payload["trials"]] == ["run_alpha_0", "run_alpha_1"]

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -348,6 +348,64 @@ def test_missing_run_raises(tmp_path: Path) -> None:
         trials.resolve_evidence_root(db, "does_not_exist")
 
 
+def test_get_trial_opens_previous_without_listing_it(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = "suite_amended"
+    suite_dir = db / ".bora" / "suite-runs" / job_id
+    suite_dir.mkdir(parents=True)
+    summary = {
+        "schema": "bora.suite.summary/1",
+        "suite_run_id": job_id,
+        "database_id": "test/suite-min",
+        "tasks": [{"task_id": "alpha", "status": "PASS", "score": 1.0, "run_id": "run_new"}],
+        "attempts": [
+            {
+                "task_id": "alpha",
+                "attempt_index": 0,
+                "status": "PASS",
+                "run_id": "run_new",
+                "previous": [
+                    {
+                        "run_id": "run_old",
+                        "status": "ERROR",
+                        "score": None,
+                        "attempt_index": 0,
+                    }
+                ],
+            }
+        ],
+        "task_refs": [
+            {
+                "task_id": "alpha",
+                "status": "PASS",
+                "score": 1.0,
+                "run_id": "run_new",
+                "previous": [
+                    {
+                        "run_id": "run_old",
+                        "status": "ERROR",
+                        "score": None,
+                        "attempt_index": 0,
+                    }
+                ],
+            }
+        ],
+        "metrics": {"n_tasks": 1, "n_pass": 1},
+    }
+    suite_dir.joinpath("summary.json").write_text(json.dumps(summary) + "\n", encoding="utf-8")
+    _write_evidence(db, "run_new", task_id="alpha")
+    _write_evidence(db, "run_old", task_id="alpha")
+
+    listed = trials.list_task_trials(db, job_id, "alpha")
+    assert [t["run_id"] for t in listed["trials"]] == ["run_new"]
+
+    old = trials.get_trial(db, job_id, "alpha", "run_old")
+    assert old["trial"]["run_id"] == "run_old"
+    assert old["slot_current_run_id"] == "run_new"
+    assert old["slot_previous"][0]["run_id"] == "run_old"
+    assert "run_old" not in old["sibling_run_ids"]
+
+
 def test_path_ids_reject_traversal(tmp_path: Path) -> None:
     db = _clean_db(tmp_path)
     job_id = _seed_suite_run(db)

--- a/website/content/docs/reference/cli.en.mdx
+++ b/website/content/docs/reference/cli.en.mdx
@@ -42,6 +42,8 @@ Path = Dataset root. Destructive commands require `--yes`; overwrite same identi
 | `--max-concurrent-tasks N` | Max concurrent units; **speeds wall time only** |
 | `--n-attempts` / `-k N` | Always-k: N independent Attempts per task (default 1); **CLI/job only** |
 | `--resume-suite <suite_run_id>` | Resume job: skip finished units, append Attempts, recompute pass@k / pass^k |
+| `--replace-slot` | With `--resume-suite --task`: re-run that finished slot; new Attempt; old row stays in `previous[]` |
+| `--attempt-index N` | Always-k slot to replace (default 0). Only with `--replace-slot` |
 | `--keep-workspace` | L1 only: keep host `l1-work/` after cleanup (default: delete; uploads never pack it). Docker volumes are still removed |
 | `--set` / `--profiles` | Overrides / alternate job binding |
 | `--probe` | Feasibility only: plan + readiness for this binding/`provider.kind`. No Agent, no bake, no lock digest change. Exit 1 if the selected path is unsatisfied. |

--- a/website/content/docs/reference/cli.mdx
+++ b/website/content/docs/reference/cli.mdx
@@ -42,6 +42,8 @@ uv run bora results upload|upload-suite|share|unshare|set-visibility|delete …
 | `--max-concurrent-tasks N` | 并行 unit 上限；**只加速**，不改 k / PASS |
 | `--n-attempts` / `-k N` | Always-k：每题 N 次独立 Attempt（默认 1）；**CLI/job only** |
 | `--resume-suite <suite_run_id>` | 并进已有 job：跳过已完成 unit，追加 Attempt，重算 pass@k / pass^k |
+| `--replace-slot` | 配合 `--resume-suite --task`：重跑该已完成槽；新 Attempt；旧行进 `previous[]` |
+| `--attempt-index N` | Always-k 要换的格（默认 0）。只与 `--replace-slot` 一起用 |
 | `--keep-workspace` | 仅 L1：清理后保留 host `l1-work/`（默认删除；上传不打包）。Docker volume 仍删除 |
 | `--set` / `--profiles` | 见下；与 job binding 相关 |
 | `--probe` | 只做可行性：按绑定 / `provider.kind` 打印 plan + readiness。不 invoke Agent、不 bake、不改 lock digest。选中路径不满足则 exit 1。 |

--- a/website/content/docs/run/suite.en.mdx
+++ b/website/content/docs/run/suite.en.mdx
@@ -26,12 +26,18 @@ uv run bora run examples/core --task sdk-agent-session -k 5
 
 # Resume: append into an existing suite job and recompute metrics
 uv run bora run examples/core --resume-suite <suite_run_id> --task sdk-agent-session -k 5
+
+# Replace one finished slot (PASS / FAIL / ERROR): new Attempt, same suite id
+uv run bora run examples/core --resume-suite <suite_run_id> --task sdk-agent-session --replace-slot
+# Always-k: one (task_id, attempt_index)
+# uv run bora run examples/core --resume-suite <id> --task sdk-agent-session --replace-slot --attempt-index 1
 ```
 
 Hard rules:
 
 - `n_attempts` is **not** allowed in `task.yaml` and is **not** part of `config_fingerprint`  
-- Resume only **appends** Attempts; finished Attempt scores / identity stay intact  
+- Resume without `--replace-slot` only **appends** missing indices; finished PASS / FAIL / ERROR stay skipped  
+- `--replace-slot` writes a **new** Attempt; the old row stays on disk and in `previous[]`; metrics use the new current only  
 - Slots that only have a **suite-cancel placeholder** (never actually ran) are **retried** on resume so pass@k is not permanently deflated
 - Progress / cancel below; Hub Leaderboard shows pass@k / pass^k / n_attempts when `metrics.pass_at_k` is present; local `metrics` are always written after Always-k  
 - Default system `suite_run_id` is **8 hex** (no `suite_` prefix)

--- a/website/content/docs/run/suite.en.mdx
+++ b/website/content/docs/run/suite.en.mdx
@@ -38,6 +38,7 @@ Hard rules:
 - `n_attempts` is **not** allowed in `task.yaml` and is **not** part of `config_fingerprint`  
 - Resume without `--replace-slot` only **appends** missing indices; finished PASS / FAIL / ERROR stay skipped  
 - `--replace-slot` writes a **new** Attempt; the old row stays on disk and in `previous[]`; metrics use the new current only  
+- Hub / Viewer history is `patch N` plus that Attempt’s start time (not the suite replace clock, not the `run_id`)  
 - Slots that only have a **suite-cancel placeholder** (never actually ran) are **retried** on resume so pass@k is not permanently deflated
 - Progress / cancel below; Hub Leaderboard shows pass@k / pass^k / n_attempts when `metrics.pass_at_k` is present; local `metrics` are always written after Always-k  
 - Default system `suite_run_id` is **8 hex** (no `suite_` prefix)

--- a/website/content/docs/run/suite.mdx
+++ b/website/content/docs/run/suite.mdx
@@ -26,12 +26,18 @@ uv run bora run examples/core --task sdk-agent-session -k 5
 
 # 补跑：并进已有 suite job，重算指标（可加 --task 只补一题）
 uv run bora run examples/core --resume-suite <suite_run_id> --task sdk-agent-session -k 5
+
+# 点名换槽（PASS / FAIL / ERROR）：新 Attempt，同一 suite id
+uv run bora run examples/core --resume-suite <suite_run_id> --task sdk-agent-session --replace-slot
+# Always-k：只换一格 (task_id, attempt_index)
+# uv run bora run examples/core --resume-suite <id> --task sdk-agent-session --replace-slot --attempt-index 1
 ```
 
 硬约束：
 
 - `n_attempts` **禁止**写进 `task.yaml`；也不进 `config_fingerprint`  
-- 补跑只**追加** Attempt，不改写已完成 Attempt 的 score / 身份  
+- 不加 `--replace-slot` 的补跑只**追加**缺失 index；已完成的 PASS / FAIL / ERROR 仍跳过  
+- `--replace-slot` 写**新** Attempt；旧行留在盘上并进入 `previous[]`；指标只按现行指针重算  
 - 因 **cancel 未真正跑过** 的占位会在 resume 时**重跑**（避免 pass@k 永久偏低）
 - 进度 / 取消见下方；Hub Leaderboard 在有 `metrics.pass_at_k` 时展示 pass@k / pass^k / n_attempts；本机 summary 始终可写 metrics  
 - 系统默认 `suite_run_id` 为 **8 位 hex**（无 `suite_` 前缀）

--- a/website/content/docs/run/suite.mdx
+++ b/website/content/docs/run/suite.mdx
@@ -38,6 +38,7 @@ uv run bora run examples/core --resume-suite <suite_run_id> --task sdk-agent-ses
 - `n_attempts` **禁止**写进 `task.yaml`；也不进 `config_fingerprint`  
 - 不加 `--replace-slot` 的补跑只**追加**缺失 index；已完成的 PASS / FAIL / ERROR 仍跳过  
 - `--replace-slot` 写**新** Attempt；旧行留在盘上并进入 `previous[]`；指标只按现行指针重算  
+- Hub / Viewer 历史列表是 `patch N` + 该 Attempt 开始时间（不是 suite 换槽时刻，也不展示 `run_id`）  
 - 因 **cancel 未真正跑过** 的占位会在 resume 时**重跑**（避免 pass@k 永久偏低）
 - 进度 / 取消见下方；Hub Leaderboard 在有 `metrics.pass_at_k` 时展示 pass@k / pass^k / n_attempts；本机 summary 始终可写 metrics  
 - 系统默认 `suite_run_id` 为 **8 位 hex**（无 `suite_` 前缀）

--- a/website/content/docs/share/hub.en.mdx
+++ b/website/content/docs/share/hub.en.mdx
@@ -70,7 +70,7 @@ Jobs rows with uploaded run artifacts open detail; others show **Not uploaded**.
 | A **Public Leaderboard** row | A **complete**, **release-bound** suite | `bora publish --draft` then `bora release` (or a direct `bora publish`) → `bora run <database>` **without** `--task` → `upload-suite --suite-run <id>` |
 | Leaderboard **Internal** | A caller-visible incomplete or draft-bound suite | Same `upload-suite`; does not appear on Public |
 | Task **Jobs** with openable Attempt / trajectory | Suite + **attempt** evidence | `upload-suite --with-attempts`; incomplete / draft-bound suites stay here |
-| Patch one finished slot on an uploaded suite | New Attempt + suite slot pointer | Local `--resume-suite --replace-slot`, then `upload-suite --suite-run <id> --task <id> [--run <run_id>]`. Hub/Viewer default to current and can open `previous[]` |
+| Patch one finished slot on an uploaded suite | New Attempt + suite slot pointer | Local `--resume-suite --replace-slot`, then `upload-suite --suite-run <id> --task <id> [--run <run_id>]`. Hub/Viewer default to current; the version list is `patch N` plus that Attempt’s start time |
 | Archive one Attempt only | `bora results upload --run <run_id>` | May exist in Registry, but **usually not** on Leaderboard |
 
 ```bash

--- a/website/content/docs/share/hub.en.mdx
+++ b/website/content/docs/share/hub.en.mdx
@@ -68,6 +68,7 @@ Jobs rows with uploaded run artifacts open detail; others show **Not uploaded**.
 | A **Public Leaderboard** row | A **complete**, **release-bound** suite | `bora publish --draft` then `bora release` (or a direct `bora publish`) → `bora run <database>` **without** `--task` → `upload-suite --suite-run <id>` |
 | Leaderboard **Internal** | A caller-visible incomplete or draft-bound suite | Same `upload-suite`; does not appear on Public |
 | Task **Jobs** with openable Attempt / trajectory | Suite + **attempt** evidence | `upload-suite --with-attempts`; incomplete / draft-bound suites stay here |
+| Patch one finished slot on an uploaded suite | New Attempt + suite slot pointer | Local `--resume-suite --replace-slot`, then `upload-suite --suite-run <id> --task <id> [--run <run_id>]`. Hub/Viewer default to current and can open `previous[]` |
 | Archive one Attempt only | `bora results upload --run <run_id>` | May exist in Registry, but **usually not** on Leaderboard |
 
 ```bash

--- a/website/content/docs/share/hub.mdx
+++ b/website/content/docs/share/hub.mdx
@@ -70,7 +70,7 @@ Jobs 列表里，已有运行产物的行可以点进去看；没上传的会显
 | Dataset **Public Leaderboard** 一行 | **完备**且绑定 **release** 的 suite | 先 `bora publish --draft` 再 `bora release`（或直接 `bora publish`）→ 省略 `--task` 的 `bora run` → `upload-suite --suite-run <id>` |
 | Leaderboard **Internal** | 当前可见的缺题或 draft 绑定 suite | 同样 `upload-suite`；不会出现在 Public |
 | Task **Jobs** 可点开 Attempt / 轨迹 | suite + **attempt 证据** | `upload-suite --with-attempts`（或等价挂上 task_refs 的 attempt）；缺题 / draft 绑定也出现在这里 |
-| 给已上传 suite 换一格 finished 槽 | 新 Attempt + suite 现行指针 | 本机 `--resume-suite --replace-slot`，再 `upload-suite --suite-run <id> --task <id> [--run <run_id>]`。Hub / Viewer 默认现行，可打开 `previous[]` |
+| 给已上传 suite 换一格 finished 槽 | 新 Attempt + suite 现行指针 | 本机 `--resume-suite --replace-slot`，再 `upload-suite --suite-run <id> --task <id> [--run <run_id>]`。Hub / Viewer 默认现行；版本列表是 `patch N` + 该 Attempt 开始时间 |
 | 只归档一次 Attempt | `bora results upload --run <run_id>` | 可以进 Registry，但 **通常不会**出现在 Leaderboard |
 
 ```bash

--- a/website/content/docs/share/hub.mdx
+++ b/website/content/docs/share/hub.mdx
@@ -68,6 +68,7 @@ Jobs 列表里，已有运行产物的行可以点进去看；没上传的会显
 | Dataset **Public Leaderboard** 一行 | **完备**且绑定 **release** 的 suite | 先 `bora publish --draft` 再 `bora release`（或直接 `bora publish`）→ 省略 `--task` 的 `bora run` → `upload-suite --suite-run <id>` |
 | Leaderboard **Internal** | 当前可见的缺题或 draft 绑定 suite | 同样 `upload-suite`；不会出现在 Public |
 | Task **Jobs** 可点开 Attempt / 轨迹 | suite + **attempt 证据** | `upload-suite --with-attempts`（或等价挂上 task_refs 的 attempt）；缺题 / draft 绑定也出现在这里 |
+| 给已上传 suite 换一格 finished 槽 | 新 Attempt + suite 现行指针 | 本机 `--resume-suite --replace-slot`，再 `upload-suite --suite-run <id> --task <id> [--run <run_id>]`。Hub / Viewer 默认现行，可打开 `previous[]` |
 | 只归档一次 Attempt | `bora results upload --run <run_id>` | 可以进 Registry，但 **通常不会**出现在 Leaderboard |
 
 ```bash


### PR DESCRIPTION
Closes #126.

## Summary

Operators can replace one finished scoring slot on an already-completed suite without rewriting the old Attempt or the suite identity.

- `--resume-suite --task T --replace-slot` (Always-k: `--attempt-index`) writes a **new** `run_id`
- The outgoing current moves onto that slot's `previous[]` (oldest → newest superseded)
- Suite metrics (`pass_rate` / `mean_score` / `pass@k` / `pass^k`) recompute from **current** pointers only
- Registry `POST /v1/results/suites/{id}/slots` and `upload-suite --task` patch one slot; they do **not** reuse whole-row `--replace`
- Hub / Viewer stay read-only: default current, optional version switcher for `previous[]`

No backward-compat path: missing `previous[]` is an empty chain.

## Acceptance

- [x] Design docs: named-slot replace = new Attempt + current + `previous[]`; metrics from current; old Attempt immutable
- [x] `--resume-suite` without `--replace-slot` still skips finished PASS / FAIL / ERROR
- [x] `--resume-suite --task T --replace-slot` re-runs that slot; old row stays on disk and in `previous[]`
- [x] Always-k replace addresses one `(task_id, attempt_index)`; siblings unchanged
- [x] Registry appends one uploaded Attempt onto an existing `suite_run_id`; old Attempt GET still works
- [x] CLI uploads that one task/run without `--replace` wiping other tasks or old blobs
- [x] Hub / Viewer default to current; operator can open a previous `run_id`
- [x] In-progress suite / missing run / foreign `run_id` / fingerprint mismatch → reject
- [x] Reader-facing docs do not cite this issue number

## Local CI

Ran the path-filtered jobs this branch would trigger:

- `python-core` equivalent (ruff format/check, pyright, pytest minus L1/e2e ignores)
- `python-registry` (`pytest tests/registry`)
- `viewer-app` lint + build
- `hub-app` lint + build
- `website` build

## Non-goals (unchanged)

Auto-retry, whole-suite snapshot versions, banning amended suites from Public Leaderboard, mutating superseded blobs, Hub GUI write, evidence-grade upgrades.