### PR TITLE
feat(eval): declare L1 clean-eval /tmp size on evaluation.tmpfs_mb

### DIFF
--- a/docs/design/02-task-package-and-config.md
+++ b/docs/design/02-task-package-and-config.md
@@ -230,7 +230,7 @@ Package 里的自然语言按读者与用途分层，**不**强制存在根级 `
 | `agent_profiles` | **角色槽**（role id + 可选 workspace 约束）；**不含** executor/entry/model | Config Core 合并后 → **Agent Service** |
 | `environment` | 外部资源、lifecycle、action allowlist | Runtime、Environment Manager |
 | `limits` | wall time、memory、process、Agent/Environment 外层硬上限（**任务契约**，job 不可覆盖） | Runtime、Provider、Capability |
-| `artifacts` / `evaluation` | 可发布产物、Evaluator 输入、隔离和结果格式 | Artifact Owner、Evaluator Runner |
+| `artifacts` / `evaluation` | 可发布产物、Evaluator 输入、隔离、结果格式、**评测沙箱**（`network`、`tmpfs_mb`） | Artifact Owner、Evaluator Runner |
 
 `parameters` 是统一的实验参数空间。`harness` 只定位入口（`runtime` + `entrypoint`），不再同时保存另一套 `params`，也不挂载任务说明或 prompt 路径。这样可以避免 `harness.params`、`tool_limits` 和 Campaign override 分散在多个位置；自然语言提示词由 package 的 `prompts/` 与 `harness.py` 负责。
 
@@ -432,6 +432,7 @@ evaluation:
   runtime: python
   entrypoint: evaluator:evaluate
   network: none
+  tmpfs_mb: 256   # optional; L1 clean-eval /tmp size (MiB); omit → 32
   inputs:
     - artifact: reducer-output
       target: artifacts/reducer-output.json
@@ -582,7 +583,8 @@ Config Core 至少检查：
 - `action_commands` 只引用已有 component；
 - limits 为非负且在实现支持范围内；
 - Artifact producer、path 和 evaluator input 引用一致；
-- evaluator runtime、network 和 output format 有对应实现。
+- evaluator runtime、network 和 output format 有对应实现；
+- `evaluation.tmpfs_mb` 若出现则必须是正整数（省略则锁定为 32）。**不是** `limits.*`。
 
 Config Core 不校验某个 Planner 会选择哪个 specialist，也不检查 Harness 是否真的调用某个 Tool。前者属于运行时算法，后者由 Harness 和测试确认。
 

--- a/docs/design/07-budget-evaluation-failure.md
+++ b/docs/design/07-budget-evaluation-failure.md
@@ -17,10 +17,13 @@
 | 类型 | 配置位置 | 执行者 | MVP 示例 |
 | --- | --- | --- | --- |
 | 硬顶 | `limits` | Provider/Runtime/Capability | wall time、memory、process、Agent invocation 总量、Environment action 总量 |
+| 评测沙箱 | `evaluation` | Evaluation Core / L1 clean-eval | `network`、`tmpfs_mb`（clean-eval `/tmp`，默认 32 MiB） |
 | 软限 | `parameters.agents` | Harness `AgentSession` | 单 Agent max turns |
 | 软限 | `parameters.tools` | Harness `CallLimit` | 单 Tool max calls |
 | 软限 | `parameters.workflow` | Harness 普通代码/helper | follow-up 次数、fan-out 并发 |
 | Campaign 边界 | Campaign plan | Campaign Coordinator | Trial/Attempt/concurrency |
+
+`evaluation.tmpfs_mb` 只约束 **L1 clean-eval** 容器的 `/tmp` tmpfs，与 Attempt / Agent 的 64 MiB `/tmp` 无关。它和 `evaluation.network` 同属评测运行时，**不要**写成 `limits.eval_tmpfs_*`：`limits` 是 Attempt / Agent / Environment 硬顶，混进去会把两个独立事实绑在同一套「不可 `--set`」契约上。省略则保持 32 MiB fail-closed 默认；非法或非正整数在 lock 失败，不静默放大。
 
 token/cost 只有在 Provider 支持调用前 reserve 时才能成为硬顶；否则只能作为 usage observation，不应把事后统计描述成执行前保证。
 
@@ -91,7 +94,7 @@ Harness returns
   → bind Result + cleanup
 ```
 
-Runtime 可以在 materialize 内部执行 Artifact digest/只读副本、clean evaluator runtime 或 Environment freeze/getter；只有对应 input strategy 声明时才启用，不把九个内部动作变成每个 task 的公共仪式。
+Runtime 可以在 materialize 内部执行 Artifact digest/只读副本、clean evaluator runtime 或 Environment freeze/getter；只有对应 input strategy 声明时才启用，不把九个内部动作变成每个 task 的公共仪式。L1 clean-eval 容器只读根文件系统，可写面是 `/tmp` tmpfs；容量读 `evaluation.tmpfs_mb`（省略 32 MiB）。snapshot 大于默认值时由 **task 声明更大的评测沙箱**，而不是抬高全局默认或改 Agent workspace `/tmp`。
 
 ## 失败语义
 

--- a/skills/bora-config-package/SKILL.md
+++ b/skills/bora-config-package/SKILL.md
@@ -217,6 +217,7 @@ evaluation:
   runtime: python
   entrypoint: evaluator:evaluate
   network: none
+  # tmpfs_mb: 256          # optional L1 clean-eval /tmp (MiB); omit → 32. Not limits.*
   inputs:
     - artifact: session-output
       target: artifacts/session-output.json

--- a/skills/bora-config-package/references/bora-yaml.md
+++ b/skills/bora-config-package/references/bora-yaml.md
@@ -20,7 +20,9 @@
   `provider.dockerfile` override) **required** at lock time
 - `agent_profiles`: role slots only (`{id}`); executor / model / `options` live in Database `profiles.yaml`
 - `limits`: wall / agent_invocations / environment_actions / memory_mb
-- `evaluation`: runtime, entrypoint, inputs, output.format
+- `evaluation`: runtime, entrypoint, inputs, output.format; optional `network`;
+  optional `tmpfs_mb` (positive int, L1 clean-eval `/tmp` MiB, default 32).
+  **Not** a `limits.*` field.
 - Optional `provenance` (fully replaces Database-root default when set)
 
 ## Provenance (optional)

--- a/src/bora/application/attempt/run_l1_evaluator.py
+++ b/src/bora/application/attempt/run_l1_evaluator.py
@@ -8,6 +8,19 @@ import textwrap
 from pathlib import Path
 from typing import Any
 
+from bora.config.constants import DEFAULT_EVAL_TMPFS_MB
+
+
+def clean_eval_tmpfs_mount(tmpfs_mb: int) -> str:
+    """Docker ``--tmpfs`` spec for the clean-eval ``/tmp``.
+
+    Fail closed on non-positive values. Never clamp to a huge default.
+    Distinct from the Agent Attempt 64 MiB ``/tmp``.
+    """
+    if not isinstance(tmpfs_mb, int) or isinstance(tmpfs_mb, bool) or tmpfs_mb < 1:
+        raise ValueError("evaluation.tmpfs_mb must be a positive integer")
+    return f"/tmp:rw,noexec,nosuid,size={tmpfs_mb}m"
+
 
 def run_clean_evaluator_container(
     *,
@@ -16,6 +29,7 @@ def run_clean_evaluator_container(
     artifact_filename: str,
     artifact_key: str,
     expected_filename: str | None,
+    tmpfs_mb: int = DEFAULT_EVAL_TMPFS_MB,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     arts = f'"artifacts": {{"{artifact_key}": "/eval/{artifact_filename}"'
     if expected_filename:
@@ -58,7 +72,7 @@ def run_clean_evaluator_container(
         "none",
         "--read-only",
         "--tmpfs",
-        "/tmp:rw,noexec,nosuid,size=32m",
+        clean_eval_tmpfs_mount(tmpfs_mb),
         "-v",
         f"{staging}:/eval:ro",
         "--workdir",

--- a/src/bora/application/attempt/run_l1_evaluator.py
+++ b/src/bora/application/attempt/run_l1_evaluator.py
@@ -12,11 +12,7 @@ from bora.config.constants import DEFAULT_EVAL_TMPFS_MB
 
 
 def clean_eval_tmpfs_mount(tmpfs_mb: int) -> str:
-    """Docker ``--tmpfs`` spec for the clean-eval ``/tmp``.
-
-    Fail closed on non-positive values. Never clamp to a huge default.
-    Distinct from the Agent Attempt 64 MiB ``/tmp``.
-    """
+    """Docker ``--tmpfs`` spec for clean-eval ``/tmp``."""
     if not isinstance(tmpfs_mb, int) or isinstance(tmpfs_mb, bool) or tmpfs_mb < 1:
         raise ValueError("evaluation.tmpfs_mb must be a positive integer")
     return f"/tmp:rw,noexec,nosuid,size={tmpfs_mb}m"

--- a/src/bora/application/attempt/run_l1_phases.py
+++ b/src/bora/application/attempt/run_l1_phases.py
@@ -23,6 +23,7 @@ from bora.application.attempt.run_l1_prepare import (
     prepare_l1_runtime,
     seed_l1_workspace,
 )
+from bora.config.constants import DEFAULT_EVAL_TMPFS_MB
 from bora.config.model import thaw
 from bora.evaluation.result_binding import bind_result
 from bora.evidence.locators import portable_run_locator
@@ -421,12 +422,15 @@ def evaluate_l1(ctx: AttemptStageContext) -> None:
             ctx.l1_meta["evaluation_runtime"] = (
                 dict(runtime_ann) if isinstance(runtime_ann, dict) else {"value": runtime_ann}
             )
+        eval_cfg = thaw(ctx.lock.evaluation)
+        raw_tmpfs = eval_cfg.get("tmpfs_mb", DEFAULT_EVAL_TMPFS_MB)
         eval_raw, eval_meta = run_clean_evaluator_container(
             image_tag=runtime.image_lock.image_tag if runtime.image_lock else "bora-attempt:l1",
             staging=staging,
             artifact_filename=artifact_filename,
             artifact_key=artifact_key,
             expected_filename=expected_filename,
+            tmpfs_mb=raw_tmpfs,
         )
         if isinstance(eval_raw, dict):
             eval_raw = hook_score_postprocess(ctx.lock, eval_raw)

--- a/src/bora/config/constants.py
+++ b/src/bora/config/constants.py
@@ -41,6 +41,9 @@ ALLOWLISTED_OVERRIDE_POINTERS = frozenset(
     }
 )
 
+# L1 clean-eval /tmp tmpfs (MiB). Not a limits.* hard ceiling — Evaluation sandbox.
+DEFAULT_EVAL_TMPFS_MB = 32
+
 # Explicit defaults applied after reading task.yaml, before variant/overrides.
 # Every allowlisted override pointer leaf must exist after defaults so --set can set it.
 DEFAULTS: dict[str, Any] = {
@@ -59,4 +62,7 @@ DEFAULTS: dict[str, Any] = {
     },
     "agent_profiles": [],
     "environment": None,
+    "evaluation": {
+        "tmpfs_mb": DEFAULT_EVAL_TMPFS_MB,
+    },
 }

--- a/src/bora/config/constants.py
+++ b/src/bora/config/constants.py
@@ -41,7 +41,7 @@ ALLOWLISTED_OVERRIDE_POINTERS = frozenset(
     }
 )
 
-# L1 clean-eval /tmp tmpfs (MiB). Not a limits.* hard ceiling — Evaluation sandbox.
+# L1 clean-eval /tmp size (MiB).
 DEFAULT_EVAL_TMPFS_MB = 32
 
 # Explicit defaults applied after reading task.yaml, before variant/overrides.

--- a/src/bora/config/validate.py
+++ b/src/bora/config/validate.py
@@ -447,6 +447,15 @@ def validate_document(
                     ERROR_PATH_OUTSIDE_PACKAGE, f"path escapes package: {pp}", location=loc
                 )
 
+    if "tmpfs_mb" in evaluation:
+        tmpfs_mb = evaluation["tmpfs_mb"]
+        if not isinstance(tmpfs_mb, int) or isinstance(tmpfs_mb, bool) or tmpfs_mb < 1:
+            raise ConfigError(
+                ERROR_INVALID_SCHEMA,
+                "evaluation.tmpfs_mb must be a positive integer",
+                location="/evaluation/tmpfs_mb",
+            )
+
 
 def collect_resolved_references(doc: dict[str, Any], root: Path) -> dict[str, Any]:
     """Collect logical, package-relative references for the lock summary."""

--- a/tests/application/test_l1_eval_tmpfs.py
+++ b/tests/application/test_l1_eval_tmpfs.py
@@ -1,0 +1,159 @@
+"""L1 clean-eval applies evaluation.tmpfs_mb to /tmp tmpfs (not Attempt /tmp)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from bora.application.attempt.run_l1_evaluator import (
+    clean_eval_tmpfs_mount,
+    run_clean_evaluator_container,
+)
+from bora.config.constants import DEFAULT_EVAL_TMPFS_MB
+
+
+def test_clean_eval_tmpfs_mount_default_and_override() -> None:
+    assert clean_eval_tmpfs_mount(DEFAULT_EVAL_TMPFS_MB) == "/tmp:rw,noexec,nosuid,size=32m"
+    assert clean_eval_tmpfs_mount(256) == "/tmp:rw,noexec,nosuid,size=256m"
+
+
+@pytest.mark.parametrize("bad", [0, -1, True, 32.5, "256", None])
+def test_clean_eval_tmpfs_mount_rejects_bad(bad: object) -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        clean_eval_tmpfs_mount(bad)  # type: ignore[arg-type]
+
+
+def test_run_clean_evaluator_uses_declared_tmpfs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        captured["cmd"] = list(cmd)
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(returncode=0, stdout='{"status":"PASS","score":1.0}\n', stderr="")
+
+    monkeypatch.setattr(
+        "bora.application.attempt.run_l1_evaluator.subprocess.run",
+        _run,
+    )
+    staging = tmp_path / "eval"
+    staging.mkdir()
+    raw, meta = run_clean_evaluator_container(
+        image_tag="bora-attempt:l1",
+        staging=staging,
+        artifact_filename="workspace-snapshot.tar.gz",
+        artifact_key="workspace-snapshot",
+        expected_filename=None,
+        tmpfs_mb=256,
+    )
+    assert raw["status"] == "PASS"
+    assert meta["ok"] is True
+    cmd = captured["cmd"]
+    assert cmd[:2] == ["docker", "run"]
+    idx = cmd.index("--tmpfs")
+    assert cmd[idx + 1] == "/tmp:rw,noexec,nosuid,size=256m"
+    assert "--read-only" in cmd
+    assert "size=32m" not in cmd
+    assert "size=64m" not in cmd
+
+
+def test_run_clean_evaluator_defaults_to_32m(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, list[str]] = {}
+
+    def _run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
+        captured["cmd"] = list(cmd)
+        return SimpleNamespace(returncode=0, stdout='{"status":"PASS","score":1.0}\n', stderr="")
+
+    monkeypatch.setattr(
+        "bora.application.attempt.run_l1_evaluator.subprocess.run",
+        _run,
+    )
+    staging = tmp_path / "eval"
+    staging.mkdir()
+    run_clean_evaluator_container(
+        image_tag="bora-attempt:l1",
+        staging=staging,
+        artifact_filename="out.json",
+        artifact_key="out",
+        expected_filename=None,
+    )
+    idx = captured["cmd"].index("--tmpfs")
+    assert captured["cmd"][idx + 1] == "/tmp:rw,noexec,nosuid,size=32m"
+
+
+def test_evaluate_l1_passes_lock_tmpfs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from bora.application.attempt.attempt_stages import AttemptStageContext
+    from bora.application.attempt.run_l1_phases import evaluate_l1
+
+    captured: dict[str, Any] = {}
+
+    def _fake_eval(**kwargs: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+        captured.update(kwargs)
+        return (
+            {"status": "PASS", "score": 1.0, "metrics": {}},
+            {"ok": True, "writer_stop_confirmed": True},
+        )
+
+    monkeypatch.setattr(
+        "bora.application.attempt.run_l1_phases.run_clean_evaluator_container",
+        _fake_eval,
+    )
+    monkeypatch.setattr(
+        "bora.application.attempt.extension_hooks.hook_evaluation_input",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "bora.application.attempt.extension_hooks.hook_evaluation_runtime",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "bora.application.attempt.extension_hooks.hook_score_postprocess",
+        lambda _lock, raw: raw,
+    )
+
+    src = tmp_path / "art.json"
+    src.write_text("{}", encoding="utf-8")
+    staging = tmp_path / "eval_staging"
+    staging.mkdir()
+    lock = SimpleNamespace(evaluation={"tmpfs_mb": 256})
+    runtime = SimpleNamespace(
+        image_lock=SimpleNamespace(image_tag="bora-pkg:test"),
+        writer_inventory=[],
+        writer_stop_confirmed=True,
+    )
+    ctx = AttemptStageContext(
+        package_root=tmp_path,
+        lock=lock,
+        run_dir=tmp_path,
+        runtime=runtime,
+        artifacts_map={
+            "artifact_key": "workspace-snapshot",
+            "artifact_filename": "workspace-snapshot.tar.gz",
+            "src": str(src),
+        },
+    )
+    evaluate_l1(ctx)
+    assert captured["tmpfs_mb"] == 256
+    assert captured["image_tag"] == "bora-pkg:test"
+
+
+def test_run_clean_evaluator_rejects_bad_tmpfs_before_docker(tmp_path: Path) -> None:
+    staging = tmp_path / "eval"
+    staging.mkdir()
+    with pytest.raises(ValueError, match="positive integer"):
+        run_clean_evaluator_container(
+            image_tag="bora-attempt:l1",
+            staging=staging,
+            artifact_filename="out.json",
+            artifact_key="out",
+            expected_filename=None,
+            tmpfs_mb=0,
+        )

--- a/tests/application/test_l1_eval_tmpfs.py
+++ b/tests/application/test_l1_eval_tmpfs.py
@@ -87,9 +87,7 @@ def test_run_clean_evaluator_defaults_to_32m(
     assert captured["cmd"][idx + 1] == "/tmp:rw,noexec,nosuid,size=32m"
 
 
-def test_evaluate_l1_passes_lock_tmpfs(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_evaluate_l1_passes_lock_tmpfs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from bora.application.attempt.attempt_stages import AttemptStageContext
     from bora.application.attempt.run_l1_phases import evaluate_l1
 

--- a/tests/config/test_load_and_lock.py
+++ b/tests/config/test_load_and_lock.py
@@ -320,9 +320,7 @@ def _clone_minimal(tmp_path: Path, *, evaluation_extra: str = "") -> Path:
     return pkg
 
 
-def test_eval_tmpfs_defaults_to_32(
-    core: ConfigCore, catalog: DeclarationCapabilityCatalog
-) -> None:
+def test_eval_tmpfs_defaults_to_32(core: ConfigCore, catalog: DeclarationCapabilityCatalog) -> None:
     locked = _lock(core, catalog, MINIMAL, "config-minimal")
     assert thaw(locked.evaluation)["tmpfs_mb"] == 32
     assert "eval_tmpfs" not in thaw(locked.limits)

--- a/tests/config/test_load_and_lock.py
+++ b/tests/config/test_load_and_lock.py
@@ -303,3 +303,52 @@ def test_database_profiles_load_via_cli_path(
     )
     assert thaw(locked.agent_profiles)[0]["id"] == "mock-default"
     assert thaw(locked.agent_profiles)[0]["executor"] == "mock"
+
+
+def _clone_minimal(tmp_path: Path, *, evaluation_extra: str = "") -> Path:
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    yaml = (MINIMAL / "task.yaml").read_text(encoding="utf-8")
+    if evaluation_extra:
+        yaml = yaml.replace(
+            "  output:\n    format: json\n",
+            f"  output:\n    format: json\n{evaluation_extra}",
+        )
+    (pkg / "task.yaml").write_text(yaml, encoding="utf-8")
+    (pkg / "harness.py").write_text((MINIMAL / "harness.py").read_text(encoding="utf-8"))
+    (pkg / "evaluator.py").write_text((MINIMAL / "evaluator.py").read_text(encoding="utf-8"))
+    return pkg
+
+
+def test_eval_tmpfs_defaults_to_32(
+    core: ConfigCore, catalog: DeclarationCapabilityCatalog
+) -> None:
+    locked = _lock(core, catalog, MINIMAL, "config-minimal")
+    assert thaw(locked.evaluation)["tmpfs_mb"] == 32
+    assert "eval_tmpfs" not in thaw(locked.limits)
+    sources = {(e.source, e.pointer) for e in locked.resolution.entries}
+    assert ("default", "/evaluation/tmpfs_mb") in sources
+
+
+def test_eval_tmpfs_override_accepted(
+    core: ConfigCore, catalog: DeclarationCapabilityCatalog, tmp_path: Path
+) -> None:
+    pkg = _clone_minimal(tmp_path, evaluation_extra="  tmpfs_mb: 256\n")
+    locked = _lock(core, catalog, pkg, "config-minimal")
+    assert thaw(locked.evaluation)["tmpfs_mb"] == 256
+    sources = {(e.source, e.pointer) for e in locked.resolution.entries}
+    assert ("default", "/evaluation/tmpfs_mb") not in sources
+
+
+@pytest.mark.parametrize("raw", ["0", "-1", "true", "32.5", '"256"'])
+def test_eval_tmpfs_rejects_bad_value(
+    core: ConfigCore,
+    catalog: DeclarationCapabilityCatalog,
+    tmp_path: Path,
+    raw: str,
+) -> None:
+    pkg = _clone_minimal(tmp_path, evaluation_extra=f"  tmpfs_mb: {raw}\n")
+    with pytest.raises(ConfigError) as ei:
+        _lock(core, catalog, pkg, "config-minimal")
+    assert ei.value.error_code == "invalid_schema"
+    assert ei.value.location == "/evaluation/tmpfs_mb"

--- a/website/content/docs/author/write-evaluator.en.mdx
+++ b/website/content/docs/author/write-evaluator.en.mdx
@@ -19,6 +19,7 @@ evaluation:
   runtime: python
   entrypoint: evaluator:evaluate
   network: none
+  # tmpfs_mb: 256   # optional L1 clean-eval /tmp (MiB); omit → 32. Not limits.*
   inputs:
     - artifact: session-output
       target: artifacts/session-output.json
@@ -31,5 +32,6 @@ evaluation:
 | Barrier | Inputs materialize after harness ends |
 | Gold | Under `evaluation/`; omitting yaml paths ≠ isolation |
 | Artifact ids | Must match files the harness actually writes |
+| `tmpfs_mb` | L1 clean-eval `/tmp` only; omit → 32 MiB. Declare a larger sandbox on the **task**, not under `limits` |
 
 Runtime and evaluation stay separate facts. See [Results and PASS](/docs/reference/results-and-pass).

--- a/website/content/docs/author/write-evaluator.mdx
+++ b/website/content/docs/author/write-evaluator.mdx
@@ -19,6 +19,7 @@ evaluation:
   runtime: python
   entrypoint: evaluator:evaluate
   network: none
+  # tmpfs_mb: 256   # 可选；L1 clean-eval /tmp（MiB），省略则 32。不是 limits.*
   inputs:
     - artifact: session-output
       target: artifacts/session-output.json
@@ -34,5 +35,6 @@ evaluation:
 | 屏障 | harness 结束后才 materialize 输入 |
 | gold | 放 `evaluation/`，不要指望「删 yaml 字段」当隔离 |
 | artifact id | 必须和 harness 实际写出的文件对上 |
+| `tmpfs_mb` | 只改 L1 clean-eval `/tmp`；省略 32 MiB。大 snapshot 在 **task** 上声明，不要写进 `limits` |
 
 读结果时 runtime 与 evaluation 是分开的事实。见 [结果与 PASS](/docs/reference/results-and-pass)。

--- a/website/content/docs/reference/config-fields.en.mdx
+++ b/website/content/docs/reference/config-fields.en.mdx
@@ -32,7 +32,7 @@ Empty suite fails lock.
 | `agent_profiles` | ACP needs `options.entry`; `api_key` = env name |
 | `limits` | wall / invokes / env actions / memory |
 | `artifacts` | publishable id + path |
-| `evaluation` | entrypoint, network, inputs, output |
+| `evaluation` | entrypoint, network, inputs, output; optional `tmpfs_mb` (L1 clean-eval `/tmp`, positive MiB, default 32; **not** `limits.*`) |
 | `provenance` | optional; member replaces root |
 
 ## Job binding (`profiles.yaml`)

--- a/website/content/docs/reference/config-fields.mdx
+++ b/website/content/docs/reference/config-fields.mdx
@@ -32,7 +32,7 @@ description: bora.yaml / task.yaml 字段与校验要点速查。
 | `agent_profiles` | `{id, executor, model, …}`；ACP 必填 `options.entry`；`api_key` 只写环境变量名 |
 | `limits` | wall / agent_invocations / environment_actions / memory_mb |
 | `artifacts.publishable` | id + path + producer |
-| `evaluation` | entrypoint、network、inputs、output.format |
+| `evaluation` | entrypoint、network、inputs、output.format；可选 `tmpfs_mb`（L1 clean-eval `/tmp`，正整数 MiB，省略 32；**不是** `limits.*`） |
 | `provenance` | 可选；成员整块替换根默认 |
 
 ## Job binding（`profiles.yaml`）


### PR DESCRIPTION
Closes #130.

## Summary

A task can declare the L1 clean-eval `/tmp` tmpfs size on member `evaluation.tmpfs_mb`. Config Core locks it; the clean-eval `docker run` applies `size=`. Omitted still means **32 MiB**. This is **not** a `limits.*` field.

No backward compatibility: omitted locks to 32, so re-lock changes digest.

## What landed

- Schema / lock accept optional `evaluation.tmpfs_mb` (positive int). Default 32. Non-positive / non-int fail closed at lock (and again when building the Docker spec — no silent clamp).
- L1 clean-eval uses the locked value for `--tmpfs /tmp:…`. Agent Attempt 64 MiB `/tmp` is unchanged.
- Design `02` / `07`, `bora-config-package` field notes, and reader-facing website pages (zh + en). No Issue numbers in reader docs.
- `limits.*` catalog unchanged.

## Replay of the original failure

Leftover `adaptive-rejection-sampler` Attempt (`eval_staging` snapshot ~271 MiB compressed, 1436 files) used to die with `OSError: [Errno 28] No space left on device` under the 32 MiB eval `/tmp`.

Replayed `run_clean_evaluator_container(..., tmpfs_mb=512)` against that staging + image `bora-pkg:8bcaf8368397`:

- Extract succeeded (`snapshot_files: 1436`)
- Container exit 0 — **no ENOSPC**
- Evaluator returned **FAIL / score 0.0** (Harbor `test_outputs.py` missing `numpy` in the eval image). That is a valid evaluation result, not an evaluation-phase ERROR. Package / image bake remains out of scope.

Lock of the same task: omitted → `tmpfs_mb: 32`; declared `512` → 512; `limits` keys unchanged.

## Local CI

- `python-core`: ruff format/check, pyright, pytest (CI ignore set) — **668 passed**
- `python-registry`: **138 passed, 2 skipped**
- `website`: `pnpm --dir website build`

## Review

Subagent review of the branch vs `origin/main`: **approve with nits** (comment noise). Those two comments were shortened on this branch.

## Non-goals (kept)

- Do not raise the global default for TB2 R installs
- Do not change Agent Attempt `/tmp`
- Do not treat this as fixing workspace `apt` bloat
- Do not claim `real-benchmark-verified` from the replay