### PR TITLE
feat(plugins): per-plugin options and home_overlay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ apps/* / services/* README  ← SPA / 服务开发细节；非产品教程权威
 | 证据等级        | **限定 `runnable-mvp`（L0）** 及部分 L1 路径；见 [examples/README.md](examples/README.md)；**不得**扩写全 suite `isolated`                                                                                                                                                  |
 | 交付跟踪        | **GitHub Issues**（无 ROADMAP / Active Spec）                                                                                                                                                                                                                               |
 | 文档站          | [`website/`](website/) 读者向 Fumadocs；机制权威仍在 `docs/`                                                                                                                                                                                                                |
-| ACP             | 产品决策已接受（`executor: acp` + `options.entry`）；余量与 gap 见 Issues（如 #4）；**有站 ≠ 证据升级**                                                                                                                                                                     |
+| ACP             | 产品决策已接受（`executor: acp` + `- plugin: acp` / `options.entry`）；余量与 gap 见 Issues（如 #4）；**有站 ≠ 证据升级**                                                                                                                                                                     |
 
 **禁止**从文档存在、Issue 存在、`bora lock` 成功或设计示意推导 `runnable-mvp` / `isolated` / `real-benchmark-verified`。
 
@@ -93,7 +93,7 @@ apps/* / services/* README  ← SPA / 服务开发细节；非产品教程权威
 
 ### Agent 后端 / ACP
 
-- Coding-agent **Target inlet**：`executor: acp` + `options.entry`；parent **唯一** ACP JSON-RPC client → `AgentResult` + evidence。
+- Coding-agent **Target inlet**：`executor: acp` + `- plugin: acp` / `options.entry`；parent **唯一** ACP JSON-RPC client → `AgentResult` + evidence。
 - Vendor 私有格式翻译在 **进程外** ACP entry（Mode 1 shim / Mode 2 原生 / Mode 3 厂商包）；**禁止**在 BORA 内再写第二套 vendor stdout scrape（含 `agent_container` heuristic JSON）。
 - **L1 官方基座** `docker/attempt` 在 **build 期** bake-in 最低 **五** entry 的 engine + ACP 入口（Mode 1 **双装**：codex/claude/**pi**+各自 adapter）；禁止 invoke 时 `npm i` / floating `npx`。Python ACP SDK **只在 parent**，不进 Attempt 镜像。
 - Pi：官方 registry **`pi-acp`**（npm `pi-acp`，桥 `pi --mode rpc`）纳入最低集；勿与反向桥 `pi-shell-acp` 混淆。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -289,6 +289,7 @@ invoke       → before_agent_invoke → executor.invoke → after_agent_invoke
                     → trajectory_seal provide → evidence_extra
 close_session → before_agent_close → executor.close → after_agent_close
 
+home_overlay → Core default builds cred tree → nxt (plugin files) → copy actor HOME
 env prepare  → seed/health → env_prepare multi (live ctx)
              → env_inject multi → env_action provide (optional action_gate)
 env teardown → env_teardown multi → EnvironmentManager.close

--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ agent_profiles:
 # bindings:
 #   solver:
 #     executor: acp
-#     options: { entry: codex }  # see: bora executors
+#     extensions:
+#       - plugin: acp
+#         options: { entry: codex }  # see: bora executors
 #     model: gpt-5.4-mini
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -137,7 +137,9 @@ agent_profiles:
 # bindings:
 #   solver:
 #     executor: acp
-#     options: { entry: codex }  # 以 bora executors 为准
+#     extensions:
+#       - plugin: acp
+#         options: { entry: codex }  # 以 bora executors 为准
 #     model: gpt-5.4-mini
 ```
 

--- a/apps/hub/src/components/plugin-slot-timeline.tsx
+++ b/apps/hub/src/components/plugin-slot-timeline.tsx
@@ -11,6 +11,7 @@ const SLOT_LEVEL: Record<string, number> = {
   before_cleanup: 0,
   after_cleanup: 0,
   image_contribute: 1,
+  home_overlay: 1,
   env_prepare_commands: 1,
   env_inject: 1,
   env_action: 1,

--- a/docs/design/01-bora-core.md
+++ b/docs/design/01-bora-core.md
@@ -215,4 +215,4 @@ src/bora/
 └── （可选 SDK 在 sdk/python/bora_sdk/）
 ```
 
-“Core”表示必须稳定的职责，不要求按图中每个名字硬拆文件。Application 负责组装；**机制实现**可以是主仓 first-party，也可以是实现约定 entry point 的用户/第三方包（见 [05-runtime/agent-service.md](05-runtime/agent-service.md) 扩展模型）。coding-agent 入口为 **`executor: acp` + `options.entry`**（adapters/acp + entry registry），不是 per-vendor 私有 CLI adapter 目录。Harness Core 是 Task Package 侧可选 library。
+“Core”表示必须稳定的职责，不要求按图中每个名字硬拆文件。Application 负责组装；**机制实现**可以是主仓 first-party，也可以是实现约定 entry point 的用户/第三方包（见 [05-runtime/agent-service.md](05-runtime/agent-service.md) 扩展模型）。coding-agent 入口为 **`executor: acp` + `- plugin: acp` / `options.entry`**（adapters/acp + entry registry），不是 per-vendor 私有 CLI adapter 目录。Harness Core 是 Task Package 侧可选 library。

--- a/docs/design/02-task-package-and-config.md
+++ b/docs/design/02-task-package-and-config.md
@@ -360,32 +360,14 @@ provider:
 
 agent_profiles:
   # profile = 可切换的 Agent 后端绑定；见 design/05-runtime/agent-service.md
-  # coding-agent: executor: acp + options.entry
+  # 成员只声明角色槽。coding-agent 绑定见 Database profiles.yaml：
+  # executor: acp + - plugin: acp / options.entry
   - id: codex-database-specialist
-    executor: acp
-    model: o4-mini
     workspace_view: agents
-    options:
-      entry: codex
   - id: codex-database-planner
-    executor: acp
-    model: o4-mini
     workspace_view: agents
-    options:
-      entry: codex
   - id: codex-database-reducer
-    executor: acp
-    model: o4-mini
     workspace_view: agents
-    options:
-      entry: codex
-  # 混用示例：planner 换 OpenCode 或 Pi ACP entry
-  # - id: opencode-database-planner
-  #   executor: acp
-  #   options: { entry: opencode }
-  # - id: pi-database-planner
-  #   executor: acp
-  #   options: { entry: pi }
 
 environment:
   id: database-attempt

--- a/docs/design/02-task-package-and-config.md
+++ b/docs/design/02-task-package-and-config.md
@@ -261,7 +261,7 @@ member task.yaml（角色槽 + intent + harness/eval）
 - Leaderboard **job 轴**是 suite 级 `profiles.yaml` / `job_overlay`（role id → entry/model），不是「各 task 角色槽拓扑是否相同」。不同 task 可用不同 role id；只要绑定文档一致，`config_homogeneous` 仍为 true，公开可比榜展示该 yaml。
 - 仅当同一 suite 内出现**同一 role id 的 entry/model 冲突**（或无法解析 job 轴）时 `config_homogeneous: false`。
 
-**Agent 后端可切换、可混用**是一等需求（见 [05-runtime/agent-service.md](05-runtime/agent-service.md)）：`parameters.models.*` 只点 **role / profile id**；真正跑哪条 coding-agent 后端写在 Database `profiles.yaml`（或 CLI overlay）。coding-agent 配置形状为 `executor: acp` + `options.entry`（registry entry_id：`codex` / `claude-code` / **`pi`** / `opencode` / `grok-build`…）；`openai-http` 为独立 api-client。Campaign 换后端时优先改 binding 的 `options.entry`/`model`（`--set '/bindings/solver/…'` 或 `--matrix`），不必改 `harness.py`。
+**Agent 后端可切换、可混用**是一等需求（见 [05-runtime/agent-service.md](05-runtime/agent-service.md)）：`parameters.models.*` 只点 **role / profile id**；真正跑哪条 coding-agent 后端写在 Database `profiles.yaml`（或 CLI overlay）。coding-agent 配置形状为 `executor: acp` + `- plugin: acp` 行上的 `options.entry`（registry entry_id：`codex` / `claude-code` / **`pi`** / `opencode` / `grok-build`…）；`openai-http` 为独立 api-client。Campaign 换后端时优先改 binding 的 executor 行 `options.entry`/`model`（`--set '/bindings/solver/…'` 或 `--matrix`），不必改 `harness.py`。
 
 #### L1 / `provider.kind: docker` 与 package Dockerfile
 

--- a/docs/design/05-runtime/agent-service.md
+++ b/docs/design/05-runtime/agent-service.md
@@ -55,13 +55,13 @@ bindings:
   # api-client（非 coding-agent ACP 路径）
   # 可选 per-profile 上游路由（与 model 同级）：
   # - base_url: non-secret endpoint（进入 lock digest）
-  # - api_key: 环境变量 *名* only（locator）；值来自 host/.env，
+  # - api_key: ${ENV_NAME} locator only；值来自 host/.env，
   #   投影进 Executor 时使用 — 永不写入 lock/evidence
   glm-coding-http:
     executor: openai-http
     model: glm-4.7
     base_url: https://open.bigmodel.cn/api/coding/paas/v4
-    api_key: zhipu_coding_api_key
+    api_key: ${zhipu_coding_api_key}
 
 parameters:
   models:

--- a/docs/design/05-runtime/agent-service.md
+++ b/docs/design/05-runtime/agent-service.md
@@ -11,7 +11,7 @@
 | 概念 | 是什么 | 谁拥有 |
 | --- | --- | --- |
 | **Task Harness** | package 的 `harness.py` / upstream workflow | Task Package |
-| **Agent 后端 / Executor** | 真正执行一次模型/agent 调用的实现。**coding-agent** 走 `executor: acp` + `options.entry`；另保留 `openai-http`（api-client） | Runtime **Agent Service** + Executor Adapter |
+| **Agent 后端 / Executor** | 真正执行一次模型/agent 调用的实现。**coding-agent** 走 `executor: acp` + `- plugin: acp` / `options.entry`；另保留 `openai-http`（api-client） | Runtime **Agent Service** + Executor Adapter |
 | **agent_profile** | 命名绑定：`executor` + `model` + `options` + `workspace_view` | `task.yaml` / Database 成员配置 → LockedTaskConfig |
 | **ACP entry** | 标准 ACP stdio 入口（官方 shim / 原生 `acp` 子命令 / 厂商包）；翻译 vendor 私有协议 | 进程外二进制；由 registry pin，L1 镜像 bake-in |
 | **profile 引用** | Harness 使用的逻辑名（如 `parameters.models.planner`） | `parameters`（可被 Campaign override） |
@@ -21,42 +21,43 @@
 ## 配置如何表达切换与混用
 
 ```yaml
-agent_profiles:
-  # coding-agent：统一 ACP client + entry
-  - id: specialist-codex
+# Database profiles.yaml（成员 task.yaml 只声明角色槽）
+bindings:
+  specialist-codex:
     executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: codex              # registry entry_id；非 package 自带 command
     model: o4-mini
-    workspace_view: agents
-    options:
-      entry: codex              # registry entry_id；非 package 自带 command
-
-  - id: specialist-cc
+  specialist-cc:
     executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: claude-code
     model: claude-sonnet-4
-    workspace_view: agents
-    options:
-      entry: claude-code
-
-  - id: planner-opencode
+  planner-opencode:
     executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: opencode
     model: entry-default        # 或 entry 支持的 exact model id
-    workspace_view: agents
-    options:
-      entry: opencode
-
-  - id: planner-pi
+  planner-pi:
     executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: pi                 # Mode 1: engine pi + pi-acp；entry_id=pi，包名 pi-acp
     model: entry-default
-    workspace_view: agents
-    options:
-      entry: pi                 # Mode 1: engine pi + pi-acp；entry_id=pi，包名 pi-acp
 
   # api-client（非 coding-agent ACP 路径）
   # 可选 per-profile 上游路由（与 model 同级）：
   # - base_url: non-secret endpoint（进入 lock digest）
   # - api_key: 环境变量 *名* only（locator）；值来自 host/.env，
   #   投影进 Executor 时使用 — 永不写入 lock/evidence
-  - id: glm-coding-http
+  glm-coding-http:
     executor: openai-http
     model: glm-4.7
     base_url: https://open.bigmodel.cn/api/coding/paas/v4
@@ -69,14 +70,14 @@ parameters:
     reducer: specialist-codex
 ```
 
-- **整 task 换后端（Codex entry → Claude entry）：** 改 profile 的 `options.entry` / `model` 或 `parameters.models.*` 引用；**不必改** `harness.py`。
+- **整 task 换后端（Codex entry → Claude entry）：** 改 binding 的 `- plugin: acp` / `options.entry` / `model` 或 `parameters.models.*` 引用；**不必改** `harness.py`。
 - **同 task 不同 Agent 用不同后端：** 各 role 引用不同 profile id；specialist=Codex entry、planner=OpenCode entry 合法。
 - **同 entry 不同模型：** 改 `model`（经 ACP config option 绑定）或并列 profile。
 - **上游 endpoint / 密钥定位：** 可选 `base_url` 与 `api_key`（env 名）与 `model` 同级；`bora run` 从 package/cwd/repo `.env` 注入宿主环境后，Runtime 按 locator 投影给 Executor / ACP child env。
 
-`load_and_lock` 必须校验：每个 `parameters` 中的 profile 引用存在；每个 `executor` kind 在 Agent Service 的注册表中可用；`executor: acp` 必须有 registry 内 `options.entry`；`workspace_view` 存在；若声明 `base_url`/`api_key` 则校验 URL 与 env 名形态（`api_key` 不得为 secret 值）。锁定结果含 profile → executor/entry/model/base_url/api_key(locator) 与 descriptor digest 的解析快照，进入 Trial identity / digest。
+`load_and_lock` 必须校验：每个 `parameters` 中的 profile 引用存在；每个 `executor` kind 在 Agent Service 的注册表中可用；`executor: acp` 必须有 `- plugin: acp` 行上 registry 内 `options.entry`；`workspace_view` 存在；若声明 `base_url`/`api_key` 则校验 URL 与 env 名形态（`api_key` 不得为 secret 值）。锁定结果含 profile → executor/entry/model/base_url/api_key(locator) 与 descriptor digest 的解析快照，进入 Trial identity / digest。
 
-**禁止：** 在 parent 内按 vendor 再写第二套 stdout scrape（含 container heuristic JSON）。coding-agent 配置形状为 `executor: acp` + `options.entry`，不是 `executor: codex|claude-code|pi|opencode` 私有 kind。
+**禁止：** 在 parent 内按 vendor 再写第二套 stdout scrape（含 container heuristic JSON）。coding-agent 配置形状为 `executor: acp` + `- plugin: acp` / `options.entry`，不是 `executor: codex|claude-code|pi|opencode` 私有 kind。
 
 ## Agent Service（Runtime）
 
@@ -100,7 +101,7 @@ ctx.agent.invoke(profile_id, messages, ...)
 
 | 职责 | 说明 |
 | --- | --- |
-| Profile 解析 | 把逻辑 profile 绑到具体 executor + model + options（含 `options.entry`） |
+| Profile 解析 | 把逻辑 profile 绑到具体 executor + model + 该插件行 options（ACP 含 `entry`） |
 | Executor 路由 | `acp`（单一 client + entry registry）、`openai-http`、已安装 `provide(executor)` 的其它 kind（L1 经 `bind_to_target`）；**不是**每个 vendor 一套 stdout parser |
 | Session 绑定 | 创建时固定 Attempt + profile + workspace；禁止跨 Attempt 复用 |
 | 统一 invoke 契约 | Harness 只见 messages / schema / tools 意图，不见各 CLI/ACP 细节 |
@@ -175,7 +176,7 @@ BORA **允许用户与第三方按 Core 契约实现定制化插件**，并以 P
 
 | 扩展面 | Core 开放的契约（方向） | 配置选型（例） | 示例实现 |
 | --- | --- | --- | --- |
-| **Agent 后端** | `AgentExecutor.invoke` | `agent_profiles.executor`（+ `options.entry` for `acp`） | 内置 `acp`、`openai-http`；第三方自定义 kind |
+| **Agent 后端** | `AgentExecutor.invoke` | `executor`（ACP 再加 `- plugin: acp` / `options.entry`） | 内置 `acp`、`openai-http`；第三方自定义 kind |
 | **Provider** | 隔离与 workspace 执行协议 | `provider.kind` | `docker` / `local` |
 | **Environment** | prepare / action / teardown（+ 可选 freeze） | component / resource kind | `postgres` / `browser` |
 | **Artifact** | publish / materialize 策略 | `artifacts` 与 materializer 实现 | filesystem 等 |
@@ -267,7 +268,7 @@ my-api = "bora_executor_my_api.executor:MyApiExecutor"
 
 ### 示例：自定义 API Executor 插件（非 coding-agent 私有 CLI）
 
-**仅演示 Agent 扩展面。** coding-agent 请用内置 `executor: acp` + `options.entry`。Provider / Environment 等面写法类似，只是接口与 entry point 组不同。
+**仅演示 Agent 扩展面。** coding-agent 请用内置 `executor: acp` + `- plugin: acp` / `options.entry`。Provider / Environment 等面写法类似，只是接口与 entry point 组不同。
 
 用户本机/CI 在 `.env` 放测试 key；Runtime 只把密钥投影给 Executor，不进 `harness.py`，也不进 Agent 可读 workspace。
 

--- a/docs/design/10-examples-database-52.md
+++ b/docs/design/10-examples-database-52.md
@@ -102,20 +102,11 @@ provider:
 
 agent_profiles:
   - id: codex-database-specialist
-    executor: acp
     workspace_view: agents
-    options:
-      entry: codex
   - id: codex-database-planner
-    executor: acp
     workspace_view: agents
-    options:
-      entry: codex
   - id: codex-database-reducer
-    executor: acp
     workspace_view: agents
-    options:
-      entry: codex
 
 environment:
   id: database-attempt

--- a/docs/design/11-extension-plugins.md
+++ b/docs/design/11-extension-plugins.md
@@ -242,8 +242,8 @@ bindings:
           agent: "lib.agents:JsonlAggAgent"  # package-local nooa.Agent
           method: "run"
     model: openai/glm-5.2
-    api_key: litellm_api_key          # env locator；值不进 lock
-    # base_url: https://…/v1          # 可选；否则回落 litellm_base_url / OPENAI_BASE_URL
+    api_key: ${litellm_api_key}          # ${ENV_NAME} locator；值不进 lock
+    # base_url: ${litellm_base_url}   # 可选；字面 URL 或 ${ENV_NAME}
 ```
 
 L1：bake 安装 `nooa` + **in-container worker**；parent 把 model/base_url/密钥投影进 worker；host SPI 不是 L1 成功路径。

--- a/docs/design/11-extension-plugins.md
+++ b/docs/design/11-extension-plugins.md
@@ -57,7 +57,7 @@
 | 层 | 代表槽 | 生产消费点 |
 | --- | --- | --- |
 | L0 | `before/after_prepare|run|evaluate|cleanup` | `application/extension_hooks` |
-| L1 | `image_contribute`、`env_*`、`env_action` | prepare bake；env prepare/teardown + action_gate |
+| L1 | `image_contribute`、`home_overlay`、`env_*`、`env_action` | prepare bake；cred 后 / HOME 拷贝前；env prepare/teardown + action_gate |
 | L2 | `executor`、agent open/invoke/close、`normalize_agent_result` | `ParentAgentService` session 钉图。L1 用 Core `TargetPlacement` + SPI `bind_to_target`；禁止 Core `if kind == …` 重建 executor |
 | L3 | `evaluation_input_contribute`、`evaluation_runtime`、`score_postprocess` | 评测前/后（fail closed；不得选 PASS 权威） |
 | L4 | `trajectory_collect|enrich|seal`、`evidence_extra` | seal 写路径（collect/enrich fail-open）。collect 可补层 B 事件；**不得**让插件直接写层 C 行，也不得再产出 ACP `session_update` 伪装 |
@@ -73,6 +73,7 @@ invoke       → before_agent_invoke → executor.invoke → after_agent_invoke
                     → trajectory_seal → evidence_extra
 close_session → before_agent_close → executor.close → after_agent_close
 
+home_overlay → Core default 建 cred 树 → nxt（插件写 HOME/workspace 文件）→ 拷入 actor HOME
 env prepare  → seed/health → env_prepare multi → env_inject → env_action provide
 env teardown → env_teardown multi → EnvironmentManager.close
 
@@ -159,10 +160,41 @@ host_requires:
 
 ## 配置与绑定
 
-- Job binding 在 `profiles.yaml`：`executor` / `options` / `extensions`（binding 字段）；选择按 **profile（role）**，不是 task 级插件列表  
+- Job binding 在 `profiles.yaml`：`executor` / `extensions`（binding 字段）；选择按 **profile（role）**，不是 task 级插件列表  
+- 插件 knobs 只写在 **`extensions[]` 行上的 `options`**。`executor:` 只选 `provide(executor)`。  
+- Profile 级 `options` **不是**插件输入（无 dual-read、无回落）。  
 - member `task.yaml` 只声明 role slot，禁止内联 binding  
 - `bora lock` 解析每个 profile → `extension_bindings` 进 digest（快照，不是选择器）  
 - 切换机制：**同一 harness**，改 profiles +（必要时）install，不改 harness 业务代码  
+
+### 每插件 `extensions[].options`
+
+`executor:` 不携带插件 knobs。每个插件只读本行 `options`。工厂与 `on` handler 物化时只拿到该行 map。
+
+```yaml
+executor: acp
+extensions:
+  - plugin: acp
+    options:
+      entry: opencode
+  - plugin: home-files
+    options:
+      files:
+        - src: overlays/opencode.litellm.json
+          dest: .config/opencode/opencode.json
+          dest_root: home
+  - plugin: dsh
+    options:
+      composition: slim
+```
+
+`--set /bindings/<role>/options/<key>` 写到 **该 role 的 executor 插件** 行（没有则补一行 `- plugin: <executor>`）。不能用同一指针表达非 executor 行（如 `home-files` 的 `files`）；那些只写 YAML。
+
+### `home_overlay`（L1 multi；L0 在 Attempt HOME 存在后同样 emit）
+
+插在 **cred 投影之后、actor HOME 拷贝之前**。不是 `after_prepare`（后者仍在选镜像 / bake 旁），也不是 `env_inject`。
+
+Core default（低 priority，先跑）：建 cred 树（今日 allowlist）；把 `package_root` / `workspace_root` / `cred_root` 放上 `ctx`/`value`；`await nxt(value)`；再把 `cred_root/home_overlay/.` 拷进 actor `$HOME/`，并完成今日 `prepare_agent_targets` 的其余步骤。插件只在 `nxt` 里写文件，不调 Docker，不发明 PASS。L0 不得写用户真 `~`。
 
 ### `extensions` 按 profile 显式 opt-in
 
@@ -190,7 +222,7 @@ bindings:
 2. `slots: [...]` → 只开列出的槽；未知槽或该插件未登记 → fail closed。  
 3. `{slot, plugin}` → 恰好那一个槽。  
 4. MULTI 链 **只**含本 profile `extensions` 点名的项。已安装但未列入的插件不进链、不进镜像。  
-5. `executor:` **不**隐含 `image_contribute`。纯 ACP profile 省略 `extensions`。  
+5. `executor:` **不**隐含 `image_contribute`。ACP 的 `entry` 写在 `- plugin: acp` 的 `options`；不再写 profile 级 `options`。  
 6. 绑定了**已安装** executor 但未选中 `image_contribute`（或缺 bake 文件）→ L1 fail closed。  
 7. 同一 job 里不同 role 可独立绑定不同插件。  
 8. 省略 `executor:` 时，若某条 `- plugin: …`（全槽）含该插件的 executor provide，可用它补上；两套都写时以 `executor:` 为准。
@@ -206,12 +238,12 @@ bindings:
     executor: nooa
     extensions:
       - plugin: nooa
+        options:
+          agent: "lib.agents:JsonlAggAgent"  # package-local nooa.Agent
+          method: "run"
     model: openai/glm-5.2
     api_key: litellm_api_key          # env locator；值不进 lock
     # base_url: https://…/v1          # 可选；否则回落 litellm_base_url / OPENAI_BASE_URL
-    options:
-      agent: "lib.agents:JsonlAggAgent"  # package-local nooa.Agent
-      method: "run"
 ```
 
 L1：bake 安装 `nooa` + **in-container worker**；parent 把 model/base_url/密钥投影进 worker；host SPI 不是 L1 成功路径。
@@ -297,5 +329,5 @@ Dockerfile 另有文件或其它 `FROM`，或任一选中扩展要 bake，仍走
 - 结构地图：[`ARCHITECTURE.md`](../../ARCHITECTURE.md)（plugins 树、emit map）  
 - Owner：[`09-owner-matrix-and-structure.md`](09-owner-matrix-and-structure.md)  
 - Runtime Agent：[`05-runtime/agent-service.md`](05-runtime/agent-service.md)  
-- 示例：`plugins/nooa`、`plugins/dsh`（`options.permission` 为插件自有键，非新 slot）、`plugins/slot-probe`、`examples/journeys/profiles.nooa.yaml`、`examples/journeys/profiles.dsh.yaml`、`examples/journeys/profiles.dsh.read-only.yaml`、`examples/slot-probe/`  
+- 示例：`plugins/nooa`、`plugins/dsh`（`options.permission` 为插件自有键，非新 slot）、`plugins/home-files`（`on: home_overlay`）、`plugins/slot-probe`、`examples/journeys/profiles.nooa.yaml`、`examples/journeys/profiles.dsh.yaml`、`examples/journeys/profiles.dsh.read-only.yaml`、`examples/slot-probe/`  
 - 交付跟踪：GitHub Issues（Epic 插件系统）

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -20,7 +20,7 @@
 | **Capability** | Attempt 内已授权操作面：agent、environment、workspace、artifacts… |
 | **Adapter / Plugin** | Capability/Provider 的实现；entry point 可分发 |
 | **Agent Service** | 主仓调度面：按 profile 路由 AgentExecutor、session、额度、投影、轨迹落盘 |
-| **AgentExecutor** | 具体 Agent 后端实现；coding-agent 为 `acp`（+ `options.entry`），另有 `openai-http` 与可分发自定义 kind |
+| **AgentExecutor** | 具体 Agent 后端实现；coding-agent 为 `acp`（+ `- plugin: acp` / `options.entry`），另有 `openai-http` 与可分发自定义 kind |
 | **ACP entry** | registry `entry_id`（如 `codex` / `pi`）；Mode 1 常与 engine + ACP 桥包（如 `pi` + npm `pi-acp`）双装 |
 | **Provider** | 物理运行时与隔离（process/container、mount、network、secret） |
 | **可见性投影** | 消费者受限视图（path/secret/network/params/materialize） |

--- a/examples/core/profiles.yaml
+++ b/examples/core/profiles.yaml
@@ -20,7 +20,7 @@ bindings:
         options:
           entry: opencode
     model: zai-coding-plan/glm-5.2
-    api_key: glm_coding_api_key
+    api_key: ${glm_coding_api_key}
   secondary:
     executor: acp
     extensions:
@@ -28,7 +28,7 @@ bindings:
         options:
           entry: pi
     model: zai-coding-cn/glm-5.2
-    api_key: glm_coding_api_key
+    api_key: ${glm_coding_api_key}
 
   # External nooa host SPI (task-local lib.agents; after bora plugin install)
   nooa-solver:

--- a/examples/core/profiles.yaml
+++ b/examples/core/profiles.yaml
@@ -5,22 +5,28 @@ bindings:
     model: none
   solver:
     executor: acp
-    options:
-      entry: codex
+    extensions:
+      - plugin: acp
+        options:
+          entry: codex
     model: gpt-5.4-mini
   http-solver:
     executor: openai-http
     model: gpt-4.1-mini
   primary:
     executor: acp
-    options:
-      entry: opencode
+    extensions:
+      - plugin: acp
+        options:
+          entry: opencode
     model: zai-coding-plan/glm-5.2
     api_key: glm_coding_api_key
   secondary:
     executor: acp
-    options:
-      entry: pi
+    extensions:
+      - plugin: acp
+        options:
+          entry: pi
     model: zai-coding-cn/glm-5.2
     api_key: glm_coding_api_key
 
@@ -29,8 +35,7 @@ bindings:
     executor: nooa
     extensions:
       - plugin: nooa
-    options:
-      agent: "lib.agents:FixedAnswerAgent"
-      method: "run"
+        options:
+          agent: "lib.agents:FixedAnswerAgent"
+          method: "run"
     model: none
-

--- a/examples/core/tasks/builtin-executor-mixed/README.md
+++ b/examples/core/tasks/builtin-executor-mixed/README.md
@@ -24,7 +24,7 @@ pi does **not** use `base_url: .../api/anthropic` for this path. Built-in provid
 **Wrong:** `model: glm-5.2` alone → pi fuzzy-matches **OpenCode Zen** → wants
 `OPENCODE_API_KEY` → `Invalid API key` if you pass a 智谱 coding key.
 
-BORA `api_key: glm_coding_api_key` projects that host env into
+BORA `api_key: ${glm_coding_api_key}` projects that host env into
 `ZAI_CODING_CN_API_KEY` / `ZAI_API_KEY` (and others) for the child process.
 
 Host/repo `.env`:

--- a/examples/journeys/acp-profiles/README.md
+++ b/examples/journeys/acp-profiles/README.md
@@ -1,0 +1,13 @@
+# ACP job bindings (LiteLLM overlay)
+
+Same journeys harness. Bind ACP `entry` on `- plugin: acp`. Bind previously
+unbound LiteLLM model ids with `- plugin: home-files` and a Database overlay
+file. No Core model-prefix switch.
+
+```bash
+uv run bora plugin install plugins/home-files
+uv run bora run examples/journeys --task terminal-jsonl-agg \
+  --profiles examples/journeys/acp-profiles/profiles.acp.opencode.qwen3.8-max.yaml
+```
+
+`api_key` is the env locator `litellm_api_key`. Overlay JSON must not embed tokens.

--- a/examples/journeys/acp-profiles/profiles.acp.opencode.claude-sonnet-4-6.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.opencode.claude-sonnet-4-6.yaml
@@ -1,5 +1,5 @@
 # ACP job binding for terminal-jsonl-agg.
-# entry: opencode  model: anthropic/claude-sonnet-4-6
+# entry: opencode  model: litellm/anthropic/claude-sonnet-4-6
 # LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
 format: bora.profiles/1
 bindings:
@@ -15,6 +15,6 @@ bindings:
             - src: overlays/opencode.litellm.json
               dest: .config/opencode/opencode.json
               dest_root: home
-    model: anthropic/claude-sonnet-4-6
-    api_key: litellm_api_key
-    base_url: http://10.130.138.46:8010/v1
+    model: litellm/anthropic/claude-sonnet-4-6
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/acp-profiles/profiles.acp.opencode.claude-sonnet-4-6.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.opencode.claude-sonnet-4-6.yaml
@@ -1,0 +1,20 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: opencode  model: anthropic/claude-sonnet-4-6
+# LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: opencode
+      - plugin: home-files
+        options:
+          files:
+            - src: overlays/opencode.litellm.json
+              dest: .config/opencode/opencode.json
+              dest_root: home
+    model: anthropic/claude-sonnet-4-6
+    api_key: litellm_api_key
+    base_url: http://10.130.138.46:8010/v1

--- a/examples/journeys/acp-profiles/profiles.acp.opencode.deepseek-v4-pro.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.opencode.deepseek-v4-pro.yaml
@@ -1,5 +1,5 @@
 # ACP job binding for terminal-jsonl-agg.
-# entry: opencode  model: deepseek/deepseek-v4-pro
+# entry: opencode  model: litellm/dashscope/deepseek-v4-pro
 # LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
 format: bora.profiles/1
 bindings:
@@ -15,6 +15,6 @@ bindings:
             - src: overlays/opencode.litellm.json
               dest: .config/opencode/opencode.json
               dest_root: home
-    model: deepseek/deepseek-v4-pro
-    api_key: litellm_api_key
-    base_url: http://10.130.138.46:8010/v1
+    model: litellm/dashscope/deepseek-v4-pro
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/acp-profiles/profiles.acp.opencode.deepseek-v4-pro.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.opencode.deepseek-v4-pro.yaml
@@ -1,0 +1,20 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: opencode  model: deepseek/deepseek-v4-pro
+# LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: opencode
+      - plugin: home-files
+        options:
+          files:
+            - src: overlays/opencode.litellm.json
+              dest: .config/opencode/opencode.json
+              dest_root: home
+    model: deepseek/deepseek-v4-pro
+    api_key: litellm_api_key
+    base_url: http://10.130.138.46:8010/v1

--- a/examples/journeys/acp-profiles/profiles.acp.opencode.glm-5.2.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.opencode.glm-5.2.yaml
@@ -1,0 +1,20 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: opencode  model: zai-coding-plan/glm-5.2
+# LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: opencode
+      - plugin: home-files
+        options:
+          files:
+            - src: overlays/opencode.litellm.json
+              dest: .config/opencode/opencode.json
+              dest_root: home
+    model: zai-coding-plan/glm-5.2
+    api_key: litellm_api_key
+    base_url: http://10.130.138.46:8010/v1

--- a/examples/journeys/acp-profiles/profiles.acp.opencode.glm-5.2.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.opencode.glm-5.2.yaml
@@ -16,5 +16,5 @@ bindings:
               dest: .config/opencode/opencode.json
               dest_root: home
     model: zai-coding-plan/glm-5.2
-    api_key: litellm_api_key
-    base_url: http://10.130.138.46:8010/v1
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/acp-profiles/profiles.acp.opencode.gpt-5.4.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.opencode.gpt-5.4.yaml
@@ -1,0 +1,20 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: opencode  model: openai/gpt-5.4
+# LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: opencode
+      - plugin: home-files
+        options:
+          files:
+            - src: overlays/opencode.litellm.json
+              dest: .config/opencode/opencode.json
+              dest_root: home
+    model: openai/gpt-5.4
+    api_key: litellm_api_key
+    base_url: http://10.130.138.46:8010/v1

--- a/examples/journeys/acp-profiles/profiles.acp.opencode.gpt-5.4.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.opencode.gpt-5.4.yaml
@@ -1,5 +1,5 @@
 # ACP job binding for terminal-jsonl-agg.
-# entry: opencode  model: openai/gpt-5.4
+# entry: opencode  model: litellm/openai/gpt-5.4
 # LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
 format: bora.profiles/1
 bindings:
@@ -15,6 +15,6 @@ bindings:
             - src: overlays/opencode.litellm.json
               dest: .config/opencode/opencode.json
               dest_root: home
-    model: openai/gpt-5.4
-    api_key: litellm_api_key
-    base_url: http://10.130.138.46:8010/v1
+    model: litellm/openai/gpt-5.4
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/acp-profiles/profiles.acp.opencode.kimi-k2.7-code.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.opencode.kimi-k2.7-code.yaml
@@ -1,0 +1,20 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: opencode  model: litellm/dashscope/kimi-k2.7-code
+# LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: opencode
+      - plugin: home-files
+        options:
+          files:
+            - src: overlays/opencode.litellm.json
+              dest: .config/opencode/opencode.json
+              dest_root: home
+    model: litellm/dashscope/kimi-k2.7-code
+    api_key: litellm_api_key
+    base_url: http://10.130.138.46:8010/v1

--- a/examples/journeys/acp-profiles/profiles.acp.opencode.kimi-k2.7-code.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.opencode.kimi-k2.7-code.yaml
@@ -16,5 +16,5 @@ bindings:
               dest: .config/opencode/opencode.json
               dest_root: home
     model: litellm/dashscope/kimi-k2.7-code
-    api_key: litellm_api_key
-    base_url: http://10.130.138.46:8010/v1
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/acp-profiles/profiles.acp.opencode.minimax-m2.7.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.opencode.minimax-m2.7.yaml
@@ -1,0 +1,20 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: opencode  model: litellm/MiniMax-M2.7
+# LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: opencode
+      - plugin: home-files
+        options:
+          files:
+            - src: overlays/opencode.litellm.json
+              dest: .config/opencode/opencode.json
+              dest_root: home
+    model: litellm/MiniMax-M2.7
+    api_key: litellm_api_key
+    base_url: http://10.130.138.46:8010/v1

--- a/examples/journeys/acp-profiles/profiles.acp.opencode.minimax-m2.7.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.opencode.minimax-m2.7.yaml
@@ -16,5 +16,5 @@ bindings:
               dest: .config/opencode/opencode.json
               dest_root: home
     model: litellm/MiniMax-M2.7
-    api_key: litellm_api_key
-    base_url: http://10.130.138.46:8010/v1
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/acp-profiles/profiles.acp.opencode.qwen3-coder-plus.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.opencode.qwen3-coder-plus.yaml
@@ -16,5 +16,5 @@ bindings:
               dest: .config/opencode/opencode.json
               dest_root: home
     model: litellm/dashscope/qwen3-coder-plus
-    api_key: litellm_api_key
-    base_url: http://10.130.138.46:8010/v1
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/acp-profiles/profiles.acp.opencode.qwen3-coder-plus.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.opencode.qwen3-coder-plus.yaml
@@ -1,0 +1,20 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: opencode  model: litellm/dashscope/qwen3-coder-plus
+# LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: opencode
+      - plugin: home-files
+        options:
+          files:
+            - src: overlays/opencode.litellm.json
+              dest: .config/opencode/opencode.json
+              dest_root: home
+    model: litellm/dashscope/qwen3-coder-plus
+    api_key: litellm_api_key
+    base_url: http://10.130.138.46:8010/v1

--- a/examples/journeys/acp-profiles/profiles.acp.opencode.qwen3.8-max.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.opencode.qwen3.8-max.yaml
@@ -1,0 +1,20 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: opencode  model: litellm/dashscope/qwen3.8-max
+# LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: opencode
+      - plugin: home-files
+        options:
+          files:
+            - src: overlays/opencode.litellm.json
+              dest: .config/opencode/opencode.json
+              dest_root: home
+    model: litellm/dashscope/qwen3.8-max
+    api_key: litellm_api_key
+    base_url: http://10.130.138.46:8010/v1

--- a/examples/journeys/acp-profiles/profiles.acp.opencode.qwen3.8-max.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.opencode.qwen3.8-max.yaml
@@ -16,5 +16,5 @@ bindings:
               dest: .config/opencode/opencode.json
               dest_root: home
     model: litellm/dashscope/qwen3.8-max
-    api_key: litellm_api_key
-    base_url: http://10.130.138.46:8010/v1
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/acp-profiles/profiles.acp.pi.claude-sonnet-4-6.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.pi.claude-sonnet-4-6.yaml
@@ -1,5 +1,5 @@
 # ACP job binding for terminal-jsonl-agg.
-# entry: pi  model: anthropic/claude-sonnet-4-6
+# entry: pi  model: litellm/anthropic/claude-sonnet-4-6
 # LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
 format: bora.profiles/1
 bindings:
@@ -15,6 +15,6 @@ bindings:
             - src: overlays/pi.litellm.json
               dest: .pi/agent/models.json
               dest_root: home
-    model: anthropic/claude-sonnet-4-6
-    api_key: litellm_api_key
-    base_url: http://10.130.138.46:8010/v1
+    model: litellm/anthropic/claude-sonnet-4-6
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/acp-profiles/profiles.acp.pi.claude-sonnet-4-6.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.pi.claude-sonnet-4-6.yaml
@@ -1,0 +1,20 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: pi  model: anthropic/claude-sonnet-4-6
+# LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: pi
+      - plugin: home-files
+        options:
+          files:
+            - src: overlays/pi.litellm.json
+              dest: .pi/agent/models.json
+              dest_root: home
+    model: anthropic/claude-sonnet-4-6
+    api_key: litellm_api_key
+    base_url: http://10.130.138.46:8010/v1

--- a/examples/journeys/acp-profiles/profiles.acp.pi.deepseek-v4-pro.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.pi.deepseek-v4-pro.yaml
@@ -1,5 +1,5 @@
 # ACP job binding for terminal-jsonl-agg.
-# entry: pi  model: deepseek/deepseek-v4-pro
+# entry: pi  model: litellm/dashscope/deepseek-v4-pro
 # LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
 format: bora.profiles/1
 bindings:
@@ -15,6 +15,6 @@ bindings:
             - src: overlays/pi.litellm.json
               dest: .pi/agent/models.json
               dest_root: home
-    model: deepseek/deepseek-v4-pro
-    api_key: litellm_api_key
-    base_url: http://10.130.138.46:8010/v1
+    model: litellm/dashscope/deepseek-v4-pro
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/acp-profiles/profiles.acp.pi.deepseek-v4-pro.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.pi.deepseek-v4-pro.yaml
@@ -1,0 +1,20 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: pi  model: deepseek/deepseek-v4-pro
+# LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: pi
+      - plugin: home-files
+        options:
+          files:
+            - src: overlays/pi.litellm.json
+              dest: .pi/agent/models.json
+              dest_root: home
+    model: deepseek/deepseek-v4-pro
+    api_key: litellm_api_key
+    base_url: http://10.130.138.46:8010/v1

--- a/examples/journeys/acp-profiles/profiles.acp.pi.glm-5.2.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.pi.glm-5.2.yaml
@@ -16,5 +16,5 @@ bindings:
               dest: .pi/agent/models.json
               dest_root: home
     model: zai-coding-cn/glm-5.2
-    api_key: litellm_api_key
-    base_url: http://10.130.138.46:8010/v1
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/acp-profiles/profiles.acp.pi.glm-5.2.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.pi.glm-5.2.yaml
@@ -1,0 +1,20 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: pi  model: zai-coding-cn/glm-5.2
+# LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: pi
+      - plugin: home-files
+        options:
+          files:
+            - src: overlays/pi.litellm.json
+              dest: .pi/agent/models.json
+              dest_root: home
+    model: zai-coding-cn/glm-5.2
+    api_key: litellm_api_key
+    base_url: http://10.130.138.46:8010/v1

--- a/examples/journeys/acp-profiles/profiles.acp.pi.gpt-5.4.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.pi.gpt-5.4.yaml
@@ -1,0 +1,20 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: pi  model: openai/gpt-5.4
+# LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: pi
+      - plugin: home-files
+        options:
+          files:
+            - src: overlays/pi.litellm.json
+              dest: .pi/agent/models.json
+              dest_root: home
+    model: openai/gpt-5.4
+    api_key: litellm_api_key
+    base_url: http://10.130.138.46:8010/v1

--- a/examples/journeys/acp-profiles/profiles.acp.pi.gpt-5.4.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.pi.gpt-5.4.yaml
@@ -1,5 +1,5 @@
 # ACP job binding for terminal-jsonl-agg.
-# entry: pi  model: openai/gpt-5.4
+# entry: pi  model: litellm/openai/gpt-5.4
 # LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
 format: bora.profiles/1
 bindings:
@@ -15,6 +15,6 @@ bindings:
             - src: overlays/pi.litellm.json
               dest: .pi/agent/models.json
               dest_root: home
-    model: openai/gpt-5.4
-    api_key: litellm_api_key
-    base_url: http://10.130.138.46:8010/v1
+    model: litellm/openai/gpt-5.4
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/acp-profiles/profiles.acp.pi.kimi-k2.7-code.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.pi.kimi-k2.7-code.yaml
@@ -16,5 +16,5 @@ bindings:
               dest: .pi/agent/models.json
               dest_root: home
     model: litellm/dashscope/kimi-k2.7-code
-    api_key: litellm_api_key
-    base_url: http://10.130.138.46:8010/v1
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/acp-profiles/profiles.acp.pi.kimi-k2.7-code.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.pi.kimi-k2.7-code.yaml
@@ -1,0 +1,20 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: pi  model: litellm/dashscope/kimi-k2.7-code
+# LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: pi
+      - plugin: home-files
+        options:
+          files:
+            - src: overlays/pi.litellm.json
+              dest: .pi/agent/models.json
+              dest_root: home
+    model: litellm/dashscope/kimi-k2.7-code
+    api_key: litellm_api_key
+    base_url: http://10.130.138.46:8010/v1

--- a/examples/journeys/acp-profiles/profiles.acp.pi.minimax-m2.7.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.pi.minimax-m2.7.yaml
@@ -1,0 +1,20 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: pi  model: litellm/MiniMax-M2.7
+# LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: pi
+      - plugin: home-files
+        options:
+          files:
+            - src: overlays/pi.litellm.json
+              dest: .pi/agent/models.json
+              dest_root: home
+    model: litellm/MiniMax-M2.7
+    api_key: litellm_api_key
+    base_url: http://10.130.138.46:8010/v1

--- a/examples/journeys/acp-profiles/profiles.acp.pi.minimax-m2.7.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.pi.minimax-m2.7.yaml
@@ -16,5 +16,5 @@ bindings:
               dest: .pi/agent/models.json
               dest_root: home
     model: litellm/MiniMax-M2.7
-    api_key: litellm_api_key
-    base_url: http://10.130.138.46:8010/v1
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/acp-profiles/profiles.acp.pi.qwen3-coder-plus.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.pi.qwen3-coder-plus.yaml
@@ -16,5 +16,5 @@ bindings:
               dest: .pi/agent/models.json
               dest_root: home
     model: litellm/dashscope/qwen3-coder-plus
-    api_key: litellm_api_key
-    base_url: http://10.130.138.46:8010/v1
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/acp-profiles/profiles.acp.pi.qwen3-coder-plus.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.pi.qwen3-coder-plus.yaml
@@ -1,0 +1,20 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: pi  model: litellm/dashscope/qwen3-coder-plus
+# LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: pi
+      - plugin: home-files
+        options:
+          files:
+            - src: overlays/pi.litellm.json
+              dest: .pi/agent/models.json
+              dest_root: home
+    model: litellm/dashscope/qwen3-coder-plus
+    api_key: litellm_api_key
+    base_url: http://10.130.138.46:8010/v1

--- a/examples/journeys/acp-profiles/profiles.acp.pi.qwen3.8-max.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.pi.qwen3.8-max.yaml
@@ -16,5 +16,5 @@ bindings:
               dest: .pi/agent/models.json
               dest_root: home
     model: litellm/dashscope/qwen3.8-max
-    api_key: litellm_api_key
-    base_url: http://10.130.138.46:8010/v1
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/acp-profiles/profiles.acp.pi.qwen3.8-max.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.pi.qwen3.8-max.yaml
@@ -1,0 +1,20 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: pi  model: litellm/dashscope/qwen3.8-max
+# LiteLLM catalog is a Database overlay (home-files), not a Core prefix.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: pi
+      - plugin: home-files
+        options:
+          files:
+            - src: overlays/pi.litellm.json
+              dest: .pi/agent/models.json
+              dest_root: home
+    model: litellm/dashscope/qwen3.8-max
+    api_key: litellm_api_key
+    base_url: http://10.130.138.46:8010/v1

--- a/examples/journeys/env.example
+++ b/examples/journeys/env.example
@@ -1,5 +1,6 @@
 # Copy to .env and fill locally. Never commit real keys.
 glm_coding_api_key=
+litellm_api_key=
 # ZAI_CODING_CN_API_KEY projected from locator when configured.
 # dsh plugin locator (runtime projects DEEPSEEK_API_KEY).
 deepseek_api_key=

--- a/examples/journeys/nooa-profiles/profiles.nooa.claude-sonnet-4-6.yaml
+++ b/examples/journeys/nooa-profiles/profiles.nooa.claude-sonnet-4-6.yaml
@@ -1,0 +1,14 @@
+# LiteLLM feasibility overlay for terminal-jsonl-agg (nooa).
+# model: openai/anthropic/claude-sonnet-4-6
+# nooa LiteLLM client: anthropic/* routes to native Anthropic, not the proxy.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: nooa
+    extensions:
+      - plugin: nooa
+        options:
+          agent: "lib.agents:JsonlAggAgent"
+          method: "run"
+    model: openai/anthropic/claude-sonnet-4-6
+    api_key: ${litellm_api_key}

--- a/examples/journeys/nooa-profiles/profiles.nooa.deepseek-v4-pro.yaml
+++ b/examples/journeys/nooa-profiles/profiles.nooa.deepseek-v4-pro.yaml
@@ -1,0 +1,15 @@
+# LiteLLM feasibility overlay for terminal-jsonl-agg (nooa).
+# model: openai/DeepSeek-V4-Pro
+# nooa LiteLLM client needs an openai/ prefix to hit litellm_base_url
+# (bare catalog id → "LLM Provider NOT provided").
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: nooa
+    extensions:
+      - plugin: nooa
+        options:
+          agent: "lib.agents:JsonlAggAgent"
+          method: "run"
+    model: openai/DeepSeek-V4-Pro
+    api_key: ${litellm_api_key}

--- a/examples/journeys/nooa-profiles/profiles.nooa.glm-5.2.yaml
+++ b/examples/journeys/nooa-profiles/profiles.nooa.glm-5.2.yaml
@@ -1,0 +1,14 @@
+# LiteLLM feasibility overlay for terminal-jsonl-agg (nooa).
+# model: openai/glm-5.2 — current journeys nooa baseline
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: nooa
+    extensions:
+      - plugin: nooa
+        options:
+          agent: "lib.agents:JsonlAggAgent"
+          method: "run"
+    model: openai/glm-5.2
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/nooa-profiles/profiles.nooa.gpt-5.4.yaml
+++ b/examples/journeys/nooa-profiles/profiles.nooa.gpt-5.4.yaml
@@ -1,0 +1,13 @@
+# LiteLLM feasibility overlay for terminal-jsonl-agg (nooa).
+# model: openai/gpt-5.4
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: nooa
+    extensions:
+      - plugin: nooa
+        options:
+          agent: "lib.agents:JsonlAggAgent"
+          method: "run"
+    model: openai/gpt-5.4
+    api_key: ${litellm_api_key}

--- a/examples/journeys/nooa-profiles/profiles.nooa.kimi-k2.7-code.yaml
+++ b/examples/journeys/nooa-profiles/profiles.nooa.kimi-k2.7-code.yaml
@@ -1,0 +1,14 @@
+# LiteLLM feasibility overlay for terminal-jsonl-agg (nooa).
+# model: openai/dashscope/kimi-k2.7-code
+# nooa LiteLLM client: dashscope/* routes to native DashScope, not the proxy.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: nooa
+    extensions:
+      - plugin: nooa
+        options:
+          agent: "lib.agents:JsonlAggAgent"
+          method: "run"
+    model: openai/dashscope/kimi-k2.7-code
+    api_key: ${litellm_api_key}

--- a/examples/journeys/nooa-profiles/profiles.nooa.minimax-m2.7.yaml
+++ b/examples/journeys/nooa-profiles/profiles.nooa.minimax-m2.7.yaml
@@ -1,0 +1,14 @@
+# LiteLLM feasibility overlay for terminal-jsonl-agg (nooa).
+# model: openai/MiniMax-M2.7
+# nooa LiteLLM client needs an openai/ prefix to hit litellm_base_url.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: nooa
+    extensions:
+      - plugin: nooa
+        options:
+          agent: "lib.agents:JsonlAggAgent"
+          method: "run"
+    model: openai/MiniMax-M2.7
+    api_key: ${litellm_api_key}

--- a/examples/journeys/nooa-profiles/profiles.nooa.qwen3-coder-plus.yaml
+++ b/examples/journeys/nooa-profiles/profiles.nooa.qwen3-coder-plus.yaml
@@ -1,0 +1,14 @@
+# LiteLLM feasibility overlay for terminal-jsonl-agg (nooa).
+# model: openai/dashscope/qwen3-coder-plus
+# nooa LiteLLM client: dashscope/* routes to native DashScope, not the proxy.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: nooa
+    extensions:
+      - plugin: nooa
+        options:
+          agent: "lib.agents:JsonlAggAgent"
+          method: "run"
+    model: openai/dashscope/qwen3-coder-plus
+    api_key: ${litellm_api_key}

--- a/examples/journeys/nooa-profiles/profiles.nooa.qwen3.8-max.yaml
+++ b/examples/journeys/nooa-profiles/profiles.nooa.qwen3.8-max.yaml
@@ -1,0 +1,15 @@
+# LiteLLM feasibility overlay for terminal-jsonl-agg (nooa).
+# model: openai/dashscope/qwen3.8-max
+# nooa LiteLLM client: dashscope/* routes to native DashScope, not the proxy.
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: nooa
+    extensions:
+      - plugin: nooa
+        options:
+          agent: "lib.agents:JsonlAggAgent"
+          method: "run"
+    model: openai/dashscope/qwen3.8-max
+    api_key: ${litellm_api_key}
+    base_url: ${litellm_base_url}

--- a/examples/journeys/overlays/opencode.litellm.json
+++ b/examples/journeys/overlays/opencode.litellm.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "litellm": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LiteLLM",
+      "options": {
+        "baseURL": "http://10.130.138.46:8010/v1"
+      },
+      "models": {
+        "dashscope/qwen3.8-max": { "name": "qwen3.8-max" },
+        "dashscope/qwen3-coder-plus": { "name": "qwen3-coder-plus" },
+        "dashscope/kimi-k2.7-code": { "name": "kimi-k2.7-code" },
+        "MiniMax-M2.7": { "name": "MiniMax-M2.7" },
+        "glm-5.2": { "name": "glm-5.2" },
+        "claude-sonnet-4-6": { "name": "claude-sonnet-4-6" },
+        "gpt-5.4": { "name": "gpt-5.4" },
+        "deepseek-v4-pro": { "name": "deepseek-v4-pro" }
+      }
+    }
+  }
+}

--- a/examples/journeys/overlays/opencode.litellm.json
+++ b/examples/journeys/overlays/opencode.litellm.json
@@ -5,7 +5,8 @@
       "npm": "@ai-sdk/openai-compatible",
       "name": "LiteLLM",
       "options": {
-        "baseURL": "http://10.130.138.46:8010/v1"
+        "baseURL": "http://10.130.138.46:8010/v1",
+        "apiKey": "{env:litellm_api_key}"
       },
       "models": {
         "dashscope/qwen3.8-max": { "name": "qwen3.8-max" },

--- a/examples/journeys/overlays/opencode.litellm.json
+++ b/examples/journeys/overlays/opencode.litellm.json
@@ -14,9 +14,9 @@
         "dashscope/kimi-k2.7-code": { "name": "kimi-k2.7-code" },
         "MiniMax-M2.7": { "name": "MiniMax-M2.7" },
         "glm-5.2": { "name": "glm-5.2" },
-        "claude-sonnet-4-6": { "name": "claude-sonnet-4-6" },
-        "gpt-5.4": { "name": "gpt-5.4" },
-        "deepseek-v4-pro": { "name": "deepseek-v4-pro" }
+        "anthropic/claude-sonnet-4-6": { "name": "claude-sonnet-4-6" },
+        "openai/gpt-5.4": { "name": "gpt-5.4" },
+        "dashscope/deepseek-v4-pro": { "name": "deepseek-v4-pro" }
       }
     }
   }

--- a/examples/journeys/overlays/pi.litellm.json
+++ b/examples/journeys/overlays/pi.litellm.json
@@ -10,9 +10,9 @@
         { "id": "dashscope/kimi-k2.7-code", "name": "kimi-k2.7-code" },
         { "id": "MiniMax-M2.7", "name": "MiniMax-M2.7" },
         { "id": "glm-5.2", "name": "glm-5.2" },
-        { "id": "claude-sonnet-4-6", "name": "claude-sonnet-4-6" },
-        { "id": "gpt-5.4", "name": "gpt-5.4" },
-        { "id": "deepseek-v4-pro", "name": "deepseek-v4-pro" }
+        { "id": "anthropic/claude-sonnet-4-6", "name": "claude-sonnet-4-6" },
+        { "id": "openai/gpt-5.4", "name": "gpt-5.4" },
+        { "id": "dashscope/deepseek-v4-pro", "name": "deepseek-v4-pro" }
       ]
     }
   }

--- a/examples/journeys/overlays/pi.litellm.json
+++ b/examples/journeys/overlays/pi.litellm.json
@@ -1,0 +1,19 @@
+{
+  "providers": {
+    "litellm": {
+      "baseUrl": "http://10.130.138.46:8010/v1",
+      "api": "openai-completions",
+      "apiKey": "$litellm_api_key",
+      "models": [
+        { "id": "dashscope/qwen3.8-max", "name": "qwen3.8-max" },
+        { "id": "dashscope/qwen3-coder-plus", "name": "qwen3-coder-plus" },
+        { "id": "dashscope/kimi-k2.7-code", "name": "kimi-k2.7-code" },
+        { "id": "MiniMax-M2.7", "name": "MiniMax-M2.7" },
+        { "id": "glm-5.2", "name": "glm-5.2" },
+        { "id": "claude-sonnet-4-6", "name": "claude-sonnet-4-6" },
+        { "id": "gpt-5.4", "name": "gpt-5.4" },
+        { "id": "deepseek-v4-pro", "name": "deepseek-v4-pro" }
+      ]
+    }
+  }
+}

--- a/examples/journeys/profiles.dsh.read-only.yaml
+++ b/examples/journeys/profiles.dsh.read-only.yaml
@@ -17,4 +17,4 @@ bindings:
         options:
           permission: read-only
     model: deepseek-v4-flash
-    api_key: deepseek_api_key
+    api_key: ${deepseek_api_key}

--- a/examples/journeys/profiles.dsh.read-only.yaml
+++ b/examples/journeys/profiles.dsh.read-only.yaml
@@ -14,7 +14,7 @@ bindings:
     executor: dsh
     extensions:
       - plugin: dsh
+        options:
+          permission: read-only
     model: deepseek-v4-flash
     api_key: deepseek_api_key
-    options:
-      permission: read-only

--- a/examples/journeys/profiles.dsh.yaml
+++ b/examples/journeys/profiles.dsh.yaml
@@ -15,7 +15,7 @@ bindings:
     executor: dsh
     extensions:
       - plugin: dsh
+        options:
+          composition: slim
     model: deepseek-v4-flash
     api_key: deepseek_api_key
-    options:
-      composition: slim

--- a/examples/journeys/profiles.dsh.yaml
+++ b/examples/journeys/profiles.dsh.yaml
@@ -7,7 +7,7 @@
 # File-effect policy: profiles.dsh.read-only.yaml, or
 #   --set '/bindings/solver/options/permission="read-only"'
 #
-# api_key = env locator name (never a secret value).
+# api_key = ${ENV_NAME} locator (never a secret value).
 # Same harness as ACP / nooa — only the job binding changes.
 format: bora.profiles/1
 bindings:
@@ -18,4 +18,4 @@ bindings:
         options:
           composition: slim
     model: deepseek-v4-flash
-    api_key: deepseek_api_key
+    api_key: ${deepseek_api_key}

--- a/examples/journeys/profiles.nooa.yaml
+++ b/examples/journeys/profiles.nooa.yaml
@@ -18,7 +18,7 @@ bindings:
           agent: "lib.agents:JsonlAggAgent"
           method: "run"
     model: openai/glm-5.2
-    api_key: litellm_api_key
+    api_key: ${litellm_api_key}
   user:
     executor: nooa
     extensions:
@@ -27,7 +27,7 @@ bindings:
           agent: "lib.agents:UserSimAgent"
           method: "run"
     model: openai/glm-5.2
-    api_key: litellm_api_key
+    api_key: ${litellm_api_key}
   service:
     executor: nooa
     extensions:
@@ -36,7 +36,7 @@ bindings:
           agent: "lib.agents:ServiceAgent"
           method: "run"
     model: openai/glm-5.2
-    api_key: litellm_api_key
+    api_key: ${litellm_api_key}
   specialist:
     executor: nooa
     extensions:
@@ -45,7 +45,7 @@ bindings:
           agent: "lib.agents:SpecialistAgent"
           method: "run"
     model: openai/glm-5.2
-    api_key: litellm_api_key
+    api_key: ${litellm_api_key}
   planner:
     executor: nooa
     extensions:
@@ -54,7 +54,7 @@ bindings:
           agent: "lib.agents:PlannerAgent"
           method: "run"
     model: openai/glm-5.2
-    api_key: litellm_api_key
+    api_key: ${litellm_api_key}
   reducer:
     executor: nooa
     extensions:
@@ -63,4 +63,4 @@ bindings:
           agent: "lib.agents:ReducerAgent"
           method: "run"
     model: openai/glm-5.2
-    api_key: litellm_api_key
+    api_key: ${litellm_api_key}

--- a/examples/journeys/profiles.nooa.yaml
+++ b/examples/journeys/profiles.nooa.yaml
@@ -14,53 +14,53 @@ bindings:
     executor: nooa
     extensions:
       - plugin: nooa
-    options:
-      agent: "lib.agents:JsonlAggAgent"
-      method: "run"
+        options:
+          agent: "lib.agents:JsonlAggAgent"
+          method: "run"
     model: openai/glm-5.2
     api_key: litellm_api_key
   user:
     executor: nooa
     extensions:
       - plugin: nooa
-    options:
-      agent: "lib.agents:UserSimAgent"
-      method: "run"
+        options:
+          agent: "lib.agents:UserSimAgent"
+          method: "run"
     model: openai/glm-5.2
     api_key: litellm_api_key
   service:
     executor: nooa
     extensions:
       - plugin: nooa
-    options:
-      agent: "lib.agents:ServiceAgent"
-      method: "run"
+        options:
+          agent: "lib.agents:ServiceAgent"
+          method: "run"
     model: openai/glm-5.2
     api_key: litellm_api_key
   specialist:
     executor: nooa
     extensions:
       - plugin: nooa
-    options:
-      agent: "lib.agents:SpecialistAgent"
-      method: "run"
+        options:
+          agent: "lib.agents:SpecialistAgent"
+          method: "run"
     model: openai/glm-5.2
     api_key: litellm_api_key
   planner:
     executor: nooa
     extensions:
       - plugin: nooa
-    options:
-      agent: "lib.agents:PlannerAgent"
-      method: "run"
+        options:
+          agent: "lib.agents:PlannerAgent"
+          method: "run"
     model: openai/glm-5.2
     api_key: litellm_api_key
   reducer:
     executor: nooa
     extensions:
       - plugin: nooa
-    options:
-      agent: "lib.agents:ReducerAgent"
-      method: "run"
+        options:
+          agent: "lib.agents:ReducerAgent"
+          method: "run"
     model: openai/glm-5.2
     api_key: litellm_api_key

--- a/examples/journeys/profiles.yaml
+++ b/examples/journeys/profiles.yaml
@@ -7,7 +7,7 @@ bindings:
         options:
           entry: pi
     model: zai-coding-cn/glm-5.2
-    api_key: glm_coding_api_key
+    api_key: ${glm_coding_api_key}
   user:
     executor: acp
     extensions:
@@ -22,7 +22,7 @@ bindings:
         options:
           entry: opencode
     model: zai-coding-plan/glm-5.2
-    api_key: glm_coding_api_key
+    api_key: ${glm_coding_api_key}
   specialist:
     executor: acp
     extensions:
@@ -30,7 +30,7 @@ bindings:
         options:
           entry: pi
     model: zai-coding-cn/glm-5.2
-    api_key: glm_coding_api_key
+    api_key: ${glm_coding_api_key}
   planner:
     executor: acp
     extensions:
@@ -38,7 +38,7 @@ bindings:
         options:
           entry: opencode
     model: zai-coding-plan/glm-5.2
-    api_key: glm_coding_api_key
+    api_key: ${glm_coding_api_key}
   reducer:
     executor: acp
     extensions:

--- a/examples/journeys/profiles.yaml
+++ b/examples/journeys/profiles.yaml
@@ -2,35 +2,47 @@ format: bora.profiles/1
 bindings:
   solver:
     executor: acp
-    options:
-      entry: pi
+    extensions:
+      - plugin: acp
+        options:
+          entry: pi
     model: zai-coding-cn/glm-5.2
     api_key: glm_coding_api_key
   user:
     executor: acp
-    options:
-      entry: grok-build
+    extensions:
+      - plugin: acp
+        options:
+          entry: grok-build
     model: entry-default
   service:
     executor: acp
-    options:
-      entry: opencode
+    extensions:
+      - plugin: acp
+        options:
+          entry: opencode
     model: zai-coding-plan/glm-5.2
     api_key: glm_coding_api_key
   specialist:
     executor: acp
-    options:
-      entry: pi
+    extensions:
+      - plugin: acp
+        options:
+          entry: pi
     model: zai-coding-cn/glm-5.2
     api_key: glm_coding_api_key
   planner:
     executor: acp
-    options:
-      entry: opencode
+    extensions:
+      - plugin: acp
+        options:
+          entry: opencode
     model: zai-coding-plan/glm-5.2
     api_key: glm_coding_api_key
   reducer:
     executor: acp
-    options:
-      entry: grok-build
+    extensions:
+      - plugin: acp
+        options:
+          entry: grok-build
     model: entry-default

--- a/examples/journeys/tasks/multiagent-env-min/README.md
+++ b/examples/journeys/tasks/multiagent-env-min/README.md
@@ -14,7 +14,7 @@ must be discovered from seeded DB rows via tools.
 
 ## ACP mix (default)
 
-| Role                    | profile id         | `options.entry` |
+| Role                    | profile id         | ACP `entry`     |
 | ----------------------- | ------------------ | --------------- |
 | specialists (×5 probes) | `specialist-pi`    | `pi`            |
 | planner                 | `planner-opencode` | `opencode`      |

--- a/examples/journeys/tasks/tau2-dialog-min/README.md
+++ b/examples/journeys/tasks/tau2-dialog-min/README.md
@@ -15,7 +15,7 @@ v1 **tau2-bench retail** case class on BORA v2 package surfaces.
 
 ## ACP mix (default)
 
-| Role           | profile id         | `options.entry` |
+| Role           | profile id         | ACP `entry`     |
 | -------------- | ------------------ | --------------- |
 | user simulator | `user-grok`        | `grok-build`    |
 | service agent  | `service-opencode` | `opencode`      |

--- a/examples/journeys/tasks/terminal-jsonl-agg/README.md
+++ b/examples/journeys/tasks/terminal-jsonl-agg/README.md
@@ -10,7 +10,7 @@ v1 **terminal-bench / jsonl-aggregator** case class:
 
 ## ACP (default)
 
-| profile id    | `options.entry` | placement                                |
+| profile id    | ACP `entry`     | placement                                |
 | ------------- | --------------- | ---------------------------------------- |
 | `terminal-pi` | `pi`            | L1 `docker exec` target (assurance:l1)   |
 

--- a/examples/l1/profiles.yaml
+++ b/examples/l1/profiles.yaml
@@ -2,27 +2,37 @@ format: bora.profiles/1
 bindings:
   solver:
     executor: acp
-    options:
-      entry: codex
+    extensions:
+      - plugin: acp
+        options:
+          entry: codex
     model: gpt-5.4-mini
   pi-solver:
     executor: acp
-    options:
-      entry: pi
+    extensions:
+      - plugin: acp
+        options:
+          entry: pi
     model: zai-coding-cn/glm-5.2
     api_key: glm_coding_api_key
   planner:
     executor: acp
-    options:
-      entry: codex
+    extensions:
+      - plugin: acp
+        options:
+          entry: codex
     model: gpt-5.4-mini
   reviewer:
     executor: acp
-    options:
-      entry: codex
+    extensions:
+      - plugin: acp
+        options:
+          entry: codex
     model: gpt-5.4-mini
   worker:
     executor: acp
-    options:
-      entry: codex
+    extensions:
+      - plugin: acp
+        options:
+          entry: codex
     model: gpt-5.4-mini

--- a/examples/l1/profiles.yaml
+++ b/examples/l1/profiles.yaml
@@ -14,7 +14,7 @@ bindings:
         options:
           entry: pi
     model: zai-coding-cn/glm-5.2
-    api_key: glm_coding_api_key
+    api_key: ${glm_coding_api_key}
   planner:
     executor: acp
     extensions:

--- a/examples/slot-probe/README.md
+++ b/examples/slot-probe/README.md
@@ -19,7 +19,7 @@ uv run bora plugin install plugins/slot-probe
 uv run bora plugin install plugins/nooa   # L0 host SPI agent
 ```
 
-L1 PASS needs ACP credentials (profile `probe-acp` uses `api_key: glm_coding_api_key`).
+L1 PASS needs ACP credentials (profile `probe-acp` uses `api_key: ${glm_coding_api_key}`).
 Copy from another Database `.env` or set the locator env var on the host
 (values never enter lock/evidence).
 

--- a/examples/slot-probe/profiles.yaml
+++ b/examples/slot-probe/profiles.yaml
@@ -20,4 +20,4 @@ bindings:
           entry: pi
       - plugin: slot-probe
     model: zai-coding-cn/glm-5.2
-    api_key: glm_coding_api_key
+    api_key: ${glm_coding_api_key}

--- a/examples/slot-probe/profiles.yaml
+++ b/examples/slot-probe/profiles.yaml
@@ -6,17 +6,18 @@ bindings:
     executor: nooa
     extensions:
       - plugin: nooa
+        options:
+          agent: "lib.agents:FixedAnswerAgent"
+          method: "run"
       - plugin: slot-probe
-    options:
-      agent: "lib.agents:FixedAnswerAgent"
-      method: "run"
     model: none
   # L1: real ACP in attempt-container. slot-probe still needs an explicit row.
   probe-acp:
     executor: acp
     extensions:
+      - plugin: acp
+        options:
+          entry: pi
       - plugin: slot-probe
-    options:
-      entry: pi
     model: zai-coding-cn/glm-5.2
     api_key: glm_coding_api_key

--- a/examples/tau3-airline/profiles.yaml
+++ b/examples/tau3-airline/profiles.yaml
@@ -2,11 +2,15 @@ format: bora.profiles/1
 bindings:
   user:
     executor: acp
-    options:
-      entry: grok-build
+    extensions:
+      - plugin: acp
+        options:
+          entry: grok-build
     model: entry-default
   service:
     executor: acp
-    options:
-      entry: grok-build
+    extensions:
+      - plugin: acp
+        options:
+          entry: grok-build
     model: entry-default

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -39,11 +39,11 @@ bindings:
     executor: dsh
     extensions:
       - plugin: dsh
+        options:
+          composition: slim               # omit permission → unrestricted local bash/fs
+          # permission: read-only         # or workspace-write | danger-full-access
     model: deepseek-v4-flash
     api_key: deepseek_api_key          # env locator
-    options:
-      composition: slim               # omit permission → unrestricted local bash/fs
-      # permission: read-only         # or workspace-write | danger-full-access
 ```
 
 `options.permission` is plugin-owned (same pattern as `composition`). Allowed

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -43,7 +43,7 @@ bindings:
           composition: slim               # omit permission → unrestricted local bash/fs
           # permission: read-only         # or workspace-write | danger-full-access
     model: deepseek-v4-flash
-    api_key: deepseek_api_key          # env locator
+    api_key: ${deepseek_api_key}          # env locator
 ```
 
 `options.permission` is plugin-owned (same pattern as `composition`). Allowed

--- a/plugins/dsh/src/dsh_plugin/factory.py
+++ b/plugins/dsh/src/dsh_plugin/factory.py
@@ -176,6 +176,7 @@ class DshExecutorSPI:
         base_url: str | None = None,
         api_key: str | None = None,
         plugin_id: str | None = None,
+        workdir: str | None = None,
         **_kwargs: Any,
     ) -> None:
         del plugin_id
@@ -191,7 +192,7 @@ class DshExecutorSPI:
         )
         self.base_url = base_url
         self.api_key_env = api_key
-        self.default_workdir = str(opts.get("_workdir")).strip() if opts.get("_workdir") else None
+        self.default_workdir = str(workdir).strip() if workdir else None
         self._harness: Any = None
         self._session: Any = None
         self._session_id = f"bora-{self.profile_id or 'solver'}-{uuid.uuid4().hex[:12]}"

--- a/plugins/home-files/README.md
+++ b/plugins/home-files/README.md
@@ -1,0 +1,46 @@
+# home-files
+
+`bora.plugin/1` that copies Database-relative overlay files into Attempt
+`$HOME` or workspace. Registers `on: home_overlay` only. No bake.
+
+## Install
+
+```bash
+uv run bora plugin install plugins/home-files
+```
+
+Install writes `$BORA_HOME/plugins` only. It never rewrites profiles.
+
+## Bind
+
+```yaml
+executor: acp
+extensions:
+  - plugin: acp
+    options:
+      entry: opencode
+  - plugin: home-files
+    options:
+      files:
+        - src: overlays/opencode.litellm.json
+          dest: .config/opencode/opencode.json
+          dest_root: home
+```
+
+| Field | Rule |
+| --- | --- |
+| `src` | Relative to Database root. No `..`, no absolute path. |
+| `dest_root` | Required: `home` or `workspace`. |
+| `dest` | Relative to that root. No `..`. Not under `evaluation/`. |
+
+Secrets stay locators. Overlay JSON must not embed tokens. No JSON deep-merge.
+
+## Run
+
+```bash
+uv run bora plugin install plugins/home-files
+uv run bora lock examples/journeys --task terminal-jsonl-agg \
+  --profiles examples/journeys/acp-profiles/profiles.acp.opencode.glm-5.2.yaml
+uv run bora run examples/journeys --task terminal-jsonl-agg \
+  --profiles examples/journeys/acp-profiles/profiles.acp.opencode.glm-5.2.yaml
+```

--- a/plugins/home-files/plugin.yaml
+++ b/plugins/home-files/plugin.yaml
@@ -1,0 +1,8 @@
+format: bora.plugin/1
+plugin_id: home-files
+version: 0.1.0
+slots:
+  "on":
+    - id: home_overlay
+      priority: 110
+      entry: "home_files.hooks:build_home_overlay"

--- a/plugins/home-files/src/home_files/__init__.py
+++ b/plugins/home-files/src/home_files/__init__.py
@@ -1,0 +1,7 @@
+"""home-files — copy Database overlay files into Attempt HOME or workspace."""
+
+from __future__ import annotations
+
+PLUGIN_ID = "home-files"
+
+__all__ = ["PLUGIN_ID"]

--- a/plugins/home-files/src/home_files/hooks.py
+++ b/plugins/home-files/src/home_files/hooks.py
@@ -91,7 +91,12 @@ def _copy_one(src: Path, dest: Path) -> None:
         if dest.exists() and dest.is_file():
             raise HomeFilesError("dest_file_src_dir", kind="home_files_dest_invalid")
         dest.mkdir(parents=True, exist_ok=True)
+        src_root = src.resolve()
         for child in src.iterdir():
+            try:
+                child.resolve().relative_to(src_root)
+            except ValueError as exc:
+                raise HomeFilesError("src_symlink_escapes", kind="home_files_path_invalid") from exc
             _copy_one(child, dest / child.name)
         return
     if dest.exists() and dest.is_dir():

--- a/plugins/home-files/src/home_files/hooks.py
+++ b/plugins/home-files/src/home_files/hooks.py
@@ -1,0 +1,113 @@
+"""on: home_overlay factory. Writes files; does not call Docker or invent PASS."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+PLUGIN_ID = "home-files"
+DEST_ROOTS = frozenset({"home", "workspace"})
+
+
+class HomeFilesError(Exception):
+    def __init__(self, message: str, *, kind: str = "home_files_invalid") -> None:
+        super().__init__(message)
+        self.kind = kind
+        self.message = message
+
+
+def _safe_rel(raw: Any, *, what: str) -> Path:
+    if not isinstance(raw, str) or not raw.strip():
+        raise HomeFilesError(f"{what}_required", kind="home_files_path_invalid")
+    text = raw.strip().replace("\\", "/")
+    if text.startswith("/") or Path(text).is_absolute():
+        raise HomeFilesError(f"{what}_absolute", kind="home_files_path_invalid")
+    parts = Path(text).parts
+    if ".." in parts or any(p == ".." for p in parts):
+        raise HomeFilesError(f"{what}_escapes", kind="home_files_path_invalid")
+    if not parts:
+        raise HomeFilesError(f"{what}_empty", kind="home_files_path_invalid")
+    return Path(*parts)
+
+
+def _reject_evaluation(dest: Path) -> None:
+    if dest.parts and dest.parts[0] == "evaluation":
+        raise HomeFilesError("dest_under_evaluation", kind="home_files_dest_invalid")
+    if "evaluation" in dest.parts:
+        raise HomeFilesError("dest_under_evaluation", kind="home_files_dest_invalid")
+
+
+def _require_dir(raw: Any, *, name: str) -> Path:
+    if raw is None:
+        raise HomeFilesError(f"{name}_required", kind="home_files_context_missing")
+    path = Path(str(raw))
+    if not path.exists():
+        path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def apply_files(files: Any, value: dict[str, Any]) -> None:
+    if files is None:
+        return
+    if not isinstance(files, list):
+        raise HomeFilesError("files_must_be_list", kind="home_files_options_invalid")
+    package_root = _require_dir(value.get("package_root"), name="package_root")
+    workspace_root = _require_dir(value.get("workspace_root"), name="workspace_root")
+    cred_root = _require_dir(value.get("cred_root"), name="cred_root")
+    home_overlay = cred_root / "home_overlay"
+    home_overlay.mkdir(parents=True, exist_ok=True)
+
+    for i, item in enumerate(files):
+        if not isinstance(item, dict):
+            raise HomeFilesError(f"files[{i}]_not_mapping", kind="home_files_options_invalid")
+        src_rel = _safe_rel(item.get("src"), what="src")
+        dest_rel = _safe_rel(item.get("dest"), what="dest")
+        dest_root = item.get("dest_root")
+        if dest_root not in DEST_ROOTS:
+            raise HomeFilesError(
+                f"dest_root_invalid:{dest_root!r}",
+                kind="home_files_dest_invalid",
+            )
+        _reject_evaluation(dest_rel)
+        src = (package_root / src_rel).resolve()
+        try:
+            src.relative_to(package_root.resolve())
+        except ValueError as exc:
+            raise HomeFilesError("src_escapes_package", kind="home_files_path_invalid") from exc
+        if not src.exists():
+            raise HomeFilesError(f"src_missing:{src_rel}", kind="home_files_src_missing")
+        root = home_overlay if dest_root == "home" else workspace_root
+        dest = (root / dest_rel).resolve()
+        try:
+            dest.relative_to(root.resolve())
+        except ValueError as exc:
+            raise HomeFilesError("dest_escapes_root", kind="home_files_path_invalid") from exc
+        _copy_one(src, dest)
+
+
+def _copy_one(src: Path, dest: Path) -> None:
+    if src.is_dir():
+        if dest.exists() and dest.is_file():
+            raise HomeFilesError("dest_file_src_dir", kind="home_files_dest_invalid")
+        dest.mkdir(parents=True, exist_ok=True)
+        for child in src.iterdir():
+            _copy_one(child, dest / child.name)
+        return
+    if dest.exists() and dest.is_dir():
+        raise HomeFilesError("dest_dir_src_file", kind="home_files_dest_invalid")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dest)
+
+
+def build_home_overlay(**kwargs: Any) -> Any:
+    options = dict(kwargs.get("options") or {})
+    files = options.get("files")
+
+    async def handler(ctx: Any, value: Any, nxt: Any) -> Any:
+        del ctx
+        payload = dict(value) if isinstance(value, dict) else {}
+        apply_files(files, payload)
+        return await nxt(payload)
+
+    return handler

--- a/plugins/nooa/README.md
+++ b/plugins/nooa/README.md
@@ -42,7 +42,7 @@ bindings:
           agent: "lib.agents:JsonlAggAgent"   # package-local nooa.Agent
           method: "run"
     model: openai/glm-5.2
-    api_key: litellm_api_key          # env locator
+    api_key: ${litellm_api_key}          # env locator
     # base_url: http://127.0.0.1:8000/v1   # optional; else litellm_base_url / OPENAI_BASE_URL
 ```
 

--- a/plugins/nooa/README.md
+++ b/plugins/nooa/README.md
@@ -38,12 +38,12 @@ bindings:
     executor: nooa
     extensions:
       - plugin: nooa
+        options:
+          agent: "lib.agents:JsonlAggAgent"   # package-local nooa.Agent
+          method: "run"
     model: openai/glm-5.2
     api_key: litellm_api_key          # env locator
     # base_url: http://127.0.0.1:8000/v1   # optional; else litellm_base_url / OPENAI_BASE_URL
-    options:
-      agent: "lib.agents:JsonlAggAgent"   # package-local nooa.Agent
-      method: "run"
 ```
 
 ## Journeys smoke (real API)

--- a/plugins/nooa/src/nooa_plugin/factory.py
+++ b/plugins/nooa/src/nooa_plugin/factory.py
@@ -200,10 +200,14 @@ class NooaExecutorSPI:
         base_url: str | None = None,
         api_key: str | None = None,
         plugin_id: str | None = None,
+        package_root: str | None = None,
+        workdir: str | None = None,
         **_kwargs: Any,
     ) -> None:
         del plugin_id
         opts = dict(options or {})
+        if package_root:
+            opts.setdefault("_package_root", package_root)
         agent_ref = opts.get("agent")
         if not agent_ref or not str(agent_ref).strip():
             raise ExtensionMaterializeError(
@@ -217,7 +221,7 @@ class NooaExecutorSPI:
         self.base_url = base_url
         self.api_key_env = api_key  # locator name
         self.options = opts
-        self.default_workdir = str(opts.get("_workdir")).strip() if opts.get("_workdir") else None
+        self.default_workdir = str(workdir).strip() if workdir else None
         self._agent_cls: Any = None
         self._agent: Any = None
         self._llm: Any = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ asyncio_default_fixture_loop_scope = "function"
 
 [tool.pyright]
 include = ["src", "tests"]
-extraPaths = ["plugins/nooa/src", "plugins/dsh/src"]
+extraPaths = ["plugins/nooa/src", "plugins/dsh/src", "plugins/home-files/src"]
 pythonVersion = "3.12"
 typeCheckingMode = "standard"
 venvPath = "."

--- a/skills/bora-cli/SKILL.md
+++ b/skills/bora-cli/SKILL.md
@@ -119,7 +119,7 @@ Job binding axes:
 - `/bindings/<role_id>/executor`
 - `/bindings/<role_id>/api_key`
 - `/bindings/<role_id>/base_url`
-- `/bindings/<role_id>/options/<key>` (plugin-opaque; ACP denylist still rejects `command` / engine keys)
+- `/bindings/<role_id>/options/<key>` (writes the **executor plugin** extensions row; ACP denylist still rejects `command` / engine keys)
 
 **Not** overridable: intent `limits.*` (task contract).
 

--- a/skills/bora-cli/SKILL.md
+++ b/skills/bora-cli/SKILL.md
@@ -82,8 +82,10 @@ Coding-agent packages use:
 
 ```yaml
 executor: acp
-options:
-  entry: opencode # or codex | claude-code | pi | grok-build | …
+extensions:
+  - plugin: acp
+    options:
+      entry: opencode # or codex | claude-code | pi | grok-build | …
 ```
 
 Do **not** hardcode a fixed list; inventory is authoritative. Do **not** use

--- a/skills/bora-cli/references/commands.md
+++ b/skills/bora-cli/references/commands.md
@@ -23,14 +23,14 @@ Stdout JSON (high level):
 - `-v` adds tools/session/stream + richer entry fields
 - No package path; no secrets; exit 0
 
-**Author packages with:** `executor: acp` + `options.entry: <entry_id from acp_entries>`.
+**Author packages with:** `executor: acp` + `- plugin: acp` / `options.entry: <entry_id from acp_entries>`.
 
 ## `bora lock`
 
 - Deterministic JSON on stdout (digest, task_id, resolution, resolved_references).
 - No secret values.
 - Does not create Run/Attempt or start Agent.
-- Rejects unknown `executor` kinds and ACP profiles missing `options.entry`.
+- Rejects unknown `executor` kinds and ACP profiles missing `- plugin: acp` / `options.entry`.
 - `--probe`: same lock plus observational `probe` (path, ready, checks). Does not
   change the digest. Exit 1 when the **selected** `provider.kind` path is unsatisfied.
   L0 runs declared `host_requires`; L1 checks bake file + Docker daemon + locator

--- a/skills/bora-cli/references/failures.md
+++ b/skills/bora-cli/references/failures.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | exit 2, empty stdout on lock | Config error on stderr (`unknown_profile`, schema, etc.) |
 | lock `unsupported_capability` / `unsupported executor` | Kind not in `bora executors` `.supported` — coding agents need `executor: acp` |
-| lock `options.entry required` | ACP profile missing `options.entry` |
+| lock `options.entry required` | ACP profile missing `- plugin: acp` / `options.entry` |
 | Agent ERROR offline | Expected under `BORA_OFFLINE_AGENT=1` |
 | `l1_executor_unbound` | L1 invoke has no SPI ``bind_to_target`` (or placement resolver missing) |
 | `image_contribute_unsatisfied` | Bound external executor but bake chain empty / no `Dockerfile.bake` — `$bora-plugin` |

--- a/skills/bora-config-package/SKILL.md
+++ b/skills/bora-config-package/SKILL.md
@@ -236,13 +236,13 @@ bindings:
         options:
           entry: opencode       # registry: codex | claude-code | pi | opencode | grok-build
     model: entry-default
-    api_key: glm_coding_api_key   # env *locator name* only
+    api_key: ${glm_coding_api_key}   # ${ENV_NAME} locator; value never in YAML/lock
   # HTTP / non-ACP example:
   # http-solver:
   #   executor: openai-http
   #   model: glm-4.7
-  #   base_url: https://open.bigmodel.cn/api/coding/paas/v4
-  #   api_key: zhipu_coding_api_key
+  #   base_url: ${OPENAI_BASE_URL}
+  #   api_key: ${zhipu_coding_api_key}
 ```
 
 ## Ownership rules

--- a/skills/bora-config-package/SKILL.md
+++ b/skills/bora-config-package/SKILL.md
@@ -231,8 +231,10 @@ format: bora.profiles/1
 bindings:
   solver:
     executor: acp
-    options:
-      entry: opencode       # registry: codex | claude-code | pi | opencode | grok-build
+    extensions:
+      - plugin: acp
+        options:
+          entry: opencode       # registry: codex | claude-code | pi | opencode | grok-build
     model: entry-default
     api_key: glm_coding_api_key   # env *locator name* only
   # HTTP / non-ACP example:
@@ -322,10 +324,10 @@ uv run bora plugin list        # installed mechanism plugins (e.g. nooa)
 | `.host_ready` | Kinds that can run here (ACP needs at least one ready entry; HTTP needs no CLI) |
 | Installed plugins | Extra executor plugin_ids after `bora plugin install` (Recognition only) |
 
-**Target (coding agents):** `executor: acp` + `options.entry: <registry-id>`.  
+**Target (coding agents):** `executor: acp` + `- plugin: acp` / `options.entry: <registry-id>`.  
 **Do not** write `executor: codex|pi|opencode|claude-code` — lock fails (`unsupported_capability`) or L1 fails (`l1_executor_unbound`).
 
-**External mechanism (e.g. nooa):** `executor: nooa` + `options.agent: "lib.agents:Class"` in
+**External mechanism (e.g. nooa):** `executor: nooa` + `- plugin: nooa` / `options.agent: "lib.agents:Class"` in
 **profiles only** — never in member `task.yaml`. `bora plugin install` does **not** rewrite
 profiles. `bora lock` writes full `extension_bindings` for the resolved extension graph.
 

--- a/skills/bora-config-package/references/bora-yaml.md
+++ b/skills/bora-config-package/references/bora-yaml.md
@@ -62,7 +62,7 @@ uv run bora executors -v   # + tools/session/stream; .acp_entries[] for ACP
 ```
 
 - **`.supported`**: kinds valid for yaml `executor:` (this BORA install).
-- **Coding agents (ACP Target):** `executor: acp` + `options.entry`.
+- **Coding agents (ACP Target):** `executor: acp` + `- plugin: acp` / `options.entry`.
 - **HTTP agents:** e.g. `executor: openai-http` (+ optional `base_url` / `api_key` locator).
 - Unknown kind fails at lock (`unsupported_capability`).
 - Private CLI kinds (`codex` / `pi` / `opencode` / `claude-code` as **executor**) are **removed**; use ACP entry ids instead.
@@ -70,23 +70,28 @@ uv run bora executors -v   # + tools/session/stream; .acp_entries[] for ACP
 ### ACP profiles
 
 ```yaml
-agent_profiles:
-  - id: codex-acp
+# Database profiles.yaml
+bindings:
+  solver:
     executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: codex                # registry entry_id
     model: entry-default          # or a model the entry accepts
-    options:
-      entry: codex                # registry entry_id
-  - id: pi-acp
+  pi-solver:
     executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: pi
     model: zai-coding-cn/glm-5.2
     api_key: glm_coding_api_key   # host env locator name only
-    options:
-      entry: pi
 ```
 
 | Field | Rule |
 | --- | --- |
-| `options.entry` | **Required** when `executor: acp`. Registry ids (discover via `bora executors -v` → `acp_entries`): typically `codex`, `claude-code`, `pi`, `opencode`, `grok-build`. |
+| `- plugin: acp` / `options.entry` | **Required** when `executor: acp`. Registry ids (discover via `bora executors -v` → `acp_entries`): typically `codex`, `claude-code`, `pi`, `opencode`, `grok-build`. |
 | `options.command` / `version` / `install_command` / … | **Forbidden** in package yaml (registry owns pins). |
 | Host readiness | Per-entry `engine_ready` + `acp_entry_ready` in inventory — not the same as yaml `executor` kind. |
 

--- a/skills/bora-config-package/references/bora-yaml.md
+++ b/skills/bora-config-package/references/bora-yaml.md
@@ -86,7 +86,7 @@ bindings:
         options:
           entry: pi
     model: zai-coding-cn/glm-5.2
-    api_key: glm_coding_api_key   # host env locator name only
+    api_key: ${glm_coding_api_key}   # host env locator name only
 ```
 
 | Field | Rule |
@@ -137,7 +137,7 @@ agent_profiles:
     executor: openai-http
     model: glm-4.7
     base_url: https://open.bigmodel.cn/api/coding/paas/v4
-    api_key: zhipu_coding_api_key
+    api_key: ${zhipu_coding_api_key}
 ```
 
 Design: `docs/design/02-task-package-and-config.md`, `docs/design/05-runtime/agent-service.md`.

--- a/skills/bora-config-package/references/isolation.md
+++ b/skills/bora-config-package/references/isolation.md
@@ -16,7 +16,7 @@
   (see docs/design/05-runtime/provider-l1.md).
   Upstream base: `FROM <image>` then install required ACP entries in that Dockerfile.
   Secrets never baked into image layers.
-- Coding agents on L1: `executor: acp` + `options.entry`; parent ACP client +
+- Coding agents on L1: `executor: acp` + `- plugin: acp` / `options.entry`; parent ACP client +
   `docker exec` placement — no private CLI scrape.
 
 ## L1 Dockerfile depth tiers (conversion)

--- a/skills/bora-platform/SKILL.md
+++ b/skills/bora-platform/SKILL.md
@@ -47,7 +47,7 @@ Authoring / porting / scenario-homogeneous Datasets: load `$bora-config-package`
 3. **Adapters** named by mechanism/protocol/resource (`acp`, `openai-http`, `postgresql`, docker; ACP **entries** `codex`/`pi`/…) — never Benchmark/task/domain names.
 4. **Do not claim** suite-wide `isolated` or `real-benchmark-verified` from one happy path.
 5. **Skills only describe shipped surfaces** — never invent CLI flags or Core APIs.
-6. **Coding-agent Target:** `executor: acp` + `options.entry` — not private CLI `executor: codex|pi|…`.
+6. **Coding-agent Target:** `executor: acp` + `- plugin: acp` / `options.entry` — not private CLI `executor: codex|pi|…`.
 7. **Plugins:** fixed L0–L5 extension points + registry; `bora plugin install` never rewrites profiles; Recognition ≠ L1 Ready (`image_contribute` bake); no executor dual path.
 8. **Hub Leaderboard / Task Jobs need suite uploads** — `bora results upload` (single Attempt) is not enough for primary Hub surfaces; use suite run + `bora results upload-suite` (often `--with-attempts`). Public Leaderboard further requires a **complete**, **release-bound** suite; incomplete or draft-bound rows stay on Jobs. Detail: `$bora-cli` § Hub visibility.
 

--- a/skills/bora-platform/references/red-lines.md
+++ b/skills/bora-platform/references/red-lines.md
@@ -9,12 +9,12 @@
 
 ## Secrets
 
-- **OK:** `agent_profiles` with `executor` / ACP `options.entry` / model id only; credentials via host env locators.
+- **OK:** Database bindings with `executor` / ACP `- plugin: acp` / `options.entry` / model id only; credentials via host env locators.
 - **Forbidden:** API keys, DSN passwords, Bearer tokens in `bora.yaml`, lock JSON, evidence files, skill text, or examples committed to git.
 
 ## Adapter naming
 
-- **OK:** yaml `executor: acp` + `options.entry: codex|pi|opencode|…`; `openai-http`; `postgresql`; docker provider.
+- **OK:** yaml `executor: acp` + `- plugin: acp` / `options.entry: codex|pi|opencode|…`; `openai-http`; `postgresql`; docker provider.
 - **Forbidden:** `executor: codex|pi|opencode|claude-code` as private CLI kinds (migrated); `TerminalBenchAdapter`; task-id branches; domain names as production adapter modules.
 
 ## Plugins

--- a/skills/bora-platform/references/shipped-surfaces.md
+++ b/skills/bora-platform/references/shipped-surfaces.md
@@ -7,7 +7,7 @@ Prefer mechanism packages under `examples/core/` and `examples/l1/`. Full list: 
 | `examples/core --task config-minimal` | `bora lock` success |
 | `examples/core --task sdk-agent-session` | Host multi-invoke + independent PASS |
 | `examples/core --task attempt-trajectory` | Per-invoke Core `trajectory.jsonl` + `Result.logs` |
-| `examples/core --task builtin-executor-conformance` | Profile-only switch (`executor: acp` + `options.entry`) |
+| `examples/core --task builtin-executor-conformance` | Profile-only switch (`executor: acp` + `- plugin: acp` / `options.entry`) |
 | `examples/core --task builtin-executor-mixed` | Two ACP profiles, independent sessions/trees |
 | `examples/core --task hard-ceiling-trajectory` | N+1 invoke denied pre-effect |
 | `examples/core --task environment-action-denied` | Env action deny-before-mutation |

--- a/skills/bora-plugin/references/authoring.md
+++ b/skills/bora-plugin/references/authoring.md
@@ -143,18 +143,19 @@ bindings:
     executor: my-mech
     extensions:
       - plugin: my-mech
+        options:
+          agent: "lib.agents:MyAgent" # plugin-owned, secret-free opaque keys
+          method: "run"
     model: openai/glm-5.2
     api_key: litellm_api_key # locator
-    options:
-      agent: "lib.agents:MyAgent" # plugin-owned, secret-free opaque keys
-      method: "run"
 ```
 
-`--set /bindings/<role>/options/<key>=…` is allowed (ACP still rejects
-`command` / engine keys). Plugin-owned keys stay opaque to Core — for
-example dsh `options.permission` (`read-only` / `workspace-write` /
-`danger-full-access`) selects a plugin composition and child env. Invalid
-values fail closed at materialize.
+`--set /bindings/<role>/options/<key>=…` writes the **executor plugin**
+row (ACP still rejects `command` / engine keys). Other plugins' options
+stay on their own `extensions` row. Plugin-owned keys stay opaque to
+Core — for example dsh `options.permission` (`read-only` /
+`workspace-write` / `danger-full-access`) selects a plugin composition
+and child env. Invalid values fail closed at materialize.
 
 ## Typed failures
 

--- a/skills/bora-plugin/references/authoring.md
+++ b/skills/bora-plugin/references/authoring.md
@@ -147,7 +147,7 @@ bindings:
           agent: "lib.agents:MyAgent" # plugin-owned, secret-free opaque keys
           method: "run"
     model: openai/glm-5.2
-    api_key: litellm_api_key # locator
+    api_key: ${litellm_api_key} # locator
 ```
 
 `--set /bindings/<role>/options/<key>=…` writes the **executor plugin**

--- a/skills/bora-plugin/references/mechanism.md
+++ b/skills/bora-plugin/references/mechanism.md
@@ -22,7 +22,7 @@ Ids live in `src/bora/plugins/slots.py`. Summary:
 | Layer | Representative slots | Who emits |
 | --- | --- | --- |
 | L0 | `before/after_prepare\|run\|evaluate\|cleanup` | `application/extension_hooks` (merge **all** profile chains, not `profiles[0]`) |
-| L1 | `image_contribute`, `env_*`, `env_action` | bake; env prepare/teardown + action |
+| L1 | `image_contribute`, `home_overlay`, `env_*`, `env_action` | bake; cred → HOME copy; env prepare/teardown + action |
 | L2 | `executor`, agent open/invoke/close, `normalize_agent_result` | `ParentAgentService`. L1: Core `TargetPlacement` + SPI `bind_to_target` |
 | L3 | `evaluation_input_contribute`, `evaluation_runtime`, `score_postprocess` | around evaluator (fail-closed; must not pick PASS) |
 | L4 | `trajectory_collect\|enrich\|seal`, `evidence_extra` | seal. collect/enrich are **fail-open** |
@@ -43,7 +43,7 @@ close        → before_agent_close → executor.close → after_agent_close
 
 ## Coexists with ACP
 
-The default coding-agent inlet remains first-party `executor: acp` + `options.entry`.
+The default coding-agent inlet remains first-party `executor: acp` + `- plugin: acp` / `options.entry`.
 An external plugin is an optional mechanism. The **same harness** switches via
 profiles. ACP is not the trajectory schema authority.
 

--- a/skills/bora-sdk-harness/SKILL.md
+++ b/skills/bora-sdk-harness/SKILL.md
@@ -28,8 +28,9 @@ from bora_sdk import (
 
 ## Minimal harness
 
-Profile **ids** come from package `agent_profiles` (which use `executor: acp` +
-`options.entry` for coding agents). Harness only opens profiles by id — never
+Profile **ids** come from package `agent_profiles` (coding agents bind
+`executor: acp` + `- plugin: acp` / `options.entry` in Database profiles).
+Harness only opens profiles by id — never
 branches Core policy on entry/executor name.
 
 ```python

--- a/skills/bora-sdk-harness/references/antipatterns.md
+++ b/skills/bora-sdk-harness/references/antipatterns.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | Treat `completed` as PASS | Independent evaluator only |
 | `if executor == "codex":` / `if entry == "pi":` for Core policy | Switch `agent_profiles` / `active_profile` / `parameters.roles` |
-| Write `executor: codex` in package yaml | `executor: acp` + `options.entry: codex` (etc.) |
+| Write `executor: codex` in package yaml | `executor: acp` + `- plugin: acp` / `options.entry: codex` (etc.) |
 | Read `~/.codex/auth.json` or print secrets | Rely on Runtime projection |
 | Write training JSON by hand under package | Use Core `trajectory.jsonl` under Result.logs |
 | Soft CallLimit as the only hard ceiling | `limits.agent_invocations` in yaml (Runtime) |

--- a/src/bora/adapters/acp/executor.py
+++ b/src/bora/adapters/acp/executor.py
@@ -343,11 +343,13 @@ class AcpExecutor(AgentExecutor):
                 return None
         # Host PATH readiness only when launching locally. L1 uses command_override
         # (docker exec) and image BOM preflight for entry presence.
+        cwd = workdir or self.workdir
+        if not cwd:
+            return "acp_workdir_required"
         if self._command_override is None and self._process_launcher is None:
             ready = readiness_for(self.descriptor)
             if ready["readiness"] != "ready":
                 return str(ready["readiness"]).replace("-", "_")
-        cwd = workdir or self.workdir or os.getcwd()
         try:
             self._run(self._spawn_and_init(cwd=cwd), timeout=min(timeout, 120.0))
         except RuntimeError as exc:

--- a/src/bora/adapters/agent_registry.py
+++ b/src/bora/adapters/agent_registry.py
@@ -37,24 +37,27 @@ def resolve_executor(
     ``entry`` / ``entry_id`` select ACP entry when *kind* is ``acp``.
     """
     from bora.plugins.bootstrap import ensure_bootstrapped
-    from bora.plugins.protocol import BindingIntent
+    from bora.plugins.protocol import BindingIntent, ExtensionSelect
     from bora.plugins.resolve import resolve
     from bora.plugins.slots import EXECUTOR
 
-    options: dict[str, Any] = {}
+    plugin_opts: dict[str, Any] = {}
     eid = entry or entry_id
     if eid:
-        options["entry"] = str(eid)
-    # Pass through known option keys from **_kw (e.g. agent for nooa).
+        plugin_opts["entry"] = str(eid)
     for key in ("agent", "method", "entry"):
         if key in _kw and _kw[key] is not None:
-            options[key] = _kw[key]
+            plugin_opts[key] = _kw[key]
 
+    plugin_id = str(kind)
+    selects = (
+        [ExtensionSelect(plugin=plugin_id, options=plugin_opts or None)] if plugin_opts else []
+    )
     reg = ensure_bootstrapped()
     intent = BindingIntent(
         profile_id="_resolve",
-        executor=str(kind),
-        options=options,
+        executor=plugin_id,
+        extension_selects=selects,
         model=model,
         base_url=base_url,
         api_key=api_key,

--- a/src/bora/adapters/provider_docker/multi_actor.py
+++ b/src/bora/adapters/provider_docker/multi_actor.py
@@ -438,6 +438,8 @@ class DockerMultiActorMixin:
             )
             lines.append(f"chown -R {b.uid}:{b.gid} '{home}/.grok' 2>/dev/null || true")
             lines.append(f"chmod 0700 '{home}/.grok' 2>/dev/null || true")
+            # Overlay + auth copies land as root; actor must own the whole HOME.
+            lines.append(f"chown -R {b.uid}:{b.gid} '{home}'")
             # Create private primary group if needed (numeric chown works without).
             lines.append(f"groupadd -g {b.gid} actor-g-{b.gid} 2>/dev/null || true")
             lines.append(

--- a/src/bora/adapters/provider_docker/multi_actor.py
+++ b/src/bora/adapters/provider_docker/multi_actor.py
@@ -397,6 +397,10 @@ class DockerMultiActorMixin:
             lines.append(f"mkdir -p '{home}'")
             lines.append(f"chmod 0700 '{home}'")
             lines.append(f"chown {b.uid}:{b.gid} '{home}'")
+            # Plugin extras first; allowlisted auth copies win on overlap.
+            lines.append(
+                f"if [ -d /creds/home_overlay ]; then cp -a /creds/home_overlay/. '{home}/'; fi"
+            )
             # Projected credential copies (allowlist) into actor HOME.
             lines.append(f"mkdir -p '{home}/.codex'")
             lines.append(

--- a/src/bora/application/attempt/agent_service_assemble.py
+++ b/src/bora/application/attempt/agent_service_assemble.py
@@ -39,6 +39,7 @@ def inject_service_profiles(
     *,
     package_root: Path,
     workdir: Path | str | None = None,
+    home: Path | str | None = None,
 ) -> list[dict[str, Any]]:
     """Copy profiles and inject package/workdir context for executor materialize."""
     service_profiles: list[dict[str, Any]] = []
@@ -49,6 +50,8 @@ def inject_service_profiles(
         row["_package_root"] = str(package_root)
         if workdir is not None:
             row.setdefault("_workdir", str(workdir))
+        if home is not None:
+            row["_home"] = str(home)
         service_profiles.append(row)
     return service_profiles
 
@@ -63,6 +66,7 @@ def assemble_parent_agent_service(
     evidence_store: Any,
     deadline_monotonic: float | None,
     workdir: Path | str | None = None,
+    home: Path | str | None = None,
     require_actor_id: bool = False,
     validate_actor_profile: Any = None,
     resolve_placement: Any = None,
@@ -78,6 +82,7 @@ def assemble_parent_agent_service(
         profiles,
         package_root=package_root,
         workdir=workdir,
+        home=home,
     )
     quota = AgentInvocationQuota(limit=inv_limit)
     kwargs: dict[str, Any] = {

--- a/src/bora/application/attempt/agent_service_assemble.py
+++ b/src/bora/application/attempt/agent_service_assemble.py
@@ -46,11 +46,9 @@ def inject_service_profiles(
         if not isinstance(p, dict):
             continue
         row = dict(p)
-        opts = dict(row.get("options") or {}) if isinstance(row.get("options"), dict) else {}
-        opts["_package_root"] = str(package_root)
+        row["_package_root"] = str(package_root)
         if workdir is not None:
-            opts.setdefault("_workdir", str(workdir))
-        row["options"] = opts
+            row.setdefault("_workdir", str(workdir))
         service_profiles.append(row)
     return service_profiles
 

--- a/src/bora/application/attempt/attempt_stages.py
+++ b/src/bora/application/attempt/attempt_stages.py
@@ -51,6 +51,7 @@ class AttemptStageContext:
     inv_count: int = 0
     wall_s: float = 0.0
     workspace_host: Path | None = None
+    host_work_root: Path | None = None
     ledger: Any = None
     topology: Any = None
     # Outputs filled by stages.

--- a/src/bora/application/attempt/campaign.py
+++ b/src/bora/application/attempt/campaign.py
@@ -79,6 +79,9 @@ async def run_campaign(
     from bora.registry.resolve import resolve_database_root
 
     database_root = resolve_database_root(package_root)
+    from bora.application.attempt.env_bootstrap import load_host_env_files
+
+    load_host_env_files(package_root=database_root)
     resolved = resolve_task(database_root, task_id)
     task_dir = resolved.task_dir
     man = load_database_manifest(resolved.database_root)

--- a/src/bora/application/attempt/extension_hooks.py
+++ b/src/bora/application/attempt/extension_hooks.py
@@ -18,6 +18,8 @@ from typing import Any
 
 from bora.config.model import LockedTaskConfig, thaw
 from bora.plugins.bootstrap import ensure_bootstrapped
+from bora.plugins.defaults.home_overlay import PLUGIN_ID as DEFAULT_PLUGIN_ID
+from bora.plugins.defaults.home_overlay import default_home_overlay
 from bora.plugins.lifecycle import (
     call_env_action,
     call_evaluation_runtime,
@@ -31,8 +33,10 @@ from bora.plugins.lifecycle import (
     emit_run,
     score_postprocess,
 )
+from bora.plugins.middleware import run_handlers
 from bora.plugins.protocol import BindingIntent, ExtensionGraph, intent_from_profile
 from bora.plugins.resolve import resolve
+from bora.plugins.slots import HOME_OVERLAY
 
 _LOG = logging.getLogger(__name__)
 
@@ -80,6 +84,51 @@ def _run(coro: Any) -> Any:
         return asyncio.run(coro)
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
         return pool.submit(asyncio.run, coro).result()
+
+
+def _per_profile_graphs(lock: LockedTaskConfig, *, materialize: bool) -> list[ExtensionGraph]:
+    reg = ensure_bootstrapped()
+    profiles = thaw(lock.agent_profiles) if lock.agent_profiles else []
+    graphs: list[ExtensionGraph] = []
+    if isinstance(profiles, list):
+        for row in profiles:
+            if not isinstance(row, dict):
+                continue
+            intent = intent_from_profile(row)
+            if not intent.profile_id:
+                intent.profile_id = str(row.get("id") or "default")
+            graphs.append(resolve(intent, reg, materialize=materialize))
+    return graphs
+
+
+def hook_home_overlay(
+    lock: LockedTaskConfig,
+    value: Any = None,
+    *,
+    ctx: Any = None,
+    fail_closed: bool = True,
+) -> Any:
+    """Emit home_overlay: Core default wraps per-profile plugin handlers."""
+
+    async def _emit() -> Any:
+        plugin_handlers = []
+        for graph in _per_profile_graphs(lock, materialize=True):
+            for href in graph.chain(HOME_OVERLAY):
+                if href.plugin_id != DEFAULT_PLUGIN_ID:
+                    plugin_handlers.append(href)
+
+        async def nxt(v: Any) -> Any:
+            return await run_handlers(plugin_handlers, v, ctx=ctx)
+
+        return await default_home_overlay(ctx, value, nxt)
+
+    try:
+        return _run(_emit())
+    except Exception:
+        if fail_closed:
+            raise
+        _LOG.exception("extension hook_home_overlay failed (fail-open)")
+        return value
 
 
 def hook_prepare(

--- a/src/bora/application/attempt/lock_command.py
+++ b/src/bora/application/attempt/lock_command.py
@@ -80,6 +80,9 @@ class LockCommand:
             raise TypeError(msg)
 
         root = resolve_database_root(raw)
+        from bora.application.attempt.env_bootstrap import load_host_env_files
+
+        load_host_env_files(package_root=root)
         resolved = resolve_task(root, task_id)
         man = load_database_manifest(root)
 

--- a/src/bora/application/attempt/probe_command.py
+++ b/src/bora/application/attempt/probe_command.py
@@ -18,6 +18,7 @@ from bora.adapters.executor_inventory import FIRST_PARTY_KINDS
 from bora.application.attempt.lock_command import LockCommand
 from bora.application.plugin_ops.image_contribute_bake import selected_contribute_plugin_ids
 from bora.config.model import LockedTaskConfig, locked_to_summary, thaw
+from bora.config.profiles import acp_entry_from_binding
 from bora.plugins.host_requires import (
     evaluate_host_requires,
     installed_plugin,
@@ -68,11 +69,9 @@ def bound_bindings(lock: LockedTaskConfig) -> list[dict[str, Any]]:
         api_key = row.get("api_key")
         if isinstance(api_key, str) and api_key.strip():
             item["api_key"] = api_key.strip()
-        options = row.get("options")
-        if isinstance(options, Mapping):
-            entry = options.get("entry")
-            if isinstance(entry, str) and entry.strip():
-                item["entry"] = entry.strip()
+        entry = acp_entry_from_binding(row)
+        if entry:
+            item["entry"] = entry
         rows.append(item)
     return rows
 

--- a/src/bora/application/attempt/run_l0.py
+++ b/src/bora/application/attempt/run_l0.py
@@ -151,6 +151,29 @@ def prepare_l0_attempt(ctx: AttemptStageContext) -> tuple[int, FlatResult, dict[
                     database_root=ctx.database_root,
                 )
             write_l0_lock_summary(ctx)
+            from types import SimpleNamespace
+
+            from bora.application.attempt.extension_hooks import hook_home_overlay
+
+            workspace_root = ctx.run_dir / "workspace"
+            workspace_root.mkdir(parents=True, exist_ok=True)
+            overlay_ctx = SimpleNamespace(
+                work_root=ctx.run_dir,
+                package_root=ctx.database_root or ctx.package_root,
+                workspace_root=workspace_root,
+            )
+            overlay_value = hook_home_overlay(
+                ctx.lock,
+                {
+                    "package_root": str(ctx.database_root or ctx.package_root),
+                    "workspace_root": str(workspace_root),
+                    "work_root": str(ctx.run_dir),
+                },
+                ctx=overlay_ctx,
+            )
+            attempt_home = None
+            if isinstance(overlay_value, dict):
+                attempt_home = overlay_value.get("home_root")
             wall_s, deadline = read_wall_deadline(lock=ctx.lock, monotonic_now=time.monotonic())
             ctx.wall_s = wall_s
             service, invoke_timeout, authority = assemble_parent_agent_service(
@@ -161,6 +184,7 @@ def prepare_l0_attempt(ctx: AttemptStageContext) -> tuple[int, FlatResult, dict[
                 params=params if isinstance(params, dict) else {},
                 evidence_store=ctx.evidence_store,
                 deadline_monotonic=deadline,
+                home=attempt_home,
             )
             ctx.agent_service = service
             ctx.authority = authority

--- a/src/bora/application/attempt/run_l0.py
+++ b/src/bora/application/attempt/run_l0.py
@@ -82,9 +82,11 @@ def write_l0_lock_summary(ctx: AttemptStageContext) -> None:
                 "executor": kind,
                 "model": p.get("model"),
             }
-            opts = p.get("options")
-            if isinstance(opts, dict) and opts.get("entry") is not None:
-                row["options"] = {"entry": opts.get("entry")}
+            from bora.config.profiles import acp_entry_from_binding
+
+            entry = acp_entry_from_binding(p)
+            if entry is not None:
+                row["options"] = {"entry": entry}
             if p.get("base_url"):
                 row["base_url"] = p.get("base_url")
             if p.get("api_key"):

--- a/src/bora/application/attempt/run_l0.py
+++ b/src/bora/application/attempt/run_l0.py
@@ -155,10 +155,13 @@ def prepare_l0_attempt(ctx: AttemptStageContext) -> tuple[int, FlatResult, dict[
 
             from bora.application.attempt.extension_hooks import hook_home_overlay
 
-            workspace_root = ctx.run_dir / "workspace"
+            host_root = Path(tempfile.mkdtemp(prefix="bora-l0-"))
+            workspace_root = host_root / "workspace"
             workspace_root.mkdir(parents=True, exist_ok=True)
+            ctx.host_work_root = host_root
+            ctx.workspace_host = workspace_root
             overlay_ctx = SimpleNamespace(
-                work_root=ctx.run_dir,
+                work_root=host_root,
                 package_root=ctx.database_root or ctx.package_root,
                 workspace_root=workspace_root,
             )
@@ -167,13 +170,17 @@ def prepare_l0_attempt(ctx: AttemptStageContext) -> tuple[int, FlatResult, dict[
                 {
                     "package_root": str(ctx.database_root or ctx.package_root),
                     "workspace_root": str(workspace_root),
-                    "work_root": str(ctx.run_dir),
+                    "work_root": str(host_root),
                 },
                 ctx=overlay_ctx,
             )
+            ctx.cred = getattr(overlay_ctx, "cred", None)
             attempt_home = None
             if isinstance(overlay_value, dict):
                 attempt_home = overlay_value.get("home_root")
+            ctx.agent_meta["workspace"] = str(workspace_root)
+            if attempt_home is not None:
+                ctx.agent_meta["attempt_home"] = str(attempt_home)
             wall_s, deadline = read_wall_deadline(lock=ctx.lock, monotonic_now=time.monotonic())
             ctx.wall_s = wall_s
             service, invoke_timeout, authority = assemble_parent_agent_service(
@@ -184,6 +191,7 @@ def prepare_l0_attempt(ctx: AttemptStageContext) -> tuple[int, FlatResult, dict[
                 params=params if isinstance(params, dict) else {},
                 evidence_store=ctx.evidence_store,
                 deadline_monotonic=deadline,
+                workdir=workspace_root,
                 home=attempt_home,
             )
             ctx.agent_service = service
@@ -224,6 +232,7 @@ async def run_l0_harness(ctx: AttemptStageContext) -> None:
             timeout_seconds=harness_timeout,
             agent_service_sock=str(ctx.agent_sock_path) if ctx.agent_sock_path else None,
             attempt=attempt,
+            workspace_root=ctx.workspace_host,
             database_root=ctx.database_root,
         )
     if ctx.agent_service is not None:
@@ -428,6 +437,15 @@ def bind_l0_result(ctx: AttemptStageContext) -> None:
     }
 
 
+def drop_l0_host_work(host_work_root: Path | None, *, keep_workspace: bool = False) -> None:
+    """Remove the Attempt-private L0 host directory (cred + HOME + workspace)."""
+    if keep_workspace or host_work_root is None:
+        return
+    if host_work_root.exists():
+        with contextlib.suppress(OSError):
+            shutil.rmtree(host_work_root)
+
+
 def cleanup_l0(ctx: AttemptStageContext) -> None:
     from bora.application.attempt.extension_hooks import hook_cleanup
 
@@ -443,6 +461,11 @@ def cleanup_l0(ctx: AttemptStageContext) -> None:
 
         teardown_attempt_environment(ctx)
         hook_cleanup(ctx.lock)
+        if ctx.cred is not None:
+            with contextlib.suppress(Exception):
+                ctx.cred.cleanup()
+            ctx.cred = None
+        drop_l0_host_work(ctx.host_work_root, keep_workspace=ctx.keep_workspace)
         for leftover in (
             ctx.package_root / ".bora_agent_result.json",
             ctx.package_root / ".bora_workspace_output.json",

--- a/src/bora/application/attempt/run_l1_phases.py
+++ b/src/bora/application/attempt/run_l1_phases.py
@@ -7,10 +7,11 @@ import shutil
 import tempfile
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
-from bora.adapters.credential_projection import project_executor_credentials
 from bora.application.attempt.attempt_stages import AttemptStageContext
+from bora.application.attempt.extension_hooks import hook_home_overlay
 from bora.application.attempt.phase_timing import PhaseTimer, format_duration_ms
 from bora.application.attempt.run_l1 import (
     _database_root_for_run,
@@ -24,11 +25,11 @@ from bora.application.attempt.run_l1_prepare import (
     seed_l1_workspace,
 )
 from bora.config.model import thaw
+from bora.config.profiles import acp_entry_from_binding
 from bora.evaluation.result_binding import bind_result
 from bora.evidence.locators import portable_run_locator
 from bora.evidence.store import AttemptEvidenceStore
 from bora.provider.isolation import parse_logical_topology
-from bora.config.profiles import acp_entry_from_binding
 from bora.runtime.identity import AttemptIdentity, assert_same_attempt
 
 
@@ -188,22 +189,24 @@ def prepare_l1_session(ctx: AttemptStageContext) -> bool:
                 lock_doc["job_overlay"] = thaw(ctx.lock.job_overlay)
             ctx.evidence_store.write_lock_summary(lock_doc)
 
-        cred = project_executor_credentials(work_root=runtime.workdir_host)
-        ctx.cred = cred
-        l1_meta["credential_projection"] = {
-            "keys": list(cred.locator_keys),
-            "has_material": cred.has_material,
-        }
-        l1_meta["isolation"] = topology.public_summary()
-        l1_meta["scheduling"] = "sdk_session"
-        l1_meta["residual_one_shot"] = False
-
+        overlay_ctx = SimpleNamespace(
+            docker=docker,
+            runtime=runtime,
+            topology=topology,
+            network_mode=network_mode,
+            work_root=runtime.workdir_host,
+            package_root=ctx.database_root or ctx.package_root,
+            workspace_root=ctx.workspace_host,
+        )
         try:
-            ledger = docker.prepare_agent_targets(
-                runtime,
-                topology,
-                cred_root=cred.root,
-                network_mode=network_mode,
+            hook_home_overlay(
+                ctx.lock,
+                {
+                    "package_root": str(ctx.database_root or ctx.package_root),
+                    "workspace_root": str(ctx.workspace_host),
+                    "work_root": str(runtime.workdir_host),
+                },
+                ctx=overlay_ctx,
             )
         except Exception as exc:  # noqa: BLE001
             _store_error(
@@ -213,7 +216,25 @@ def prepare_l1_session(ctx: AttemptStageContext) -> bool:
                 kind="target_prepare_failed",
             )
             return False
+        cred = getattr(overlay_ctx, "cred", None)
+        ledger = getattr(overlay_ctx, "ledger", None)
+        if cred is None or ledger is None:
+            _store_error(
+                ctx,
+                "provider",
+                {**l1_meta, "prepare_error": "home_overlay_incomplete"},
+                kind="target_prepare_failed",
+            )
+            return False
+        ctx.cred = cred
         ctx.ledger = ledger
+        l1_meta["credential_projection"] = {
+            "keys": list(cred.locator_keys),
+            "has_material": cred.has_material,
+        }
+        l1_meta["isolation"] = topology.public_summary()
+        l1_meta["scheduling"] = "sdk_session"
+        l1_meta["residual_one_shot"] = False
         l1_meta["targets"] = [t.public_view() for t in ledger.targets.values()]
         l1_meta["actors"] = [a.public_view() for a in ledger.actors.values()]
 

--- a/src/bora/application/attempt/run_l1_phases.py
+++ b/src/bora/application/attempt/run_l1_phases.py
@@ -28,7 +28,12 @@ from bora.evaluation.result_binding import bind_result
 from bora.evidence.locators import portable_run_locator
 from bora.evidence.store import AttemptEvidenceStore
 from bora.provider.isolation import parse_logical_topology
+from bora.config.profiles import acp_entry_from_binding
 from bora.runtime.identity import AttemptIdentity, assert_same_attempt
+
+
+def _lock_acp_entry(profile: dict[str, Any]) -> str | None:
+    return acp_entry_from_binding(profile)
 
 
 def _timer(ctx: AttemptStageContext) -> PhaseTimer:
@@ -169,9 +174,8 @@ def prepare_l1_session(ctx: AttemptStageContext) -> bool:
                         "executor": p.get("executor"),
                         "model": p.get("model"),
                         **(
-                            {"options": {"entry": (p.get("options") or {}).get("entry")}}
-                            if isinstance(p.get("options"), dict)
-                            and (p.get("options") or {}).get("entry") is not None
+                            {"options": {"entry": _lock_acp_entry(p)}}
+                            if _lock_acp_entry(p) is not None
                             else {}
                         ),
                     }

--- a/src/bora/application/suite/suite_config_fingerprint.py
+++ b/src/bora/application/suite/suite_config_fingerprint.py
@@ -437,12 +437,14 @@ def load_actors_from_task_lock(
 ) -> list[dict[str, str]]:
     """Lock a task (same overrides as suite) and project agent_profiles."""
     from bora.adapters.package_fs import LocalPackageReader
+    from bora.application.attempt.env_bootstrap import load_host_env_files
     from bora.config.capabilities import DeclarationCapabilityCatalog
     from bora.config.database import load_database_manifest, resolve_task
     from bora.config.load_and_lock import ConfigCore
     from bora.config.model import thaw
     from bora.config.profiles import resolve_profile_bindings
 
+    load_host_env_files(package_root=database_root)
     resolved = resolve_task(database_root, task_id)
     man = load_database_manifest(resolved.database_root)
     bindings = resolve_profile_bindings(resolved.database_root, profiles_path=profiles_path)
@@ -470,12 +472,14 @@ def load_job_overlay_from_task_lock(
 ) -> dict[str, Any] | None:
     """Live-lock a task and project secret-free job_overlay (#59)."""
     from bora.adapters.package_fs import LocalPackageReader
+    from bora.application.attempt.env_bootstrap import load_host_env_files
     from bora.config.capabilities import DeclarationCapabilityCatalog
     from bora.config.database import load_database_manifest, resolve_task
     from bora.config.load_and_lock import ConfigCore
     from bora.config.model import thaw
     from bora.config.profiles import resolve_profile_bindings
 
+    load_host_env_files(package_root=database_root)
     resolved = resolve_task(database_root, task_id)
     man = load_database_manifest(resolved.database_root)
     bindings = resolve_profile_bindings(resolved.database_root, profiles_path=profiles_path)
@@ -521,6 +525,13 @@ def _suite_level_job_overlay(
                 except Exception:  # noqa: BLE001
                     continue
     if not bindings:
+        return None
+    from bora.config.env_refs import expand_binding_env_refs
+
+    try:
+        for role_id, row in bindings.items():
+            expand_binding_env_refs(row, location=f"/bindings/{role_id}")
+    except Exception:  # noqa: BLE001
         return None
     return project_job_overlay(bindings)
 

--- a/src/bora/application/suite/suite_config_fingerprint.py
+++ b/src/bora/application/suite/suite_config_fingerprint.py
@@ -27,12 +27,15 @@ _SKIP_PLUGIN_IDS = frozenset({"default", "acp", "openai-http"})
 
 def _profile_entry(profile: Mapping[str, Any]) -> str:
     """Display id: ACP ``options.entry``, else plugin ``options.agent``, else kind."""
-    options = profile.get("options")
-    if isinstance(options, Mapping):
-        for key in ("entry", "agent"):
-            val = options.get(key)
-            if val is not None and str(val).strip():
-                return str(val).strip()
+    from bora.config.profiles import acp_entry_from_binding, executor_plugin_options
+
+    entry = acp_entry_from_binding(profile)
+    if entry:
+        return entry
+    plugin_opts = executor_plugin_options(profile)
+    agent = plugin_opts.get("agent")
+    if agent is not None and str(agent).strip():
+        return str(agent).strip()
     executor = profile.get("executor")
     if executor is not None and str(executor).strip():
         return str(executor).strip()
@@ -40,10 +43,9 @@ def _profile_entry(profile: Mapping[str, Any]) -> str:
 
 
 def _profile_options(profile: Mapping[str, Any]) -> dict[str, Any]:
-    from bora.config.profiles import secret_free_options
+    from bora.config.profiles import executor_plugin_options, secret_free_options
 
-    raw = profile.get("options")
-    return secret_free_options(raw if isinstance(raw, Mapping) else None)
+    return secret_free_options(executor_plugin_options(profile))
 
 
 def actors_summary_from_profiles(

--- a/src/bora/cli/README.md
+++ b/src/bora/cli/README.md
@@ -210,7 +210,7 @@ uv run bora lock examples/core --task config-minimal --probe
 # --probe: plan + readiness for this binding / provider.kind; no Agent, no bake
 ```
 
-Coding-agent packages use `executor: acp` + `options.entry: …`. Prefer inventory output over hardcoded vendor lists.
+Coding-agent packages use `executor: acp` + `- plugin: acp` / `options.entry: …`. Prefer inventory output over hardcoded vendor lists.
 
 ---
 

--- a/src/bora/cli/README.md
+++ b/src/bora/cli/README.md
@@ -157,7 +157,7 @@ Job binding axes:
 - `/bindings/<role_id>/executor`
 - `/bindings/<role_id>/api_key`
 - `/bindings/<role_id>/base_url`
-- `/bindings/<role_id>/options/<key>` (opaque plugin options; ACP still rejects `command` / engine keys)
+- `/bindings/<role_id>/options/<key>` (executor plugin row; ACP still rejects `command` / engine keys)
 
 **Not** overridable: intent `limits.*` (task contract).
 

--- a/src/bora/config/env_refs.py
+++ b/src/bora/config/env_refs.py
@@ -1,0 +1,85 @@
+"""Profile binding ``${ENV_NAME}`` refs.
+
+``api_key: ${NAME}`` unwraps to locator ``NAME`` (secret value never enters the
+binding). ``base_url: ${NAME}`` substitutes the host env value. Bare locator
+names are rejected.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from bora.config.errors import ERROR_INVALID_SCHEMA, ConfigError
+
+_ENV_REF = re.compile(r"^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$")
+
+
+def parse_env_ref(raw: str) -> str | None:
+    text = raw.strip()
+    match = _ENV_REF.fullmatch(text)
+    return match.group(1) if match else None
+
+
+def expand_api_key_locator(raw: str, *, location: str) -> str:
+    name = parse_env_ref(raw)
+    if name is None:
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            "profile.api_key must be ${ENV_NAME} (env locator; never a bare name or secret)",
+            location=location,
+        )
+    return name
+
+
+def expand_base_url_value(
+    raw: str,
+    *,
+    location: str,
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    name = parse_env_ref(raw)
+    if name is None:
+        return raw.strip()
+    env = os.environ if environ is None else environ
+    val = env.get(name)
+    if not val or not str(val).strip():
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            f"profile.base_url ${{{name}}} is unset (set it in process env or package/repo .env)",
+            location=location,
+        )
+    return str(val).strip()
+
+
+def expand_binding_env_refs(
+    binding: dict[str, Any],
+    *,
+    location: str,
+    environ: Mapping[str, str] | None = None,
+) -> None:
+    """Rewrite api_key / base_url ${} refs in place on one binding."""
+    api_key = binding.get("api_key")
+    if api_key is not None:
+        if not isinstance(api_key, str) or not api_key.strip():
+            raise ConfigError(
+                ERROR_INVALID_SCHEMA,
+                "profile.api_key must be a non-empty ${ENV_NAME} when set",
+                location=f"{location}/api_key",
+            )
+        binding["api_key"] = expand_api_key_locator(api_key, location=f"{location}/api_key")
+    base_url = binding.get("base_url")
+    if base_url is not None:
+        if not isinstance(base_url, str) or not base_url.strip():
+            raise ConfigError(
+                ERROR_INVALID_SCHEMA,
+                "profile.base_url must be a non-empty string when set",
+                location=f"{location}/base_url",
+            )
+        binding["base_url"] = expand_base_url_value(
+            base_url,
+            location=f"{location}/base_url",
+            environ=environ,
+        )

--- a/src/bora/config/load_and_lock.py
+++ b/src/bora/config/load_and_lock.py
@@ -1,8 +1,9 @@
 """Config Core façade: load, merge, validate, canonicalize, digest, freeze.
 
 This module is the only normative reader of member ``task.yaml``. It never imports or
-executes package-local Python, never expands environment variables as experiment
-semantics, and never starts an Attempt.
+executes package-local Python and never starts an Attempt. Profile ``api_key`` /
+``base_url`` may use ``${ENV_NAME}`` refs (locator unwrap / value substitute);
+other package YAML still rejects interpolation.
 
 Pure helpers: ``constants``, ``yaml_io``, ``overrides``, ``digest``, ``validate`` (chore #31).
 """
@@ -242,6 +243,10 @@ class ConfigCore:
                     param_overrides[pointer_s] = value
 
         if bindings:
+            from bora.config.env_refs import expand_binding_env_refs
+
+            for role_id, row in bindings.items():
+                expand_binding_env_refs(row, location=f"/bindings/{role_id}")
             resolution.append(
                 ResolutionEntry(
                     source="profiles.yaml",

--- a/src/bora/config/profiles.py
+++ b/src/bora/config/profiles.py
@@ -3,8 +3,8 @@
 Task identity (member ``task.yaml``) declares **role slots** only.
 Job binding (executor / entry / model / key locator) lives in Database
 ``profiles.yaml`` (or CLI ``--profiles`` / binding overrides) and is merged by
-Config Core at ``load_and_lock`` time. Secrets never appear here — only env
-locator names.
+Config Core at ``load_and_lock`` time. ``api_key`` is ``${ENV_NAME}`` (unwraps
+to a locator). ``base_url`` may be a literal URL or ``${ENV_NAME}`` (substituted).
 """
 
 from __future__ import annotations
@@ -72,10 +72,6 @@ def load_profiles_document(path: Path) -> dict[str, dict[str, Any]]:
             f"cannot read profiles file: {exc}",
             location=str(path),
         ) from exc
-
-    from bora.config.checks import reject_env_interpolation
-
-    reject_env_interpolation(text, what="profiles.yaml", location=str(path))
 
     try:
         data = yaml.safe_load(text)
@@ -544,10 +540,21 @@ def job_overlay_to_profiles_document(overlay: Mapping[str, Any]) -> dict[str, An
             location="/job_overlay/bindings",
         )
     # Re-validate shape via parse so export stays lock-safe.
+    # Lock stores the unwrapped locator; YAML form is ${NAME}.
+    bindings: dict[str, Any] = {}
+    for role_id, raw in bindings_raw.items():
+        if not isinstance(raw, Mapping):
+            bindings[str(role_id)] = raw
+            continue
+        row = dict(raw)
+        api_key = row.get("api_key")
+        if isinstance(api_key, str) and api_key and not api_key.startswith("${"):
+            row["api_key"] = f"${{{api_key}}}"
+        bindings[str(role_id)] = row
     return {
         "format": PROFILES_FORMAT,
         "bindings": parse_profiles_mapping(
-            {"format": PROFILES_FORMAT, "bindings": dict(bindings_raw)},
+            {"format": PROFILES_FORMAT, "bindings": bindings},
             location="job_overlay",
         ),
     }

--- a/src/bora/config/profiles.py
+++ b/src/bora/config/profiles.py
@@ -325,13 +325,36 @@ def apply_binding_override(
     target = bindings[role_id]
     if field.startswith("options/"):
         opt_key = field[len("options/") :]
-        options = target.get("options")
-        if not isinstance(options, dict):
-            options = {}
-            target["options"] = options
-        options[opt_key] = value
+        executor = target.get("executor")
+        if not isinstance(executor, str) or not executor.strip():
+            raise ConfigError(
+                ERROR_INVALID_SCHEMA,
+                "options override requires bindings.<role>.executor",
+                location=pointer,
+            )
+        _upsert_executor_option(target, plugin=executor.strip(), key=opt_key, value=value)
         return
     target[field] = value
+
+
+def _upsert_executor_option(binding: dict[str, Any], *, plugin: str, key: str, value: Any) -> None:
+    """Write ``--set /bindings/<role>/options/<key>`` onto the executor plugin row."""
+    rows = binding.get("extensions")
+    if not isinstance(rows, list):
+        rows = []
+        binding["extensions"] = rows
+    match: dict[str, Any] | None = None
+    for item in rows:
+        if isinstance(item, dict) and str(item.get("plugin") or "").strip() == plugin:
+            match = item
+    if match is None:
+        match = {"plugin": plugin}
+        rows.append(match)
+    options = match.get("options")
+    if not isinstance(options, dict):
+        options = {}
+        match["options"] = options
+    options[key] = value
 
 
 def is_binding_override_pointer(pointer: str) -> bool:
@@ -371,6 +394,48 @@ def secret_free_options(options: Mapping[str, Any] | None) -> dict[str, Any]:
     return out
 
 
+def _secret_free_extension_row(item: Mapping[str, Any]) -> dict[str, Any]:
+    out = {k: copy.deepcopy(v) for k, v in item.items() if k != "options"}
+    cleaned = secret_free_options(
+        item.get("options") if isinstance(item.get("options"), Mapping) else None
+    )
+    if cleaned:
+        out["options"] = cleaned
+    return out
+
+
+def plugin_row_options(binding: Mapping[str, Any], plugin_id: str) -> dict[str, Any]:
+    """Last ``extensions`` row for *plugin_id* wins. Profile-level options are ignored."""
+    found: dict[str, Any] = {}
+    rows = binding.get("extensions")
+    if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes)):
+        return {}
+    for item in rows:
+        if not isinstance(item, Mapping):
+            continue
+        if str(item.get("plugin") or "").strip() != plugin_id:
+            continue
+        raw = item.get("options")
+        if isinstance(raw, Mapping):
+            found = dict(raw)
+    return found
+
+
+def executor_plugin_options(binding: Mapping[str, Any]) -> dict[str, Any]:
+    executor = binding.get("executor")
+    if not isinstance(executor, str) or not executor.strip():
+        return {}
+    return plugin_row_options(binding, executor.strip())
+
+
+def acp_entry_from_binding(binding: Mapping[str, Any]) -> str | None:
+    """ACP ``entry`` lives on ``- plugin: acp`` options. No profile-options fallback."""
+    entry = plugin_row_options(binding, "acp").get("entry")
+    if entry is not None and str(entry).strip():
+        return str(entry).strip()
+    return None
+
+
 def display_agent_name(binding: Mapping[str, Any]) -> str:
     """Jobs / Hub agent axis. Never reads ``options.agent`` (plugin start path).
 
@@ -381,11 +446,9 @@ def display_agent_name(binding: Mapping[str, Any]) -> str:
         return label.strip()
     executor = str(binding.get("executor") or "").strip()
     if executor == "acp":
-        options = binding.get("options")
-        if isinstance(options, Mapping):
-            entry = options.get("entry")
-            if entry is not None and str(entry).strip():
-                return str(entry).strip()
+        entry = acp_entry_from_binding(binding)
+        if entry:
+            return entry
         projected = binding.get("entry")
         if isinstance(projected, str) and projected.strip():
             return projected.strip()
@@ -451,7 +514,12 @@ def project_job_overlay(
                 row[k] = raw[k]
         extensions = raw.get("extensions")
         if isinstance(extensions, Sequence) and not isinstance(extensions, (str, bytes)):
-            row["extensions"] = copy.deepcopy(list(extensions))
+            row["extensions"] = [
+                _secret_free_extension_row(item)
+                if isinstance(item, Mapping)
+                else copy.deepcopy(item)
+                for item in extensions
+            ]
         options = secret_free_options(
             raw.get("options") if isinstance(raw.get("options"), Mapping) else None
         )

--- a/src/bora/config/validate.py
+++ b/src/bora/config/validate.py
@@ -251,8 +251,9 @@ def validate_document(
                     location=f"{loc}/extensions",
                 )
             _write_acp_entry(profile, entry.strip())
-        # Optional upstream routing (non-secret). api_key is an env *locator name*
-        # only — values live in host/.env and are projected at invoke time.
+        # Optional upstream routing (non-secret). api_key is the unwrapped
+        # ${ENV_NAME} locator — values live in host/.env and are projected
+        # at invoke time. base_url ${ENV_NAME} is already substituted.
         base_url = profile.get("base_url")
         if base_url is not None:
             if not isinstance(base_url, str) or not base_url.strip():
@@ -272,7 +273,7 @@ def validate_document(
             if not isinstance(api_key, str) or not api_key:
                 raise ConfigError(
                     ERROR_INVALID_SCHEMA,
-                    "profile.api_key must be a non-empty env locator name when set",
+                    "profile.api_key must be ${ENV_NAME} (locator only)",
                     location=f"{loc}/api_key",
                 )
             if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", api_key):

--- a/src/bora/config/validate.py
+++ b/src/bora/config/validate.py
@@ -55,6 +55,26 @@ def validate_top_level_layout(reader: PackageReader, root: Path) -> None:
                 )
 
 
+def _write_acp_entry(profile: dict[str, Any], entry: str) -> None:
+    """Normalize ``entry`` onto the acp extensions row (no profile-level options)."""
+    rows = profile.get("extensions")
+    if not isinstance(rows, list):
+        rows = []
+        profile["extensions"] = rows
+    match: dict[str, Any] | None = None
+    for item in rows:
+        if isinstance(item, dict) and str(item.get("plugin") or "").strip() == "acp":
+            match = item
+    if match is None:
+        match = {"plugin": "acp"}
+        rows.append(match)
+    options = match.get("options")
+    if not isinstance(options, dict):
+        options = {}
+        match["options"] = options
+    options["entry"] = entry
+
+
 def validate_document(
     reader: PackageReader,
     doc: dict[str, Any],
@@ -192,24 +212,19 @@ def validate_document(
             raise ConfigError(
                 ERROR_INVALID_SCHEMA, "profile.model required", location=f"{loc}/model"
             )
-        # Spec 19: executor: acp requires options.entry from static registry.
+        # executor: acp requires - plugin: acp / options.entry from static registry.
         # Packages must not override command/version/install.
         if executor == "acp":
             from bora.adapters.acp_registry import get_entry
+            from bora.config.profiles import plugin_row_options
 
-            options = profile.get("options")
-            if not isinstance(options, dict):
-                raise ConfigError(
-                    ERROR_INVALID_SCHEMA,
-                    "executor acp requires options mapping with entry",
-                    location=f"{loc}/options",
-                )
+            options = plugin_row_options(profile, "acp")
             entry = options.get("entry")
             if not isinstance(entry, str) or not entry.strip():
                 raise ConfigError(
                     ERROR_INVALID_SCHEMA,
-                    "options.entry required for executor acp",
-                    location=f"{loc}/options/entry",
+                    "executor acp requires - plugin: acp options.entry",
+                    location=f"{loc}/extensions",
                 )
             for forbidden in (
                 "command",
@@ -226,34 +241,16 @@ def validate_document(
                     raise ConfigError(
                         ERROR_INVALID_SCHEMA,
                         f"options.{forbidden} is not package-overridable for acp",
-                        location=f"{loc}/options/{forbidden}",
+                        location=f"{loc}/extensions",
                     )
             desc = get_entry(entry.strip())
             if desc is None:
                 raise ConfigError(
                     ERROR_UNSUPPORTED_CAPABILITY,
                     f"unknown acp entry: {entry!r}",
-                    location=f"{loc}/options/entry",
+                    location=f"{loc}/extensions",
                 )
-            cleaned = {
-                k: v
-                for k, v in options.items()
-                if k
-                not in {
-                    "command",
-                    "args",
-                    "detect_command",
-                    "install_command",
-                    "version",
-                    "acp_command",
-                    "engine_command",
-                    "acp_version",
-                    "credential_env_names",
-                    "_acp_lock",
-                }
-            }
-            cleaned["entry"] = entry.strip()
-            profile["options"] = cleaned
+            _write_acp_entry(profile, entry.strip())
         # Optional upstream routing (non-secret). api_key is an env *locator name*
         # only — values live in host/.env and are projected at invoke time.
         base_url = profile.get("base_url")

--- a/src/bora/plugins/contrib/acp/__init__.py
+++ b/src/bora/plugins/contrib/acp/__init__.py
@@ -65,11 +65,14 @@ class AcpExecutorSPI(ExecutorSPI):
                 "XDG_STATE_HOME": f"{home_s}/.local/state",
                 "XDG_DATA_HOME": f"{home_s}/.local/share",
             }
+        workdir = _kwargs.get("workdir")
+        workdir_s = str(workdir).strip() if workdir else None
         self._inner = AcpExecutor(
             entry_id=self._entry_id,
             model=self._model,
             base_url=base_url,
             api_key_env=api_key,
+            workdir=workdir_s or None,
             env=extra_env,
         )
 

--- a/src/bora/plugins/contrib/acp/__init__.py
+++ b/src/bora/plugins/contrib/acp/__init__.py
@@ -34,6 +34,7 @@ class AcpExecutorSPI(ExecutorSPI):
         base_url: str | None = None,
         api_key: str | None = None,
         plugin_id: str | None = None,
+        home: str | None = None,
         **_kwargs: Any,
     ) -> None:
         del plugin_id
@@ -53,11 +54,23 @@ class AcpExecutorSPI(ExecutorSPI):
         self._model = model or "entry-default"
         self._base_url = base_url
         self._api_key_env = api_key
+        extra_env: dict[str, str] | None = None
+        if home and str(home).strip():
+            home_s = str(home).strip()
+            extra_env = {
+                "HOME": home_s,
+                "CODEX_HOME": f"{home_s}/.codex",
+                "XDG_CONFIG_HOME": f"{home_s}/.config",
+                "XDG_CACHE_HOME": f"{home_s}/.cache",
+                "XDG_STATE_HOME": f"{home_s}/.local/state",
+                "XDG_DATA_HOME": f"{home_s}/.local/share",
+            }
         self._inner = AcpExecutor(
             entry_id=self._entry_id,
             model=self._model,
             base_url=base_url,
             api_key_env=api_key,
+            env=extra_env,
         )
 
     @staticmethod

--- a/src/bora/plugins/defaults/__init__.py
+++ b/src/bora/plugins/defaults/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from bora.plugins.defaults.home_overlay import HOME_OVERLAY_PRIORITY, default_home_overlay
 from bora.plugins.middleware import passthrough_handler
 from bora.plugins.registry import ExtensionRegistry
 from bora.plugins.slots import (
@@ -37,6 +38,7 @@ from bora.plugins.slots import (
     EVALUATION_INPUT_CONTRIBUTE,
     EVALUATION_RUNTIME,
     EVIDENCE_EXTRA,
+    HOME_OVERLAY,
     IMAGE_CONTRIBUTE,
     NORMALIZE_AGENT_RESULT,
     SCORE_POSTPROCESS,
@@ -93,6 +95,15 @@ def register_defaults(registry: ExtensionRegistry) -> None:
         CLEANUP_ACTIONS,
         CLEANUP_REPORT,
     ]
+    registry.on(
+        HOME_OVERLAY,
+        PLUGIN_ID,
+        default_home_overlay,
+        priority=HOME_OVERLAY_PRIORITY,
+        source="default",
+        is_default=True,
+        is_factory=False,
+    )
     for slot in multi_slots:
         assert get_slot_kind(slot) is SlotKind.MULTI
         registry.on(

--- a/src/bora/plugins/defaults/home_overlay.py
+++ b/src/bora/plugins/defaults/home_overlay.py
@@ -87,6 +87,7 @@ async def default_home_overlay(ctx: Any, value: Any, nxt: NextFn) -> Any:
 
     docker = getattr(ctx, "docker", None) if ctx is not None else None
     if docker is not None:
+        assert ctx is not None
         ledger = docker.prepare_agent_targets(
             ctx.runtime,
             ctx.topology,

--- a/src/bora/plugins/defaults/home_overlay.py
+++ b/src/bora/plugins/defaults/home_overlay.py
@@ -1,0 +1,111 @@
+"""Core default ``home_overlay`` handler.
+
+Creates the cred tree, lets plugins write extras, then copies into actor HOME.
+Plugins must not call Docker or invent PASS.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+from bora.adapters.credential_projection import project_executor_credentials
+from bora.plugins.middleware import NextFn
+
+PLUGIN_ID = "default"
+# Stronger than typical plugin 110 so this wrapper is outermost (cred → nxt → copy).
+HOME_OVERLAY_PRIORITY = 10
+
+
+def _as_path(raw: Any) -> Path | None:
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    return Path(text) if text else None
+
+
+def copy_home_overlay_tree(overlay_root: Path, dest_home: Path) -> None:
+    """Copy ``overlay_root/.`` into *dest_home* (merge; same-name overwrite)."""
+    if not overlay_root.is_dir():
+        return
+    dest_home.mkdir(parents=True, exist_ok=True)
+    for src in overlay_root.rglob("*"):
+        rel = src.relative_to(overlay_root)
+        dest = dest_home / rel
+        if src.is_dir():
+            dest.mkdir(parents=True, exist_ok=True)
+            continue
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+
+
+def copy_allowlisted_auth_into_home(cred_root: Path, dest_home: Path) -> None:
+    """Today's engine auth copies. Overlay tree is applied separately."""
+    dest_home.mkdir(parents=True, exist_ok=True)
+    pairs = (
+        (cred_root / "codex_home" / "auth.json", dest_home / ".codex" / "auth.json"),
+        (cred_root / "codex_home" / "config.toml", dest_home / ".codex" / "config.toml"),
+        (cred_root / "codex_home" / "config.json", dest_home / ".codex" / "config.json"),
+        (cred_root / "pi_home" / "agent" / "auth.json", dest_home / ".pi" / "agent" / "auth.json"),
+        (
+            cred_root / "opencode" / "auth.json",
+            dest_home / ".local" / "share" / "opencode" / "auth.json",
+        ),
+        (cred_root / "grok_home" / "auth.json", dest_home / ".grok" / "auth.json"),
+    )
+    for src, dest in pairs:
+        if not src.is_file():
+            continue
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+
+
+async def default_home_overlay(ctx: Any, value: Any, nxt: NextFn) -> Any:
+    payload = dict(value) if isinstance(value, dict) else {}
+    work_root = _as_path(payload.get("work_root"))
+    if work_root is None and ctx is not None:
+        work_root = _as_path(getattr(ctx, "work_root", None))
+    if work_root is None:
+        raise RuntimeError("home_overlay_missing_work_root")
+
+    cred = project_executor_credentials(work_root=work_root)
+    overlay_dir = cred.root / "home_overlay"
+    overlay_dir.mkdir(parents=True, exist_ok=True)
+    payload["cred"] = cred
+    payload["cred_root"] = cred.root
+    if payload.get("package_root") is None:
+        payload["package_root"] = getattr(ctx, "package_root", None)
+    if payload.get("workspace_root") is None:
+        payload["workspace_root"] = getattr(ctx, "workspace_root", None)
+    if ctx is not None:
+        ctx.cred = cred
+
+    out = await nxt(payload)
+    if isinstance(out, dict):
+        payload = out
+
+    docker = getattr(ctx, "docker", None) if ctx is not None else None
+    if docker is not None:
+        ledger = docker.prepare_agent_targets(
+            ctx.runtime,
+            ctx.topology,
+            cred_root=cred.root,
+            network_mode=getattr(ctx, "network_mode", None),
+        )
+        payload["ledger"] = ledger
+        if ctx is not None:
+            ctx.ledger = ledger
+        return payload
+
+    home_root = _as_path(payload.get("home_root")) or (work_root / "attempt-home")
+    home_root.mkdir(parents=True, exist_ok=True)
+    workspace_root = _as_path(payload.get("workspace_root"))
+    if workspace_root is not None:
+        workspace_root.mkdir(parents=True, exist_ok=True)
+    copy_home_overlay_tree(overlay_dir, home_root)
+    copy_allowlisted_auth_into_home(cred.root, home_root)
+    payload["home_root"] = home_root
+    if ctx is not None:
+        ctx.home_root = home_root
+    return payload

--- a/src/bora/plugins/lifecycle.py
+++ b/src/bora/plugins/lifecycle.py
@@ -32,6 +32,7 @@ from bora.plugins.slots import (
     EVALUATION_INPUT_CONTRIBUTE,
     EVALUATION_RUNTIME,
     EVIDENCE_EXTRA,
+    HOME_OVERLAY,
     IMAGE_CONTRIBUTE,
     NORMALIZE_AGENT_RESULT,
     SCORE_POSTPROCESS,
@@ -78,6 +79,11 @@ async def emit_cleanup(graph: ExtensionGraph, value: Any = None, *, ctx: Any = N
     )
     mid = await run_chain(graph, CLEANUP_ACTIONS, mid, ctx=ctx)
     return await run_chain(graph, CLEANUP_REPORT, mid, ctx=ctx)
+
+
+async def emit_home_overlay(graph: ExtensionGraph, value: Any = None, *, ctx: Any = None) -> Any:
+    """Multi home_overlay: cred → plugin files → actor HOME copy."""
+    return await run_chain(graph, HOME_OVERLAY, value, ctx=ctx)
 
 
 async def collect_image_contribute(

--- a/src/bora/plugins/protocol.py
+++ b/src/bora/plugins/protocol.py
@@ -67,6 +67,7 @@ class ExplicitBinding:
     priority: int | None = None
     replace_default: bool = False
     source: str = "explicit"
+    options: Mapping[str, Any] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -81,6 +82,7 @@ class ExtensionSelect:
     priority: int | None = None
     replace_default: bool = False
     source: str = "explicit"
+    options: Mapping[str, Any] | None = None
 
 
 @dataclass
@@ -96,6 +98,9 @@ class BindingIntent:
     model: str | None = None
     base_url: str | None = None
     api_key: str | None = None
+    package_root: str | None = None
+    workdir: str | None = None
+    home: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -110,6 +115,7 @@ class ProviderRef:
     digest: str | None = None
     replaced_default: bool = False
     slot: str = ""
+    options: Mapping[str, Any] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -124,6 +130,7 @@ class HandlerRef:
     digest: str | None = None
     replaced_default: bool = False
     slot: str = ""
+    options: Mapping[str, Any] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -197,6 +204,9 @@ def intent_from_profile(profile: Mapping[str, Any]) -> BindingIntent:
     api_key = (
         str(api_key_raw).strip() if isinstance(api_key_raw, str) and api_key_raw.strip() else None
     )
+    package_root = _optional_str(profile.get("_package_root") or profile.get("package_root"))
+    workdir = _optional_str(profile.get("_workdir") or profile.get("workdir"))
+    home = _optional_str(profile.get("_home") or profile.get("home"))
     return BindingIntent(
         profile_id=profile_id,
         executor=executor,
@@ -206,7 +216,43 @@ def intent_from_profile(profile: Mapping[str, Any]) -> BindingIntent:
         model=model,
         base_url=base_url,
         api_key=api_key,
+        package_root=package_root,
+        workdir=workdir,
+        home=home,
     )
+
+
+def _optional_str(raw: Any) -> str | None:
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return None
+
+
+def row_options(item: Mapping[str, Any]) -> dict[str, Any]:
+    """Parse optional ``options`` on one extensions row. Missing → empty map."""
+    raw = item.get("options")
+    if raw is None:
+        return {}
+    if not isinstance(raw, Mapping):
+        from bora.plugins.errors import ExtensionRegistryError
+
+        raise ExtensionRegistryError(
+            "extensions.options must be a mapping",
+            kind="invalid_extension_binding",
+        )
+    return dict(raw)
+
+
+def options_for_plugin(intent: BindingIntent, plugin_id: str) -> dict[str, Any]:
+    """Last matching extensions row for *plugin_id* wins (same dest last-writer)."""
+    found: dict[str, Any] = {}
+    for sel in intent.extension_selects:
+        if sel.plugin == plugin_id and sel.options:
+            found = dict(sel.options)
+    for binding in intent.extensions:
+        if binding.plugin == plugin_id and binding.options:
+            found = dict(binding.options)
+    return found
 
 
 def parse_extension_row(item: Any) -> tuple[ExplicitBinding | None, ExtensionSelect | None]:
@@ -230,6 +276,7 @@ def parse_extension_row(item: Any) -> tuple[ExplicitBinding | None, ExtensionSel
     prio = item.get("priority")
     priority = int(prio) if prio is not None else None
     replace_default = bool(item.get("replace_default"))
+    options = row_options(item)
     if slot_raw is not None and slots_raw is not None:
         raise ExtensionRegistryError(
             "extensions row cannot set both slot and slots",
@@ -248,6 +295,7 @@ def parse_extension_row(item: Any) -> tuple[ExplicitBinding | None, ExtensionSel
                 priority=priority,
                 replace_default=replace_default,
                 source="explicit",
+                options=options or None,
             ),
             None,
         )
@@ -277,6 +325,7 @@ def parse_extension_row(item: Any) -> tuple[ExplicitBinding | None, ExtensionSel
                 slots=tuple(slots),
                 priority=priority,
                 replace_default=replace_default,
+                options=options or None,
             ),
         )
     return (
@@ -286,5 +335,6 @@ def parse_extension_row(item: Any) -> tuple[ExplicitBinding | None, ExtensionSel
             slots=None,
             priority=priority,
             replace_default=replace_default,
+            options=options or None,
         ),
     )

--- a/src/bora/plugins/resolve.py
+++ b/src/bora/plugins/resolve.py
@@ -18,6 +18,7 @@ from bora.plugins.protocol import (
     ExtensionSelect,
     HandlerRef,
     ProviderRef,
+    options_for_plugin,
 )
 from bora.plugins.registry import ExtensionRegistry, Registration
 from bora.plugins.slots import ALL_PUBLIC_SLOTS, EXECUTOR, SlotKind, get_slot_kind, is_public_slot
@@ -52,6 +53,7 @@ def resolve(
                 slot=EXECUTOR,
                 plugin=str(intent.executor),
                 source="profile_executor_field",
+                options=options_for_plugin(intent, str(intent.executor)) or None,
             )
         )
 
@@ -87,7 +89,8 @@ def resolve(
                     f"invalid registration object for {slot}",
                     kind="extension_materialize_failed",
                 )
-            impl = _materialize(reg, intent) if materialize else reg.impl
+            plugin_opts = _options_for_winner(intent, explicit, slot, winner.plugin_id)
+            impl = _materialize(reg, intent, plugin_opts) if materialize else reg.impl
             # replaced_default if a default candidate existed and winner is not default.
             replaced_default = any(c.is_default for c in candidates) and not winner.is_default
             pref = ProviderRef(
@@ -99,6 +102,7 @@ def resolve(
                 digest=winner.digest,
                 replaced_default=replaced_default,
                 slot=slot,
+                options=plugin_opts or None,
             )
             graph.providers[slot] = pref
             graph.records.append(
@@ -126,7 +130,8 @@ def resolve(
                         f"invalid registration object for {slot}",
                         kind="extension_materialize_failed",
                     )
-                handler = _materialize(reg, intent) if materialize else reg.impl
+                plugin_opts = _options_for_winner(intent, explicit, slot, item.plugin_id)
+                handler = _materialize(reg, intent, plugin_opts) if materialize else reg.impl
                 href = HandlerRef(
                     plugin_id=item.plugin_id,
                     handler=handler,
@@ -136,6 +141,7 @@ def resolve(
                     digest=item.digest,
                     replaced_default=False,
                     slot=slot,
+                    options=plugin_opts or None,
                 )
                 refs.append(href)
                 graph.records.append(
@@ -155,28 +161,61 @@ def resolve(
     return graph
 
 
-def _materialize(reg: Registration, intent: BindingIntent) -> Any:
-    """If registration is a factory, construct with intent options; else return impl."""
+def _materialize(
+    reg: Registration,
+    intent: BindingIntent,
+    options: dict[str, Any] | None = None,
+) -> Any:
+    """If registration is a factory, construct with *row* options only."""
     impl = reg.impl
+    plugin_opts = dict(options or {})
     if not reg.is_factory:
+        if _looks_like_handler(impl):
+            return impl
+        if callable(impl):
+            return _call_factory(reg, intent, impl, plugin_opts)
         return impl
     if not callable(impl):
         raise ExtensionMaterializeError(
             f"factory for plugin {reg.plugin_id!r} slot {reg.slot!r} is not callable",
             kind="extension_materialize_failed",
         )
+    return _call_factory(reg, intent, impl, plugin_opts)
+
+
+def _looks_like_handler(impl: Any) -> bool:
+    import inspect
+
+    if not inspect.iscoroutinefunction(impl):
+        return False
+    try:
+        params = list(inspect.signature(impl).parameters)
+    except (TypeError, ValueError):
+        return False
+    return len(params) >= 3
+
+
+def _call_factory(
+    reg: Registration,
+    intent: BindingIntent,
+    impl: Any,
+    plugin_opts: dict[str, Any],
+) -> Any:
     try:
         return impl(
-            options=dict(intent.options),
+            options=plugin_opts,
             profile_id=intent.profile_id,
             model=intent.model,
             base_url=intent.base_url,
             api_key=intent.api_key,
             plugin_id=reg.plugin_id,
+            package_root=intent.package_root,
+            workdir=intent.workdir,
+            home=intent.home,
         )
     except TypeError:
         try:
-            return impl(options=dict(intent.options), profile_id=intent.profile_id)
+            return impl(options=plugin_opts, profile_id=intent.profile_id)
         except TypeError:
             try:
                 return impl()
@@ -192,6 +231,21 @@ def _materialize(reg: Registration, intent: BindingIntent) -> Any:
             f"materialize failed for plugin {reg.plugin_id!r} slot {reg.slot!r}: {exc}",
             kind="extension_materialize_failed",
         ) from exc
+
+
+def _options_for_winner(
+    intent: BindingIntent,
+    explicit: list[ExplicitBinding],
+    slot: str,
+    plugin_id: str,
+) -> dict[str, Any]:
+    found: dict[str, Any] = {}
+    for binding in explicit:
+        if binding.slot == slot and binding.plugin == plugin_id and binding.options:
+            found = dict(binding.options)
+    if found:
+        return found
+    return options_for_plugin(intent, plugin_id)
 
 
 def resolve_for_lock(
@@ -239,6 +293,7 @@ def expand_extension_selects(
                     priority=sel.priority,
                     replace_default=sel.replace_default,
                     source=sel.source,
+                    options=dict(sel.options) if sel.options else None,
                 )
             )
     return out

--- a/src/bora/plugins/slots.py
+++ b/src/bora/plugins/slots.py
@@ -7,6 +7,7 @@ Production consumers (#71 — host **awaits** handlers / SPI methods; no command
 
 - L0 ``before/after_*`` phase bookends → ``application/extension_hooks``
 - L1 ``image_contribute`` → bake path
+- L1 ``home_overlay`` → after cred pack, before actor HOME copy
 - L1 env multi/provide → env prepare/teardown + optional action gate
 - L2 ``executor`` + agent open/invoke/close/normalize → ``ParentAgentService``
 - L3 evaluation input/runtime/score → pre/post evaluator (fail closed)
@@ -43,6 +44,7 @@ AFTER_CLEANUP: Final = "after_cleanup"
 
 # --- L1: environment / image (mostly multi merge; env_action single) ---
 IMAGE_CONTRIBUTE: Final = "image_contribute"
+HOME_OVERLAY: Final = "home_overlay"
 ENV_PREPARE_COMMANDS: Final = "env_prepare_commands"
 ENV_INJECT: Final = "env_inject"
 ENV_ACTION: Final = "env_action"
@@ -89,6 +91,7 @@ _SLOT_KINDS: Final[dict[str, SlotKind]] = {
     AFTER_CLEANUP: SlotKind.MULTI,
     # L1
     IMAGE_CONTRIBUTE: SlotKind.MULTI,
+    HOME_OVERLAY: SlotKind.MULTI,
     ENV_PREPARE_COMMANDS: SlotKind.MULTI,
     ENV_INJECT: SlotKind.MULTI,
     ENV_ACTION: SlotKind.PROVIDE,
@@ -129,6 +132,7 @@ SLOT_LEVEL: Final[dict[str, int]] = {
     BEFORE_CLEANUP: 0,
     AFTER_CLEANUP: 0,
     IMAGE_CONTRIBUTE: 1,
+    HOME_OVERLAY: 1,
     ENV_PREPARE_COMMANDS: 1,
     ENV_INJECT: 1,
     ENV_ACTION: 1,

--- a/src/bora/viewer/trials/surface.py
+++ b/src/bora/viewer/trials/surface.py
@@ -80,16 +80,12 @@ def _profile_variant(profile: dict[str, Any]) -> str | None:
     label = profile.get("label")
     if isinstance(label, str) and label.strip():
         return label.strip()
-    opts = profile.get("options") if isinstance(profile.get("options"), dict) else {}
-    if not isinstance(opts, dict):
-        return None
-    val = opts.get("label")
-    if isinstance(val, str) and val.strip():
-        return val.strip()
+    from bora.config.profiles import acp_entry_from_binding
+
     if str(profile.get("executor") or "").strip() == "acp":
-        entry = opts.get("entry")
-        if isinstance(entry, str) and entry.strip():
-            return entry.strip()
+        entry = acp_entry_from_binding(profile)
+        if entry:
+            return entry
     return None
 
 

--- a/tests/adapters/test_agent_acp.py
+++ b/tests/adapters/test_agent_acp.py
@@ -29,6 +29,13 @@ def test_offline_forced() -> None:
         os.environ.pop("BORA_OFFLINE_AGENT", None)
 
 
+def test_ensure_session_requires_workdir() -> None:
+    os.environ.pop("BORA_OFFLINE_AGENT", None)
+    ex = AcpExecutor(entry_id="opencode", model="entry-default")
+    err = ex._ensure_session(workdir=None, timeout=1.0)
+    assert err == "acp_workdir_required"
+
+
 def test_unknown_entry_raises() -> None:
     try:
         AcpExecutor(entry_id="not-an-entry", model="x")

--- a/tests/application/test_l0_host_work.py
+++ b/tests/application/test_l0_host_work.py
@@ -1,0 +1,154 @@
+"""L0 host layout: cred/HOME/workspace stay outside the evidence run_dir."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from bora.application.attempt.attempt_stages import AttemptStageContext
+from bora.application.attempt.run_l0 import cleanup_l0, drop_l0_host_work, prepare_l0_attempt
+from bora.runtime.identity import IdentityFactory
+
+
+def _attempt():
+    factory = IdentityFactory()
+    run = factory.new_run()
+    trial = factory.new_trial(run, "sha256:" + "c" * 64)
+    return factory.new_attempt(trial)
+
+
+class _FakeCred:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.cleanup_calls = 0
+
+    def cleanup(self) -> None:
+        self.cleanup_calls += 1
+        if self.root.exists():
+            self.root.joinpath("gone").write_text("1", encoding="utf-8")
+
+
+class _FakeServer:
+    def start(self) -> None:
+        return None
+
+    def stop(self) -> None:
+        return None
+
+
+def _lock() -> SimpleNamespace:
+    return SimpleNamespace(
+        digest="sha256:" + "a" * 64,
+        agent_profiles=[{"id": "solver", "executor": "acp"}],
+        parameters={},
+        limits={"wall_time_seconds": 30, "agent_invocations": 1},
+        provenance=None,
+        job_overlay=None,
+    )
+
+
+def test_drop_l0_host_work_removes_dir(tmp_path: Path) -> None:
+    host = tmp_path / "bora-l0-x"
+    (host / "workspace").mkdir(parents=True)
+    (host / "attempt-home" / ".config").mkdir(parents=True)
+    (host / "workspace" / "out.py").write_text("x = 1\n", encoding="utf-8")
+    drop_l0_host_work(host, keep_workspace=False)
+    assert not host.exists()
+
+
+def test_drop_l0_host_work_keep_retains(tmp_path: Path) -> None:
+    host = tmp_path / "bora-l0-y"
+    (host / "workspace").mkdir(parents=True)
+    (host / "workspace" / "out.py").write_text("x = 1\n", encoding="utf-8")
+    drop_l0_host_work(host, keep_workspace=True)
+    assert (host / "workspace" / "out.py").is_file()
+
+
+def test_cleanup_l0_drops_cred_and_host_not_run_dir(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "result.json").write_text("{}\n", encoding="utf-8")
+    host = tmp_path / "host"
+    cred_root = host / "bora-cred-x"
+    cred_root.mkdir(parents=True)
+    (cred_root / "openai_api_key").write_text("SECRET\n", encoding="utf-8")
+    (host / "workspace").mkdir()
+    cred = _FakeCred(cred_root)
+    ctx = AttemptStageContext(
+        package_root=tmp_path,
+        lock=_lock(),
+        run_dir=run_dir,
+        attempt=_attempt(),
+        cred=cred,
+        host_work_root=host,
+        workspace_host=host / "workspace",
+    )
+    cleanup_l0(ctx)
+    assert cred.cleanup_calls == 1
+    assert not host.exists()
+    assert (run_dir / "result.json").is_file()
+    assert not (run_dir / "bora-cred-x").exists()
+    assert not (run_dir / "attempt-home").exists()
+    assert not (run_dir / "workspace").exists()
+
+
+def test_prepare_l0_uses_host_root_not_run_dir(tmp_path: Path, monkeypatch) -> None:
+    captured: dict[str, str] = {}
+
+    def _hook(_lock, value, *, ctx=None):  # type: ignore[no-untyped-def]
+        captured["work_root"] = str(value["work_root"])
+        captured["workspace_root"] = str(value["workspace_root"])
+        root = Path(value["work_root"])
+        cred_root = root / "bora-cred-test"
+        cred_root.mkdir()
+        (cred_root / "openai_api_key").write_text("SECRET\n", encoding="utf-8")
+        home = root / "attempt-home"
+        home.mkdir()
+        if ctx is not None:
+            ctx.cred = _FakeCred(cred_root)
+        return {"home_root": home}
+
+    def _assemble(**kwargs):  # type: ignore[no-untyped-def]
+        captured["workdir"] = str(kwargs.get("workdir") or "")
+        captured["home"] = str(kwargs.get("home") or "")
+        return SimpleNamespace(invocations_completed=0), 30.0, None
+
+    monkeypatch.setattr(
+        "bora.application.attempt.extension_hooks.hook_home_overlay",
+        _hook,
+    )
+    monkeypatch.setattr(
+        "bora.application.attempt.agent_service_assemble.assemble_parent_agent_service",
+        _assemble,
+    )
+    monkeypatch.setattr(
+        "bora.runtime.agent_service_protocol.AgentServiceServer",
+        lambda *_a, **_k: _FakeServer(),
+    )
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    ctx = AttemptStageContext(
+        package_root=tmp_path,
+        lock=_lock(),
+        run_dir=run_dir,
+        attempt=_attempt(),
+        database_root=tmp_path,
+    )
+    early = prepare_l0_attempt(ctx)
+    assert early is None
+    assert ctx.host_work_root is not None
+    assert ctx.workspace_host == ctx.host_work_root / "workspace"
+    assert ctx.run_dir not in ctx.host_work_root.parents
+    assert ctx.host_work_root != ctx.run_dir
+    assert captured["work_root"] == str(ctx.host_work_root)
+    assert captured["workspace_root"] == str(ctx.workspace_host)
+    assert captured["workdir"] == str(ctx.workspace_host)
+    assert captured["home"] == str(ctx.host_work_root / "attempt-home")
+    assert not list(run_dir.glob("bora-cred-*"))
+    assert not (run_dir / "attempt-home").exists()
+    assert not (run_dir / "workspace").exists()
+    assert ctx.agent_meta.get("workspace") == str(ctx.workspace_host)
+
+    cleanup_l0(ctx)
+    assert ctx.host_work_root is None or not ctx.host_work_root.exists()

--- a/tests/application/test_l1_stage_cleanup.py
+++ b/tests/application/test_l1_stage_cleanup.py
@@ -124,8 +124,18 @@ def _install_l1_fakes(
         "bora.application.attempt.run_l1_phases.prepare_l1_runtime",
         lambda *_a, **_k: (docker, runtime, {"containment": "full_l1_attempt"}),
     )
+
+    def _fake_home_overlay(_lock, _value, *, ctx=None, **_k):  # type: ignore[no-untyped-def]
+        if ctx is not None:
+            ctx.cred = cred
+            ctx.ledger = docker.prepare_agent_targets(
+                runtime, SimpleNamespace(), cred_root=cred.root
+            )
+        return {"cred": cred}
+
     monkeypatch.setattr(
-        "bora.application.attempt.run_l1_phases.project_executor_credentials", lambda **_k: cred
+        "bora.application.attempt.run_l1_phases.hook_home_overlay",
+        _fake_home_overlay,
     )
     monkeypatch.setattr(
         "bora.application.attempt.run_l1_phases.seed_l1_workspace", lambda **_k: None

--- a/tests/application/test_suite_config_fingerprint.py
+++ b/tests/application/test_suite_config_fingerprint.py
@@ -30,13 +30,13 @@ def test_actors_summary_sorted_and_secret_free() -> None:
             "executor": "acp",
             "model": "m2",
             "api_key": "SECRET_LOCATOR",
-            "options": {"entry": "pi"},
+            "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}],
         },
         {
             "id": "planner",
             "executor": "acp",
             "model": "m1",
-            "options": {"entry": "codex"},
+            "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}],
         },
     ]
     actors = actors_summary_from_profiles(profiles)
@@ -54,17 +54,17 @@ def test_job_overlay_axis_ignores_role_topology_diff() -> None:
         "bindings": {
             "solver": {
                 "executor": "acp",
-                "options": {"entry": "pi"},
+                "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}],
                 "model": "m",
             },
             "user": {
                 "executor": "acp",
-                "options": {"entry": "grok-build"},
+                "extensions": [{"plugin": "acp", "options": {"entry": "grok-build"}}],
                 "model": "entry-default",
             },
             "service": {
                 "executor": "acp",
-                "options": {"entry": "opencode"},
+                "extensions": [{"plugin": "acp", "options": {"entry": "opencode"}}],
                 "model": "m2",
             },
         }
@@ -100,7 +100,7 @@ def test_job_overlay_conflict_not_homogeneous() -> None:
         "bindings": {
             "solver": {
                 "executor": "acp",
-                "options": {"entry": "pi"},
+                "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}],
                 "model": "m1",
             }
         }
@@ -109,7 +109,7 @@ def test_job_overlay_conflict_not_homogeneous() -> None:
         "bindings": {
             "solver": {
                 "executor": "acp",
-                "options": {"entry": "codex"},
+                "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}],
                 "model": "m1",
             }
         }
@@ -125,20 +125,20 @@ def test_job_overlay_conflict_not_homogeneous() -> None:
 def test_job_overlays_compatible_helper() -> None:
     suite = {
         "bindings": {
-            "a": {"executor": "acp", "options": {"entry": "pi"}, "model": "m"},
-            "b": {"executor": "acp", "options": {"entry": "codex"}, "model": "n"},
+            "a": {"executor": "acp", "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}], "model": "m"},
+            "b": {"executor": "acp", "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}], "model": "n"},
         }
     }
     assert job_overlays_compatible(suite, [None, {"bindings": {"a": suite["bindings"]["a"]}}])
     assert not job_overlays_compatible(
         suite,
-        [{"bindings": {"a": {"executor": "acp", "options": {"entry": "opencode"}, "model": "m"}}}],
+        [{"bindings": {"a": {"executor": "acp", "extensions": [{"plugin": "acp", "options": {"entry": "opencode"}}], "model": "m"}}}],
     )
 
 
 def test_homogeneous_true_identical_topology() -> None:
     a = actors_summary_from_profiles(
-        [{"id": "solo", "executor": "acp", "model": "x", "options": {"entry": "pi"}}]
+        [{"id": "solo", "executor": "acp", "model": "x", "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}]}]
     )
     fields = compute_suite_config_fields([a, a, a])
     assert fields["config_homogeneous"] is True
@@ -167,7 +167,7 @@ def test_derive_labels_nooa_uses_executor_not_options_agent() -> None:
 def test_empty_agent_tasks_do_not_break_fallback_homogeneity() -> None:
     """No-agent tasks + identical agent tasks remain homogeneous (fallback path)."""
     solo = actors_summary_from_profiles(
-        [{"id": "solo", "executor": "acp", "model": "x", "options": {"entry": "pi"}}]
+        [{"id": "solo", "executor": "acp", "model": "x", "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}]}]
     )
     fields = compute_suite_config_fields([[], solo, solo])
     assert fields["config_homogeneous"] is True
@@ -176,10 +176,10 @@ def test_empty_agent_tasks_do_not_break_fallback_homogeneity() -> None:
 
 def test_fallback_different_models_not_homogeneous() -> None:
     a = actors_summary_from_profiles(
-        [{"id": "solo", "executor": "acp", "model": "gpt-a", "options": {"entry": "codex"}}]
+        [{"id": "solo", "executor": "acp", "model": "gpt-a", "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}]}]
     )
     b = actors_summary_from_profiles(
-        [{"id": "solo", "executor": "acp", "model": "gpt-b", "options": {"entry": "codex"}}]
+        [{"id": "solo", "executor": "acp", "model": "gpt-b", "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}]}]
     )
     fields = compute_suite_config_fields([a, b])
     assert fields["config_homogeneous"] is False
@@ -189,7 +189,7 @@ def test_fingerprint_stable() -> None:
     actors = actors_summary_from_profiles(
         [
             {"id": "b", "executor": "openai-http", "model": "m"},
-            {"id": "a", "executor": "acp", "model": "n", "options": {"entry": "pi"}},
+            {"id": "a", "executor": "acp", "model": "n", "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}]},
         ]
     )
     assert fingerprint_for_actors(actors) == fingerprint_for_actors(list(reversed(actors)))
@@ -267,7 +267,7 @@ def test_plugins_from_job_overlay_skips_builtin_executors() -> None:
     overlay = {
         "bindings": {
             "solver": {"executor": "nooa", "model": "m"},
-            "user": {"executor": "acp", "options": {"entry": "codex"}},
+            "user": {"executor": "acp", "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}]},
             "alt": {"executor": "ACP"},
             "http": {"executor": "OpenAI-HTTP"},
         }

--- a/tests/application/test_suite_config_fingerprint.py
+++ b/tests/application/test_suite_config_fingerprint.py
@@ -125,20 +125,45 @@ def test_job_overlay_conflict_not_homogeneous() -> None:
 def test_job_overlays_compatible_helper() -> None:
     suite = {
         "bindings": {
-            "a": {"executor": "acp", "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}], "model": "m"},
-            "b": {"executor": "acp", "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}], "model": "n"},
+            "a": {
+                "executor": "acp",
+                "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}],
+                "model": "m",
+            },
+            "b": {
+                "executor": "acp",
+                "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}],
+                "model": "n",
+            },
         }
     }
     assert job_overlays_compatible(suite, [None, {"bindings": {"a": suite["bindings"]["a"]}}])
     assert not job_overlays_compatible(
         suite,
-        [{"bindings": {"a": {"executor": "acp", "extensions": [{"plugin": "acp", "options": {"entry": "opencode"}}], "model": "m"}}}],
+        [
+            {
+                "bindings": {
+                    "a": {
+                        "executor": "acp",
+                        "extensions": [{"plugin": "acp", "options": {"entry": "opencode"}}],
+                        "model": "m",
+                    }
+                }
+            }
+        ],
     )
 
 
 def test_homogeneous_true_identical_topology() -> None:
     a = actors_summary_from_profiles(
-        [{"id": "solo", "executor": "acp", "model": "x", "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}]}]
+        [
+            {
+                "id": "solo",
+                "executor": "acp",
+                "model": "x",
+                "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}],
+            }
+        ]
     )
     fields = compute_suite_config_fields([a, a, a])
     assert fields["config_homogeneous"] is True
@@ -167,7 +192,14 @@ def test_derive_labels_nooa_uses_executor_not_options_agent() -> None:
 def test_empty_agent_tasks_do_not_break_fallback_homogeneity() -> None:
     """No-agent tasks + identical agent tasks remain homogeneous (fallback path)."""
     solo = actors_summary_from_profiles(
-        [{"id": "solo", "executor": "acp", "model": "x", "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}]}]
+        [
+            {
+                "id": "solo",
+                "executor": "acp",
+                "model": "x",
+                "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}],
+            }
+        ]
     )
     fields = compute_suite_config_fields([[], solo, solo])
     assert fields["config_homogeneous"] is True
@@ -176,10 +208,24 @@ def test_empty_agent_tasks_do_not_break_fallback_homogeneity() -> None:
 
 def test_fallback_different_models_not_homogeneous() -> None:
     a = actors_summary_from_profiles(
-        [{"id": "solo", "executor": "acp", "model": "gpt-a", "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}]}]
+        [
+            {
+                "id": "solo",
+                "executor": "acp",
+                "model": "gpt-a",
+                "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}],
+            }
+        ]
     )
     b = actors_summary_from_profiles(
-        [{"id": "solo", "executor": "acp", "model": "gpt-b", "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}]}]
+        [
+            {
+                "id": "solo",
+                "executor": "acp",
+                "model": "gpt-b",
+                "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}],
+            }
+        ]
     )
     fields = compute_suite_config_fields([a, b])
     assert fields["config_homogeneous"] is False
@@ -189,7 +235,12 @@ def test_fingerprint_stable() -> None:
     actors = actors_summary_from_profiles(
         [
             {"id": "b", "executor": "openai-http", "model": "m"},
-            {"id": "a", "executor": "acp", "model": "n", "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}]},
+            {
+                "id": "a",
+                "executor": "acp",
+                "model": "n",
+                "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}],
+            },
         ]
     )
     assert fingerprint_for_actors(actors) == fingerprint_for_actors(list(reversed(actors)))
@@ -267,7 +318,10 @@ def test_plugins_from_job_overlay_skips_builtin_executors() -> None:
     overlay = {
         "bindings": {
             "solver": {"executor": "nooa", "model": "m"},
-            "user": {"executor": "acp", "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}]},
+            "user": {
+                "executor": "acp",
+                "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}],
+            },
             "alt": {"executor": "ACP"},
             "http": {"executor": "OpenAI-HTTP"},
         }

--- a/tests/config/test_acp_profile.py
+++ b/tests/config/test_acp_profile.py
@@ -63,14 +63,14 @@ def test_acp_profile_lock_snapshot(tmp_path: Path) -> None:
             "opencode-acp": {
                 "executor": "acp",
                 "model": "entry-default",
-                "options": {"entry": "opencode"},
+                "extensions": [{"plugin": "acp", "options": {"entry": "opencode"}}],
             }
         },
     )
     profiles = thaw(lock.agent_profiles)
     assert profiles[0]["executor"] == "acp"
-    assert profiles[0]["options"]["entry"] == "opencode"
-    assert "_acp_lock" not in profiles[0]["options"]
+    assert profiles[0]["extensions"][0]["options"]["entry"] == "opencode"
+    assert "_acp_lock" not in profiles[0]["extensions"][0]["options"]
     blob = str(profiles)
     assert "/opt/" not in blob
     assert "sk-" not in blob
@@ -79,7 +79,7 @@ def test_acp_profile_lock_snapshot(tmp_path: Path) -> None:
 def test_acp_missing_entry_fails(tmp_path: Path) -> None:
     pkg = _write_pkg(tmp_path / "pkg", ["bad"])
     with pytest.raises(ConfigError):
-        _lock(pkg, {"bad": {"executor": "acp", "model": "m", "options": {}}})
+        _lock(pkg, {"bad": {"executor": "acp", "model": "m"}})
 
 
 def test_acp_unknown_entry_fails(tmp_path: Path) -> None:
@@ -91,7 +91,7 @@ def test_acp_unknown_entry_fails(tmp_path: Path) -> None:
                 "bad": {
                     "executor": "acp",
                     "model": "m",
-                    "options": {"entry": "not-registered"},
+                    "extensions": [{"plugin": "acp", "options": {"entry": "not-registered"}}],
                 }
             },
         )
@@ -106,7 +106,9 @@ def test_acp_package_cannot_override_command(tmp_path: Path) -> None:
                 "bad": {
                     "executor": "acp",
                     "model": "m",
-                    "options": {"entry": "opencode", "command": ["evil"]},
+                    "extensions": [
+                        {"plugin": "acp", "options": {"entry": "opencode", "command": ["evil"]}}
+                    ],
                 }
             },
         )

--- a/tests/config/test_agent_isolation.py
+++ b/tests/config/test_agent_isolation.py
@@ -74,7 +74,7 @@ _P1_BINDINGS = {
     "p1": {
         "executor": "acp",
         "model": "entry-default",
-        "options": {"entry": "codex"},
+        "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}],
     }
 }
 

--- a/tests/config/test_docker_dockerfile_required.py
+++ b/tests/config/test_docker_dockerfile_required.py
@@ -63,7 +63,7 @@ _P1_BINDINGS = {
     "p1": {
         "executor": "acp",
         "model": "entry-default",
-        "options": {"entry": "pi"},
+        "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}],
     }
 }
 

--- a/tests/config/test_profile_upstream_fields.py
+++ b/tests/config/test_profile_upstream_fields.py
@@ -58,7 +58,7 @@ def test_accepts_base_url_and_api_key_locator(tmp_path: Path) -> None:
                 "executor": "openai-http",
                 "model": "glm-4.7",
                 "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
-                "api_key": "zhipu_coding_api_key",
+                "api_key": "${zhipu_coding_api_key}",
             }
         },
     )
@@ -99,6 +99,66 @@ def test_rejects_non_url_base(tmp_path: Path) -> None:
                     "executor": "openai-http",
                     "model": "glm-4.7",
                     "base_url": "not-a-url",
+                }
+            },
+        )
+
+
+def test_expands_base_url_env_ref(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_LITELLM_BASE", "http://127.0.0.1:8010/v1")
+    pkg = _write_pkg(tmp_path, slot_id="glm")
+    core = ConfigCore(package_reader=LocalPackageReader())
+    locked = core.load_and_lock(
+        pkg,
+        "profile-upstream",
+        capabilities=DeclarationCapabilityCatalog(),
+        profile_bindings={
+            "glm": {
+                "executor": "openai-http",
+                "model": "glm-4.7",
+                "base_url": "${TEST_LITELLM_BASE}",
+                "api_key": "${zhipu_coding_api_key}",
+            }
+        },
+    )
+    profiles = thaw(locked.agent_profiles)
+    assert profiles[0]["base_url"] == "http://127.0.0.1:8010/v1"
+    assert profiles[0]["api_key"] == "zhipu_coding_api_key"
+
+
+def test_rejects_bare_api_key_locator(tmp_path: Path) -> None:
+    pkg = _write_pkg(tmp_path, slot_id="glm")
+    core = ConfigCore(package_reader=LocalPackageReader())
+    with pytest.raises(ConfigError, match=r"\$\{ENV_NAME\}"):
+        core.load_and_lock(
+            pkg,
+            "profile-upstream",
+            capabilities=DeclarationCapabilityCatalog(),
+            profile_bindings={
+                "glm": {
+                    "executor": "openai-http",
+                    "model": "glm-4.7",
+                    "api_key": "zhipu_coding_api_key",
+                }
+            },
+        )
+
+
+def test_rejects_unset_base_url_ref(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MISSING_BASE_URL", raising=False)
+    pkg = _write_pkg(tmp_path, slot_id="glm")
+    core = ConfigCore(package_reader=LocalPackageReader())
+    with pytest.raises(ConfigError, match="unset"):
+        core.load_and_lock(
+            pkg,
+            "profile-upstream",
+            capabilities=DeclarationCapabilityCatalog(),
+            profile_bindings={
+                "glm": {
+                    "executor": "openai-http",
+                    "model": "glm-4.7",
+                    "base_url": "${MISSING_BASE_URL}",
+                    "api_key": "${zhipu_coding_api_key}",
                 }
             },
         )

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -93,7 +93,7 @@ def test_merge_bindings_and_cli_override(tmp_path: Path) -> None:
         profile_bindings={
             "solver": {
                 "executor": "acp",
-                "options": {"entry": "codex"},
+                "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}],
                 "model": "gpt-5.4-mini",
             }
         },
@@ -105,11 +105,11 @@ def test_merge_bindings_and_cli_override(tmp_path: Path) -> None:
     profiles = thaw(locked.agent_profiles)
     assert profiles[0]["id"] == "solver"
     assert profiles[0]["executor"] == "acp"
-    assert profiles[0]["options"]["entry"] == "pi"
+    assert profiles[0]["extensions"][0]["options"]["entry"] == "pi"
     assert profiles[0]["model"] == "claude-haiku-4-5"
     assert locked.job_overlay is not None
     overlay = thaw(locked.job_overlay)
-    assert overlay["bindings"]["solver"]["options"]["entry"] == "pi"
+    assert overlay["bindings"]["solver"]["extensions"][0]["options"]["entry"] == "pi"
 
 
 def test_empty_slots_need_no_bindings(tmp_path: Path) -> None:
@@ -134,7 +134,7 @@ def test_profiles_document_parse(tmp_path: Path) -> None:
                 "bindings": {
                     "solver": {
                         "executor": "acp",
-                        "options": {"entry": "codex"},
+                        "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}],
                         "model": "m",
                     }
                 },
@@ -166,7 +166,7 @@ def test_job_overlay_omits_secrets() -> None:
         {
             "solver": {
                 "executor": "acp",
-                "options": {"entry": "pi"},
+                "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}],
                 "model": "m",
                 "api_key": "MY_KEY_LOCATOR",
             }
@@ -188,7 +188,7 @@ def test_job_overlay_to_profiles_roundtrip(tmp_path: Path) -> None:
         {
             "solver": {
                 "executor": "acp",
-                "options": {"entry": "pi"},
+                "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}],
                 "model": "m",
                 "api_key": "LOC",
             }
@@ -198,7 +198,7 @@ def test_job_overlay_to_profiles_roundtrip(tmp_path: Path) -> None:
     path = tmp_path / "profiles.from-suite.yaml"
     write_profiles_yaml(path, doc)
     loaded = load_profiles_document(path)
-    assert loaded["solver"]["options"]["entry"] == "pi"
+    assert loaded["solver"]["extensions"][0]["options"]["entry"] == "pi"
     assert loaded["solver"]["api_key"] == "LOC"
 
 
@@ -208,16 +208,21 @@ def test_job_overlay_keeps_plugin_options() -> None:
             "solver": {
                 "executor": "nooa",
                 "model": "openai/glm-5.2",
-                "options": {
-                    "agent": "lib.agents:JsonlAggAgent",
-                    "method": "run",
-                    "command": ["secret"],
-                    "_acp_lock": {"entry_id": "x"},
-                },
+                "extensions": [
+                    {
+                        "plugin": "nooa",
+                        "options": {
+                            "agent": "lib.agents:JsonlAggAgent",
+                            "method": "run",
+                            "command": ["secret"],
+                            "_acp_lock": {"entry_id": "x"},
+                        },
+                    }
+                ],
             }
         }
     )
-    opts = overlay["bindings"]["solver"]["options"]
+    opts = overlay["bindings"]["solver"]["extensions"][0]["options"]
     assert opts["agent"] == "lib.agents:JsonlAggAgent"
     assert opts["method"] == "run"
     assert "command" not in opts
@@ -229,7 +234,9 @@ def test_display_agent_name_never_uses_options_agent() -> None:
         display_agent_name(
             {
                 "executor": "nooa",
-                "options": {"agent": "lib.agents:JsonlAggAgent"},
+                "extensions": [
+                    {"plugin": "nooa", "options": {"agent": "lib.agents:JsonlAggAgent"}}
+                ],
             }
         )
         == "nooa"
@@ -239,12 +246,19 @@ def test_display_agent_name_never_uses_options_agent() -> None:
             {
                 "executor": "nooa",
                 "label": "nooa",
-                "options": {"agent": "lib.agents:JsonlAggAgent"},
+                "extensions": [
+                    {"plugin": "nooa", "options": {"agent": "lib.agents:JsonlAggAgent"}}
+                ],
             }
         )
         == "nooa"
     )
-    assert display_agent_name({"executor": "acp", "options": {"entry": "pi"}}) == "pi"
+    assert (
+        display_agent_name(
+            {"executor": "acp", "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}]}
+        )
+        == "pi"
+    )
     assert display_agent_name({"executor": "dsh"}) == "dsh"
 
 
@@ -252,7 +266,11 @@ def test_display_labels_from_overlay_joins_distinct() -> None:
     agent, model = display_labels_from_overlay(
         {
             "bindings": {
-                "a": {"executor": "acp", "options": {"entry": "pi"}, "model": "m1"},
+                "a": {
+                    "executor": "acp",
+                    "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}],
+                    "model": "m1",
+                },
                 "b": {"executor": "dsh", "model": "m2"},
             }
         }

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -199,7 +199,7 @@ def test_job_overlay_to_profiles_roundtrip(tmp_path: Path) -> None:
     write_profiles_yaml(path, doc)
     loaded = load_profiles_document(path)
     assert loaded["solver"]["extensions"][0]["options"]["entry"] == "pi"
-    assert loaded["solver"]["api_key"] == "LOC"
+    assert loaded["solver"]["api_key"] == "${LOC}"
 
 
 def test_job_overlay_keeps_plugin_options() -> None:

--- a/tests/fixtures/databases/probe-min/profiles.no-ext.yaml
+++ b/tests/fixtures/databases/probe-min/profiles.no-ext.yaml
@@ -3,4 +3,4 @@ bindings:
   solver:
     executor: host-probe
     model: none
-    api_key: PROBE_API_KEY
+    api_key: ${PROBE_API_KEY}

--- a/tests/fixtures/databases/probe-min/profiles.yaml
+++ b/tests/fixtures/databases/probe-min/profiles.yaml
@@ -5,4 +5,4 @@ bindings:
     extensions:
       - plugin: host-probe
     model: none
-    api_key: PROBE_API_KEY
+    api_key: ${PROBE_API_KEY}

--- a/tests/helpers/bindings.py
+++ b/tests/helpers/bindings.py
@@ -1,0 +1,23 @@
+"""Job-binding helpers for tests (extension-row options, no profile bag)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def acp_extensions(entry: str, **extra: Any) -> list[dict[str, Any]]:
+    opts: dict[str, Any] = {"entry": entry, **extra}
+    return [{"plugin": "acp", "options": opts}]
+
+
+def plugin_extensions(plugin: str, **options: Any) -> list[dict[str, Any]]:
+    row: dict[str, Any] = {"plugin": plugin}
+    if options:
+        row["options"] = dict(options)
+    return [row]
+
+
+def acp_binding(entry: str, **fields: Any) -> dict[str, Any]:
+    row = {"executor": "acp", "extensions": acp_extensions(entry)}
+    row.update(fields)
+    return row

--- a/tests/plugins/test_acp_nooa_contrib.py
+++ b/tests/plugins/test_acp_nooa_contrib.py
@@ -10,7 +10,7 @@ from bora.plugins.bootstrap import bootstrap_registry
 from bora.plugins.contrib.acp import PLUGIN_ID as ACP_ID
 from bora.plugins.errors import ExtensionMaterializeError
 from bora.plugins.lock_bind import extension_graph_to_lock
-from bora.plugins.protocol import BindingIntent
+from bora.plugins.protocol import BindingIntent, ExtensionSelect
 from bora.plugins.registry import ExtensionRegistry, reset_global_registry
 from bora.plugins.resolve import resolve
 from bora.plugins.slots import EXECUTOR
@@ -109,13 +109,18 @@ def test_dual_profile_acp_and_nooa_session_graphs(bora_home_with_nooa: Path) -> 
                 "id": "solver",
                 "executor": "nooa",
                 "model": "m",
-                "options": {"agent": "types:SimpleNamespace", "method": "__str__"},
+                "extensions": [
+                    {
+                        "plugin": "nooa",
+                        "options": {"agent": "types:SimpleNamespace", "method": "__str__"},
+                    }
+                ],
             },
             {
                 "id": "user",
                 "executor": "acp",
                 "model": "m",
-                "options": {"entry": "pi"},
+                "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}],
             },
         ],
         agent_invocation_limit=2,
@@ -150,7 +155,13 @@ def test_nooa_uninstalled_fail_closed(tmp_path: Path, monkeypatch: pytest.Monkey
     bootstrap_registry(reg, include_mock=False, include_openai_http=False)
     with pytest.raises(ExtensionPluginNotFoundError):
         resolve(
-            BindingIntent(profile_id="s", executor="nooa", options={"agent": "x:Y"}),
+            BindingIntent(
+                profile_id="s",
+                executor="nooa",
+                extension_selects=[
+                    ExtensionSelect(plugin="nooa", options={"agent": "x:Y"}),
+                ],
+            ),
             reg,
             materialize=False,
         )

--- a/tests/plugins/test_extension_row_options.py
+++ b/tests/plugins/test_extension_row_options.py
@@ -1,0 +1,69 @@
+"""extensions[].options is the only map a plugin factory sees."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bora.plugins.protocol import BindingIntent, ExtensionSelect, intent_from_profile
+from bora.plugins.registry import ExtensionRegistry
+from bora.plugins.resolve import resolve
+from bora.plugins.slots import EXECUTOR
+
+
+def _factory(
+    *, options: dict[str, Any] | None = None, plugin_id: str | None = None, **kwargs: Any
+) -> dict[str, Any]:
+    return {"options": dict(options or {}), "plugin_id": plugin_id, "kwargs": kwargs}
+
+
+def test_factory_sees_only_its_row_options() -> None:
+    reg = ExtensionRegistry()
+    captured: list[dict[str, Any]] = []
+
+    def acp_factory(**kwargs: Any) -> dict[str, Any]:
+        captured.append({"plugin": "acp", **_factory(**kwargs)})
+        return captured[-1]
+
+    def dsh_factory(**kwargs: Any) -> dict[str, Any]:
+        captured.append({"plugin": "dsh", **_factory(**kwargs)})
+        return captured[-1]
+
+    reg.provide(EXECUTOR, "acp", acp_factory, source="first-party", is_factory=True)
+    reg.provide(EXECUTOR, "dsh", dsh_factory, source="installed", is_factory=True)
+
+    intent = intent_from_profile(
+        {
+            "id": "solver",
+            "executor": "dsh",
+            "options": {"entry": "opencode", "composition": "must-not-leak"},
+            "extensions": [
+                {"plugin": "acp", "options": {"entry": "opencode"}},
+                {"plugin": "dsh", "options": {"composition": "slim"}},
+            ],
+        }
+    )
+    graph = resolve(intent, reg)
+    impl = graph.providers[EXECUTOR].impl
+    assert impl["plugin"] == "dsh"
+    assert impl["options"] == {"composition": "slim"}
+    assert "entry" not in impl["options"]
+    assert "must-not-leak" not in str(impl["options"])
+
+
+def test_profile_options_are_not_plugin_input() -> None:
+    reg = ExtensionRegistry()
+
+    def acp_factory(**kwargs: Any) -> dict[str, Any]:
+        return _factory(**kwargs)
+
+    reg.provide(EXECUTOR, "acp", acp_factory, source="first-party", is_factory=True)
+    graph = resolve(
+        BindingIntent(
+            profile_id="s",
+            executor="acp",
+            options={"entry": "pi"},
+            extension_selects=[ExtensionSelect(plugin="acp")],
+        ),
+        reg,
+    )
+    assert graph.providers[EXECUTOR].impl["options"] == {}

--- a/tests/plugins/test_extensions_opt_in.py
+++ b/tests/plugins/test_extensions_opt_in.py
@@ -165,7 +165,7 @@ def test_intent_from_profile_parses_all_three_shapes() -> None:
             "executor": "dsh",
             "extensions": [
                 {"plugin": "nooa"},
-                {"plugin": "dsh", "slots": ["image_contribute"]},
+                {"plugin": "dsh", "slots": ["image_contribute"], "options": {"composition": "slim"}},
                 {"slot": "trajectory_collect", "plugin": "dsh"},
             ],
         }
@@ -175,6 +175,7 @@ def test_intent_from_profile_parses_all_three_shapes() -> None:
     assert intent.extension_selects[0].plugin == "nooa"
     assert intent.extension_selects[0].slots is None
     assert intent.extension_selects[1].slots == (IMAGE_CONTRIBUTE,)
+    assert intent.extension_selects[1].options == {"composition": "slim"}
     assert len(intent.extensions) == 1
     assert intent.extensions[0].slot == TRAJECTORY_COLLECT
     assert intent.extensions[0].plugin == "dsh"

--- a/tests/plugins/test_extensions_opt_in.py
+++ b/tests/plugins/test_extensions_opt_in.py
@@ -165,7 +165,11 @@ def test_intent_from_profile_parses_all_three_shapes() -> None:
             "executor": "dsh",
             "extensions": [
                 {"plugin": "nooa"},
-                {"plugin": "dsh", "slots": ["image_contribute"], "options": {"composition": "slim"}},
+                {
+                    "plugin": "dsh",
+                    "slots": ["image_contribute"],
+                    "options": {"composition": "slim"},
+                },
                 {"slot": "trajectory_collect", "plugin": "dsh"},
             ],
         }

--- a/tests/plugins/test_home_files.py
+++ b/tests/plugins/test_home_files.py
@@ -158,6 +158,21 @@ def test_journeys_overlay_profile_locks(tmp_path: Path, monkeypatch: pytest.Monk
     assert "home-files" in plugins
 
 
+def test_symlink_child_outside_src_fails(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    src_dir = ctx["package_root"] / "overlays" / "skills"
+    src_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret\n", encoding="utf-8")
+    (src_dir / "link").symlink_to(outside)
+    with pytest.raises(HomeFilesError) as ei:
+        apply_files(
+            [{"src": "overlays/skills", "dest": ".agents/skills", "dest_root": "workspace"}],
+            {k: str(v) for k, v in ctx.items()},
+        )
+    assert ei.value.kind == "home_files_path_invalid"
+
+
 def test_dest_root_required(tmp_path: Path) -> None:
     ctx = _ctx(tmp_path)
     src = ctx["package_root"] / "overlays" / "a.json"

--- a/tests/plugins/test_home_files.py
+++ b/tests/plugins/test_home_files.py
@@ -1,0 +1,128 @@
+"""home-files dest safety, overwrite, and directory merge."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).resolve().parents[2] / "plugins" / "home-files" / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from home_files.hooks import HomeFilesError, apply_files  # noqa: E402
+
+
+def _ctx(tmp: Path) -> dict[str, Path]:
+    pkg = tmp / "db"
+    ws = tmp / "ws"
+    cred = tmp / "cred"
+    pkg.mkdir()
+    ws.mkdir()
+    cred.mkdir()
+    (cred / "home_overlay").mkdir()
+    return {"package_root": pkg, "workspace_root": ws, "cred_root": cred}
+
+
+def test_file_overwrite_home(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    src = ctx["package_root"] / "overlays" / "a.json"
+    src.parent.mkdir()
+    src.write_text('{"v":1}\n', encoding="utf-8")
+    dest = ctx["cred_root"] / "home_overlay" / ".config" / "x.json"
+    dest.parent.mkdir(parents=True)
+    dest.write_text("old\n", encoding="utf-8")
+    apply_files(
+        [{"src": "overlays/a.json", "dest": ".config/x.json", "dest_root": "home"}],
+        {k: str(v) for k, v in ctx.items()},
+    )
+    assert dest.read_text(encoding="utf-8") == '{"v":1}\n'
+
+
+def test_directory_merge_keeps_extra(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    src_dir = ctx["package_root"] / "overlays" / "skills"
+    (src_dir / "foo").mkdir(parents=True)
+    (src_dir / "foo" / "SKILL.md").write_text("new\n", encoding="utf-8")
+    dest_dir = ctx["workspace_root"] / ".agents" / "skills"
+    (dest_dir / "foo").mkdir(parents=True)
+    (dest_dir / "foo" / "SKILL.md").write_text("old\n", encoding="utf-8")
+    (dest_dir / "keep").mkdir()
+    (dest_dir / "keep" / "x.md").write_text("stay\n", encoding="utf-8")
+    apply_files(
+        [{"src": "overlays/skills", "dest": ".agents/skills", "dest_root": "workspace"}],
+        {k: str(v) for k, v in ctx.items()},
+    )
+    assert (dest_dir / "foo" / "SKILL.md").read_text(encoding="utf-8") == "new\n"
+    assert (dest_dir / "keep" / "x.md").read_text(encoding="utf-8") == "stay\n"
+
+
+def test_reject_parent_and_absolute(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    payload = {k: str(v) for k, v in ctx.items()}
+    with pytest.raises(HomeFilesError) as ei:
+        apply_files(
+            [{"src": "../secret", "dest": "x", "dest_root": "home"}],
+            payload,
+        )
+    assert ei.value.kind == "home_files_path_invalid"
+    with pytest.raises(HomeFilesError) as ei:
+        apply_files(
+            [{"src": "/etc/passwd", "dest": "x", "dest_root": "home"}],
+            payload,
+        )
+    assert ei.value.kind == "home_files_path_invalid"
+    with pytest.raises(HomeFilesError) as ei:
+        apply_files(
+            [{"src": "overlays/a", "dest": "../escape", "dest_root": "home"}],
+            payload,
+        )
+    assert ei.value.kind == "home_files_path_invalid"
+
+
+def test_reject_evaluation_dest(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    src = ctx["package_root"] / "overlays" / "gold.json"
+    src.parent.mkdir()
+    src.write_text("{}\n", encoding="utf-8")
+    with pytest.raises(HomeFilesError) as ei:
+        apply_files(
+            [
+                {
+                    "src": "overlays/gold.json",
+                    "dest": "evaluation/gold.json",
+                    "dest_root": "workspace",
+                }
+            ],
+            {k: str(v) for k, v in ctx.items()},
+        )
+    assert ei.value.kind == "home_files_dest_invalid"
+
+
+def test_dest_file_src_dir_fails(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    src_dir = ctx["package_root"] / "overlays" / "dir"
+    src_dir.mkdir(parents=True)
+    (src_dir / "a.txt").write_text("x\n", encoding="utf-8")
+    dest = ctx["workspace_root"] / "out"
+    dest.write_text("file\n", encoding="utf-8")
+    with pytest.raises(HomeFilesError) as ei:
+        apply_files(
+            [{"src": "overlays/dir", "dest": "out", "dest_root": "workspace"}],
+            {k: str(v) for k, v in ctx.items()},
+        )
+    assert ei.value.kind == "home_files_dest_invalid"
+
+
+def test_dest_root_required(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    src = ctx["package_root"] / "overlays" / "a.json"
+    src.parent.mkdir()
+    src.write_text("{}\n", encoding="utf-8")
+    with pytest.raises(HomeFilesError) as ei:
+        apply_files(
+            [{"src": "overlays/a.json", "dest": "x.json"}],
+            {k: str(v) for k, v in ctx.items()},
+        )
+    assert ei.value.kind == "home_files_dest_invalid"

--- a/tests/plugins/test_home_files.py
+++ b/tests/plugins/test_home_files.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -113,6 +116,46 @@ def test_dest_file_src_dir_fails(tmp_path: Path) -> None:
             {k: str(v) for k, v in ctx.items()},
         )
     assert ei.value.kind == "home_files_dest_invalid"
+
+
+def test_journeys_overlay_profile_locks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from bora.plugins import bootstrap as boot
+    from bora.plugins.registry import reset_global_registry
+    from bora.plugins.store import install_from_path
+
+    home = tmp_path / "bora-home"
+    home.mkdir()
+    monkeypatch.setenv("BORA_HOME", str(home))
+    boot._BOOTSTRAPPED = False  # type: ignore[attr-defined]
+    reset_global_registry()
+    install_from_path(Path(__file__).resolve().parents[2] / "plugins" / "home-files")
+
+    root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["BORA_HOME"] = str(home)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bora.cli.main",
+            "lock",
+            str(root / "examples/journeys"),
+            "--task",
+            "terminal-jsonl-agg",
+            "--profiles",
+            str(root / "examples/journeys/acp-profiles/profiles.acp.opencode.qwen3.8-max.yaml"),
+        ],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    data = json.loads(proc.stdout)
+    solver = data["extension_bindings"]["solver"]
+    plugins = {item.get("plugin") for item in (solver.get("home_overlay") or {}).get("chain") or []}
+    assert "home-files" in plugins
 
 
 def test_dest_root_required(tmp_path: Path) -> None:

--- a/tests/plugins/test_home_overlay_default.py
+++ b/tests/plugins/test_home_overlay_default.py
@@ -1,0 +1,58 @@
+"""Core default home_overlay preserves cred allowlist and wraps nxt."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+from bora.plugins.defaults.home_overlay import (
+    copy_home_overlay_tree,
+    default_home_overlay,
+)
+from bora.plugins.slots import HOME_OVERLAY, SlotKind, get_slot_kind
+
+
+def test_home_overlay_is_public_multi() -> None:
+    assert get_slot_kind(HOME_OVERLAY) is SlotKind.MULTI
+
+
+def test_default_creates_cred_then_calls_nxt_then_copies(tmp_path: Path) -> None:
+    seen: list[str] = []
+
+    async def plugin(value):  # type: ignore[no-untyped-def]
+        seen.append("plugin")
+        root = Path(value["cred_root"])
+        dest = root / "home_overlay" / ".config" / "opencode" / "opencode.json"
+        dest.parent.mkdir(parents=True)
+        dest.write_text('{"provider":{}}\n', encoding="utf-8")
+        assert (root / "home").is_dir()
+        return value
+
+    work = tmp_path / "work"
+    work.mkdir()
+    ctx = SimpleNamespace(work_root=work)
+    out = asyncio.run(
+        default_home_overlay(
+            ctx,
+            {"work_root": work, "package_root": tmp_path, "workspace_root": tmp_path / "ws"},
+            plugin,
+        )
+    )
+    assert seen == ["plugin"]
+    home = Path(out["home_root"])
+    assert (home / ".config" / "opencode" / "opencode.json").is_file()
+    assert "home/" in ctx.cred.locator_keys
+
+
+def test_overlay_tree_merges_and_overwrites(tmp_path: Path) -> None:
+    src = tmp_path / "overlay"
+    dest = tmp_path / "home"
+    (src / "a").mkdir(parents=True)
+    (src / "a" / "one.txt").write_text("new\n", encoding="utf-8")
+    (dest / "a").mkdir(parents=True)
+    (dest / "a" / "one.txt").write_text("old\n", encoding="utf-8")
+    (dest / "a" / "keep.txt").write_text("stay\n", encoding="utf-8")
+    copy_home_overlay_tree(src, dest)
+    assert (dest / "a" / "one.txt").read_text(encoding="utf-8") == "new\n"
+    assert (dest / "a" / "keep.txt").read_text(encoding="utf-8") == "stay\n"

--- a/tests/security/test_acp_lock_no_secret.py
+++ b/tests/security/test_acp_lock_no_secret.py
@@ -50,7 +50,7 @@ def test_acp_lock_snapshot_is_safe(tmp_path: Path) -> None:
             "p": {
                 "executor": "acp",
                 "model": "entry-default",
-                "options": {"entry": "codex"},
+                "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}],
                 "api_key": "OPENAI_API_KEY",
             }
         },
@@ -60,6 +60,6 @@ def test_acp_lock_snapshot_is_safe(tmp_path: Path) -> None:
     assert "/Users/" not in payload
     assert "/home/" not in payload
     assert "OPENAI_API_KEY" in payload  # locator ok
-    opts = thaw(lock.agent_profiles)[0]["options"]
+    opts = thaw(lock.agent_profiles)[0]["extensions"][0]["options"]
     assert opts["entry"] == "codex"
     assert "_acp_lock" not in opts

--- a/tests/security/test_acp_lock_no_secret.py
+++ b/tests/security/test_acp_lock_no_secret.py
@@ -51,7 +51,7 @@ def test_acp_lock_snapshot_is_safe(tmp_path: Path) -> None:
                 "executor": "acp",
                 "model": "entry-default",
                 "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}],
-                "api_key": "OPENAI_API_KEY",
+                "api_key": "${OPENAI_API_KEY}",
             }
         },
     )

--- a/tests/security/test_executor_env_projection.py
+++ b/tests/security/test_executor_env_projection.py
@@ -35,7 +35,7 @@ def test_agent_service_with_acp_offline_no_secret_in_evidence(
                 "id": "p1",
                 "executor": "acp",
                 "model": "entry-default",
-                "options": {"entry": "opencode"},
+                "extensions": [{"plugin": "acp", "options": {"entry": "opencode"}}],
             }
         ],
         agent_invocation_limit=1,

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -69,7 +69,7 @@ def _write_evidence(db: Path, run_id: str, *, task_id: str = "alpha") -> Path:
                         "id": "main",
                         "executor": "acp",
                         "model": "test-model",
-                        "options": {"entry": "pi"},
+                        "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}],
                         "capabilities": {"execution_mode": "acp-stdio"},
                     }
                 ],
@@ -413,14 +413,14 @@ def _write_multi_role_evidence(db: Path, run_id: str, *, task_id: str = "alpha")
                         "id": "user-grok",
                         "executor": "acp",
                         "model": "entry-default",
-                        "options": {"entry": "grok"},
+                        "extensions": [{"plugin": "acp", "options": {"entry": "grok"}}],
                         "capabilities": {"execution_mode": "acp-stdio"},
                     },
                     {
                         "id": "service-opencode",
                         "executor": "acp",
                         "model": "glm-5.2",
-                        "options": {"entry": "opencode"},
+                        "extensions": [{"plugin": "acp", "options": {"entry": "opencode"}}],
                         "capabilities": {"execution_mode": "acp-stdio"},
                     },
                 ],
@@ -574,7 +574,7 @@ def test_legacy_usage_cost_only_no_used_as_tokens(tmp_path: Path) -> None:
                     {
                         "id": "main-pi",
                         "executor": "acp",
-                        "options": {"entry": "pi"},
+                        "extensions": [{"plugin": "acp", "options": {"entry": "pi"}}],
                         "capabilities": {"execution_mode": "acp-stdio"},
                     }
                 ],

--- a/website/content/docs/agents/acp-profiles.en.mdx
+++ b/website/content/docs/agents/acp-profiles.en.mdx
@@ -1,23 +1,26 @@
 ---
 title: ACP profiles
-description: "Plug coding agents with executor: acp + options.entry."
+description: "Plug coding agents with executor: acp and - plugin: acp options.entry."
 ---
 
 ## Recommended config
 
 ```yaml
-agent_profiles:
-  - id: main
+# Database profiles.yaml
+bindings:
+  main:
     executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: codex
     model: gpt-5.4-mini
-    options:
-      entry: codex
 ```
 
 | Field | Note |
 | --- | --- |
 | `executor` | Use `acp` for coding agents |
-| `options.entry` | **Required**; discover with `bora executors -v` |
+| `- plugin: acp` / `options.entry` | **Required**; discover with `bora executors -v` |
 | `model` | Model id for that entry |
 | `api_key` | Optional env **name** |
 

--- a/website/content/docs/agents/acp-profiles.mdx
+++ b/website/content/docs/agents/acp-profiles.mdx
@@ -1,24 +1,27 @@
 ---
 title: ACP Profiles
-description: "用 executor: acp + options.entry 接 coding agent。"
+description: "用 executor: acp 与 - plugin: acp 的 options.entry 接 coding agent。"
 ---
 
 ## 推荐配置
 
 ```yaml
-agent_profiles:
-  - id: main
+# Database profiles.yaml
+bindings:
+  main:
     executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: codex
     model: gpt-5.4-mini
-    options:
-      entry: codex
     # api_key: MY_ENV_NAME
 ```
 
 | 字段 | 说明 |
 | --- | --- |
 | `executor` | coding agent 用 `acp`（不要用已废弃的 `executor: codex` 等） |
-| `options.entry` | **必填**；本机可用 id 以 `bora executors -v` 为准 |
+| `- plugin: acp` / `options.entry` | **必填**；本机可用 id 以 `bora executors -v` 为准 |
 | `model` | 交给该 entry 的模型 |
 | `api_key` | 可选；**环境变量名** |
 

--- a/website/content/docs/agents/acp-profiles.mdx
+++ b/website/content/docs/agents/acp-profiles.mdx
@@ -15,7 +15,7 @@ bindings:
         options:
           entry: codex
     model: gpt-5.4-mini
-    # api_key: MY_ENV_NAME
+    # api_key: ${MY_ENV_NAME}
 ```
 
 | 字段 | 说明 |
@@ -23,7 +23,8 @@ bindings:
 | `executor` | coding agent 用 `acp`（不要用已废弃的 `executor: codex` 等） |
 | `- plugin: acp` / `options.entry` | **必填**；本机可用 id 以 `bora executors -v` 为准 |
 | `model` | 交给该 entry 的模型 |
-| `api_key` | 可选；**环境变量名** |
+| `api_key` | 可选；`${ENV_NAME}` locator |
+| `base_url` | 可选；字面 URL 或 `${ENV_NAME}` |
 
 不要在 yaml 里写 command / version / install——版本钉在安装与镜像构建。
 

--- a/website/content/docs/agents/multi-agent.en.mdx
+++ b/website/content/docs/agents/multi-agent.en.mdx
@@ -11,16 +11,21 @@ parameters:
     planner: planner-pi
     worker: worker-codex
 
-agent_profiles:
-  - id: planner-pi
+# Database profiles.yaml
+bindings:
+  planner-pi:
     executor: acp
-    options:
-      entry: pi
+    extensions:
+      - plugin: acp
+        options:
+          entry: pi
     model: …
-  - id: worker-codex
+  worker-codex:
     executor: acp
-    options:
-      entry: codex
+    extensions:
+      - plugin: acp
+        options:
+          entry: codex
     model: …
 ```
 

--- a/website/content/docs/agents/multi-agent.mdx
+++ b/website/content/docs/agents/multi-agent.mdx
@@ -11,16 +11,21 @@ parameters:
     planner: planner-pi
     worker: worker-codex
 
-agent_profiles:
-  - id: planner-pi
+# Database profiles.yaml
+bindings:
+  planner-pi:
     executor: acp
-    options:
-      entry: pi
+    extensions:
+      - plugin: acp
+        options:
+          entry: pi
     model: …
-  - id: worker-codex
+  worker-codex:
     executor: acp
-    options:
-      entry: codex
+    extensions:
+      - plugin: acp
+        options:
+          entry: codex
     model: …
 ```
 

--- a/website/content/docs/author/tutorial.en.mdx
+++ b/website/content/docs/author/tutorial.en.mdx
@@ -38,10 +38,6 @@ provider:
 
 agent_profiles:
   - id: main
-    executor: acp
-    model: gpt-5.4-mini
-    options:
-      entry: codex
 
 limits:
   wall_time_seconds: 300

--- a/website/content/docs/author/tutorial.mdx
+++ b/website/content/docs/author/tutorial.mdx
@@ -98,7 +98,7 @@ Evaluator 读 `evaluation.inputs` 准备好的文件，输出分数 / 判定。
 | 问题                     | 处理                                                     |
 | ------------------------ | -------------------------------------------------------- |
 | `task_id` 和目录名不一致 | 改到一致                                                 |
-| 缺 `options.entry`       | ACP 必填                                                 |
+| 缺 `- plugin: acp` / `entry` | ACP 必填；写在 Database `profiles.yaml`               |
 | docker 无 Dockerfile     | 见 [Docker 与可见性](/docs/author/docker-and-visibility) |
 | 评测找不到 artifact      | harness 是否写出、id 是否对上                            |
 

--- a/website/content/docs/author/tutorial.mdx
+++ b/website/content/docs/author/tutorial.mdx
@@ -43,10 +43,6 @@ provider:
 
 agent_profiles:
   - id: main
-    executor: acp
-    model: gpt-5.4-mini
-    options:
-      entry: codex
 
 limits:
   wall_time_seconds: 300

--- a/website/content/docs/reference/config-fields.en.mdx
+++ b/website/content/docs/reference/config-fields.en.mdx
@@ -29,7 +29,7 @@ Empty suite fails lock.
 | `harness` | `runtime` + `entrypoint` |
 | `parameters` | For harness; common keys: `active_profile`, `harness_timeout_seconds`, `agent_timeout_seconds`, `roles`, `seed` |
 | `provider` | `local` \| `docker` (+ Dockerfile) |
-| `agent_profiles` | ACP needs `options.entry`; `api_key` = env name |
+| `agent_profiles` | Role slots `{id}` only; ACP `entry` lives on Database `- plugin: acp`; `api_key` = env name |
 | `limits` | wall / invokes / env actions / memory |
 | `artifacts` | publishable id + path |
 | `evaluation` | entrypoint, network, inputs, output |
@@ -37,7 +37,7 @@ Empty suite fails lock.
 
 ## Job binding (`profiles.yaml`)
 
-Optional `label` on a role is the Jobs / Hub Agents axis. If omitted: ACP uses `options.entry`, other kinds use `executor`. Never treat `options.agent` as a display name.
+Optional `label` on a role is the Jobs / Hub Agents axis. If omitted: ACP uses `- plugin: acp` / `options.entry`, other kinds use `executor`. Never treat `options.agent` as a display name.
 
 ## Allowed top-level dirs
 

--- a/website/content/docs/reference/config-fields.mdx
+++ b/website/content/docs/reference/config-fields.mdx
@@ -49,8 +49,10 @@ role 上可选 `label`，作为 Jobs / Hub 的 Agents 轴。缺省：ACP 用 `op
 - id: main
   executor: acp
   model: gpt-5.4-mini
-  options:
-    entry: codex
+  extensions:
+    - plugin: acp
+      options:
+        entry: codex
 ```
 
 `bora executors -v` 查 entry 与就绪状态。

--- a/website/content/docs/reference/config-fields.mdx
+++ b/website/content/docs/reference/config-fields.mdx
@@ -29,7 +29,7 @@ description: bora.yaml / task.yaml 字段与校验要点速查。
 | `harness` | `runtime` + `entrypoint`（`模块:函数`） |
 | `parameters` | 给 harness；常见 `active_profile`、`harness_timeout_seconds`、`agent_timeout_seconds`、`roles`、`seed`、`environment_resource` |
 | `provider` | `kind: local\|docker`；docker 要 `environment/Dockerfile` |
-| `agent_profiles` | `{id, executor, model, …}`；ACP 必填 `options.entry`；`api_key` 只写环境变量名 |
+| `agent_profiles` | 成员只写 `{id}`；ACP `entry` 写在 Database `profiles.yaml` 的 `- plugin: acp`；`api_key` 只写环境变量名 |
 | `limits` | wall / agent_invocations / environment_actions / memory_mb |
 | `artifacts.publishable` | id + path + producer |
 | `evaluation` | entrypoint、network、inputs、output.format |
@@ -37,7 +37,7 @@ description: bora.yaml / task.yaml 字段与校验要点速查。
 
 ## Job binding（`profiles.yaml`）
 
-role 上可选 `label`，作为 Jobs / Hub 的 Agents 轴。缺省：ACP 用 `options.entry`，其它 kind 用 `executor`。**不要**把 `options.agent` 当展示名。
+role 上可选 `label`，作为 Jobs / Hub 的 Agents 轴。缺省：ACP 用 `- plugin: acp` 的 `options.entry`，其它 kind 用 `executor`。**不要**把 `options.agent` 当展示名。
 
 ## 成员一级目录白名单
 
@@ -46,13 +46,15 @@ role 上可选 `label`，作为 Jobs / Hub 的 Agents 轴。缺省：ACP 用 `op
 ## ACP profile 片段
 
 ```yaml
-- id: main
-  executor: acp
-  model: gpt-5.4-mini
-  extensions:
-    - plugin: acp
-      options:
-        entry: codex
+# Database profiles.yaml
+bindings:
+  main:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: codex
+    model: gpt-5.4-mini
 ```
 
 `bora executors -v` 查 entry 与就绪状态。

--- a/website/content/docs/run/plugins.en.mdx
+++ b/website/content/docs/run/plugins.en.mdx
@@ -32,16 +32,17 @@ bindings:
     executor: nooa
     extensions:
       - plugin: nooa
-    options:
-      agent: "lib.agents:JsonlAggAgent"
-      method: "run"
+        options:
+          agent: "lib.agents:JsonlAggAgent"
+          method: "run"
 ```
 
 `executor:` selects `provide(executor)` only — it does **not** bake or attach
-other `on:` slots. Add `extensions` on the same role when L1 needs bake /
-trajectory collect (short ids match a path install). ACP-only profiles omit
-`extensions`. Hub publish stores `org/name`; a Hub install records that
-namespaced id, and profiles for that cache row must use the same address.
+other `on:` slots. Plugin knobs live on that plugin's `extensions` row. Add
+`extensions` on the same role when L1 needs bake / trajectory collect (short
+ids match a path install). ACP `entry` lives on `- plugin: acp`. Hub publish
+stores `org/name`; a Hub install records that namespaced id, and profiles for
+that cache row must use the same address.
 
 Use an alternate profiles file at run time without changing Database ACP defaults:
 

--- a/website/content/docs/run/plugins.en.mdx
+++ b/website/content/docs/run/plugins.en.mdx
@@ -96,7 +96,7 @@ off the Attempt image.
 
 ## Relation to ACP
 
-The default coding-agent path remains `executor: acp` + `options.entry`. Plugins are
+The default coding-agent path remains `executor: acp` + `- plugin: acp` / `options.entry`. Plugins are
 **optional** mechanisms beside first-party ACP; the same harness switches only via profiles.
 
 Mechanism contracts live in design docs (`docs/design`); this page does not raise evidence grades.

--- a/website/content/docs/run/plugins.mdx
+++ b/website/content/docs/run/plugins.mdx
@@ -31,12 +31,12 @@ bindings:
     executor: nooa
     extensions:
       - plugin: nooa
-    options:
-      agent: "lib.agents:JsonlAggAgent"
-      method: "run"
+        options:
+          agent: "lib.agents:JsonlAggAgent"
+          method: "run"
 ```
 
-`executor:` 只选 `provide(executor)`，**不**自动 bake 或挂上其它 `on:`。L1 需要 bake / 轨迹收集时，在同一 role 下写 `extensions`（短 id 与路径安装一致）。纯 ACP profile 省略 `extensions`。Hub 发布存 `org/name`；从 Hub 安装后本地 index 记这个带命名空间的 id，该 cache 行的 profiles 必须写同一地址。
+`executor:` 只选 `provide(executor)`，**不**自动 bake 或挂上其它 `on:`。插件 knobs 只写在该插件的 `extensions` 行上。L1 需要 bake / 轨迹收集时，在同一 role 下写 `extensions`（短 id 与路径安装一致）。ACP 的 `entry` 写在 `- plugin: acp`。Hub 发布存 `org/name`；从 Hub 安装后本地 index 记这个带命名空间的 id，该 cache 行的 profiles 必须写同一地址。
 
 运行时用备用 profiles 文件切换，不必改 Database 默认 ACP 配置：
 

--- a/website/content/docs/run/plugins.mdx
+++ b/website/content/docs/run/plugins.mdx
@@ -86,7 +86,7 @@ L1 不要求宿主 extra，只看本 profile `extensions` 是否选中 `image_co
 
 ## 与 ACP 的关系
 
-默认 coding-agent 路径仍是 `executor: acp` + `options.entry`。插件是 **可选** 机制，
+默认 coding-agent 路径仍是 `executor: acp` + `- plugin: acp` / `options.entry`。插件是 **可选** 机制，
 与 ACP first-party 并列；同一 harness 只靠 profiles 切换。
 
 更多机制契约见设计文档（贡献者侧 `docs/design`）；本页不改变证据等级声明。

--- a/website/content/docs/run/switch-agent.en.mdx
+++ b/website/content/docs/run/switch-agent.en.mdx
@@ -16,21 +16,15 @@ Check `engine_ready` / `acp_entry_ready` per ACP entry.
 ## Declare in config
 
 ```yaml
-parameters:
-  active_profile: codex-mini
-
-agent_profiles:
-  - id: codex-mini
+# Database profiles.yaml
+bindings:
+  solver:
     executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: codex
     model: gpt-5.4-mini
-    options:
-      entry: codex
-  - id: pi-mini
-    executor: acp
-    model: zai-coding-cn/glm-5.2
-    api_key: glm_coding_api_key
-    options:
-      entry: pi
 ```
 
 ## Temporary switch

--- a/website/content/docs/run/switch-agent.mdx
+++ b/website/content/docs/run/switch-agent.mdx
@@ -33,7 +33,7 @@ bindings:
   #       options:
   #         entry: pi
   #   model: zai-coding-cn/glm-5.2
-  #   api_key: glm_coding_api_key
+  #   api_key: ${glm_coding_api_key}
 ```
 
 ## 临时切换（不用改文件）

--- a/website/content/docs/run/switch-agent.mdx
+++ b/website/content/docs/run/switch-agent.mdx
@@ -16,21 +16,24 @@ uv run bora executors -v
 ## 配置里声明
 
 ```yaml
-parameters:
-  active_profile: codex-mini
-
-agent_profiles:
-  - id: codex-mini
+# Database profiles.yaml
+bindings:
+  solver:
     executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: codex
     model: gpt-5.4-mini
-    options:
-      entry: codex
-  - id: pi-mini
-    executor: acp
-    model: zai-coding-cn/glm-5.2
-    api_key: glm_coding_api_key   # 环境变量名
-    options:
-      entry: pi
+  # 或换一条 binding / --profiles / --set
+  # solver:
+  #   executor: acp
+  #   extensions:
+  #     - plugin: acp
+  #       options:
+  #         entry: pi
+  #   model: zai-coding-cn/glm-5.2
+  #   api_key: glm_coding_api_key
 ```
 
 ## 临时切换（不用改文件）


### PR DESCRIPTION
Closes #132.

Plugin knobs stay on each `extensions` row. A new multi slot `home_overlay` copies Database overlay files into Attempt HOME. Core does not grow a per-entry catalog synthesizer.

## Behavior
- Factory / `on` handler for plugin `P` sees only `- plugin: P` / `options`. No dual-read of the profile `options` bag.
- ACP `entry` and DSH `composition` / `permission` live on their own rows.
- `--set /bindings/<role>/options/<key>` writes the **executor** plugin row. Other plugins (e.g. `home-files`) stay YAML-only.
- Slot `home_overlay` (multi): Core default builds the cred tree, `await nxt`, then copies `cred_root/home_overlay/.` into actor HOME (L1) or an Attempt-scoped HOME (L0; does not write the user's `~`).
- External `plugins/home-files` registers `on: home_overlay` only. `src` / `dest` fail closed on `..`, absolute paths, `evaluation/`, dest-file/src-dir, and symlink escape.

## Journeys
- `examples/journeys/overlays/` ships complete OpenCode / Pi LiteLLM catalogs (locators, no tokens).
- `examples/journeys/acp-profiles/` binds previously unbound `litellm/...` models via home-files.

## Docs
- Design, website (zh/en), README, skills, and plugin READMEs use the extension-row shape.
- Reader-facing pages have no GitHub issue numbers.

## Verified (local CI equivalents)
- python-core: ruff format / ruff check / pyright / pytest (offline ignore set) — 663 passed
- python-registry: pytest tests/registry — 138 passed, 2 skipped
- hub-app: pnpm lint + build
- website: pnpm build

## Local L1 (not in CI)
- `bora plugin install plugins/home-files`
- `bora run examples/journeys --task terminal-jsonl-agg` with:
  - `profiles.acp.opencode.glm-5.2.yaml` → PASS, `assurance:l1`
  - `profiles.acp.opencode.qwen3.8-max.yaml` → PASS, `assurance:l1`
  - `profiles.acp.pi.qwen3.8-max.yaml` → PASS, `assurance:l1`

## Non-goals (issue)
- Backward compatible profile-level plugin options
- Host-`~` as overlay `src`
- JSON deep-merge
- Baking overlays into `bora-attempt:l1`
- Hub / Viewer UI for overlays