### PR TITLE
feat(plugins): plugin_requires graph and agent-skills overlay

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -130,7 +130,7 @@ BORA/
 │   ├── plugins/               # 扩展点注册表（slots/registry/resolve/defaults/contrib）
 │   │   ├── defaults/          # L0–L5 默认 multi/provide（无 legacy executor 桥）
 │   │   ├── lifecycle.py       # emit helpers：host 在控制点 await chain / provide SPI
-│   │   ├── manifest.py        # bora.plugin/1 + host_requires allowlist
+│   │   ├── manifest.py        # bora.plugin/1 + host_requires / plugin_requires allowlist
 │   │   └── contrib/           # first-party：acp / openai_http / mock（nooa 为外置包）
 │   ├── viewer/                # 本地 Jobs/Trial HTTP API（trials/ 包）
 │   └── adapters/
@@ -168,6 +168,8 @@ BORA/
 ├── plugins/                   # 外置 bora.plugin/1 示例（不进 Core contrib）
 │   ├── nooa/                  # executor provide + image_contribute Ready
 │   ├── dsh/                   # DeepSeek Harness JSON-RPC executor + bake
+│   ├── home-files/            # on: home_overlay 复制原语
+│   ├── agent-skills/          # home_overlay dest 展开（plugin_requires: home-files）
 │   └── slot-probe/            # multi 钩子可观测探针
 ├── tests/
 │   ├── acceptance/

--- a/docs/design/11-extension-plugins.md
+++ b/docs/design/11-extension-plugins.md
@@ -91,8 +91,9 @@ evaluate     → evaluation_input_contribute → evaluation_runtime
 
 - 根 `plugin.yaml`：`plugin_id`、`version`、`slots.provide` / `slots.on` + entry  
 - 可选 `host_requires`（L0 host SPI 构造前提；见下）  
+- 可选 `plugin_requires`（本地 plugin cache 依赖；见下。与 `host_requires` 并列，不是同一列表）  
 - 可选 `docker/Dockerfile.bake`（L1 bake-declared，须本 profile `extensions` 选中 `image_contribute`）  
-- install：`bora plugin install <path|org/name@version>` → `~/.bora/plugins`  
+- install：`bora plugin install <path|org/name@version>` → `~/.bora/plugins`；默认先装 `plugin_requires` 再装被请求的包  
 - Hub/Registry：`package_kind=plugin`；media type `application/vnd.bora.plugin.v1.tar+gzip`  
 - Dataset 与 plugin **fail closed** 区分（Hub 列表过滤 / detail 拒绝混开）
 
@@ -139,15 +140,58 @@ host_requires:
 
 未声明 `host_requires`：插件主张「无宿主 extra」。此时 `host_ready` 仍要求能经工厂到达 `describe()`（registry 持有的是 factory，不得因缺 binary PATH 默认 `true`）。既无声明又看不到 `describe()` → `host_ready: false`。
 
+### `plugin_requires`（插件图，不是 host extra）
+
+`host_requires` 只声明宿主 extra（import / 插件根内文件）。插件之间的依赖另写 **`plugin_requires`**。不要把 `plugin_id` 塞进 `host_requires`。
+
+```yaml
+format: bora.plugin/1
+plugin_id: agent-skills
+version: 0.1.0
+plugin_requires:
+  - plugin_id: home-files              # 短 id：只认 cache / 本地 sibling
+  # - plugin_id: Official/home-files   # Hub 地址：才允许从 Hub 拉
+    hint: "bora plugin install plugins/home-files"
+```
+
+| 规则 | 语义 |
+| --- | --- |
+| 条目允许键 | **allowlist**：`plugin_id`（必填）、`hint`（可选操作者字符串；Core 不执行）。未知键 → `plugin_requires_invalid` |
+| `plugin_id` 语法 | 与 manifest `plugin_id` 相同：短 `name` **或** Hub `org/name`（`normalize_plugin_id`） |
+| 满足条件 | 本地 cache 里存在 **恰好** 该 id 的已安装行。`Official/home-files` 与短 `home-files` **不是** 同一行 |
+| 版本 | 任一已装版本即可。本增量不做 version range / pin |
+| 绑定 | **不**把依赖自动写入 `extensions[]`。profiles 仍显式 opt-in |
+| 省略 | 省略或 `[]` ≡ 今日单树安装 |
+
+**解析只看该行声明的 `plugin_id`。禁止用正在安装的父插件 org 改写短 id**（装 `OrgA/foo` 且依赖写 `bar`，不得变成 `OrgA/bar`）。
+
+| 声明的 `plugin_id` | 解析顺序（先命中先赢） |
+| --- | --- |
+| 短 `name`（无 `/`） | (1) cache 已有 `name` → skip。(2) 仅当 install **源是本地目录**：sibling `<source.parent>/<name>/` 且其 manifest `plugin_id` 就是 `name`。(3) 否则 fail closed。**短 id 永不访问 Hub** |
+| Hub `org/name` | (1) cache 已有 `org/name` → skip。(2) 拉该 **精确** Hub 包 `org/name` 的最新已发布 plugin release。(3) 否则 fail closed。不查 sibling |
+
+`bora plugin install <source>` **默认传递**：先装 `plugin_requires`，再装被请求的包。本增量无 `--no-deps`。成功 JSON 列出被请求的包以及每个已装或已在 cache 的依赖。
+
+其它语义：
+
+- 环（`A → B → A`）在 install **和** lock / materialize fail closed  
+- `bora plugin uninstall` **不**卸依赖  
+- 依赖装失败 → 被请求的包 **不**写入 index（无部分行）  
+- `bora plugin list` / `bora executors`：每个已装插件报告 `plugin_requires` 是否满足；不满足 → 不是 host-ready  
+- `bora lock` / materialize：本 profile `extensions` 点名的每个插件，其 `plugin_requires` 必须已装（exact id）；否则 fail closed  
+- materialize 插件 P 时，先把它声明的每个依赖的包根与 `src/` 放上 `sys.path`，再 import P 的 entry  
+
+外置 `plugins/agent-skills` 是 `home_overlay` 的 dest 展开消费者：声明 `plugin_requires: [{plugin_id: home-files}]`（仓内短 id），调用 `home-files` 的 copy helper，不另造复制引擎。Hub 发布该插件时必须把依赖写成 `<org>/home-files`。authoring 面在插件 README。
+
 ### 三级就绪
 
 | 等级 | 含义 | 来源 |
 | --- | --- | --- |
 | **Recognition** | 本机识别到 `provide(executor)` | `bora plugin install` / `plugin list` / `executors.supported` / lock `extension_bindings` |
-| **L0 host-ready** | 宿主可构造 host SPI | 已安装 + 声明的 `host_requires` 全满足（或无声明且 `describe()` 可达） |
+| **L0 host-ready** | 宿主可构造 host SPI | 已安装 + 声明的 `host_requires` 全满足（或无声明且 `describe()` 可达）**且** `plugin_requires` 全满足 |
 | **L1 bake-declared** | **本 profile** 会走 contribute bake | `extensions` 选中 `image_contribute` 且已安装根有 `docker/Dockerfile.bake` |
 
-`bora executors.host_ready` = **L0 host-ready**（无 package，故不看 `extensions`）。`l1_bake_declared` 在 inventory 上只表示插件 **具备** bake 文件 + 槽；`--probe` 的 L1 就绪还要求本 profile `extensions` 选中了 contribute。不得对插件 PATH 探测 wheel 内二进制（如 `dsh-jsonrpc-agent`）来代替 `host_requires`。
+`bora executors.host_ready` = **L0 host-ready**（无 package，故不看 `extensions`）。`plugin_requires` 是 cache 图，L0 与 L1 `--probe` 都检查。`l1_bake_declared` 在 inventory 上只表示插件 **具备** bake 文件 + 槽；`--probe` 的 L1 就绪还要求本 profile `extensions` 选中了 contribute。不得对插件 PATH 探测 wheel 内二进制（如 `dsh-jsonrpc-agent`）来代替 `host_requires`。
 
 ### First-party vs 外置
 
@@ -194,7 +238,7 @@ extensions:
 
 插在 **cred 投影之后、actor HOME 拷贝之前**。不是 `after_prepare`（后者仍在选镜像 / bake 旁），也不是 `env_inject`。
 
-Core default（低 priority，先跑）：建 cred 树（今日 allowlist）；把 `package_root` / `workspace_root` / `cred_root` 放上 `ctx`/`value`；`await nxt(value)`；再把 `cred_root/home_overlay/.` 拷进 actor `$HOME/`，并完成今日 `prepare_agent_targets` 的其余步骤。插件只在 `nxt` 里写文件，不调 Docker，不发明 PASS。L0 不得写用户真 `~`。
+Core default（低 priority，先跑）：建 cred 树（今日 allowlist）；把 `package_root` / `workspace_root` / `cred_root` 放上 `ctx`/`value`；`hook_home_overlay` 还把本 lock 全部 ACP `options.entry` 收集为 `value.acp_entries`（插件不读 sibling `acp` 行）；`await nxt(value)`；再把 `cred_root/home_overlay/.` 拷进 actor `$HOME/`，并完成今日 `prepare_agent_targets` 的其余步骤。插件只在 `nxt` 里写文件，不调 Docker，不发明 PASS。L0 不得写用户真 `~`。`plugins/agent-skills` 只展开 dest，复制仍走 `home-files`。
 
 ### `extensions` 按 profile 显式 opt-in
 
@@ -264,8 +308,8 @@ Dockerfile 另有文件或其它 `FROM`，或任一选中扩展要 bake，仍走
 
 | 命令 | 行为 |
 | --- | --- |
-| `bora plugin install` | 写 cache / index；可 registry 远程 |
-| `bora plugin list` | 读 index |
+| `bora plugin install` | 写 cache / index；可 registry 远程。默认先解析并安装 `plugin_requires`（短 id = sibling/cache；`org/name` = Hub 精确地址） |
+| `bora plugin list` | 读 index；报告每包 `plugin_requires` 是否满足 |
 | `bora plugin uninstall` | 可逆移除；不改 profiles |
 | `bora plugin publish` | `package_kind=plugin` 上传 Registry |
 | `bora plugin materialize-docs` | 显式拷贝 README/skills；非 silent |
@@ -294,16 +338,19 @@ Dockerfile 另有文件或其它 `FROM`，或任一选中扩展要 bake，仍走
 3. profile / `describe()` 声明的 credential locator **名**在 env 中存在（只查名）
 4. 声明的 `file:` 在已安装插件缓存中存在
 
+另外：走本 profile `extensions` **全部**已绑定插件（不只是 executor）。新检查：`plugin_installed`、`plugin_requires`（cache 图；缺行 → `ready: false`）。
+
 缺 `import` → 类型化 miss（如 `host_import: missing`）+ 插件 `hint`。
 
 #### L1（`provider.kind: docker`）
 
-**不**要求 host extra。检查：
+**不**要求 host extra（`host_requires.import` / `.file` 仍跳过）。检查：
 
 1. 插件已安装
 2. 本 profile `extensions` 选中了 `image_contribute`，且 `Dockerfile.bake` 存在
 3. Docker daemon 可达（`BORA_SKIP_DOCKER=1` 视为不可达）
 4. credential locator **名**存在（parent 投影需要）
+5. 与 L0 相同：走全部已绑定 extension 插件的 `plugin_installed` / `plugin_requires`（这是 plugin cache，不是 host extra）
 
 `executor:` 单独不够。绑定了已安装外置 executor 但未在 `extensions` 点名 contribute → 探针 **不 ready**（与生产 fail closed 一致）。ACP-only（无 `extensions`）不要求 bake；官方 `FROM`-only 包复用 `bora-attempt:l1`。
 
@@ -329,5 +376,5 @@ Dockerfile 另有文件或其它 `FROM`，或任一选中扩展要 bake，仍走
 - 结构地图：[`ARCHITECTURE.md`](../../ARCHITECTURE.md)（plugins 树、emit map）  
 - Owner：[`09-owner-matrix-and-structure.md`](09-owner-matrix-and-structure.md)  
 - Runtime Agent：[`05-runtime/agent-service.md`](05-runtime/agent-service.md)  
-- 示例：`plugins/nooa`、`plugins/dsh`（`options.permission` 为插件自有键，非新 slot）、`plugins/home-files`（`on: home_overlay`）、`plugins/slot-probe`、`examples/journeys/profiles.nooa.yaml`、`examples/journeys/profiles.dsh.yaml`、`examples/journeys/profiles.dsh.read-only.yaml`、`examples/slot-probe/`  
+- 示例：`plugins/nooa`、`plugins/dsh`（`options.permission` 为插件自有键，非新 slot）、`plugins/home-files`（`on: home_overlay` 复制原语）、`plugins/agent-skills`（`home_overlay` dest 展开，`plugin_requires: home-files`）、`plugins/slot-probe`、`examples/journeys/profiles.nooa.yaml`、`examples/journeys/profiles.dsh.yaml`、`examples/journeys/profiles.dsh.read-only.yaml`、`examples/slot-probe/`  
 - 交付跟踪：GitHub Issues（Epic 插件系统）

--- a/examples/journeys/acp-profiles/README.md
+++ b/examples/journeys/acp-profiles/README.md
@@ -11,3 +11,11 @@ uv run bora run examples/journeys --task terminal-jsonl-agg \
 ```
 
 `api_key` is the env locator `litellm_api_key`. Overlay JSON must not embed tokens.
+
+To ship skill folders for a cwd-scanning ACP entry (generic `.agents/skills`):
+
+```bash
+uv run bora plugin install plugins/agent-skills
+uv run bora run examples/journeys --task terminal-jsonl-agg \
+  --profiles examples/journeys/acp-profiles/profiles.acp.grok-build.agent-skills.yaml
+```

--- a/examples/journeys/acp-profiles/profiles.acp.grok-build.agent-skills.yaml
+++ b/examples/journeys/acp-profiles/profiles.acp.grok-build.agent-skills.yaml
@@ -1,0 +1,19 @@
+# ACP job binding for terminal-jsonl-agg.
+# entry: grok-build  model: entry-default
+# Skills land in Attempt HOME and workspace .agents/skills (cwd-scanning).
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: acp
+    extensions:
+      - plugin: acp
+        options:
+          entry: grok-build
+      - plugin: agent-skills
+        options:
+          dest_roots: [home, workspace]
+          skills:
+            - src: overlays/skills/jsonl-agg
+          instructions:
+            - src: overlays/AGENTS.md
+    model: entry-default

--- a/examples/journeys/overlays/AGENTS.md
+++ b/examples/journeys/overlays/AGENTS.md
@@ -1,0 +1,2 @@
+Use the `jsonl-agg` skill in `.agents/skills/jsonl-agg` before writing
+`aggregates.json`. Follow that skill's aggregation rules exactly.

--- a/examples/journeys/overlays/skills/jsonl-agg/SKILL.md
+++ b/examples/journeys/overlays/skills/jsonl-agg/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: jsonl-agg
+description: Aggregate records_*.jsonl in the workspace into aggregates.json
+---
+
+# jsonl-agg
+
+Read every `records_*.jsonl` file in the current working directory. Do not
+invent numbers. Write `aggregates.json` in the cwd with exactly:
+
+```json
+{
+  "top_5_users_by_amount": {
+    "<user>": {"total_amount": <float rounded to 2 decimals>, "total_items": <int>}
+  },
+  "top_5_tags_by_count": {
+    "<tag>": {"count": <int>}
+  }
+}
+```
+
+- Sum `amount` and `items` per `user`. Keep top 5 users by `total_amount`
+  descending. Ties: higher `total_items`, then user name ascending.
+- Count tag occurrences across all `tags` arrays. Keep top 5 tags by count
+  descending. Ties: tag name ascending.
+- After the file is written, reply with the same JSON object or
+  `{"status":"completed"}`.

--- a/examples/journeys/tasks/terminal-jsonl-agg/README.md
+++ b/examples/journeys/tasks/terminal-jsonl-agg/README.md
@@ -14,7 +14,9 @@ v1 **terminal-bench / jsonl-aggregator** case class:
 | ------------- | --------------- | ---------------------------------------- |
 | `terminal-pi` | `pi`            | L1 `docker exec` target (assurance:l1)   |
 
-Profiles: `terminal-pi` (default), `terminal-opencode`, `terminal-grok`.
+Profiles: Database `profiles.yaml` (default ACP mix), `acp-profiles/` overlays
+(including `profiles.acp.grok-build.agent-skills.yaml` for grok-build plus a
+shipped `jsonl-agg` skill).
 
 ```bash
 uv run bora run examples/journeys --task terminal-jsonl-agg

--- a/plugins/agent-skills/README.md
+++ b/plugins/agent-skills/README.md
@@ -43,7 +43,25 @@ extensions:
 | `instructions[]` | `AGENTS.md` and (when `claude-code` is bound) `CLAUDE.md`. |
 | `dest_roots` | Default `[home]`. Authors may add `workspace`. |
 
-`grok-build` uses the generic `.agents/skills/` dests only.
+Skills copy `<src>` → `<root>/<prefix>/<skill-name>/`. Dests are deduped.
+
+| entry | HOME prefix (default) | workspace prefix (opt-in) |
+| --- | --- | --- |
+| always | `.agents/skills/` | `.agents/skills/` |
+| `codex` | `.codex/skills/` | `.codex/skills/` |
+| `claude-code` | `.claude/skills/` | `.claude/skills/` |
+| `opencode` | `.config/opencode/skills/` | `.opencode/skills/` |
+| `pi` | `.pi/agent/skills/` | `.pi/skills/` |
+| `grok-build` | generic `.agents` only | generic `.agents` only |
+
+Instruction files (same bytes as each `instructions[]` src):
+
+| file | when | HOME | workspace |
+| --- | --- | --- | --- |
+| `AGENTS.md` | any `instructions` row | `.codex/AGENTS.md` if lock has `codex` | always workspace root `AGENTS.md` |
+| `CLAUDE.md` | lock has `claude-code` | `.claude/CLAUDE.md` | workspace root `CLAUDE.md` |
+
+Do not drop `AGENTS.md` at `$HOME/AGENTS.md`. Engines do not look there.
 
 ## Run
 

--- a/plugins/agent-skills/README.md
+++ b/plugins/agent-skills/README.md
@@ -1,0 +1,56 @@
+# agent-skills
+
+`bora.plugin/1` that expands Database skill folders and instruction files
+into the dests each bound ACP entry actually reads. Copy stays in
+`home-files`. Registers `on: home_overlay` only. No bake.
+
+Default landing zone is each actor's Attempt `$HOME`. Workspace is opt-in
+for skills (`dest_roots`). Workspace-root `AGENTS.md` is always written
+when an `instructions` row is present.
+
+## Install
+
+```bash
+uv run bora plugin install plugins/agent-skills
+```
+
+That also installs sibling `plugins/home-files` when the cache is empty.
+Install writes `$BORA_HOME/plugins` only. It never rewrites profiles and
+never inserts `home-files` into `extensions[]`.
+
+## Bind
+
+```yaml
+executor: acp
+extensions:
+  - plugin: acp
+    options:
+      entry: grok-build
+  - plugin: agent-skills
+    options:
+      dest_roots: [home, workspace]
+      skills:
+        - src: overlays/skills/jsonl-agg
+      instructions:
+        - src: overlays/AGENTS.md
+```
+
+| Field | Rule |
+| --- | --- |
+| `src` | Relative to Database root. No `..`, no absolute path, no host `~`. |
+| `dest` | Not author-written. Dest comes from the entry table. |
+| `skills[]` | One folder per row. Folder must contain `SKILL.md`. Folder name is the skill name. |
+| `instructions[]` | `AGENTS.md` and (when `claude-code` is bound) `CLAUDE.md`. |
+| `dest_roots` | Default `[home]`. Authors may add `workspace`. |
+
+`grok-build` uses the generic `.agents/skills/` dests only.
+
+## Run
+
+```bash
+uv run bora plugin install plugins/agent-skills
+uv run bora lock examples/journeys --task terminal-jsonl-agg \
+  --profiles examples/journeys/acp-profiles/profiles.acp.grok-build.agent-skills.yaml
+uv run bora run examples/journeys --task terminal-jsonl-agg \
+  --profiles examples/journeys/acp-profiles/profiles.acp.grok-build.agent-skills.yaml
+```

--- a/plugins/agent-skills/plugin.yaml
+++ b/plugins/agent-skills/plugin.yaml
@@ -1,0 +1,11 @@
+format: bora.plugin/1
+plugin_id: agent-skills
+version: 0.1.0
+plugin_requires:
+  - plugin_id: home-files
+    hint: "bora plugin install plugins/home-files"
+slots:
+  "on":
+    - id: home_overlay
+      priority: 120
+      entry: "agent_skills.hooks:build_home_overlay"

--- a/plugins/agent-skills/src/agent_skills/__init__.py
+++ b/plugins/agent-skills/src/agent_skills/__init__.py
@@ -1,0 +1,1 @@
+"""agent-skills: dest fan-out for ACP skill folders. Copy stays in home-files."""

--- a/plugins/agent-skills/src/agent_skills/hooks.py
+++ b/plugins/agent-skills/src/agent_skills/hooks.py
@@ -1,0 +1,190 @@
+"""on: home_overlay factory. Expands dests; copy is home-files.apply_files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from home_files.hooks import apply_files
+
+PLUGIN_ID = "agent-skills"
+DEST_ROOTS = frozenset({"home", "workspace"})
+KNOWN_ACP_ENTRIES = frozenset({"codex", "claude-code", "opencode", "pi", "grok-build"})
+
+# Always-on generic dests, then per-entry extras. grok-build has no extra prefix.
+_SKILL_PREFIX: dict[str, dict[str, str]] = {
+    "_always": {"home": ".agents/skills", "workspace": ".agents/skills"},
+    "codex": {"home": ".codex/skills", "workspace": ".codex/skills"},
+    "claude-code": {"home": ".claude/skills", "workspace": ".claude/skills"},
+    "opencode": {"home": ".config/opencode/skills", "workspace": ".opencode/skills"},
+    "pi": {"home": ".pi/agent/skills", "workspace": ".pi/skills"},
+}
+
+
+class AgentSkillsError(Exception):
+    def __init__(self, message: str, *, kind: str = "agent_skills_invalid") -> None:
+        super().__init__(message)
+        self.kind = kind
+        self.message = message
+
+
+def _dest_roots(raw: Any) -> list[str]:
+    if raw is None:
+        return ["home"]
+    if not isinstance(raw, list) or not raw:
+        raise AgentSkillsError("dest_roots_invalid", kind="agent_skills_options_invalid")
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in raw:
+        if item not in DEST_ROOTS:
+            raise AgentSkillsError(
+                f"dest_root_invalid:{item!r}",
+                kind="agent_skills_options_invalid",
+            )
+        root = str(item)
+        if root not in seen:
+            seen.add(root)
+            out.append(root)
+    return out
+
+
+def _require_src(raw: Any, *, what: str) -> str:
+    if not isinstance(raw, dict):
+        raise AgentSkillsError(f"{what}_not_mapping", kind="agent_skills_options_invalid")
+    src = raw.get("src")
+    if not isinstance(src, str) or not src.strip():
+        raise AgentSkillsError(f"{what}_src_required", kind="agent_skills_path_invalid")
+    if raw.get("dest") is not None:
+        raise AgentSkillsError(f"{what}_dest_not_allowed", kind="agent_skills_options_invalid")
+    return src.strip().replace("\\", "/")
+
+
+def _acp_entries(value: dict[str, Any]) -> list[str]:
+    raw = value.get("acp_entries")
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise AgentSkillsError("acp_entries_invalid", kind="agent_skills_context_missing")
+    out: list[str] = []
+    for item in raw:
+        entry = str(item).strip()
+        if not entry:
+            continue
+        if entry not in KNOWN_ACP_ENTRIES:
+            raise AgentSkillsError(
+                f"unknown_acp_entry:{entry}",
+                kind="agent_skills_entry_invalid",
+            )
+        if entry not in out:
+            out.append(entry)
+    return out
+
+
+def _add(
+    files: list[dict[str, str]],
+    seen: set[tuple[str, str]],
+    *,
+    src: str,
+    dest: str,
+    dest_root: str,
+) -> None:
+    key = (dest_root, dest)
+    if key in seen:
+        return
+    seen.add(key)
+    files.append({"src": src, "dest": dest, "dest_root": dest_root})
+
+
+def expand_files(options: dict[str, Any], value: dict[str, Any]) -> list[dict[str, str]]:
+    """Turn skills/instructions into home-files rows. Dedup dests."""
+    dest_roots = _dest_roots(options.get("dest_roots"))
+    entries = _acp_entries(value)
+    files: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+
+    skills = options.get("skills")
+    if skills is None:
+        skills = []
+    if not isinstance(skills, list):
+        raise AgentSkillsError("skills_must_be_list", kind="agent_skills_options_invalid")
+    prefixes = [_SKILL_PREFIX["_always"]]
+    for entry in entries:
+        extra = _SKILL_PREFIX.get(entry)
+        if extra is not None:
+            prefixes.append(extra)
+    for i, row in enumerate(skills):
+        src = _require_src(row, what=f"skills[{i}]")
+        name = Path(src).name
+        if not name or name in {".", ".."}:
+            raise AgentSkillsError("skill_name_invalid", kind="agent_skills_path_invalid")
+        for dest_root in dest_roots:
+            for prefix_map in prefixes:
+                prefix = prefix_map[dest_root]
+                _add(
+                    files,
+                    seen,
+                    src=src,
+                    dest=f"{prefix}/{name}",
+                    dest_root=dest_root,
+                )
+
+    instructions = options.get("instructions")
+    if instructions is None:
+        instructions = []
+    if not isinstance(instructions, list):
+        raise AgentSkillsError("instructions_must_be_list", kind="agent_skills_options_invalid")
+    for i, row in enumerate(instructions):
+        src = _require_src(row, what=f"instructions[{i}]")
+        fname = Path(src).name
+        if fname == "AGENTS.md":
+            # Instruction exception: always workspace-root AGENTS.md.
+            _add(files, seen, src=src, dest="AGENTS.md", dest_root="workspace")
+            if "codex" in entries and "home" in dest_roots:
+                _add(files, seen, src=src, dest=".codex/AGENTS.md", dest_root="home")
+        elif fname == "CLAUDE.md":
+            if "claude-code" not in entries:
+                continue
+            if "home" in dest_roots:
+                _add(files, seen, src=src, dest=".claude/CLAUDE.md", dest_root="home")
+            _add(files, seen, src=src, dest="CLAUDE.md", dest_root="workspace")
+        else:
+            raise AgentSkillsError(
+                f"instruction_unsupported:{fname}",
+                kind="agent_skills_options_invalid",
+            )
+    return files
+
+
+def _assert_skill_markdown(files: list[dict[str, str]], value: dict[str, Any]) -> None:
+    package_raw = value.get("package_root")
+    if package_raw is None:
+        raise AgentSkillsError("package_root_required", kind="agent_skills_context_missing")
+    package_root = Path(str(package_raw))
+    checked: set[str] = set()
+    for row in files:
+        src = row["src"]
+        if src in checked:
+            continue
+        checked.add(src)
+        folder = package_root / Path(*Path(src).parts)
+        if not folder.is_dir():
+            continue
+        if not (folder / "SKILL.md").is_file():
+            raise AgentSkillsError(
+                f"skill_md_missing:{src}",
+                kind="agent_skills_skill_invalid",
+            )
+
+
+def build_home_overlay(**kwargs: Any) -> Any:
+    options = dict(kwargs.get("options") or {})
+
+    async def handler(ctx: Any, value: Any, nxt: Any) -> Any:
+        del ctx
+        payload = dict(value) if isinstance(value, dict) else {}
+        files = expand_files(options, payload)
+        _assert_skill_markdown(files, payload)
+        apply_files(files, payload)
+        return await nxt(payload)
+
+    return handler

--- a/plugins/agent-skills/src/agent_skills/hooks.py
+++ b/plugins/agent-skills/src/agent_skills/hooks.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from home_files.hooks import apply_files
-
 PLUGIN_ID = "agent-skills"
 DEST_ROOTS = frozenset({"home", "workspace"})
 KNOWN_ACP_ENTRIES = frozenset({"codex", "claude-code", "opencode", "pi", "grok-build"})
@@ -181,6 +179,8 @@ def build_home_overlay(**kwargs: Any) -> Any:
 
     async def handler(ctx: Any, value: Any, nxt: Any) -> Any:
         del ctx
+        from home_files.hooks import apply_files
+
         payload = dict(value) if isinstance(value, dict) else {}
         files = expand_files(options, payload)
         _assert_skill_markdown(files, payload)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ asyncio_default_fixture_loop_scope = "function"
 
 [tool.pyright]
 include = ["src", "tests"]
-extraPaths = ["plugins/nooa/src", "plugins/dsh/src", "plugins/home-files/src", "plugins/miniswe/src"]
+extraPaths = ["plugins/nooa/src", "plugins/dsh/src", "plugins/home-files/src", "plugins/agent-skills/src", "plugins/miniswe/src"]
 pythonVersion = "3.12"
 typeCheckingMode = "standard"
 venvPath = "."

--- a/skills/bora-plugin/SKILL.md
+++ b/skills/bora-plugin/SKILL.md
@@ -49,7 +49,9 @@ Handlers are **awaited** at the control point with a live `ctx`. Do not dump
 | Credential **projection** (locator → scoped env) | Use only projected env | Secrets in lock / plugin.yaml / evidence |
 
 `bora plugin install` writes **only** `$BORA_HOME/plugins` (default `~/.bora/plugins`).
-It **never** rewrites `profiles.yaml` / `task.yaml` / harness.
+It **never** rewrites `profiles.yaml` / `task.yaml` / harness. A declared
+`plugin_requires` row is installed first: short `name` is cache or local
+sibling only (never Hub); `org/name` fetches that exact Hub package.
 
 ### Recognition ≠ L0 host-ready ≠ L1 bake-declared
 

--- a/src/bora/adapters/executor_inventory.py
+++ b/src/bora/adapters/executor_inventory.py
@@ -143,6 +143,7 @@ def _describe_plugin_executor(
         installed_plugin,
         l1_bake_declared,
     )
+    from bora.plugins.plugin_requires import plugin_requires_satisfied
 
     found = installed_plugin(kind)
     l1_declared = False
@@ -153,7 +154,10 @@ def _describe_plugin_executor(
     if found is not None:
         manifest, root = found
         l1_declared = l1_bake_declared(manifest, root)
-        if manifest.host_requires:
+        requires_ok = plugin_requires_satisfied(manifest.plugin_requires)
+        if not requires_ok:
+            host_ready = False
+        elif manifest.host_requires:
             host_ready = host_requires_satisfied(manifest.host_requires, root=root)
         elif caps is not None:
             host_ready = True

--- a/src/bora/application/attempt/extension_hooks.py
+++ b/src/bora/application/attempt/extension_hooks.py
@@ -14,9 +14,11 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import logging
+from collections.abc import Mapping
 from typing import Any
 
 from bora.config.model import LockedTaskConfig, thaw
+from bora.config.profiles import acp_entry_from_binding
 from bora.plugins.bootstrap import ensure_bootstrapped
 from bora.plugins.defaults.home_overlay import PLUGIN_ID as DEFAULT_PLUGIN_ID
 from bora.plugins.defaults.home_overlay import default_home_overlay
@@ -101,6 +103,29 @@ def _per_profile_graphs(lock: LockedTaskConfig, *, materialize: bool) -> list[Ex
     return graphs
 
 
+def acp_entries_from_lock(lock: LockedTaskConfig) -> list[str]:
+    """Unique ACP ``options.entry`` values on this lock (job overlay + profiles)."""
+    seen: list[str] = []
+
+    def add(binding: Mapping[str, Any]) -> None:
+        entry = acp_entry_from_binding(binding)
+        if entry and entry not in seen:
+            seen.append(entry)
+
+    overlay = thaw(lock.job_overlay) or {}
+    bindings = overlay.get("bindings") if isinstance(overlay, Mapping) else None
+    if isinstance(bindings, Mapping):
+        for row in bindings.values():
+            if isinstance(row, Mapping):
+                add(row)
+    profiles = thaw(lock.agent_profiles) if lock.agent_profiles else []
+    if isinstance(profiles, list):
+        for row in profiles:
+            if isinstance(row, Mapping):
+                add(row)
+    return seen
+
+
 def hook_home_overlay(
     lock: LockedTaskConfig,
     value: Any = None,
@@ -117,10 +142,13 @@ def hook_home_overlay(
                 if href.plugin_id != DEFAULT_PLUGIN_ID:
                     plugin_handlers.append(href)
 
+        payload = dict(value) if isinstance(value, dict) else {}
+        payload["acp_entries"] = acp_entries_from_lock(lock)
+
         async def nxt(v: Any) -> Any:
             return await run_handlers(plugin_handlers, v, ctx=ctx)
 
-        return await default_home_overlay(ctx, value, nxt)
+        return await default_home_overlay(ctx, payload, nxt)
 
     try:
         return _run(_emit())

--- a/src/bora/application/attempt/probe_command.py
+++ b/src/bora/application/attempt/probe_command.py
@@ -267,9 +267,7 @@ def _probe_extension_plugins(lock: LockedTaskConfig) -> list[dict[str, Any]]:
         if found is None:
             continue
         manifest, _root = found
-        checks.extend(
-            evaluate_plugin_requires(manifest.plugin_requires, plugin_id=plugin_id)
-        )
+        checks.extend(evaluate_plugin_requires(manifest.plugin_requires, plugin_id=plugin_id))
     return checks
 
 

--- a/src/bora/application/attempt/probe_command.py
+++ b/src/bora/application/attempt/probe_command.py
@@ -25,6 +25,7 @@ from bora.plugins.host_requires import (
     l1_bake_declared,
     locator_names_present,
 )
+from bora.plugins.plugin_requires import evaluate_plugin_requires
 from bora.runtime.offline import is_offline_agent
 
 DockerProbe = Callable[[], bool]
@@ -73,6 +74,38 @@ def bound_bindings(lock: LockedTaskConfig) -> list[dict[str, Any]]:
         if entry:
             item["entry"] = entry
         rows.append(item)
+    return rows
+
+
+def bound_extension_plugins(lock: LockedTaskConfig) -> list[dict[str, str]]:
+    """Every ``extensions[].plugin`` (and executor) named on the locked job."""
+    overlay = thaw(lock.job_overlay) or {}
+    bindings = overlay.get("bindings") if isinstance(overlay, Mapping) else None
+    if not isinstance(bindings, Mapping):
+        return []
+    rows: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for role, row in bindings.items():
+        if not isinstance(row, Mapping):
+            continue
+        role_id = str(role)
+        candidates: list[str] = []
+        extensions = row.get("extensions")
+        if isinstance(extensions, Sequence) and not isinstance(extensions, (str, bytes)):
+            for item in extensions:
+                if isinstance(item, Mapping):
+                    plugin = str(item.get("plugin") or "").strip()
+                    if plugin:
+                        candidates.append(plugin)
+        executor = str(row.get("executor") or "").strip()
+        if executor:
+            candidates.append(executor)
+        for plugin in candidates:
+            key = (role_id, plugin)
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append({"role": role_id, "plugin": plugin})
     return rows
 
 
@@ -202,6 +235,44 @@ def _probe_first_party(
     return checks
 
 
+def _probe_extension_plugins(lock: LockedTaskConfig) -> list[dict[str, Any]]:
+    """plugin_installed + plugin_requires for every bound extension (L0 and L1)."""
+    checks: list[dict[str, Any]] = []
+    seen_plugins: set[str] = set()
+    for row in bound_extension_plugins(lock):
+        plugin_id = row["plugin"]
+        if plugin_id in seen_plugins:
+            continue
+        seen_plugins.add(plugin_id)
+        if plugin_id in FIRST_PARTY_KINDS:
+            checks.append(
+                {
+                    "id": "plugin_installed",
+                    "ok": True,
+                    "plugin": plugin_id,
+                    "role": row["role"],
+                    "source": "first-party",
+                }
+            )
+            continue
+        found = installed_plugin(plugin_id)
+        checks.append(
+            {
+                "id": "plugin_installed",
+                "ok": found is not None,
+                "plugin": plugin_id,
+                "role": row["role"],
+            }
+        )
+        if found is None:
+            continue
+        manifest, _root = found
+        checks.extend(
+            evaluate_plugin_requires(manifest.plugin_requires, plugin_id=plugin_id)
+        )
+    return checks
+
+
 def probe_locked(
     lock: LockedTaskConfig,
     *,
@@ -238,6 +309,7 @@ def probe_locked(
                     selected_contribute=selected_contribute,
                 )
             )
+    checks.extend(_probe_extension_plugins(lock))
     ready = all(bool(c.get("ok")) for c in checks)
     return {
         "ready": ready,

--- a/src/bora/application/composition.py
+++ b/src/bora/application/composition.py
@@ -125,6 +125,8 @@ def build_plugin_commands() -> Any:
         (),
         {
             "install_plugin_from_registry": install.install_plugin_from_registry,
+            "fetch_latest_plugin": install.fetch_latest_plugin,
+            "cleanup_plugin_tmp": install._cleanup_tmp,
             "publish_plugin": publish.publish_plugin,
         },
     )()

--- a/src/bora/application/plugin_ops/plugin_install_remote.py
+++ b/src/bora/application/plugin_ops/plugin_install_remote.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from typing import Any
 
 from bora.config.errors import ConfigError
-from bora.plugins.store import install_from_path
+from bora.plugins.install import install_extracted_hub
+from bora.plugins.plugin_requires import PluginRequiresError
 from bora.registry.archive import extract_archive
 from bora.registry.client import RegistryError
 from bora.registry.plugin_package import PLUGIN_MEDIA_TYPE
@@ -16,6 +17,7 @@ from bora.registry.plugin_package import PLUGIN_MEDIA_TYPE
 class PluginInstallCommand:
     def __init__(self, client_factory: Any) -> None:
         self._client_factory = client_factory
+        self._tmp_dirs: list[tempfile.TemporaryDirectory[str]] = []  # kept until install copies
 
     def install_plugin_from_registry(
         self,
@@ -37,23 +39,96 @@ class PluginInstallCommand:
         if not package_id or not ver_or_digest:
             raise ConfigError("invalid_ref", "empty package_id or version", location=locator)
 
-        client = self._client_factory(
+        client = self._bind_client(registry_url=registry_url, token=token)
+        try:
+            extract_dir = self._download_plugin(
+                client,
+                package_id=package_id,
+                version=None if ver_or_digest.startswith("sha256:") else ver_or_digest,
+                package_digest=ver_or_digest if ver_or_digest.startswith("sha256:") else None,
+                location=locator,
+            )
+            result = install_extracted_hub(
+                extract_dir,
+                plugin_id=package_id,
+                hub_fetch=lambda pid: self.fetch_latest_plugin(
+                    pid, registry_url=registry_url, token=token
+                ),
+            )
+        except PluginRequiresError as exc:
+            raise ConfigError(exc.kind, exc.message, location=locator) from exc
+        except RegistryError as exc:
+            raise ConfigError(exc.code, exc.message, location="registry") from exc
+        finally:
+            self._cleanup_tmp()
+        summary = result.as_cli_dict()
+        summary["from"] = locator
+        return summary
+
+    def fetch_latest_plugin(
+        self,
+        package_id: str,
+        *,
+        registry_url: str | None = None,
+        token: str | None = None,
+    ) -> Path:
+        """Extract the latest published plugin release of *package_id* (exact Hub id)."""
+        client = self._bind_client(registry_url=registry_url, token=token)
+        try:
+            versions = client.list_package_versions(package_id)
+        except RegistryError as exc:
+            raise ConfigError(exc.code, exc.message, location="registry") from exc
+        published = [row for row in versions if not row.is_draft]
+        if not published:
+            raise ConfigError(
+                "plugin_requires_unsatisfied",
+                f"no published plugin release for {package_id!r}",
+                location=package_id,
+            )
+        latest = max(published, key=lambda row: (row.created_at, row.version))
+        return self._download_plugin(
+            client,
+            package_id=package_id,
+            version=latest.version,
+            package_digest=None,
+            location=package_id,
+        )
+
+    def _bind_client(
+        self,
+        *,
+        registry_url: str | None,
+        token: str | None,
+    ) -> Any:
+        return self._client_factory(
             registry_url=registry_url,
             token=token,
             require_token=True,
         )
+
+    def _download_plugin(
+        self,
+        client: Any,
+        *,
+        package_id: str,
+        version: str | None,
+        package_digest: str | None,
+        location: str,
+    ) -> Path:
         try:
-            if ver_or_digest.startswith("sha256:"):
-                meta = client.get_metadata(database_id=package_id, package_digest=ver_or_digest)
+            if package_digest:
+                meta = client.get_metadata(database_id=package_id, package_digest=package_digest)
             else:
-                meta = client.get_metadata(database_id=package_id, version=ver_or_digest)
+                meta = client.get_metadata(database_id=package_id, version=version)
             if meta.media_type != PLUGIN_MEDIA_TYPE:
                 raise ConfigError(
                     "invalid_package_kind",
                     f"release is not a plugin (media_type={meta.media_type})",
-                    location=locator,
+                    location=location,
                 )
-            archive_path = Path(tempfile.mkdtemp(prefix="bora-plugin-dl-")) / "plugin.tar.gz"
+            tmp = tempfile.TemporaryDirectory(prefix="bora-plugin-dl-")
+            self._tmp_dirs.append(tmp)
+            archive_path = Path(tmp.name) / "plugin.tar.gz"
             client.fetch_content(
                 database_id=package_id,
                 package_digest=meta.package_digest,
@@ -61,18 +136,13 @@ class PluginInstallCommand:
             )
         except RegistryError as exc:
             raise ConfigError(exc.code, exc.message, location="registry") from exc
+        extract_dir = Path(tmp.name) / "pkg"
+        extract_dir.mkdir()
+        extract_archive(archive_path, extract_dir)
+        archive_path.unlink(missing_ok=True)
+        return extract_dir
 
-        with tempfile.TemporaryDirectory(prefix="bora-plugin-") as tmp:
-            extract_dir = Path(tmp) / "pkg"
-            extract_dir.mkdir()
-            extract_archive(archive_path, extract_dir)
-            archive_path.unlink(missing_ok=True)
-            entry = install_from_path(extract_dir, plugin_id=package_id)
-        return {
-            "ok": True,
-            "plugin_id": entry.plugin_id,
-            "version": entry.version,
-            "digest": entry.digest,
-            "path": entry.path,
-            "from": locator,
-        }
+    def _cleanup_tmp(self) -> None:
+        while self._tmp_dirs:
+            tmp = self._tmp_dirs.pop()
+            tmp.cleanup()

--- a/src/bora/cli/cmd_plugin.py
+++ b/src/bora/cli/cmd_plugin.py
@@ -41,8 +41,9 @@ def plugin_install(
 ) -> None:
     """Install a plugin into the local cache (never edits profiles)."""
     from bora.config.errors import ConfigError
+    from bora.plugins.install import install_from_local
     from bora.plugins.manifest import PluginManifestError
-    from bora.plugins.store import install_from_path
+    from bora.plugins.plugin_requires import PluginRequiresError
 
     # Registry locator: contains @ and does not exist as a local path.
     src_path = Path(source)
@@ -62,27 +63,33 @@ def plugin_install(
         typer.echo(json.dumps(summary, sort_keys=True))
         return
 
+    from bora.application.composition import build_plugin_commands
+
+    cmds = build_plugin_commands()
+
+    def _hub_fetch(package_id: str) -> Path:
+        return cmds.fetch_latest_plugin(package_id)
+
     try:
-        entry = install_from_path(src_path)
+        result = install_from_local(src_path, hub_fetch=_hub_fetch)
+    except PluginRequiresError as exc:
+        typer.echo(json.dumps({"ok": False, "error": exc.kind, "message": exc.message}), err=True)
+        raise typer.Exit(code=2) from exc
     except PluginManifestError as exc:
         typer.echo(json.dumps({"ok": False, "error": exc.kind, "message": exc.message}), err=True)
+        raise typer.Exit(code=2) from exc
+    except ConfigError as exc:
+        typer.echo(
+            json.dumps({"ok": False, "error": exc.error_code, "message": str(exc)}),
+            err=True,
+        )
         raise typer.Exit(code=2) from exc
     except OSError as exc:
         typer.echo(json.dumps({"ok": False, "error": "io_error", "message": str(exc)}), err=True)
         raise typer.Exit(code=2) from exc
-    typer.echo(
-        json.dumps(
-            {
-                "ok": True,
-                "plugin_id": entry.plugin_id,
-                "version": entry.version,
-                "digest": entry.digest,
-                "path": entry.path,
-                "slots_summary": entry.slots_summary,
-            },
-            sort_keys=True,
-        )
-    )
+    finally:
+        cmds.cleanup_plugin_tmp()
+    typer.echo(json.dumps(result.as_cli_dict(), sort_keys=True))
 
 
 @plugin_app.command("publish")
@@ -111,9 +118,10 @@ def plugin_publish(
 @plugin_app.command("list")
 def plugin_list() -> None:
     """List installed plugins from the local index."""
+    from bora.plugins.plugin_requires import list_row_with_requires
     from bora.plugins.store import list_installed
 
-    rows = [e.as_dict() for e in list_installed()]
+    rows = [list_row_with_requires(e) for e in list_installed()]
     typer.echo(json.dumps({"ok": True, "plugins": rows}, sort_keys=True))
 
 

--- a/src/bora/config/load_and_lock.py
+++ b/src/bora/config/load_and_lock.py
@@ -11,7 +11,7 @@ Pure helpers: ``constants``, ``yaml_io``, ``overrides``, ``digest``, ``validate`
 from __future__ import annotations
 
 import copy
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +47,46 @@ from bora.config.validate import (
 from bora.config.yaml_io import deep_merge, parse_yaml
 
 
+def _bound_plugin_ids(profile: Mapping[str, Any]) -> list[str]:
+    ids: list[str] = []
+    seen: set[str] = set()
+
+    def add(raw: object) -> None:
+        plugin_id = str(raw or "").strip()
+        if plugin_id and plugin_id not in seen:
+            seen.add(plugin_id)
+            ids.append(plugin_id)
+
+    add(profile.get("executor"))
+    rows = profile.get("extensions")
+    if isinstance(rows, Sequence) and not isinstance(rows, (str, bytes)):
+        for item in rows:
+            if isinstance(item, Mapping):
+                add(item.get("plugin"))
+    return ids
+
+
+def _assert_bound_plugin_requires(profile: Mapping[str, Any]) -> None:
+    from bora.plugins.host_requires import installed_plugin
+    from bora.plugins.plugin_requires import (
+        PluginRequiresError,
+        assert_plugin_requires_installed,
+    )
+
+    for plugin_id in _bound_plugin_ids(profile):
+        found = installed_plugin(plugin_id)
+        if found is None:
+            continue
+        try:
+            assert_plugin_requires_installed(found[0])
+        except PluginRequiresError as exc:
+            raise ConfigError(
+                exc.kind,
+                f"extension resolve failed for profile {profile.get('id')!r}: {exc}",
+                location=f"/agent_profiles/{profile.get('id')}/plugin_requires",
+            ) from exc
+
+
 def _resolve_extension_bindings(
     profiles_raw: list[Any],
 ) -> dict[str, dict[str, Any]] | None:
@@ -76,8 +116,11 @@ def _resolve_extension_bindings(
         if not intent.profile_id:
             intent.profile_id = pid.strip()
         try:
+            _assert_bound_plugin_requires(profile)
             # Dry-run factory so missing plugin options fail at lock, not mid-Attempt.
             graph = resolve_extensions(intent, registry, materialize=True)
+        except ConfigError:
+            raise
         except (ExtensionRegistryError, ExtensionMaterializeError) as exc:
             raise ConfigError(
                 ERROR_INVALID_SCHEMA,

--- a/src/bora/plugins/install.py
+++ b/src/bora/plugins/install.py
@@ -116,7 +116,8 @@ def _install_tree(
             items.append(item)
     prior = load_index().find(index_id)
     entry = install_from_path(source, plugin_id=index_id)
-    status = "already_present" if prior is not None and prior.digest == entry.digest else "installed"
+    same_digest = prior is not None and prior.digest == entry.digest
+    status = "already_present" if same_digest else "installed"
     if index_id not in seen:
         items.append(
             InstalledItem(

--- a/src/bora/plugins/install.py
+++ b/src/bora/plugins/install.py
@@ -1,0 +1,232 @@
+"""Transitive ``bora plugin install`` (plugin_requires first, then the request)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from bora.plugins.host_requires import installed_plugin
+from bora.plugins.manifest import (
+    PluginManifestError,
+    load_manifest,
+    split_plugin_id,
+)
+from bora.plugins.plugin_requires import PluginRequiresError, assert_no_plugin_requires_cycle
+from bora.plugins.store import IndexEntry, install_from_path, load_index
+
+HubFetch = Callable[[str], Path]
+
+
+@dataclass
+class InstalledItem:
+    plugin_id: str
+    version: str
+    digest: str
+    path: str
+    status: str  # installed | already_present
+
+
+@dataclass
+class InstallResult:
+    entry: IndexEntry
+    items: list[InstalledItem] = field(default_factory=list)
+
+    def as_cli_dict(self) -> dict[str, object]:
+        return {
+            "ok": True,
+            "plugin_id": self.entry.plugin_id,
+            "version": self.entry.version,
+            "digest": self.entry.digest,
+            "path": self.entry.path,
+            "slots_summary": self.entry.slots_summary,
+            "installed": [
+                {
+                    "digest": item.digest,
+                    "plugin_id": item.plugin_id,
+                    "status": item.status,
+                    "version": item.version,
+                }
+                for item in self.items
+            ],
+        }
+
+
+def install_from_local(source: Path, *, hub_fetch: HubFetch | None = None) -> InstallResult:
+    """Install a local plugin directory and its ``plugin_requires``."""
+    root = source.expanduser().resolve(strict=False)
+    manifest = load_manifest(root)
+    return _install_tree(
+        root,
+        index_id=manifest.plugin_id,
+        source_kind="local",
+        stack=(),
+        hub_fetch=hub_fetch,
+    )
+
+
+def install_extracted_hub(
+    source: Path,
+    *,
+    plugin_id: str,
+    hub_fetch: HubFetch | None = None,
+) -> InstallResult:
+    """Install an extracted Hub tree under the exact ``org/name`` cache id."""
+    root = source.expanduser().resolve(strict=False)
+    return _install_tree(
+        root,
+        index_id=plugin_id,
+        source_kind="hub",
+        stack=(),
+        hub_fetch=hub_fetch,
+    )
+
+
+def _install_tree(
+    source: Path,
+    *,
+    index_id: str,
+    source_kind: str,
+    stack: tuple[str, ...],
+    hub_fetch: HubFetch | None,
+) -> InstallResult:
+    if index_id in stack:
+        chain = " -> ".join((*stack, index_id))
+        raise PluginRequiresError(
+            f"plugin_requires cycle: {chain}",
+            kind="plugin_requires_cycle",
+        )
+    manifest = load_manifest(source)
+    nxt = (*stack, index_id)
+    items: list[InstalledItem] = []
+    seen: set[str] = set()
+    for req in manifest.plugin_requires:
+        dep = _resolve_require(
+            req.plugin_id,
+            source=source,
+            source_kind=source_kind,
+            stack=nxt,
+            hub_fetch=hub_fetch,
+            hint=req.hint,
+        )
+        for item in dep.items:
+            if item.plugin_id in seen:
+                continue
+            seen.add(item.plugin_id)
+            items.append(item)
+    prior = load_index().find(index_id)
+    entry = install_from_path(source, plugin_id=index_id)
+    status = "already_present" if prior is not None and prior.digest == entry.digest else "installed"
+    if index_id not in seen:
+        items.append(
+            InstalledItem(
+                plugin_id=entry.plugin_id,
+                version=entry.version,
+                digest=entry.digest,
+                path=entry.path,
+                status=status,
+            )
+        )
+    return InstallResult(entry=entry, items=items)
+
+
+def _resolve_require(
+    plugin_id: str,
+    *,
+    source: Path,
+    source_kind: str,
+    stack: tuple[str, ...],
+    hub_fetch: HubFetch | None,
+    hint: str | None,
+) -> InstallResult:
+    if plugin_id in stack:
+        chain = " -> ".join((*stack, plugin_id))
+        raise PluginRequiresError(
+            f"plugin_requires cycle: {chain}",
+            kind="plugin_requires_cycle",
+        )
+    cached = load_index().find(plugin_id)
+    if cached is not None:
+        assert_no_plugin_requires_cycle(plugin_id, stack=stack)
+        return InstallResult(entry=cached, items=[_item_from_entry(cached, "already_present")])
+
+    org, name = split_plugin_id(plugin_id)
+    if org is None:
+        if source_kind != "local":
+            raise _unsatisfied(plugin_id, hint, "short plugin_id is not in cache (no Hub guess)")
+        sibling = source.parent / name
+        if not sibling.is_dir():
+            raise _unsatisfied(plugin_id, hint, f"sibling missing: {sibling.name}")
+        try:
+            sibling_manifest = load_manifest(sibling)
+        except PluginManifestError as exc:
+            raise _unsatisfied(plugin_id, hint, f"sibling is not a plugin: {exc.message}") from exc
+        if sibling_manifest.plugin_id != name:
+            raise _unsatisfied(
+                plugin_id,
+                hint,
+                f"sibling plugin_id is {sibling_manifest.plugin_id!r}, want {name!r}",
+            )
+        return _install_tree(
+            sibling,
+            index_id=name,
+            source_kind="local",
+            stack=stack,
+            hub_fetch=hub_fetch,
+        )
+
+    if hub_fetch is None:
+        raise _unsatisfied(plugin_id, hint, "Hub locator requires a registry fetch")
+    extracted = hub_fetch(plugin_id)
+    return _install_tree(
+        extracted,
+        index_id=plugin_id,
+        source_kind="hub",
+        stack=stack,
+        hub_fetch=hub_fetch,
+    )
+
+
+def _item_from_entry(entry: IndexEntry, status: str) -> InstalledItem:
+    return InstalledItem(
+        plugin_id=entry.plugin_id,
+        version=entry.version,
+        digest=entry.digest,
+        path=entry.path,
+        status=status,
+    )
+
+
+def _unsatisfied(plugin_id: str, hint: str | None, detail: str) -> PluginRequiresError:
+    suffix = f" ({hint})" if hint else ""
+    return PluginRequiresError(
+        f"plugin_requires {plugin_id!r} unsatisfied: {detail}{suffix}",
+        kind="plugin_requires_unsatisfied",
+    )
+
+
+def required_package_roots(plugin_id: str) -> list[Path]:
+    """Installed package roots for *plugin_id* and its requires (cycle-safe)."""
+    roots: list[Path] = []
+    seen: set[str] = set()
+
+    def walk(pid: str, stack: tuple[str, ...]) -> None:
+        if pid in stack:
+            chain = " -> ".join((*stack, pid))
+            raise PluginRequiresError(
+                f"plugin_requires cycle: {chain}",
+                kind="plugin_requires_cycle",
+            )
+        if pid in seen:
+            return
+        found = installed_plugin(pid)
+        if found is None:
+            return
+        seen.add(pid)
+        _manifest, root = found
+        roots.append(root)
+        for item in _manifest.plugin_requires:
+            walk(item.plugin_id, (*stack, pid))
+
+    walk(plugin_id, ())
+    return roots

--- a/src/bora/plugins/load_installed.py
+++ b/src/bora/plugins/load_installed.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import importlib
 import sys
+from collections.abc import Sequence
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
+from bora.plugins.host_requires import installed_plugin
 from bora.plugins.manifest import PluginManifest, PluginManifestError, load_manifest
+from bora.plugins.plugin_requires import PluginRequiresError, assert_no_plugin_requires_cycle
 from bora.plugins.registry import ExtensionRegistry
 from bora.plugins.slots import get_slot_kind
 from bora.plugins.store import list_installed, resolve_package_root
@@ -21,13 +24,17 @@ class PluginLoadError(Exception):
         self.message = message
 
 
-def _import_entry(package_root: Path, entry: str) -> Any:
-    """Load ``module:attr`` with *package_root* (and package_root/src) on sys.path."""
+def _import_entry(package_root: Path, entry: str, extra_roots: Sequence[Path] = ()) -> Any:
+    """Load ``module:attr`` with required neighbors then *package_root* on sys.path."""
     if ":" not in entry:
         raise PluginLoadError(f"bad entry {entry!r}", kind="plugin_entry_invalid")
     mod_name, attr = entry.split(":", 1)
     added: list[str] = []
-    for p in (package_root, package_root / "src"):
+    roots: list[Path] = []
+    for extra in extra_roots:
+        roots.extend((extra, extra / "src"))
+    roots.extend((package_root, package_root / "src"))
+    for p in roots:
         s = str(p.resolve(strict=False))
         if p.is_dir() and s not in sys.path:
             sys.path.insert(0, s)
@@ -53,6 +60,21 @@ def _manifest_with_index_id(manifest: PluginManifest, plugin_id: str) -> PluginM
     return replace(manifest, plugin_id=plugin_id)
 
 
+def _required_roots(manifest: PluginManifest) -> list[Path]:
+    """Package roots of declared plugin_requires that are already cached."""
+    try:
+        assert_no_plugin_requires_cycle(manifest.plugin_id)
+    except PluginRequiresError as exc:
+        raise PluginLoadError(exc.message, kind=exc.kind) from exc
+    roots: list[Path] = []
+    for item in manifest.plugin_requires:
+        found = installed_plugin(item.plugin_id)
+        if found is None:
+            continue
+        roots.append(found[1])
+    return roots
+
+
 def register_manifest(
     registry: ExtensionRegistry,
     manifest: Any,
@@ -62,6 +84,7 @@ def register_manifest(
     source: str = "installed",
 ) -> None:
     """Register all provide/on entries from a loaded manifest."""
+    extra_roots = _required_roots(manifest)
     for slot_entry in manifest.provide:
         kind = get_slot_kind(slot_entry.id)
         if kind.value != "provide":
@@ -69,7 +92,7 @@ def register_manifest(
                 f"slot {slot_entry.id!r} is multi; cannot provide()",
                 kind="plugin_slot_kind_mismatch",
             )
-        factory = _import_entry(package_root, slot_entry.entry)
+        factory = _import_entry(package_root, slot_entry.entry, extra_roots)
         registry.provide(
             slot_entry.id,
             manifest.plugin_id,
@@ -87,7 +110,7 @@ def register_manifest(
                 f"slot {slot_entry.id!r} is provide; cannot on()",
                 kind="plugin_slot_kind_mismatch",
             )
-        handler = _import_entry(package_root, slot_entry.entry)
+        handler = _import_entry(package_root, slot_entry.entry, extra_roots)
         registry.on(
             slot_entry.id,
             manifest.plugin_id,

--- a/src/bora/plugins/manifest.py
+++ b/src/bora/plugins/manifest.py
@@ -16,6 +16,7 @@ DEFAULT_OFFICIAL_ORG = "official"
 # Same slash form as Dataset database_id. Not org.name. Official is mixed-case.
 _PLUGIN_ID_SEGMENT = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$")
 HOST_REQUIRES_KEYS = frozenset({"import", "file", "hint"})
+PLUGIN_REQUIRES_KEYS = frozenset({"plugin_id", "hint"})
 
 
 class PluginManifestError(Exception):
@@ -90,6 +91,14 @@ class HostRequire:
 
 
 @dataclass(frozen=True, slots=True)
+class PluginRequire:
+    """One declared plugin-cache dependency. Not a host extra."""
+
+    plugin_id: str
+    hint: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class PluginManifest:
     format: str
     plugin_id: str
@@ -97,6 +106,7 @@ class PluginManifest:
     provide: tuple[SlotEntry, ...] = ()
     on: tuple[SlotEntry, ...] = ()
     host_requires: tuple[HostRequire, ...] = ()
+    plugin_requires: tuple[PluginRequire, ...] = ()
     source_path: str | None = None
 
     def slots_summary(self) -> dict[str, list[str]]:
@@ -183,6 +193,7 @@ def parse_manifest_mapping(raw: dict[str, Any], *, location: str = "plugin.yaml"
         provide=_entries("provide"),
         on=_entries("on"),
         host_requires=_parse_host_requires(raw.get("host_requires")),
+        plugin_requires=_parse_plugin_requires(raw.get("plugin_requires")),
         source_path=location,
     )
 
@@ -237,6 +248,51 @@ def _parse_host_requires(raw: Any) -> tuple[HostRequire, ...]:
                 kind="plugin_host_requires_invalid",
             )
         out.append(HostRequire(import_name=imp, file=file_s, hint=hint_s))
+    return tuple(out)
+
+
+def _parse_plugin_requires(raw: Any) -> tuple[PluginRequire, ...]:
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise PluginManifestError(
+            "plugin_requires must be a list",
+            kind="plugin_requires_invalid",
+        )
+    out: list[PluginRequire] = []
+    for i, row in enumerate(raw):
+        if not isinstance(row, dict):
+            raise PluginManifestError(
+                f"plugin_requires[{i}] must be a mapping",
+                kind="plugin_requires_invalid",
+            )
+        unknown = sorted(str(k) for k in row if str(k) not in PLUGIN_REQUIRES_KEYS)
+        if unknown:
+            raise PluginManifestError(
+                f"plugin_requires[{i}] unknown keys: {unknown}",
+                kind="plugin_requires_invalid",
+            )
+        plugin_id = row.get("plugin_id")
+        hint = row.get("hint")
+        if not isinstance(plugin_id, str) or not plugin_id.strip():
+            raise PluginManifestError(
+                f"plugin_requires[{i}].plugin_id required",
+                kind="plugin_requires_invalid",
+            )
+        try:
+            normalized = normalize_plugin_id(plugin_id)
+        except PluginManifestError as exc:
+            raise PluginManifestError(
+                f"plugin_requires[{i}].plugin_id invalid: {exc.message}",
+                kind="plugin_requires_invalid",
+            ) from exc
+        if hint is not None and (not isinstance(hint, str) or not hint.strip()):
+            raise PluginManifestError(
+                f"plugin_requires[{i}].hint must be a non-empty string",
+                kind="plugin_requires_invalid",
+            )
+        hint_s = hint.strip() if isinstance(hint, str) else None
+        out.append(PluginRequire(plugin_id=normalized, hint=hint_s))
     return tuple(out)
 
 

--- a/src/bora/plugins/plugin_requires.py
+++ b/src/bora/plugins/plugin_requires.py
@@ -1,0 +1,108 @@
+"""Evaluate ``plugin_requires`` against the local plugin cache.
+
+This is a cache-graph check, not a host extra. Exact ``plugin_id`` match only.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from bora.plugins.host_requires import installed_plugin
+from bora.plugins.manifest import PluginManifest, PluginRequire
+from bora.plugins.store import IndexEntry, list_installed
+
+
+class PluginRequiresError(Exception):
+    """Unsatisfied or cyclic plugin_requires (fail closed)."""
+
+    def __init__(self, message: str, *, kind: str) -> None:
+        super().__init__(message)
+        self.kind = kind
+        self.message = message
+
+
+def plugin_requires_satisfied(requires: Sequence[PluginRequire]) -> bool:
+    if not requires:
+        return True
+    return all(installed_plugin(item.plugin_id) is not None for item in requires)
+
+
+def evaluate_plugin_requires(
+    requires: Sequence[PluginRequire],
+    *,
+    plugin_id: str,
+) -> list[dict[str, Any]]:
+    """One check dict per declared row. No secret values."""
+    checks: list[dict[str, Any]] = []
+    for item in requires:
+        ok = installed_plugin(item.plugin_id) is not None
+        row: dict[str, Any] = {
+            "id": "plugin_requires",
+            "ok": ok,
+            "status": "ok" if ok else "missing",
+            "required": item.plugin_id,
+            "plugin": plugin_id,
+        }
+        if item.hint:
+            row["hint"] = item.hint
+        checks.append(row)
+    return checks
+
+
+def assert_no_plugin_requires_cycle(plugin_id: str, *, stack: tuple[str, ...] = ()) -> None:
+    """Walk installed requires; raise on A → … → A."""
+    if plugin_id in stack:
+        chain = " -> ".join((*stack, plugin_id))
+        raise PluginRequiresError(
+            f"plugin_requires cycle: {chain}",
+            kind="plugin_requires_cycle",
+        )
+    found = installed_plugin(plugin_id)
+    if found is None:
+        return
+    manifest, _root = found
+    nxt = (*stack, plugin_id)
+    for item in manifest.plugin_requires:
+        assert_no_plugin_requires_cycle(item.plugin_id, stack=nxt)
+
+
+def assert_plugin_requires_installed(manifest: PluginManifest) -> None:
+    """Fail closed when a declared neighbor is missing or the graph cycles."""
+    assert_no_plugin_requires_cycle(manifest.plugin_id)
+    missing = [item for item in manifest.plugin_requires if installed_plugin(item.plugin_id) is None]
+    if not missing:
+        return
+    first = missing[0]
+    hint = f" ({first.hint})" if first.hint else ""
+    raise PluginRequiresError(
+        f"plugin {manifest.plugin_id!r} requires {first.plugin_id!r}{hint}",
+        kind="plugin_requires_unsatisfied",
+    )
+
+
+def list_row_with_requires(entry: IndexEntry) -> dict[str, Any]:
+    """Index row plus live ``plugin_requires`` satisfaction."""
+    row = entry.as_dict()
+    found = installed_plugin(entry.plugin_id)
+    if found is None:
+        row["plugin_requires_ok"] = False
+        row["plugin_requires"] = []
+        return row
+    manifest, _root = found
+    checks = evaluate_plugin_requires(manifest.plugin_requires, plugin_id=entry.plugin_id)
+    ok = all(bool(c.get("ok")) for c in checks) if checks else True
+    row["plugin_requires_ok"] = ok
+    row["plugin_requires"] = [
+        {
+            "plugin_id": c["required"],
+            "ok": c["ok"],
+            **({"hint": c["hint"]} if c.get("hint") else {}),
+        }
+        for c in checks
+    ]
+    return row
+
+
+def installed_plugin_ids() -> set[str]:
+    return {entry.plugin_id for entry in list_installed()}

--- a/src/bora/plugins/plugin_requires.py
+++ b/src/bora/plugins/plugin_requires.py
@@ -70,7 +70,9 @@ def assert_no_plugin_requires_cycle(plugin_id: str, *, stack: tuple[str, ...] = 
 def assert_plugin_requires_installed(manifest: PluginManifest) -> None:
     """Fail closed when a declared neighbor is missing or the graph cycles."""
     assert_no_plugin_requires_cycle(manifest.plugin_id)
-    missing = [item for item in manifest.plugin_requires if installed_plugin(item.plugin_id) is None]
+    missing = [
+        item for item in manifest.plugin_requires if installed_plugin(item.plugin_id) is None
+    ]
     if not missing:
         return
     first = missing[0]

--- a/tests/application/test_probe_command.py
+++ b/tests/application/test_probe_command.py
@@ -175,6 +175,96 @@ def test_offline_is_reported(bora_home: Path, monkeypatch: pytest.MonkeyPatch) -
     assert payload["probe"]["offline_agent"] is True
 
 
+def test_probe_walks_extension_plugin_requires(
+    bora_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from bora.application.attempt.probe_command import probe_locked
+    from bora.application.composition import build_lock_command
+    from bora.plugins.install import install_from_local
+    from bora.plugins.store import uninstall
+
+    del bora_home
+    monkeypatch.setenv("PROBE_API_KEY", "x")
+    plugins = tmp_path / "plugins"
+    for name in ("neighbor", "needs-neighbor"):
+        root = plugins / name
+        root.mkdir(parents=True)
+        requires = "plugin_requires:\n  - plugin_id: neighbor\n" if name == "needs-neighbor" else ""
+        (root / "plugin.yaml").write_text(
+            (
+                "format: bora.plugin/1\n"
+                f"plugin_id: {name}\n"
+                "version: 0.1.0\n"
+                f"{requires}"
+                "slots:\n"
+                '  "on":\n'
+                "    - id: home_overlay\n"
+                "      priority: 120\n"
+                "      entry: demo.hooks:build\n"
+            ),
+            encoding="utf-8",
+        )
+        src = root / "src" / "demo"
+        src.mkdir(parents=True)
+        (src / "__init__.py").write_text("", encoding="utf-8")
+        (src / "hooks.py").write_text(
+            "def build(**_k):\n    async def h(ctx, value, nxt):\n        return await nxt(value)\n    return h\n",
+            encoding="utf-8",
+        )
+    install_from_local(plugins / "needs-neighbor")
+    profiles = tmp_path / "profiles.yaml"
+    profiles.write_text(
+        (
+            "format: bora.profiles/1\n"
+            "bindings:\n"
+            "  solver:\n"
+            "    executor: host-probe\n"
+            "    extensions:\n"
+            "      - plugin: host-probe\n"
+            "      - plugin: needs-neighbor\n"
+            "    model: none\n"
+            "    api_key: ${PROBE_API_KEY}\n"
+        ),
+        encoding="utf-8",
+    )
+    from bora.plugins import bootstrap as boot
+    from bora.plugins.registry import reset_global_registry
+
+    boot._BOOTSTRAPPED = False  # type: ignore[attr-defined]
+    reset_global_registry()
+    locked, _extra = build_lock_command().lock_with_provenance(
+        database_root=DB,
+        task_id="l0-task",
+        profiles_path=profiles,
+    )
+    locked_l1, _ = build_lock_command().lock_with_provenance(
+        database_root=DB,
+        task_id="l1-task",
+        profiles_path=profiles,
+    )
+    ok_probe = probe_locked(locked, environ={"PROBE_API_KEY": "x"})
+    reqs = [c for c in ok_probe["checks"] if c["id"] == "plugin_requires"]
+    assert reqs and all(c["ok"] for c in reqs)
+    installed = [c for c in ok_probe["checks"] if c["id"] == "plugin_installed"]
+    assert any(c["plugin"] == "needs-neighbor" and c["ok"] for c in installed)
+
+    uninstall("neighbor")
+    missing = probe_locked(locked, environ={"PROBE_API_KEY": "x"})
+    assert missing["ready"] is False
+    reqs = [c for c in missing["checks"] if c["id"] == "plugin_requires"]
+    assert reqs and any(c["ok"] is False and c["required"] == "neighbor" for c in reqs)
+
+    l1_probe = probe_locked(
+        locked_l1,
+        environ={"PROBE_API_KEY": "x"},
+        docker_reachable=lambda: True,
+    )
+    assert l1_probe["path"] == "l1"
+    assert l1_probe["ready"] is False
+    assert any(c["id"] == "plugin_requires" and c["ok"] is False for c in l1_probe["checks"])
+    assert "host_import" not in {c["id"] for c in l1_probe["checks"]}
+
+
 def test_no_plugin_id_extra_table() -> None:
     text = (
         Path(__file__).resolve().parents[2]

--- a/tests/application/test_probe_command.py
+++ b/tests/application/test_probe_command.py
@@ -208,7 +208,10 @@ def test_probe_walks_extension_plugin_requires(
         src.mkdir(parents=True)
         (src / "__init__.py").write_text("", encoding="utf-8")
         (src / "hooks.py").write_text(
-            "def build(**_k):\n    async def h(ctx, value, nxt):\n        return await nxt(value)\n    return h\n",
+            "def build(**_k):\n"
+            "    async def h(ctx, value, nxt):\n"
+            "        return await nxt(value)\n"
+            "    return h\n",
             encoding="utf-8",
         )
     install_from_local(plugins / "needs-neighbor")

--- a/tests/plugins/test_agent_skills.py
+++ b/tests/plugins/test_agent_skills.py
@@ -1,0 +1,281 @@
+"""agent-skills dest expansion and fail-closed cases."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_HF = Path(__file__).resolve().parents[2] / "plugins" / "home-files" / "src"
+_AS = Path(__file__).resolve().parents[2] / "plugins" / "agent-skills" / "src"
+for _p in (_HF, _AS):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from agent_skills.hooks import AgentSkillsError, expand_files  # noqa: E402
+from home_files.hooks import apply_files  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _ctx(tmp: Path) -> dict[str, str]:
+    pkg = tmp / "db"
+    ws = tmp / "ws"
+    cred = tmp / "cred"
+    pkg.mkdir()
+    ws.mkdir()
+    cred.mkdir()
+    (cred / "home_overlay").mkdir()
+    skill = pkg / "overlays" / "skills" / "jsonl-review"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# jsonl-review\n", encoding="utf-8")
+    (pkg / "overlays").mkdir(exist_ok=True)
+    (pkg / "overlays" / "AGENTS.md").write_text("use jsonl-review\n", encoding="utf-8")
+    (pkg / "overlays" / "CLAUDE.md").write_text("claude notes\n", encoding="utf-8")
+    return {
+        "package_root": str(pkg),
+        "workspace_root": str(ws),
+        "cred_root": str(cred),
+    }
+
+
+def test_acp_entries_from_lock() -> None:
+    from types import SimpleNamespace
+
+    from bora.application.attempt.extension_hooks import acp_entries_from_lock
+
+    lock = SimpleNamespace(
+        job_overlay={
+            "bindings": {
+                "solver": {
+                    "executor": "acp",
+                    "extensions": [{"plugin": "acp", "options": {"entry": "grok-build"}}],
+                },
+                "reviewer": {
+                    "executor": "acp",
+                    "extensions": [{"plugin": "acp", "options": {"entry": "codex"}}],
+                },
+            }
+        },
+        agent_profiles=(),
+    )
+    assert acp_entries_from_lock(lock) == ["grok-build", "codex"]
+
+
+def test_expand_generic_and_bound_entry() -> None:
+    files = expand_files(
+        {"skills": [{"src": "overlays/skills/jsonl-review"}]},
+        {"acp_entries": ["opencode"]},
+    )
+    dests = {(row["dest_root"], row["dest"]) for row in files}
+    assert ("home", ".agents/skills/jsonl-review") in dests
+    assert ("home", ".config/opencode/skills/jsonl-review") in dests
+    assert all(row["dest_root"] == "home" for row in files)
+
+
+def test_codex_and_pi_prefixes() -> None:
+    files = expand_files(
+        {"skills": [{"src": "overlays/skills/jsonl-review"}]},
+        {"acp_entries": ["codex", "pi"]},
+    )
+    dests = {row["dest"] for row in files}
+    assert ".agents/skills/jsonl-review" in dests
+    assert ".codex/skills/jsonl-review" in dests
+    assert ".pi/agent/skills/jsonl-review" in dests
+
+
+def test_grok_build_is_generic_only() -> None:
+    files = expand_files(
+        {"skills": [{"src": "overlays/skills/jsonl-review"}]},
+        {"acp_entries": ["grok-build"]},
+    )
+    dests = {row["dest"] for row in files}
+    assert dests == {".agents/skills/jsonl-review"}
+
+
+def test_same_entry_dedups_dest() -> None:
+    files = expand_files(
+        {"skills": [{"src": "overlays/skills/jsonl-review"}]},
+        {"acp_entries": ["codex", "codex"]},
+    )
+    dests = [row["dest"] for row in files]
+    assert dests.count(".codex/skills/jsonl-review") == 1
+
+
+def test_instructions_workspace_agents_and_codex_home() -> None:
+    files = expand_files(
+        {"instructions": [{"src": "overlays/AGENTS.md"}]},
+        {"acp_entries": ["codex"]},
+    )
+    dests = {(row["dest_root"], row["dest"]) for row in files}
+    assert ("workspace", "AGENTS.md") in dests
+    assert ("home", ".codex/AGENTS.md") in dests
+    assert ("home", "AGENTS.md") not in dests
+
+
+def test_unknown_entry_fail_closed() -> None:
+    with pytest.raises(AgentSkillsError) as ei:
+        expand_files(
+            {"skills": [{"src": "overlays/skills/jsonl-review"}]},
+            {"acp_entries": ["not-an-entry"]},
+        )
+    assert ei.value.kind == "agent_skills_entry_invalid"
+
+
+def test_author_dest_rejected() -> None:
+    with pytest.raises(AgentSkillsError) as ei:
+        expand_files(
+            {"skills": [{"src": "overlays/skills/jsonl-review", "dest": "evil"}]},
+            {"acp_entries": []},
+        )
+    assert ei.value.kind == "agent_skills_options_invalid"
+
+
+def test_missing_skill_md_fail_closed(tmp_path: Path) -> None:
+    from agent_skills.hooks import _assert_skill_markdown
+
+    ctx = _ctx(tmp_path)
+    bad = Path(ctx["package_root"]) / "overlays" / "skills" / "empty"
+    bad.mkdir(parents=True)
+    files = expand_files({"skills": [{"src": "overlays/skills/empty"}]}, {"acp_entries": []})
+    with pytest.raises(AgentSkillsError) as ei:
+        _assert_skill_markdown(files, ctx)
+    assert ei.value.kind == "agent_skills_skill_invalid"
+
+
+def test_path_escape_rejected(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    files = expand_files(
+        {"skills": [{"src": "../secret"}]},
+        {"acp_entries": []},
+    )
+    with pytest.raises(Exception) as ei:
+        apply_files(files, ctx)
+    assert getattr(ei.value, "kind", "") == "home_files_path_invalid"
+
+
+def test_apply_writes_home_and_workspace(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    files = expand_files(
+        {
+            "dest_roots": ["home", "workspace"],
+            "skills": [{"src": "overlays/skills/jsonl-review"}],
+            "instructions": [{"src": "overlays/AGENTS.md"}],
+        },
+        {"acp_entries": ["codex"]},
+    )
+    apply_files(files, ctx)
+    home = Path(ctx["cred_root"]) / "home_overlay"
+    ws = Path(ctx["workspace_root"])
+    assert (home / ".agents" / "skills" / "jsonl-review" / "SKILL.md").is_file()
+    assert (home / ".codex" / "skills" / "jsonl-review" / "SKILL.md").is_file()
+    assert (home / ".codex" / "AGENTS.md").read_text(encoding="utf-8") == "use jsonl-review\n"
+    assert (ws / ".agents" / "skills" / "jsonl-review" / "SKILL.md").is_file()
+    assert (ws / "AGENTS.md").read_text(encoding="utf-8") == "use jsonl-review\n"
+
+
+def test_does_not_collide_with_home_files_litellm(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    pkg = Path(ctx["package_root"])
+    catalog = pkg / "overlays" / "opencode.litellm.json"
+    catalog.write_text('{"ok": true}\n', encoding="utf-8")
+    apply_files(
+        [
+            {
+                "src": "overlays/opencode.litellm.json",
+                "dest": ".config/opencode/opencode.json",
+                "dest_root": "home",
+            }
+        ],
+        ctx,
+    )
+    files = expand_files(
+        {"skills": [{"src": "overlays/skills/jsonl-review"}]},
+        {"acp_entries": ["opencode"]},
+    )
+    apply_files(files, ctx)
+    home = Path(ctx["cred_root"]) / "home_overlay"
+    assert (home / ".config" / "opencode" / "opencode.json").read_text(
+        encoding="utf-8"
+    ) == '{"ok": true}\n'
+    assert (home / ".config" / "opencode" / "skills" / "jsonl-review" / "SKILL.md").is_file()
+
+
+@pytest.fixture()
+def bora_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "bora-home"
+    home.mkdir()
+    monkeypatch.setenv("BORA_HOME", str(home))
+    from bora.plugins import bootstrap as boot
+    from bora.plugins.registry import reset_global_registry
+
+    boot._BOOTSTRAPPED = False  # type: ignore[attr-defined]
+    reset_global_registry()
+    return home
+
+
+def test_install_agent_skills_pulls_home_files(bora_home: Path) -> None:
+    env = {**os.environ, "BORA_HOME": str(bora_home)}
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bora.cli.main",
+            "plugin",
+            "install",
+            str(ROOT / "plugins" / "agent-skills"),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    data = json.loads(proc.stdout)
+    ids = {row["plugin_id"] for row in data["installed"]}
+    assert ids == {"agent-skills", "home-files"}
+
+
+def test_journeys_agent_skills_profile_locks(
+    bora_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from bora.plugins.install import install_from_local
+
+    install_from_local(ROOT / "plugins" / "agent-skills")
+    from bora.plugins import bootstrap as boot
+    from bora.plugins.registry import reset_global_registry
+
+    boot._BOOTSTRAPPED = False  # type: ignore[attr-defined]
+    reset_global_registry()
+    env = os.environ.copy()
+    env["BORA_HOME"] = str(bora_home)
+    env.setdefault("XAI_API_KEY", "ci-test-key")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bora.cli.main",
+            "lock",
+            str(ROOT / "examples/journeys"),
+            "--task",
+            "terminal-jsonl-agg",
+            "--profiles",
+            str(ROOT / "examples/journeys/acp-profiles/profiles.acp.grok-build.agent-skills.yaml"),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    data = json.loads(proc.stdout)
+    solver = data["extension_bindings"]["solver"]
+    plugins = {item.get("plugin") for item in (solver.get("home_overlay") or {}).get("chain") or []}
+    assert "agent-skills" in plugins
+    assert "home-files" not in plugins

--- a/tests/plugins/test_agent_skills.py
+++ b/tests/plugins/test_agent_skills.py
@@ -63,7 +63,7 @@ def test_acp_entries_from_lock() -> None:
         },
         agent_profiles=(),
     )
-    assert acp_entries_from_lock(lock) == ["grok-build", "codex"]
+    assert acp_entries_from_lock(lock) == ["grok-build", "codex"]  # type: ignore[arg-type]
 
 
 def test_expand_generic_and_bound_entry() -> None:

--- a/tests/plugins/test_plugin_requires_install.py
+++ b/tests/plugins/test_plugin_requires_install.py
@@ -21,7 +21,7 @@ def _write_plugin(root: Path, plugin_id: str, *, requires: list[str] | None = No
     root.mkdir(parents=True, exist_ok=True)
     rows = ""
     if requires:
-        req_yaml = "\n".join(f'  - plugin_id: {pid}' for pid in requires)
+        req_yaml = "\n".join(f"  - plugin_id: {pid}" for pid in requires)
         rows = f"plugin_requires:\n{req_yaml}\n"
     (root / "plugin.yaml").write_text(
         (

--- a/tests/plugins/test_plugin_requires_install.py
+++ b/tests/plugins/test_plugin_requires_install.py
@@ -41,7 +41,10 @@ def _write_plugin(root: Path, plugin_id: str, *, requires: list[str] | None = No
     src.mkdir(parents=True)
     (src / "__init__.py").write_text("", encoding="utf-8")
     (src / "hooks.py").write_text(
-        "def build(**_k):\n    async def h(ctx, value, nxt):\n        return await nxt(value)\n    return h\n",
+        "def build(**_k):\n"
+        "    async def h(ctx, value, nxt):\n"
+        "        return await nxt(value)\n"
+        "    return h\n",
         encoding="utf-8",
     )
     return root

--- a/tests/plugins/test_plugin_requires_install.py
+++ b/tests/plugins/test_plugin_requires_install.py
@@ -1,0 +1,169 @@
+"""Transitive plugin install: sibling vs Hub org/name, cycles, no partial row."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from bora.plugins.install import install_extracted_hub, install_from_local
+from bora.plugins.plugin_requires import PluginRequiresError
+from bora.plugins.store import list_installed, uninstall
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_plugin(root: Path, plugin_id: str, *, requires: list[str] | None = None) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    rows = ""
+    if requires:
+        req_yaml = "\n".join(f'  - plugin_id: {pid}' for pid in requires)
+        rows = f"plugin_requires:\n{req_yaml}\n"
+    (root / "plugin.yaml").write_text(
+        (
+            "format: bora.plugin/1\n"
+            f"plugin_id: {plugin_id}\n"
+            "version: 0.1.0\n"
+            f"{rows}"
+            "slots:\n"
+            '  "on":\n'
+            "    - id: home_overlay\n"
+            "      priority: 120\n"
+            "      entry: demo.hooks:build\n"
+        ),
+        encoding="utf-8",
+    )
+    src = root / "src" / "demo"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text("", encoding="utf-8")
+    (src / "hooks.py").write_text(
+        "def build(**_k):\n    async def h(ctx, value, nxt):\n        return await nxt(value)\n    return h\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+@pytest.fixture()
+def bora_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "bora-home"
+    home.mkdir()
+    monkeypatch.setenv("BORA_HOME", str(home))
+    from bora.plugins import bootstrap as boot
+    from bora.plugins.registry import reset_global_registry
+
+    boot._BOOTSTRAPPED = False  # type: ignore[attr-defined]
+    reset_global_registry()
+    return home
+
+
+def test_local_sibling_installs_both(bora_home: Path, tmp_path: Path) -> None:
+    del bora_home
+    plugins = tmp_path / "plugins"
+    _write_plugin(plugins / "home-files", "home-files")
+    _write_plugin(plugins / "agent-skills", "agent-skills", requires=["home-files"])
+    result = install_from_local(plugins / "agent-skills")
+    ids = {e.plugin_id for e in list_installed()}
+    assert ids == {"agent-skills", "home-files"}
+    statuses = {item.plugin_id: item.status for item in result.items}
+    assert statuses["home-files"] == "installed"
+    assert statuses["agent-skills"] == "installed"
+    again = install_from_local(plugins / "agent-skills")
+    assert all(item.status == "already_present" for item in again.items)
+
+
+def test_short_id_missing_sibling_no_partial_row(bora_home: Path, tmp_path: Path) -> None:
+    del bora_home
+    plugins = tmp_path / "plugins"
+    _write_plugin(plugins / "agent-skills", "agent-skills", requires=["home-files"])
+    fetched: list[str] = []
+
+    def hub_fetch(package_id: str) -> Path:
+        fetched.append(package_id)
+        raise AssertionError(f"short id must not hit Hub: {package_id}")
+
+    with pytest.raises(PluginRequiresError) as ei:
+        install_from_local(plugins / "agent-skills", hub_fetch=hub_fetch)
+    assert ei.value.kind == "plugin_requires_unsatisfied"
+    assert fetched == []
+    assert list_installed() == []
+
+
+def test_hub_dep_uses_declared_org_not_parent(bora_home: Path, tmp_path: Path) -> None:
+    del bora_home
+    parent = _write_plugin(tmp_path / "a", "a", requires=["OrgB/b"])
+    dep = _write_plugin(tmp_path / "b", "b")
+    fetched: list[str] = []
+
+    def hub_fetch(package_id: str) -> Path:
+        fetched.append(package_id)
+        assert package_id == "OrgB/b"
+        return dep
+
+    result = install_extracted_hub(parent, plugin_id="OrgA/a", hub_fetch=hub_fetch)
+    assert fetched == ["OrgB/b"]
+    ids = {e.plugin_id for e in list_installed()}
+    assert ids == {"OrgA/a", "OrgB/b"}
+    assert result.entry.plugin_id == "OrgA/a"
+
+
+def test_hub_parent_short_dep_does_not_guess_org(bora_home: Path, tmp_path: Path) -> None:
+    del bora_home
+    parent = _write_plugin(tmp_path / "a", "a", requires=["b"])
+    fetched: list[str] = []
+
+    def hub_fetch(package_id: str) -> Path:
+        fetched.append(package_id)
+        raise AssertionError("must not fetch OrgA/b")
+
+    with pytest.raises(PluginRequiresError) as ei:
+        install_extracted_hub(parent, plugin_id="OrgA/a", hub_fetch=hub_fetch)
+    assert ei.value.kind == "plugin_requires_unsatisfied"
+    assert fetched == []
+    assert list_installed() == []
+
+
+def test_cycle_fail_closed(bora_home: Path, tmp_path: Path) -> None:
+    del bora_home
+    plugins = tmp_path / "plugins"
+    _write_plugin(plugins / "alpha", "alpha", requires=["beta"])
+    _write_plugin(plugins / "beta", "beta", requires=["alpha"])
+    with pytest.raises(PluginRequiresError) as ei:
+        install_from_local(plugins / "alpha")
+    assert ei.value.kind == "plugin_requires_cycle"
+    assert list_installed() == []
+
+
+def test_uninstall_depender_leaves_dep(bora_home: Path, tmp_path: Path) -> None:
+    del bora_home
+    plugins = tmp_path / "plugins"
+    _write_plugin(plugins / "home-files", "home-files")
+    _write_plugin(plugins / "agent-skills", "agent-skills", requires=["home-files"])
+    install_from_local(plugins / "agent-skills")
+    assert uninstall("agent-skills") is True
+    ids = {e.plugin_id for e in list_installed()}
+    assert ids == {"home-files"}
+
+
+def test_cli_install_sibling_json(bora_home: Path, tmp_path: Path) -> None:
+    plugins = tmp_path / "plugins"
+    _write_plugin(plugins / "home-files", "home-files")
+    _write_plugin(plugins / "agent-skills", "agent-skills", requires=["home-files"])
+    env = {**os.environ, "BORA_HOME": str(bora_home)}
+    proc = subprocess.run(
+        [sys.executable, "-m", "bora.cli.main", "plugin", "install", str(plugins / "agent-skills")],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    data = json.loads(proc.stdout)
+    assert data["ok"] is True
+    assert data["plugin_id"] == "agent-skills"
+    listed_ids = {row["plugin_id"] for row in data["installed"]}
+    assert listed_ids == {"agent-skills", "home-files"}

--- a/tests/plugins/test_plugin_requires_lock.py
+++ b/tests/plugins/test_plugin_requires_lock.py
@@ -47,8 +47,7 @@ def _write_plugin(
     src.mkdir(parents=True)
     (src / "__init__.py").write_text('VALUE = "ok"\n', encoding="utf-8")
     (src / "hooks.py").write_text(
-        extra_py
-        + "def build(**_k):\n"
+        extra_py + "def build(**_k):\n"
         "    async def h(ctx, value, nxt):\n"
         "        return await nxt(value)\n"
         "    return h\n",
@@ -137,9 +136,7 @@ def test_lock_ok_when_required_plugin_installed(
     assert "needs-neighbor" in plugins_in_chain
 
 
-def test_materialize_can_import_required_module(
-    bora_home: Path, tmp_path: Path
-) -> None:
+def test_materialize_can_import_required_module(bora_home: Path, tmp_path: Path) -> None:
     del bora_home
     plugins = tmp_path / "plugins"
     _write_plugin(plugins / "neighbor", "neighbor", module="neighbor_mod")

--- a/tests/plugins/test_plugin_requires_lock.py
+++ b/tests/plugins/test_plugin_requires_lock.py
@@ -1,0 +1,183 @@
+"""Lock / materialize / import path for plugin_requires."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from bora.config.errors import ConfigError
+from bora.plugins.install import install_from_local
+from bora.plugins.store import install_from_path, uninstall
+
+ROOT = Path(__file__).resolve().parents[2]
+PROBE_DB = ROOT / "tests/fixtures/databases/probe-min"
+HOST_PROBE = ROOT / "tests/fixtures/plugins/host-probe"
+
+
+def _write_plugin(
+    root: Path,
+    plugin_id: str,
+    *,
+    requires: list[str] | None = None,
+    module: str = "demo",
+    extra_py: str = "",
+) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    rows = ""
+    if requires:
+        req_yaml = "\n".join(f"  - plugin_id: {pid}" for pid in requires)
+        rows = f"plugin_requires:\n{req_yaml}\n"
+    (root / "plugin.yaml").write_text(
+        (
+            "format: bora.plugin/1\n"
+            f"plugin_id: {plugin_id}\n"
+            "version: 0.1.0\n"
+            f"{rows}"
+            "slots:\n"
+            '  "on":\n'
+            "    - id: home_overlay\n"
+            "      priority: 120\n"
+            f"      entry: {module}.hooks:build\n"
+        ),
+        encoding="utf-8",
+    )
+    src = root / "src" / module
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text('VALUE = "ok"\n', encoding="utf-8")
+    (src / "hooks.py").write_text(
+        extra_py
+        + "def build(**_k):\n"
+        "    async def h(ctx, value, nxt):\n"
+        "        return await nxt(value)\n"
+        "    return h\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+@pytest.fixture()
+def bora_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "bora-home"
+    home.mkdir()
+    monkeypatch.setenv("BORA_HOME", str(home))
+    from bora.plugins import bootstrap as boot
+    from bora.plugins.registry import reset_global_registry
+
+    boot._BOOTSTRAPPED = False  # type: ignore[attr-defined]
+    reset_global_registry()
+    install_from_path(HOST_PROBE)
+    boot._BOOTSTRAPPED = False  # type: ignore[attr-defined]
+    reset_global_registry()
+    return home
+
+
+def _profiles(tmp: Path, extra_plugin: str) -> Path:
+    path = tmp / "profiles.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "format": "bora.profiles/1",
+                "bindings": {
+                    "solver": {
+                        "executor": "host-probe",
+                        "extensions": [
+                            {"plugin": "host-probe"},
+                            {"plugin": extra_plugin},
+                        ],
+                        "model": "none",
+                        "api_key": "${PROBE_API_KEY}",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_lock_fails_when_required_plugin_missing(
+    bora_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    del bora_home
+    monkeypatch.setenv("PROBE_API_KEY", "x")
+    plugins = tmp_path / "plugins"
+    _write_plugin(plugins / "needs-neighbor", "needs-neighbor", requires=["neighbor"])
+    install_from_path(plugins / "needs-neighbor")
+    from bora.application.composition import build_lock_command
+
+    with pytest.raises(ConfigError) as ei:
+        build_lock_command().run(
+            database_root=PROBE_DB,
+            task_id="l0-task",
+            profiles_path=_profiles(tmp_path, "needs-neighbor"),
+        )
+    assert ei.value.error_code == "plugin_requires_unsatisfied"
+
+
+def test_lock_ok_when_required_plugin_installed(
+    bora_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    del bora_home
+    monkeypatch.setenv("PROBE_API_KEY", "x")
+    plugins = tmp_path / "plugins"
+    _write_plugin(plugins / "neighbor", "neighbor")
+    _write_plugin(plugins / "needs-neighbor", "needs-neighbor", requires=["neighbor"])
+    install_from_local(plugins / "needs-neighbor")
+    from bora.application.composition import build_lock_command
+
+    summary = build_lock_command().run(
+        database_root=PROBE_DB,
+        task_id="l0-task",
+        profiles_path=_profiles(tmp_path, "needs-neighbor"),
+    )
+    chain = (summary["extension_bindings"]["solver"].get("home_overlay") or {}).get("chain") or []
+    plugins_in_chain = {item.get("plugin") for item in chain}
+    assert "needs-neighbor" in plugins_in_chain
+
+
+def test_materialize_can_import_required_module(
+    bora_home: Path, tmp_path: Path
+) -> None:
+    del bora_home
+    plugins = tmp_path / "plugins"
+    _write_plugin(plugins / "neighbor", "neighbor", module="neighbor_mod")
+    _write_plugin(
+        plugins / "needs-neighbor",
+        "needs-neighbor",
+        requires=["neighbor"],
+        module="needs_neighbor",
+        extra_py="from neighbor_mod import VALUE\nassert VALUE == 'ok'\n",
+    )
+    install_from_local(plugins / "needs-neighbor")
+    from bora.plugins import bootstrap as boot
+    from bora.plugins.registry import reset_global_registry
+
+    boot._BOOTSTRAPPED = False  # type: ignore[attr-defined]
+    reset_global_registry()
+    from bora.plugins.bootstrap import ensure_bootstrapped
+
+    ensure_bootstrapped()
+    import neighbor_mod
+
+    assert neighbor_mod.VALUE == "ok"
+
+
+def test_uninstall_depender_lock_still_works_with_dep(
+    bora_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    del bora_home
+    monkeypatch.setenv("PROBE_API_KEY", "x")
+    plugins = tmp_path / "plugins"
+    _write_plugin(plugins / "neighbor", "neighbor")
+    _write_plugin(plugins / "needs-neighbor", "needs-neighbor", requires=["neighbor"])
+    install_from_local(plugins / "needs-neighbor")
+    assert uninstall("needs-neighbor") is True
+    from bora.application.composition import build_lock_command
+
+    summary = build_lock_command().run(
+        database_root=PROBE_DB,
+        task_id="l0-task",
+    )
+    assert summary["task_id"] == "l0-task"

--- a/tests/plugins/test_plugin_requires_lock.py
+++ b/tests/plugins/test_plugin_requires_lock.py
@@ -156,7 +156,7 @@ def test_materialize_can_import_required_module(bora_home: Path, tmp_path: Path)
     from bora.plugins.bootstrap import ensure_bootstrapped
 
     ensure_bootstrapped()
-    import neighbor_mod
+    import neighbor_mod  # type: ignore[import-not-found]
 
     assert neighbor_mod.VALUE == "ok"
 

--- a/tests/plugins/test_plugin_requires_manifest.py
+++ b/tests/plugins/test_plugin_requires_manifest.py
@@ -12,9 +12,7 @@ def _base(**extra: object) -> dict[str, object]:
         "format": "bora.plugin/1",
         "plugin_id": "demo",
         "version": "0.1.0",
-        "slots": {
-            "on": [{"id": "home_overlay", "priority": 120, "entry": "demo.hooks:build"}]
-        },
+        "slots": {"on": [{"id": "home_overlay", "priority": 120, "entry": "demo.hooks:build"}]},
     }
     payload.update(extra)
     return payload

--- a/tests/plugins/test_plugin_requires_manifest.py
+++ b/tests/plugins/test_plugin_requires_manifest.py
@@ -1,0 +1,66 @@
+"""plugin_requires allowlist on bora.plugin/1."""
+
+from __future__ import annotations
+
+import pytest
+
+from bora.plugins.manifest import PluginManifestError, parse_manifest_mapping
+
+
+def _base(**extra: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "format": "bora.plugin/1",
+        "plugin_id": "demo",
+        "version": "0.1.0",
+        "slots": {
+            "on": [{"id": "home_overlay", "priority": 120, "entry": "demo.hooks:build"}]
+        },
+    }
+    payload.update(extra)
+    return payload
+
+
+def test_plugin_requires_short_and_hub_ids() -> None:
+    man = parse_manifest_mapping(
+        _base(
+            plugin_requires=[
+                {"plugin_id": "home-files", "hint": "bora plugin install plugins/home-files"},
+                {"plugin_id": "Official/home-files"},
+            ]
+        )
+    )
+    assert len(man.plugin_requires) == 2
+    assert man.plugin_requires[0].plugin_id == "home-files"
+    assert man.plugin_requires[0].hint == "bora plugin install plugins/home-files"
+    assert man.plugin_requires[1].plugin_id == "Official/home-files"
+    assert man.plugin_requires[1].hint is None
+
+
+def test_omitted_and_empty_plugin_requires() -> None:
+    assert parse_manifest_mapping(_base()).plugin_requires == ()
+    assert parse_manifest_mapping(_base(plugin_requires=[])).plugin_requires == ()
+
+
+def test_unknown_plugin_requires_key_fail_closed() -> None:
+    with pytest.raises(PluginManifestError) as ei:
+        parse_manifest_mapping(_base(plugin_requires=[{"plugin_id": "home-files", "version": "1"}]))
+    assert ei.value.kind == "plugin_requires_invalid"
+    assert "unknown keys" in str(ei.value)
+
+
+def test_invalid_plugin_id_fail_closed() -> None:
+    with pytest.raises(PluginManifestError) as ei:
+        parse_manifest_mapping(_base(plugin_requires=[{"plugin_id": "org.name"}]))
+    assert ei.value.kind == "plugin_requires_invalid"
+
+
+def test_plugin_requires_not_a_list() -> None:
+    with pytest.raises(PluginManifestError) as ei:
+        parse_manifest_mapping(_base(plugin_requires={"plugin_id": "home-files"}))
+    assert ei.value.kind == "plugin_requires_invalid"
+
+
+def test_plugin_requires_missing_id() -> None:
+    with pytest.raises(PluginManifestError) as ei:
+        parse_manifest_mapping(_base(plugin_requires=[{"hint": "only hint"}]))
+    assert ei.value.kind == "plugin_requires_invalid"


### PR DESCRIPTION
## Summary

Plugins can now declare **`plugin_requires`** (a cache graph, not a host extra). `bora plugin install` installs those neighbors first: a short id is cache or a local sibling only and never hits Hub; a Hub `org/name` fetches that exact package at its latest plugin release and is not rewritten with the parent org. `plugins/agent-skills` expands Database skill folders onto the dests each bound ACP entry actually reads; copy still goes through `home-files`.

## Approach

- Design first in `docs/design/11-extension-plugins.md`.
- Manifest allowlist: `plugin_id` + optional `hint`; omit/`[]` keeps today's single-tree install.
- Install, list, lock, `--probe` (L0 and L1), and `executors.host_ready` all honor exact cache-id satisfaction. Cycles and missing neighbors fail closed. Uninstall does not remove dependencies. Profiles still opt in via `extensions[]`.
- `hook_home_overlay` publishes `value.acp_entries`. `agent-skills` only expands dests (default `dest_roots: [home]`); unknown ACP entries, missing `SKILL.md`, and path escapes fail closed.
- Journey profile `examples/journeys/acp-profiles/profiles.acp.grok-build.agent-skills.yaml` ships a `jsonl-agg` skill for grok-build. This is not a new official smoke or evidence-grade claim.

## Test plan

- [x] Local `python-core` equivalent: ruff format/check, pyright, pytest (780 passed)
- [x] Local `python-registry` equivalent: `pytest tests/registry` (162 passed, 2 skipped)
- [x] Default: plugin with no `plugin_requires` still installs/lists/locks as today
- [x] Short `plugin_id` never requests Hub; Hub `org/name` fetches that exact address
- [x] Local `bora plugin install plugins/agent-skills` also installs sibling `home-files`
- [x] Lock/probe fail closed when a bound plugin's required neighbor is missing
- [x] Dest expansion + fail-closed cases under `tests/plugins/test_agent_skills.py`
- [x] Real L1 e2e: `bora run examples/journeys --task terminal-jsonl-agg --profiles examples/journeys/acp-profiles/profiles.acp.grok-build.agent-skills.yaml` → PASS (`assurance: l1`, score 1.0). Grok read workspace `.agents/skills/jsonl-agg/SKILL.md` before writing `aggregates.json`.

## Follow-ups

- Website / `bora-cli` probe copy still describe install without the cache graph.
- `load_installed` puts only direct required roots on `sys.path` (enough for agent-skills → home-files).
- No `bora plugin list` / `bora executors` assertion that `host_ready` flips when requires are missing (logic is wired).

Closes #139
Closes #140