### PR TITLE
feat: Agent Hub — first-class bora.agent/1 object (publish / install / run via --agent)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ apps/* / services/* README  ← SPA / 服务开发细节；非产品教程权威
 | 交付跟踪        | **GitHub Issues**（无 ROADMAP / Active Spec）                                                                                                                                                                                                                               |
 | 文档站          | [`website/`](website/) 读者向 Fumadocs；机制权威仍在 `docs/`                                                                                                                                                                                                                |
 | ACP             | 产品决策已接受（`executor: acp` + `- plugin: acp` / `options.entry`）；余量与 gap 见 Issues（如 #4）；**有站 ≠ 证据升级**                                                                                                                                                                     |
+| Agent Hub       | 设计定稿 [docs/design/14](docs/design/14-agent-hub.md)：`bora.agent/1` 单 binding 对象、`--agent` 投影进 profiles 通道、`agent_ref` 溯源非身份、Registry `package_kind=agent`；交付进度以 Issues 为准                                                                        |
 
 **禁止**从文档存在、Issue 存在、`bora lock` 成功或设计示意推导 `runnable-mvp` / `isolated` / `real-benchmark-verified`。
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -118,6 +118,7 @@ BORA/
 │   │   ├── suite/             # suite_run、fingerprint、suite_metrics
 │   │   ├── registry_ops/      # results / publish / login / org / list（注入 client factory）
 │   │   ├── plugin_ops/        # plugin install / publish / image_contribute bake
+│   │   ├── agent_ops/         # agent 投影（--agent → 合成 profiles）/ publish / install（design/14）
 │   │   └── local_jobs/        # 本机 Job 删除（Viewer / bora jobs delete；suite 级联 Attempt）
 │   ├── config/                # Core 1（load_and_lock + constants/yaml_io/overrides/digest/validate）
 │   ├── runtime/               # Core 2：identity、lifecycle、coordinator、task_worker、
@@ -175,7 +176,7 @@ BORA/
 │   ├── config/
 │   ├── plugins/               # registry / lock bindings / slot wiring / CLI lifecycle
 │   └── test_package_baseline.py
-├── docs/                      # 设计权威（00–12）
+├── docs/                      # 设计权威（00–14）
 └── website/                   # 读者向文档站（Fumadocs；非设计权威）
 ```
 

--- a/apps/hub/src/App.tsx
+++ b/apps/hub/src/App.tsx
@@ -1,6 +1,8 @@
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 
 import { Shell } from "@/components/layout";
+import { AgentDetailPage } from "@/pages/AgentDetailPage";
+import { AgentsPage } from "@/pages/AgentsPage";
 import { AttemptEvidencePage } from "@/pages/AttemptEvidencePage";
 import { DatasetDetailPage } from "@/pages/DatasetDetailPage";
 import { DatasetsPage } from "@/pages/DatasetsPage";
@@ -35,6 +37,8 @@ export default function App() {
           />
           <Route path="/plugins" element={<PluginsPage />} />
           <Route path="/plugins/:pluginId" element={<PluginDetailPage />} />
+          <Route path="/agents" element={<AgentsPage />} />
+          <Route path="/agents/:agentId" element={<AgentDetailPage />} />
           <Route path="/runtimes" element={<RuntimesPage />} />
           <Route path="/runtimes/:runtimeId" element={<RuntimeDetailPage />} />
           <Route path="/organizations" element={<OrganizationsPage />} />

--- a/apps/hub/src/components/layout.tsx
+++ b/apps/hub/src/components/layout.tsx
@@ -61,6 +61,9 @@ export function Shell({
           <NavLink to="/plugins" className={navClass} end={false}>
             Plugins
           </NavLink>
+          <NavLink to="/agents" className={navClass} end={false}>
+            Agents
+          </NavLink>
           <NavLink to="/runtimes" className={navClass} end={false}>
             Runtimes
           </NavLink>

--- a/apps/hub/src/lib/api.ts
+++ b/apps/hub/src/lib/api.ts
@@ -21,6 +21,18 @@ export type PluginPreview = {
   files?: string[];
 };
 
+export type AgentPreview = {
+  agent_id?: string;
+  version?: string;
+  format?: string;
+  label?: string | null;
+  description?: string | null;
+  tags?: string[];
+  /** Secret-free job binding (design/14): executor/model/options/extensions. */
+  binding?: Record<string, unknown>;
+  files?: string[];
+};
+
 export type SuitePluginRef = {
   plugin_id: string;
   version?: string;
@@ -42,14 +54,16 @@ export type PackageRelease = {
   blob_digest: string;
   size: number;
   media_type?: string;
-  /** Registry package_kind: database | plugin. */
-  package_kind?: "database" | "plugin" | string;
+  /** Registry package_kind: database | plugin | agent. */
+  package_kind?: "database" | "plugin" | "agent" | string;
   created_at?: number;
   org_id?: string;
   /** Registry marketplace display: upload org is on the official-org allowlist. */
   official?: boolean;
   /** Present on by-digest / version get for plugins. */
   plugin_preview?: PluginPreview;
+  /** Present on by-digest / version get for agents (design/14). */
+  agent_preview?: AgentPreview;
   /** Draft slot (entitled callers only). */
   is_draft?: boolean;
   slot?: string;
@@ -236,7 +250,17 @@ export type RuntimeAppearance = {
   created_at?: number;
   teammates?: RuntimeTeammate[];
   overlays?: string[];
+  /** Provenance: bora.agent/1 ref that produced this binding (design/14). */
+  agent_ref?: string;
 };
+
+/** Hub package id from an agent_ref (`org/name@ver+sha…`); null for local/file refs. */
+export function agentRefPackageId(ref: string | undefined | null): string | null {
+  if (!ref || ref.startsWith("file:")) return null;
+  const id = ref.split("@", 1)[0] ?? "";
+  if (!id.includes("/") || id.startsWith("local/")) return null;
+  return id;
+}
 
 export type RuntimeDetail = RuntimeCard & {
   appearances: RuntimeAppearance[];
@@ -334,7 +358,7 @@ export function decodeDatasetId(param: string): string {
 
 export async function listPackages(
   token: string | null,
-  opts?: { packageKind?: "database" | "plugin"; mine?: boolean },
+  opts?: { packageKind?: "database" | "plugin" | "agent"; mine?: boolean },
 ): Promise<PackageRelease[]> {
   // With token, server may include private; without, public only.
   const q = new URLSearchParams();

--- a/apps/hub/src/pages/AgentDetailPage.tsx
+++ b/apps/hub/src/pages/AgentDetailPage.tsx
@@ -1,0 +1,320 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { BreadcrumbNav } from "@/components/breadcrumb";
+import { CommandStrip } from "@/components/command-strip";
+import { DisplayNameEditor } from "@/components/display-name-editor";
+import { OfficialMark } from "@/components/official-mark";
+import { FileSplitPanel } from "@/components/file-split-panel";
+import {
+  decodeDatasetId,
+  decodeFileContent,
+  getOrg,
+  getPackageByDigest,
+  getPackageFile,
+  listPackageFiles,
+  listPackageVersions,
+  splitPackageId,
+  updatePackageDisplayName,
+  type AgentPreview,
+  type PackageRelease,
+  RegistryHttpError,
+} from "@/lib/api";
+import { getToken } from "@/lib/auth";
+import { buildNestedTree, type TreeNode } from "@/lib/file-tree";
+
+export function AgentDetailPage() {
+  const { agentId: rawId } = useParams();
+  const agentId = decodeDatasetId(rawId || "");
+  const token = getToken();
+
+  const [release, setRelease] = useState<PackageRelease | null>(null);
+  const [preview, setPreview] = useState<AgentPreview | null>(null);
+  const [tree, setTree] = useState<TreeNode[]>([]);
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [fileContent, setFileContent] = useState<string | null>(null);
+  const [fileNote, setFileNote] = useState<string | null>(null);
+  const [treeLoading, setTreeLoading] = useState(true);
+  const [fileLoading, setFileLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [canEditName, setCanEditName] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setTreeLoading(true);
+      setError(null);
+      try {
+        const versions = await listPackageVersions(agentId, token);
+        if (!versions.length) {
+          throw new RegistryHttpError(404, "not_found", "agent not found");
+        }
+        const latest = [...versions].sort(
+          (a, b) => (b.created_at ?? 0) - (a.created_at ?? 0),
+        )[0];
+        if (cancelled) return;
+
+        let meta: PackageRelease = latest;
+        try {
+          meta = await getPackageByDigest(agentId, latest.package_digest, token);
+        } catch {
+          /* list meta is enough for non-preview fields */
+        }
+        if (cancelled) return;
+
+        if (meta.package_kind && meta.package_kind !== "agent") {
+          throw new RegistryHttpError(
+            404,
+            "not_found",
+            "not an agent package (use Datasets / Plugins for other kinds)",
+          );
+        }
+
+        setRelease(meta);
+        setPreview(meta.agent_preview || null);
+        if (token && meta.org_id) {
+          try {
+            const org = await getOrg(meta.org_id, token);
+            if (!cancelled) {
+              setCanEditName((org.role || "").toLowerCase() === "owner");
+            }
+          } catch {
+            if (!cancelled) setCanEditName(false);
+          }
+        } else if (!cancelled) {
+          setCanEditName(false);
+        }
+
+        const files = await listPackageFiles(agentId, latest.package_digest, token);
+        if (cancelled) return;
+        const nested = buildNestedTree(files.items);
+        setTree(nested);
+        const prefer =
+          files.items.find((e) => e.path === "agent.yaml") ||
+          files.items.find((e) => e.path === "README.md") ||
+          files.items.find((e) => e.type !== "dir");
+        if (prefer) setSelectedPath(prefer.path);
+      } catch (err) {
+        if (cancelled) return;
+        if (err instanceof RegistryHttpError) {
+          setError(`${err.code}: ${err.message}`);
+        } else {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+        setRelease(null);
+        setPreview(null);
+        setTree([]);
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+          setTreeLoading(false);
+        }
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId, token]);
+
+  useEffect(() => {
+    if (!release || !selectedPath) {
+      setFileContent(null);
+      setFileNote(null);
+      return;
+    }
+    let cancelled = false;
+    setFileLoading(true);
+    setFileNote(null);
+    getPackageFile(agentId, release.package_digest, selectedPath, token)
+      .then((f) => {
+        if (cancelled) return;
+        try {
+          setFileContent(decodeFileContent(f));
+        } catch {
+          setFileContent(null);
+          setFileNote("Could not decode file content.");
+        }
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setFileContent(null);
+        if (err instanceof RegistryHttpError) {
+          setFileNote(`${err.code}: ${err.message}`);
+        } else {
+          setFileNote(err instanceof Error ? err.message : String(err));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setFileLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId, release, selectedPath, token]);
+
+  const installCmd = useMemo(() => {
+    if (!release) return `bora agent install ${agentId}@<version>`;
+    return `bora agent install ${agentId}@${release.version}`;
+  }, [agentId, release]);
+
+  const runCmd = useMemo(() => {
+    const ver = release?.version || "<version>";
+    return `bora run <dataset> --agent ${agentId}@${ver}`;
+  }, [agentId, release]);
+
+  const formatBadge =
+    preview?.format || (release?.package_kind === "agent" ? "bora.agent/1" : null);
+
+  const packageParts = useMemo(() => splitPackageId(agentId), [agentId]);
+
+  const bindingRows = useMemo(() => {
+    const binding = preview?.binding || {};
+    return Object.entries(binding).filter(([, v]) => v !== null && v !== undefined);
+  }, [preview]);
+
+  return (
+    <>
+      <BreadcrumbNav
+        items={[{ label: "Agent hub", href: "/agents" }, { label: agentId || "…" }]}
+        className="mb-4"
+      />
+
+      <div className="mb-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <DisplayNameEditor
+            value={
+              release?.display_name?.trim() ||
+              preview?.label?.trim() ||
+              packageParts.name
+            }
+            prefix={packageParts.org ? `${packageParts.org}/` : null}
+            canEdit={Boolean(token && canEditName && release)}
+            headingClassName="text-xl font-semibold tracking-tight text-ink"
+            afterTitle={release?.official ? <OfficialMark /> : null}
+            onSave={async (next) => {
+              const updated = await updatePackageDisplayName(agentId, next, token);
+              setRelease((prev) =>
+                prev ? { ...prev, display_name: updated.display_name || next } : prev,
+              );
+            }}
+          />
+          {formatBadge ? (
+            <span className="text-[11px] font-medium font-mono px-2 py-0.5 rounded border border-hairline bg-canvas-soft text-body">
+              {formatBadge}
+            </span>
+          ) : null}
+        </div>
+        {release ? (
+          <p className="text-sm text-mute mt-1">
+            <span className="font-mono">@{agentId}</span>
+            {" · "}
+            v{release.version} · {release.visibility}
+            {release.org_id ? (
+              <>
+                {" "}
+                · org{" "}
+                <span className="inline-flex items-center gap-1">
+                  <Link
+                    to={`/organizations/${encodeURIComponent(release.org_id)}`}
+                    className="font-mono text-xs text-body hover:text-ink"
+                  >
+                    {release.org_id}
+                  </Link>
+                  {release.official ? <OfficialMark kind="org" /> : null}
+                </span>
+              </>
+            ) : null}
+          </p>
+        ) : null}
+        {preview?.description ? (
+          <p className="text-sm text-body mt-2 max-w-2xl">{preview.description}</p>
+        ) : null}
+        {preview?.tags?.length ? (
+          <p className="mt-2 flex flex-wrap gap-1.5">
+            {preview.tags.map((t) => (
+              <span
+                key={t}
+                className="text-[11px] font-mono px-1.5 py-0.5 rounded border border-hairline bg-canvas-soft text-mute"
+              >
+                {t}
+              </span>
+            ))}
+          </p>
+        ) : null}
+      </div>
+
+      {loading && <p className="text-sm text-mute">Loading…</p>}
+      {error && (
+        <div className="rounded-[8px] border border-hairline bg-canvas-soft p-4 text-sm">
+          <p className="text-error font-medium">Could not load agent</p>
+          <p className="mt-1 font-mono text-xs text-body">{error}</p>
+          <p className="mt-3">
+            <Link to="/agents" className="underline underline-offset-2 text-body">
+              ← Back to Agent hub
+            </Link>
+          </p>
+        </div>
+      )}
+
+      {!loading && !error && release && (
+        <div className="space-y-6">
+          <section className="space-y-2">
+            <h2 className="text-sm font-medium text-ink">Install &amp; run (CLI)</h2>
+            <CommandStrip command={installCmd} />
+            <CommandStrip command={runCmd} />
+            <p className="text-xs text-mute">
+              Install writes only the local cache; the binding applies per run via{" "}
+              <span className="font-mono">--agent</span> and lands in the lock&apos;s
+              job_overlay as <span className="font-mono">agent_ref</span> (provenance,
+              not fingerprint identity).
+            </p>
+          </section>
+
+          <section className="space-y-2">
+            <h2 className="text-sm font-medium text-ink">Job binding</h2>
+            {bindingRows.length === 0 ? (
+              <p className="text-sm text-mute">No binding preview available.</p>
+            ) : (
+              <div className="rounded-[8px] border border-hairline bg-canvas-soft p-4">
+                <dl className="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-1.5 text-sm">
+                  {bindingRows.map(([key, value]) => (
+                    <div key={key} className="contents">
+                      <dt className="font-mono text-xs text-mute pt-0.5">{key}</dt>
+                      <dd className="font-mono text-xs text-body break-all">
+                        {typeof value === "string"
+                          ? value
+                          : JSON.stringify(value, null, 1)}
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+            )}
+          </section>
+
+          <section id="agent-files" className="space-y-2">
+            <h2 className="text-sm font-medium text-ink">Files</h2>
+            <p className="text-xs text-mute">
+              Read-only preview. Agent packages carry configuration only — locator
+              names, never secret values.
+            </p>
+            <div className="rounded-[8px] border border-hairline overflow-hidden">
+              <FileSplitPanel
+                tree={tree}
+                treeLoading={treeLoading}
+                selectedPath={selectedPath}
+                onSelect={setSelectedPath}
+                fileContent={fileContent}
+                fileLoading={fileLoading}
+                fileNote={fileNote}
+              />
+            </div>
+          </section>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/hub/src/pages/AgentsPage.tsx
+++ b/apps/hub/src/pages/AgentsPage.tsx
@@ -1,0 +1,262 @@
+import { Bot } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+
+import { CatalogScopeBar } from "@/components/catalog-scope-bar";
+import { OfficialMark } from "@/components/official-mark";
+import { PageHead } from "@/components/page-head";
+import { SignInLink } from "@/components/sign-in-button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  encodeDatasetId,
+  listOrgs,
+  listPackages,
+  packageDisplayTitle,
+  type PackageRelease,
+  RegistryHttpError,
+} from "@/lib/api";
+import { getToken } from "@/lib/auth";
+import { formatDate } from "@/lib/utils";
+
+/** Collapse multi-version list to latest per package id (by created_at). */
+function latestByPackage(items: PackageRelease[]): PackageRelease[] {
+  const map = new Map<string, PackageRelease>();
+  for (const row of items) {
+    const prev = map.get(row.database_id);
+    if (!prev) {
+      map.set(row.database_id, row);
+      continue;
+    }
+    const a = prev.created_at ?? 0;
+    const b = row.created_at ?? 0;
+    if (b >= a) map.set(row.database_id, row);
+  }
+  return Array.from(map.values()).sort((x, y) =>
+    x.database_id.localeCompare(y.database_id),
+  );
+}
+
+type Scope = "orgs" | "explore";
+
+export function AgentsPage() {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const scope: Scope =
+    searchParams.get("scope") === "explore" ? "explore" : "orgs";
+
+  const [items, setItems] = useState<PackageRelease[]>([]);
+  const [myOrgIds, setMyOrgIds] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState("");
+  const token = getToken();
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    const packagesP = listPackages(token, { packageKind: "agent" });
+    const orgsP = token
+      ? listOrgs(token).catch(() => [] as Awaited<ReturnType<typeof listOrgs>>)
+      : Promise.resolve([]);
+
+    Promise.all([packagesP, orgsP])
+      .then(([rows, orgs]) => {
+        if (cancelled) return;
+        setItems(rows);
+        setMyOrgIds(new Set(orgs.map((o) => o.org_id)));
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof RegistryHttpError) {
+          setError(`${err.code}: ${err.message}`);
+        } else {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+        setItems([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const agents = useMemo(() => {
+    const latest = latestByPackage(items);
+    const scoped =
+      scope === "orgs"
+        ? latest.filter((r) => r.org_id && myOrgIds.has(r.org_id) && token)
+        : latest.filter((r) => r.visibility === "public");
+    const q = query.trim().toLowerCase();
+    if (!q) return scoped;
+    return scoped.filter(
+      (r) =>
+        r.database_id.toLowerCase().includes(q) ||
+        (r.org_id && r.org_id.toLowerCase().includes(q)),
+    );
+  }, [items, scope, myOrgIds, query, token]);
+
+  function setScope(next: Scope) {
+    setSearchParams(next === "explore" ? { scope: "explore" } : {}, {
+      replace: true,
+    });
+  }
+
+  function openAgent(id: string) {
+    navigate(`/agents/${encodeDatasetId(id)}`);
+  }
+
+  return (
+    <>
+      <PageHead
+        title="Agent hub"
+        sub={
+          <>
+            Browse <span className="font-mono text-xs">bora.agent/1</span>{" "}
+            definitions (one job binding: executor × model × options). Install
+            is CLI-only and never edits profiles; bind at run time with{" "}
+            <span className="font-mono text-xs">--agent</span>.
+          </>
+        }
+      />
+
+      <CatalogScopeBar
+        scope={scope}
+        onScope={setScope}
+        query={query}
+        onQuery={setQuery}
+        searchLabel="Search agents"
+        searchPlaceholder="Search agents…"
+      />
+
+      {scope === "orgs" && !token ? (
+        <div className="rounded-[8px] border border-hairline bg-canvas-soft p-6 text-sm text-body">
+          <p className="font-medium text-ink">Sign in to see org agents</p>
+          <p className="mt-1 text-mute">
+            <SignInLink /> to list agents from your organizations. Public
+            agents are under{" "}
+            <button
+              type="button"
+              className="underline underline-offset-2"
+              onClick={() => setScope("explore")}
+            >
+              Explore
+            </button>
+            .
+          </p>
+        </div>
+      ) : loading ? (
+        <p className="text-sm text-mute">Loading…</p>
+      ) : error ? (
+        <div className="rounded-[8px] border border-hairline bg-canvas-soft p-4 text-sm text-body">
+          <p className="text-error font-medium">Could not load agents</p>
+          <p className="mt-1 font-mono text-xs">{error}</p>
+        </div>
+      ) : (
+        <>
+          {agents.length === 0 ? (
+            <div className="rounded-[8px] border border-dashed border-hairline bg-canvas-soft p-10 text-center text-sm text-body">
+              <div className="flex justify-center mb-4">
+                <div className="flex h-16 w-16 items-center justify-center rounded-[12px] bg-canvas border border-hairline text-mute">
+                  <Bot className="h-8 w-8" strokeWidth={1.5} aria-hidden />
+                </div>
+              </div>
+              <p className="font-medium text-ink">No agents found</p>
+              <p className="mt-1 text-mute max-w-md mx-auto">
+                {scope === "orgs"
+                  ? "No agent packages from your organizations yet. Publish with bora agent publish <path> --org <id>."
+                  : "No public agent packages on this Registry yet."}
+              </p>
+            </div>
+          ) : (
+            <div className="rounded-[8px] border border-hairline overflow-hidden">
+              <Table>
+                <TableHeader>
+                  <TableRow className="hover:bg-transparent">
+                    <TableHead>Agent</TableHead>
+                    <TableHead>Org</TableHead>
+                    <TableHead>Version</TableHead>
+                    <TableHead>Visibility</TableHead>
+                    <TableHead className="text-right tabular-nums">Size</TableHead>
+                    <TableHead>Updated</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {agents.map((row) => (
+                    <TableRow
+                      key={`${row.database_id}@${row.version}`}
+                      className="cursor-pointer"
+                      onClick={() => openAgent(row.database_id)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          openAgent(row.database_id);
+                        }
+                      }}
+                      tabIndex={0}
+                      role="link"
+                    >
+                      <TableCell className="font-medium font-mono text-sm">
+                        <span className="inline-flex items-center gap-1.5 min-w-0">
+                          <span className="truncate">
+                            {packageDisplayTitle(
+                              row.database_id,
+                              row.display_name,
+                            )}
+                          </span>
+                          {row.official ? <OfficialMark /> : null}
+                        </span>
+                      </TableCell>
+                      <TableCell className="font-mono text-xs text-mute">
+                        {row.org_id ? (
+                          <span className="inline-flex items-center gap-1">
+                            <Link
+                              to={`/organizations/${encodeURIComponent(row.org_id)}`}
+                              className="hover:text-ink"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              @{row.org_id}
+                            </Link>
+                            {row.official ? <OfficialMark kind="org" /> : null}
+                          </span>
+                        ) : (
+                          "—"
+                        )}
+                      </TableCell>
+                      <TableCell className="font-mono text-xs text-body">
+                        {row.version}
+                      </TableCell>
+                      <TableCell className="text-body">{row.visibility}</TableCell>
+                      <TableCell className="text-right tabular-nums text-body">
+                        {row.size.toLocaleString()}
+                      </TableCell>
+                      <TableCell className="text-mute text-xs">
+                        {typeof row.created_at === "number"
+                          ? formatDate(
+                              new Date(row.created_at * 1000).toISOString(),
+                            )
+                          : "-"}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+          <p className="text-xs text-mute mt-3 tabular-nums">
+            {agents.length} agent{agents.length === 1 ? "" : "s"}
+          </p>
+        </>
+      )}
+    </>
+  );
+}

--- a/apps/hub/src/pages/DatasetDetailPage.tsx
+++ b/apps/hub/src/pages/DatasetDetailPage.tsx
@@ -143,6 +143,13 @@ export function DatasetDetailPage() {
             "not a database package (open Plugin marketplace instead)",
           );
         }
+        if (meta.package_kind === "agent" || selected.package_kind === "agent") {
+          throw new RegistryHttpError(
+            404,
+            "not_found",
+            "not a database package (open Agent hub instead)",
+          );
+        }
         const chosen = meta.package_digest ? meta : selected;
         setRelease(chosen);
         const files = await listPackageFiles(

--- a/apps/hub/src/pages/RuntimeDetailPage.tsx
+++ b/apps/hub/src/pages/RuntimeDetailPage.tsx
@@ -29,6 +29,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import {
+  agentRefPackageId,
   decodeFileContent,
   encodeDatasetId,
   getPackageFile,
@@ -339,6 +340,25 @@ export function RuntimeDetailPage() {
                 </code>
               </pre>
             </div>
+            {selectedAppearance?.agent_ref ? (
+              <p className="text-xs text-mute">
+                Agent:{" "}
+                {agentRefPackageId(selectedAppearance.agent_ref) ? (
+                  <Link
+                    to={`/agents/${encodeDatasetId(
+                      agentRefPackageId(selectedAppearance.agent_ref) ?? "",
+                    )}`}
+                    className="font-mono text-body underline underline-offset-2 hover:text-ink"
+                  >
+                    {selectedAppearance.agent_ref}
+                  </Link>
+                ) : (
+                  <span className="font-mono text-body">
+                    {selectedAppearance.agent_ref}
+                  </span>
+                )}
+              </p>
+            ) : null}
           </section>
 
           <section className="space-y-2">

--- a/docs/design/14-agent-hub.md
+++ b/docs/design/14-agent-hub.md
@@ -1,0 +1,115 @@
+# 14 — Agent Hub 与 `bora.agent/1`
+
+| 字段 | 值 |
+| --- | --- |
+| 产品 | Bounded Orchestration for Runtime Agents（BORA） |
+| 权威 | 本文件与同目录其它 design 文档共同构成设计权威 |
+| 摘要 | 一等 Agent 对象：`bora.agent/1` 包格式、本地缓存与 Hub 地址、`--agent` 投影进 profiles 通道、通配 `"*"` 默认绑定、`agent_ref` 溯源非身份、Registry `package_kind=agent`、Hub Agents 页与 plaza 互链 |
+
+---
+
+## 模型
+
+**Agent** 是可发布、可拉取、版本化的 **job 绑定配置对象**：恰好一条 `bora.profiles/1` binding（executor / model / options / extensions / locator），加显示元数据。它回答「怎么跑一个 agent」，与 Dataset（「测什么」）和 plugin（「机制怎么实现」）正交。
+
+| 对象 | 回答 | 交付单位 |
+| --- | --- | --- |
+| Dataset（`bora.database/1`） | 测什么（task 身份 + evaluator truth） | 包 |
+| Plugin（`bora.plugin/1`） | 机制怎么实现（executor / 槽位 handler） | 包 |
+| **Agent（`bora.agent/1`）** | **怎么跑一个 agent（binding 选型）** | 包 |
+
+Agent **不是**新的执行机制：运行期它只是投影成一份 profiles 绑定,走既有
+`resolve_profile_bindings` → `merge_bindings_onto_slots` → `job_overlay` → lock digest / suite fingerprint 通道。Config Core 之下无新分支。
+
+## 包格式 `bora.agent/1`
+
+包根 `agent.yaml`（可伴随 `README.md` / `docs/`；**不含**其它运行时文件）：
+
+```yaml
+format: bora.agent/1
+agent_id: swe-codex-high        # ^[a-z0-9][a-z0-9_-]*$；Hub 地址为 org/agent_id
+version: "0.1.0"                # publish 必填；进 lock 溯源
+label: "Codex · GPT-5.4 · high" # 显示名；binding 未给 label 时下沉为 binding.label
+description: "…"                # 可选
+tags: [coding, swe]             # 可选 list[str]
+binding:                        # 恰好一条 bora.profiles/1 binding；同一校验器
+  executor: acp
+  model: gpt-5.4-mini
+  extensions:
+    - plugin: acp
+      options: { entry: codex, reasoning_effort: high }
+  api_key: openai_api_key       # env locator 名 only；出现 secret 值 → fail closed
+  # base_url / options / overlays 同 profiles binding 语义
+```
+
+| 规则 | 说明 |
+| --- | --- |
+| 顶层 allowlist | `{format, agent_id, version, label, description, tags, binding}`；未知键 fail closed |
+| binding 校验 | 复用 profiles 的 binding 键 allowlist（`BINDING_FIELD_KEYS`）与 options denylist；**禁止**手写 `binding.agent_ref`（保留键，投影时注入） |
+| `binding.overlays` | 允许声明；路径仍按**运行 Database 根**解析（`overlays/` 前缀 + lock fail-closed 扫描,见 12）。Agent 包本身不携带这些字节 |
+| secret | 包内全部文件过 overlay 同款 secret 扫描（PEM / token / 高熵）;publish 与 install 双侧 fail closed |
+| 单 binding | 一个 Agent = 一个可运行 actor 产品;多角色组合是运行期事（多个 `--agent role=ref`） |
+
+## 地址、缓存与 install
+
+与 plugin 的双地址规则（11 §两套地址）同构：
+
+| 动作 | id / 地址 |
+| --- | --- |
+| 路径安装 `bora agent install ./my-agent/` | `agent.yaml` 短 id；index 记 `local/<agent_id>`;不访问 Registry |
+| `bora agent publish --org acme` | Hub 地址 `acme/<agent_id>`;短 id 拼接,已带 `org/` 前缀须一致 |
+| `bora agent install acme/x@1.0.0`（或 `@sha256:…`） | index 记 Hub id + version + digest;**无浮动 latest** |
+| `--agent` 引用 | 本地 index 中的 id（`local/x@0.1.0` / `acme/x@1.0.0`）,或**直连文件路径**（开发环） |
+
+缓存布局镜像 plugins：`$BORA_HOME/agents/<id>/<version>/` + `index.json`。
+install **只写本地缓存**,永不改写 profiles / task.yaml（同 11 不变量 3）。
+
+## 运行投影：`--agent` → profiles 通道
+
+`bora lock|run|campaign … --agent <spec>`（可重复）;spec 三种形态：
+
+| spec | 语义 |
+| --- | --- |
+| `<ref>` | 绑定**所有** role 槽（投影为通配键 `"*"`,见下） |
+| `<role>=<ref>` | 只绑该 role;与通配可共存,精确优先 |
+| `<path>`（目录或 `agent.yaml`） | 直连本地文件,ref 记作 `file:<path>@dev` |
+
+投影器把各 spec 合成**一份 `bora.profiles/1` 文档**(每条 binding 注入 `agent_ref`),
+落盘 `<database>/.bora/agent-profiles/<hash>.yaml`,作为 `profiles_path` 进入既有通道 ——
+应用层 resolve 调用点零改动。`--agent` 与 `--profiles` **互斥**（都在整体替换 job 绑定）。
+
+### 通配 `"*"` 默认绑定（`bora.profiles/1` 语义扩展）
+
+`bindings` 映射允许保留键 `"*"`：merge 时**先精确 role id,缺则回退 `"*"`**,再走既有缺绑定 fail-closed;`project_job_overlay` 按实际 role id 展开(overlay 内无 `"*"` 残留)。该扩展对手写 profiles.yaml 同样可用(套件内异构 role 拓扑的默认绑定),不改变既有文档的行为。
+
+### `agent_ref`：溯源,不是身份
+
+`agent_ref = "<id>@<version>+sha256:<tree-digest12>"`（本地开发为 `file:<path>@dev+…`）。
+
+| 去向 | 是否包含 | 理由 |
+| --- | --- | --- |
+| binding 键（`BINDING_FIELD_KEYS`） | ✅ 新增保留键 | 让合成文档可解析、job_overlay 可 round-trip;task.yaml 槽位自动被禁(inline-binding 断言) |
+| `job_overlay` / lock digest | ✅ 投影透传 | 运行可归因、可 `results export-profiles` 复跑 |
+| suite fingerprint `_ACTOR_KEYS` / plaza `rt_*` | ❌ | **binding 相同的两个 Agent 是同一 runtime**;可比性只看 entry/executor/model/options |
+
+## Registry / Hub
+
+- `package_kind=agent`;media type `application/vnd.bora.agent.v1.tar+gzip`;走泛型 `/v1/packages` 通道(publish / release / versions / files / by-digest),无新路由。
+- 服务端 publish 校验：解析 `agent.yaml` + 包级 secret 扫描 + 与 `bora.yaml` / `plugin.yaml` **fail closed 互斥**;产出 binding 摘要(secret-free)供详情页。
+- Hub：Agents 列表 / 详情页(binding YAML、版本、文件、install / `--agent` 复跑命令);Dataset 列表继续排除非 database kind。
+- Runtime plaza(12)：suite 行 job_overlay 带 `agent_ref` 时,plaza 详情渲染指向 Agent 详情的链接;`rt_*` 身份不变。
+
+## 产品不变量
+
+1. Agent 只是 binding 选型：Config Core 之下**不得**出现 `if agent…` 新分支;投影后与手写 profiles 完全同构。
+2. `agent.yaml` 与缓存包内**永不**出现 secret 值;`api_key` / `base_url` 只承载 locator 名。
+3. lock 内 agent 引用必须钉死 `version+digest`;**禁止**浮动 `@latest` 进 lock。
+4. `agent_ref` 不进 suite fingerprint / `rt_*`;进 `job_overlay` 与 lock digest。
+5. `--agent` 与 `--profiles` 互斥;`bora agent install` 只写本地缓存。
+6. PASS 仍只来自独立 evaluator;Agent 对象与评分无关。
+
+## 非目标
+
+- **v1 不携带运行时文件**（skills / overlay 字节）：`binding.overlays` 仍指向运行 Database 的 `overlays/` 树。Agent 包内嵌文件并 staging 进 Database 是后续独立设计回合。
+- 不做开放商店信任：信任来自 pin + digest + org allowlist 展示策略(同 11)。
+- 不引入 Agent 级评分 / 榜单权威:Leaderboard 仍由 suite 结果派生。

--- a/docs/design/14-agent-hub.md
+++ b/docs/design/14-agent-hub.md
@@ -8,6 +8,16 @@
 
 ---
 
+## 概念对照(三个易混词)
+
+| 词 | 所在文件 | 是什么 | 类比 |
+| --- | --- | --- | --- |
+| 角色槽(`agent_profiles`) | 成员 `task.yaml` | 任务身份:声明需要哪些 role id,**禁止**内嵌绑定字段 | 插座 |
+| 绑定映射(profiles) | `bora.profiles/1`(库根 / `--profiles` / `--agent` 投影产物) | job 轴:role → binding 的映射表,随 Dataset/本次运行走 | 接线表 |
+| **Agent** | `bora.agent/1` 包 | **一条** binding + 身份元数据;版本化、digest 钉死、可发布/拉取、跨 Dataset 复用 | 有版本号的插头 |
+
+运行期恒有:Agent → 投影成 profiles 文档 → merge 到角色槽 → lock 的 `agent_profiles` 行 + `job_overlay`。
+
 ## 模型
 
 **Agent** 是可发布、可拉取、版本化的 **job 绑定配置对象**：恰好一条 `bora.profiles/1` binding（executor / model / options / extensions / locator），加显示元数据。它回答「怎么跑一个 agent」，与 Dataset（「测什么」）和 plugin（「机制怎么实现」）正交。
@@ -80,7 +90,13 @@ install **只写本地缓存**,永不改写 profiles / task.yaml（同 11 不变
 
 ### 通配 `"*"` 默认绑定（`bora.profiles/1` 语义扩展）
 
-`bindings` 映射允许保留键 `"*"`：merge 时**先精确 role id,缺则回退 `"*"`**,再走既有缺绑定 fail-closed;`project_job_overlay` 按实际 role id 展开(overlay 内无 `"*"` 残留)。该扩展对手写 profiles.yaml 同样可用(套件内异构 role 拓扑的默认绑定),不改变既有文档的行为。
+`bindings` 映射允许保留键 `"*"`,语义为**字段级默认值**:
+
+1. **解析**:某 role 的有效绑定 = 通配行字段 ⊕ 精确行字段(精确覆盖同名字段;`options`/`extensions` 被设置了的精确行整体替换,不做深合并)。两行都缺 → 既有缺绑定 fail-closed。由此 `--set /bindings/<role>/<leaf>` 可对通配绑定做单字段微调而不丢其余字段。
+2. **溯源不继承**:`agent_ref` 只在该 role 纯由通配覆盖时随通配流动;存在精确行且其未声明 `agent_ref` 时,通配的 `agent_ref` **不**参与回退——显式改绑过的角色不归因于该 Agent。
+3. **身份**:通配与显式展开是**同一 job 配置**。suite fingerprint 在摘要前把 `"*"` 按任务实际 role id 展开(`project_job_overlay` 与 lock 侧同理),两种写法产生相同 `config_fingerprint`;摘要存储的 `job_overlay` 保留操作者书写形态以保复跑保真。
+
+该扩展对手写 profiles.yaml 同样可用,不改变无通配文档的行为。
 
 ### `agent_ref`：溯源,不是身份
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -53,6 +53,7 @@ Issues                   增量交付与实现缺口
 | [11-extension-plugins.md](11-extension-plugins.md) | 扩展点 L0–L5、注册表、lock bindings、`bora.plugin/1`、Recognition ≠ L0 host-ready ≠ L1 bake-declared、`--probe` |
 | [12-hub-dataset-and-leaderboard.md](12-hub-dataset-and-leaderboard.md) | Dataset draft/release、dataset ACL、Leaderboard 完备性、suite 插件出处、个人主页、chrome |
 | [13-web-ui-tokens.md](13-web-ui-tokens.md) | Web UI 令牌与不变量(website/hub/viewer 三端):色彩、字体、形状、十条不变量、机检 |
+| [14-agent-hub.md](14-agent-hub.md) | 一等 Agent 对象:`bora.agent/1`、`--agent` 投影、通配 `"*"` 默认绑定、`agent_ref` 溯源、`package_kind=agent` |
 
 ### Runtime 子文（执行链）
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,11 +5,24 @@ selected popular-bench **conversion** packages.
 
 ```text
 examples/
+├── agents/         # bora.agent/1 examples (mock-default / cc-default / pi-default)
+├── alfworld-mini/  # Database eval/alfworld-mini — ALFWorld-style text household eval
 ├── core/           # Database example/core — Core surface gates
 ├── journeys/       # Database example/journeys — case-class fidelity
 ├── l1/             # Database example/l1 — Provider L1
+├── scienceqa-mini/ # Database eval/scienceqa-mini — ScienceQA-style MCQ eval
 ├── slot-probe/     # multi-slot plugin e2e (install plugins first)
-└── tau3-airline/   # Database my-lab/tau3-airline — τ³-bench airline port
+├── tau3-airline/   # Database my-lab/tau3-airline — τ³-bench airline port
+└── webshop-mini/   # Database eval/webshop-mini — WebShop-style shopping eval (graded reward)
+```
+
+The three `*-mini` Databases are agent-eval suites: `profiles.yaml` binds the
+CI-safe `mock` executor so `bora lock` works offline; real evals swap the whole
+binding via the Agent lane (design/14), e.g.
+
+```bash
+uv run bora agent install examples/agents/cc-default
+uv run bora run examples/webshop-mini --agent local/cc-default@0.1.0   # needs host claude-code entry
 ```
 
 Each top-level directory is one Database (`bora.database/1`). Members live under

--- a/examples/agents/cc-default/agent.yaml
+++ b/examples/agents/cc-default/agent.yaml
@@ -1,0 +1,12 @@
+format: bora.agent/1
+agent_id: cc-default
+version: "0.1.0"
+label: "Claude Code (entry default)"
+description: "Anthropic Claude Code via ACP with the entry's default model."
+tags: [coding, acp, eval]
+binding:
+  executor: acp
+  model: entry-default
+  extensions:
+    - plugin: acp
+      options: { entry: claude-code }

--- a/examples/agents/mock-default/agent.yaml
+++ b/examples/agents/mock-default/agent.yaml
@@ -1,0 +1,11 @@
+format: bora.agent/1
+agent_id: mock-default
+version: "0.1.0"
+label: "Mock Default"
+description: >-
+  Deterministic first-party mock executor binding for lock-lane demos and CI
+  acceptance (no network, no credentials). Real runs need a real agent binding.
+tags: [ci, smoke]
+binding:
+  executor: mock
+  model: none

--- a/examples/agents/pi-default/agent.yaml
+++ b/examples/agents/pi-default/agent.yaml
@@ -1,0 +1,12 @@
+format: bora.agent/1
+agent_id: pi-default
+version: "0.1.0"
+label: "Pi (entry default)"
+description: "Pi coding agent via ACP with the entry's default model. Needs a provider API key."
+tags: [coding, acp, eval]
+binding:
+  executor: acp
+  model: entry-default
+  extensions:
+    - plugin: acp
+      options: { entry: pi }

--- a/examples/alfworld-mini/bora.yaml
+++ b/examples/alfworld-mini/bora.yaml
@@ -1,0 +1,6 @@
+format: bora.database/1
+database_id: eval/alfworld-mini
+version: 0.1.0
+description: ALFWorld-style text household mini suite
+tasks:
+  root: tasks

--- a/examples/alfworld-mini/profiles.yaml
+++ b/examples/alfworld-mini/profiles.yaml
@@ -1,0 +1,7 @@
+# Default job binding so `bora lock` works offline. Real evals bind a real
+# agent instead: `bora run <db> --agent <id>@<version>` (design/14).
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: mock
+    model: none

--- a/examples/alfworld-mini/tasks/alf-drawer-key/evaluator.py
+++ b/examples/alfworld-mini/tasks/alf-drawer-key/evaluator.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+# Evaluator-only truth: goal spec is re-declared here, independent of harness params.
+GOAL: dict[str, str] = {'key': 'desk'}
+
+
+def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:
+    data = json.loads(Path(inputs["artifacts"]["trace"]).read_text(encoding="utf-8"))
+    locations = data.get("final_locations") or {}
+    ok = all(locations.get(obj) == dest for obj, dest in GOAL.items())
+    steps = data.get("steps") or []
+    return {
+        "status": "PASS" if ok else "FAIL",
+        "score": 1.0 if ok else 0.0,
+        "metrics": {
+            "goal": GOAL,
+            "final_locations": {k: locations.get(k) for k in GOAL},
+            "n_steps": len(steps),
+            "n_noop": sum(1 for s in steps if not s.get("cmd")),
+        },
+    }

--- a/examples/alfworld-mini/tasks/alf-drawer-key/harness.py
+++ b/examples/alfworld-mini/tasks/alf-drawer-key/harness.py
@@ -1,0 +1,126 @@
+"""ALFWorld-mini harness: tiny text household world, multi-turn command loop."""
+
+from __future__ import annotations
+
+import re
+
+from bora_sdk import Agent, HarnessContext, HarnessTerminal
+
+CMD_RE = re.compile(
+    r"^\s*(look|inventory|open\s+(?P<open_r>[\w ]+)|take\s+(?P<take_o>[\w ]+)"
+    r"|put\s+(?P<put_o>[\w ]+)\s+on\s+(?P<put_r>[\w ]+))\s*$",
+    re.IGNORECASE,
+)
+
+
+class World:
+    def __init__(self, spec: dict) -> None:
+        self.loc = {k: str(v["at"]) for k, v in (spec.get("objects") or {}).items()}
+        self.receptacles = [str(r) for r in (spec.get("receptacles") or [])]
+        self.closed = {str(r) for r in (spec.get("closed") or [])}
+        self.holding: list[str] = []
+
+    def observe(self) -> str:
+        parts = []
+        for recep in self.receptacles:
+            if recep in self.closed:
+                parts.append(f"the {recep} is closed")
+                continue
+            here = sorted(o for o, at in self.loc.items() if at == recep)
+            inside = ", ".join(f"a {o}" for o in here) if here else "nothing"
+            parts.append(f"on the {recep} you see {inside}")
+        inv = ", ".join(f"a {o}" for o in self.holding) if self.holding else "nothing"
+        return "You look around. " + "; ".join(parts) + f". You are carrying {inv}."
+
+    def step(self, cmd: str) -> str:
+        m = CMD_RE.match(cmd)
+        if not m:
+            return "Nothing happens. (Unknown command.)"
+        text = m.group(1).lower()
+        if text == "look":
+            return self.observe()
+        if text == "inventory":
+            inv = ", ".join(self.holding) or "nothing"
+            return f"You are carrying: {inv}."
+        if m.group("open_r"):
+            recep = m.group("open_r").strip().lower()
+            if recep in self.closed:
+                self.closed.discard(recep)
+                here = sorted(o for o, at in self.loc.items() if at == recep)
+                inside = ", ".join(f"a {o}" for o in here) if here else "nothing"
+                return f"You open the {recep}. Inside you see {inside}."
+            return f"The {recep} is not something you can open here."
+        if m.group("take_o"):
+            obj = m.group("take_o").strip().lower()
+            at = self.loc.get(obj)
+            if at is None or obj in self.holding:
+                return f"You don't see a {obj} you can take."
+            if at in self.closed:
+                return f"You can't reach the {obj}."
+            self.loc[obj] = "carried"
+            self.holding.append(obj)
+            return f"You pick up the {obj}."
+        if m.group("put_o") and m.group("put_r"):
+            obj = m.group("put_o").strip().lower()
+            recep = m.group("put_r").strip().lower()
+            if obj not in self.holding:
+                return f"You are not carrying a {obj}."
+            if recep not in self.receptacles:
+                return f"There is no {recep} here."
+            if recep in self.closed:
+                return f"The {recep} is closed."
+            self.holding.remove(obj)
+            self.loc[obj] = recep
+            return f"You put the {obj} on the {recep}."
+        return "Nothing happens."
+
+
+def _extract_command(text: str) -> str | None:
+    for line in text.splitlines():
+        line = line.strip().strip("`>*-").strip()
+        if line and CMD_RE.match(line):
+            return line
+    return None
+
+
+async def run(ctx: HarnessContext) -> HarnessTerminal:
+    goal = ctx.params.require_str("goal")
+    spec = ctx.params.get("world") or {}
+    max_steps = int(ctx.params.get("max_steps") or 8)
+    goal_spec = {str(k): str(v) for k, v in (ctx.params.get("goal_spec") or {}).items()}
+    world = World(dict(spec))
+    trace: list[dict[str, str]] = []
+
+    system = (
+        "You are an agent in a text household world. Interact ONLY by replying "
+        "with exactly ONE command per turn, chosen from: look | inventory | "
+        "open <receptacle> | take <object> | put <object> on <receptacle>. "
+        "Reply with the bare command, no punctuation, no explanation.\n"
+        f"Your task: {goal}\n\n"
+    )
+
+    agent = Agent(attempt_id=ctx.scope.attempt_id)
+    async with agent.session("solver", max_turns=max_steps + 2) as session:
+        observation = world.observe()
+        for _step in range(max_steps):
+            resp = await session.invoke(system + "Current observation: " + observation)
+            if not resp.get("ok"):
+                return HarnessTerminal.failed(str(resp.get("error") or "invoke_failed"))
+            reply = str(resp.get("text") or "")
+            cmd = _extract_command(reply)
+            if cmd is None:
+                observation = "Nothing happens. Reply with exactly one bare command."
+                trace.append({"reply": reply[:400], "cmd": "", "result": observation})
+                continue
+            result = world.step(cmd)
+            trace.append({"reply": reply[:400], "cmd": cmd, "result": result})
+            observation = result
+            if goal_spec and all(world.loc.get(o) == d for o, d in goal_spec.items()):
+                break  # goal reached — end the episode, no idle turns
+
+    ctx.publish_json(
+        "trace",
+        {"goal": goal, "steps": trace, "final_locations": dict(world.loc),
+         "holding": list(world.holding)},
+    )
+    return HarnessTerminal.completed("alfworld-mini")

--- a/examples/alfworld-mini/tasks/alf-drawer-key/task.yaml
+++ b/examples/alfworld-mini/tasks/alf-drawer-key/task.yaml
@@ -1,0 +1,46 @@
+format: bora.task/1
+task_id: alf-drawer-key
+harness:
+  runtime: python
+  entrypoint: harness:run
+parameters:
+  goal: find the key and put it on the desk
+  world:
+    objects:
+      key:
+        at: drawer
+      pen:
+        at: desk
+    receptacles:
+    - desk
+    - drawer
+    - shelf
+    closed:
+    - drawer
+  max_steps: 8
+  goal_spec:
+    key: desk
+provider:
+  kind: local
+  assurance: l0
+agent_profiles:
+- id: solver
+limits:
+  wall_time_seconds: 900
+  agent_invocations: 12
+  environment_actions: 0
+artifacts:
+  publishable:
+  - id: trace
+    producer: harness
+    path: artifacts/trace.json
+    media_type: application/json
+evaluation:
+  runtime: python
+  entrypoint: evaluator:evaluate
+  network: none
+  inputs:
+  - artifact: trace
+    target: trace.json
+  output:
+    format: json

--- a/examples/alfworld-mini/tasks/alf-put-mug/evaluator.py
+++ b/examples/alfworld-mini/tasks/alf-put-mug/evaluator.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+# Evaluator-only truth: goal spec is re-declared here, independent of harness params.
+GOAL: dict[str, str] = {'mug': 'desk'}
+
+
+def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:
+    data = json.loads(Path(inputs["artifacts"]["trace"]).read_text(encoding="utf-8"))
+    locations = data.get("final_locations") or {}
+    ok = all(locations.get(obj) == dest for obj, dest in GOAL.items())
+    steps = data.get("steps") or []
+    return {
+        "status": "PASS" if ok else "FAIL",
+        "score": 1.0 if ok else 0.0,
+        "metrics": {
+            "goal": GOAL,
+            "final_locations": {k: locations.get(k) for k in GOAL},
+            "n_steps": len(steps),
+            "n_noop": sum(1 for s in steps if not s.get("cmd")),
+        },
+    }

--- a/examples/alfworld-mini/tasks/alf-put-mug/harness.py
+++ b/examples/alfworld-mini/tasks/alf-put-mug/harness.py
@@ -1,0 +1,126 @@
+"""ALFWorld-mini harness: tiny text household world, multi-turn command loop."""
+
+from __future__ import annotations
+
+import re
+
+from bora_sdk import Agent, HarnessContext, HarnessTerminal
+
+CMD_RE = re.compile(
+    r"^\s*(look|inventory|open\s+(?P<open_r>[\w ]+)|take\s+(?P<take_o>[\w ]+)"
+    r"|put\s+(?P<put_o>[\w ]+)\s+on\s+(?P<put_r>[\w ]+))\s*$",
+    re.IGNORECASE,
+)
+
+
+class World:
+    def __init__(self, spec: dict) -> None:
+        self.loc = {k: str(v["at"]) for k, v in (spec.get("objects") or {}).items()}
+        self.receptacles = [str(r) for r in (spec.get("receptacles") or [])]
+        self.closed = {str(r) for r in (spec.get("closed") or [])}
+        self.holding: list[str] = []
+
+    def observe(self) -> str:
+        parts = []
+        for recep in self.receptacles:
+            if recep in self.closed:
+                parts.append(f"the {recep} is closed")
+                continue
+            here = sorted(o for o, at in self.loc.items() if at == recep)
+            inside = ", ".join(f"a {o}" for o in here) if here else "nothing"
+            parts.append(f"on the {recep} you see {inside}")
+        inv = ", ".join(f"a {o}" for o in self.holding) if self.holding else "nothing"
+        return "You look around. " + "; ".join(parts) + f". You are carrying {inv}."
+
+    def step(self, cmd: str) -> str:
+        m = CMD_RE.match(cmd)
+        if not m:
+            return "Nothing happens. (Unknown command.)"
+        text = m.group(1).lower()
+        if text == "look":
+            return self.observe()
+        if text == "inventory":
+            inv = ", ".join(self.holding) or "nothing"
+            return f"You are carrying: {inv}."
+        if m.group("open_r"):
+            recep = m.group("open_r").strip().lower()
+            if recep in self.closed:
+                self.closed.discard(recep)
+                here = sorted(o for o, at in self.loc.items() if at == recep)
+                inside = ", ".join(f"a {o}" for o in here) if here else "nothing"
+                return f"You open the {recep}. Inside you see {inside}."
+            return f"The {recep} is not something you can open here."
+        if m.group("take_o"):
+            obj = m.group("take_o").strip().lower()
+            at = self.loc.get(obj)
+            if at is None or obj in self.holding:
+                return f"You don't see a {obj} you can take."
+            if at in self.closed:
+                return f"You can't reach the {obj}."
+            self.loc[obj] = "carried"
+            self.holding.append(obj)
+            return f"You pick up the {obj}."
+        if m.group("put_o") and m.group("put_r"):
+            obj = m.group("put_o").strip().lower()
+            recep = m.group("put_r").strip().lower()
+            if obj not in self.holding:
+                return f"You are not carrying a {obj}."
+            if recep not in self.receptacles:
+                return f"There is no {recep} here."
+            if recep in self.closed:
+                return f"The {recep} is closed."
+            self.holding.remove(obj)
+            self.loc[obj] = recep
+            return f"You put the {obj} on the {recep}."
+        return "Nothing happens."
+
+
+def _extract_command(text: str) -> str | None:
+    for line in text.splitlines():
+        line = line.strip().strip("`>*-").strip()
+        if line and CMD_RE.match(line):
+            return line
+    return None
+
+
+async def run(ctx: HarnessContext) -> HarnessTerminal:
+    goal = ctx.params.require_str("goal")
+    spec = ctx.params.get("world") or {}
+    max_steps = int(ctx.params.get("max_steps") or 8)
+    goal_spec = {str(k): str(v) for k, v in (ctx.params.get("goal_spec") or {}).items()}
+    world = World(dict(spec))
+    trace: list[dict[str, str]] = []
+
+    system = (
+        "You are an agent in a text household world. Interact ONLY by replying "
+        "with exactly ONE command per turn, chosen from: look | inventory | "
+        "open <receptacle> | take <object> | put <object> on <receptacle>. "
+        "Reply with the bare command, no punctuation, no explanation.\n"
+        f"Your task: {goal}\n\n"
+    )
+
+    agent = Agent(attempt_id=ctx.scope.attempt_id)
+    async with agent.session("solver", max_turns=max_steps + 2) as session:
+        observation = world.observe()
+        for _step in range(max_steps):
+            resp = await session.invoke(system + "Current observation: " + observation)
+            if not resp.get("ok"):
+                return HarnessTerminal.failed(str(resp.get("error") or "invoke_failed"))
+            reply = str(resp.get("text") or "")
+            cmd = _extract_command(reply)
+            if cmd is None:
+                observation = "Nothing happens. Reply with exactly one bare command."
+                trace.append({"reply": reply[:400], "cmd": "", "result": observation})
+                continue
+            result = world.step(cmd)
+            trace.append({"reply": reply[:400], "cmd": cmd, "result": result})
+            observation = result
+            if goal_spec and all(world.loc.get(o) == d for o, d in goal_spec.items()):
+                break  # goal reached — end the episode, no idle turns
+
+    ctx.publish_json(
+        "trace",
+        {"goal": goal, "steps": trace, "final_locations": dict(world.loc),
+         "holding": list(world.holding)},
+    )
+    return HarnessTerminal.completed("alfworld-mini")

--- a/examples/alfworld-mini/tasks/alf-put-mug/task.yaml
+++ b/examples/alfworld-mini/tasks/alf-put-mug/task.yaml
@@ -1,0 +1,45 @@
+format: bora.task/1
+task_id: alf-put-mug
+harness:
+  runtime: python
+  entrypoint: harness:run
+parameters:
+  goal: put the mug on the desk
+  world:
+    objects:
+      mug:
+        at: coffee table
+      apple:
+        at: sidetable
+    receptacles:
+    - coffee table
+    - desk
+    - sidetable
+    closed: []
+  max_steps: 6
+  goal_spec:
+    mug: desk
+provider:
+  kind: local
+  assurance: l0
+agent_profiles:
+- id: solver
+limits:
+  wall_time_seconds: 900
+  agent_invocations: 10
+  environment_actions: 0
+artifacts:
+  publishable:
+  - id: trace
+    producer: harness
+    path: artifacts/trace.json
+    media_type: application/json
+evaluation:
+  runtime: python
+  entrypoint: evaluator:evaluate
+  network: none
+  inputs:
+  - artifact: trace
+    target: trace.json
+  output:
+    format: json

--- a/examples/alfworld-mini/tasks/alf-two-objects/evaluator.py
+++ b/examples/alfworld-mini/tasks/alf-two-objects/evaluator.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+# Evaluator-only truth: goal spec is re-declared here, independent of harness params.
+GOAL: dict[str, str] = {'apple': 'desk', 'mug': 'desk'}
+
+
+def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:
+    data = json.loads(Path(inputs["artifacts"]["trace"]).read_text(encoding="utf-8"))
+    locations = data.get("final_locations") or {}
+    ok = all(locations.get(obj) == dest for obj, dest in GOAL.items())
+    steps = data.get("steps") or []
+    return {
+        "status": "PASS" if ok else "FAIL",
+        "score": 1.0 if ok else 0.0,
+        "metrics": {
+            "goal": GOAL,
+            "final_locations": {k: locations.get(k) for k in GOAL},
+            "n_steps": len(steps),
+            "n_noop": sum(1 for s in steps if not s.get("cmd")),
+        },
+    }

--- a/examples/alfworld-mini/tasks/alf-two-objects/harness.py
+++ b/examples/alfworld-mini/tasks/alf-two-objects/harness.py
@@ -1,0 +1,126 @@
+"""ALFWorld-mini harness: tiny text household world, multi-turn command loop."""
+
+from __future__ import annotations
+
+import re
+
+from bora_sdk import Agent, HarnessContext, HarnessTerminal
+
+CMD_RE = re.compile(
+    r"^\s*(look|inventory|open\s+(?P<open_r>[\w ]+)|take\s+(?P<take_o>[\w ]+)"
+    r"|put\s+(?P<put_o>[\w ]+)\s+on\s+(?P<put_r>[\w ]+))\s*$",
+    re.IGNORECASE,
+)
+
+
+class World:
+    def __init__(self, spec: dict) -> None:
+        self.loc = {k: str(v["at"]) for k, v in (spec.get("objects") or {}).items()}
+        self.receptacles = [str(r) for r in (spec.get("receptacles") or [])]
+        self.closed = {str(r) for r in (spec.get("closed") or [])}
+        self.holding: list[str] = []
+
+    def observe(self) -> str:
+        parts = []
+        for recep in self.receptacles:
+            if recep in self.closed:
+                parts.append(f"the {recep} is closed")
+                continue
+            here = sorted(o for o, at in self.loc.items() if at == recep)
+            inside = ", ".join(f"a {o}" for o in here) if here else "nothing"
+            parts.append(f"on the {recep} you see {inside}")
+        inv = ", ".join(f"a {o}" for o in self.holding) if self.holding else "nothing"
+        return "You look around. " + "; ".join(parts) + f". You are carrying {inv}."
+
+    def step(self, cmd: str) -> str:
+        m = CMD_RE.match(cmd)
+        if not m:
+            return "Nothing happens. (Unknown command.)"
+        text = m.group(1).lower()
+        if text == "look":
+            return self.observe()
+        if text == "inventory":
+            inv = ", ".join(self.holding) or "nothing"
+            return f"You are carrying: {inv}."
+        if m.group("open_r"):
+            recep = m.group("open_r").strip().lower()
+            if recep in self.closed:
+                self.closed.discard(recep)
+                here = sorted(o for o, at in self.loc.items() if at == recep)
+                inside = ", ".join(f"a {o}" for o in here) if here else "nothing"
+                return f"You open the {recep}. Inside you see {inside}."
+            return f"The {recep} is not something you can open here."
+        if m.group("take_o"):
+            obj = m.group("take_o").strip().lower()
+            at = self.loc.get(obj)
+            if at is None or obj in self.holding:
+                return f"You don't see a {obj} you can take."
+            if at in self.closed:
+                return f"You can't reach the {obj}."
+            self.loc[obj] = "carried"
+            self.holding.append(obj)
+            return f"You pick up the {obj}."
+        if m.group("put_o") and m.group("put_r"):
+            obj = m.group("put_o").strip().lower()
+            recep = m.group("put_r").strip().lower()
+            if obj not in self.holding:
+                return f"You are not carrying a {obj}."
+            if recep not in self.receptacles:
+                return f"There is no {recep} here."
+            if recep in self.closed:
+                return f"The {recep} is closed."
+            self.holding.remove(obj)
+            self.loc[obj] = recep
+            return f"You put the {obj} on the {recep}."
+        return "Nothing happens."
+
+
+def _extract_command(text: str) -> str | None:
+    for line in text.splitlines():
+        line = line.strip().strip("`>*-").strip()
+        if line and CMD_RE.match(line):
+            return line
+    return None
+
+
+async def run(ctx: HarnessContext) -> HarnessTerminal:
+    goal = ctx.params.require_str("goal")
+    spec = ctx.params.get("world") or {}
+    max_steps = int(ctx.params.get("max_steps") or 8)
+    goal_spec = {str(k): str(v) for k, v in (ctx.params.get("goal_spec") or {}).items()}
+    world = World(dict(spec))
+    trace: list[dict[str, str]] = []
+
+    system = (
+        "You are an agent in a text household world. Interact ONLY by replying "
+        "with exactly ONE command per turn, chosen from: look | inventory | "
+        "open <receptacle> | take <object> | put <object> on <receptacle>. "
+        "Reply with the bare command, no punctuation, no explanation.\n"
+        f"Your task: {goal}\n\n"
+    )
+
+    agent = Agent(attempt_id=ctx.scope.attempt_id)
+    async with agent.session("solver", max_turns=max_steps + 2) as session:
+        observation = world.observe()
+        for _step in range(max_steps):
+            resp = await session.invoke(system + "Current observation: " + observation)
+            if not resp.get("ok"):
+                return HarnessTerminal.failed(str(resp.get("error") or "invoke_failed"))
+            reply = str(resp.get("text") or "")
+            cmd = _extract_command(reply)
+            if cmd is None:
+                observation = "Nothing happens. Reply with exactly one bare command."
+                trace.append({"reply": reply[:400], "cmd": "", "result": observation})
+                continue
+            result = world.step(cmd)
+            trace.append({"reply": reply[:400], "cmd": cmd, "result": result})
+            observation = result
+            if goal_spec and all(world.loc.get(o) == d for o, d in goal_spec.items()):
+                break  # goal reached — end the episode, no idle turns
+
+    ctx.publish_json(
+        "trace",
+        {"goal": goal, "steps": trace, "final_locations": dict(world.loc),
+         "holding": list(world.holding)},
+    )
+    return HarnessTerminal.completed("alfworld-mini")

--- a/examples/alfworld-mini/tasks/alf-two-objects/task.yaml
+++ b/examples/alfworld-mini/tasks/alf-two-objects/task.yaml
@@ -1,0 +1,46 @@
+format: bora.task/1
+task_id: alf-two-objects
+harness:
+  runtime: python
+  entrypoint: harness:run
+parameters:
+  goal: put the apple and the mug on the desk
+  world:
+    objects:
+      apple:
+        at: sidetable
+      mug:
+        at: coffee table
+    receptacles:
+    - coffee table
+    - desk
+    - sidetable
+    closed: []
+  max_steps: 10
+  goal_spec:
+    apple: desk
+    mug: desk
+provider:
+  kind: local
+  assurance: l0
+agent_profiles:
+- id: solver
+limits:
+  wall_time_seconds: 900
+  agent_invocations: 14
+  environment_actions: 0
+artifacts:
+  publishable:
+  - id: trace
+    producer: harness
+    path: artifacts/trace.json
+    media_type: application/json
+evaluation:
+  runtime: python
+  entrypoint: evaluator:evaluate
+  network: none
+  inputs:
+  - artifact: trace
+    target: trace.json
+  output:
+    format: json

--- a/examples/scienceqa-mini/bora.yaml
+++ b/examples/scienceqa-mini/bora.yaml
@@ -1,0 +1,6 @@
+format: bora.database/1
+database_id: eval/scienceqa-mini
+version: 0.1.0
+description: ScienceQA-style MCQ mini suite
+tasks:
+  root: tasks

--- a/examples/scienceqa-mini/profiles.yaml
+++ b/examples/scienceqa-mini/profiles.yaml
@@ -1,0 +1,7 @@
+# Default job binding so `bora lock` works offline. Real evals bind a real
+# agent instead: `bora run <db> --agent <id>@<version>` (design/14).
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: mock
+    model: none

--- a/examples/scienceqa-mini/tasks/sqa-conductor/evaluator.py
+++ b/examples/scienceqa-mini/tasks/sqa-conductor/evaluator.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+GOLD = "C"
+
+
+def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:
+    data = json.loads(Path(inputs["artifacts"]["answer"]).read_text(encoding="utf-8"))
+    predicted = data.get("letter")
+    ok = predicted == GOLD
+    return {
+        "status": "PASS" if ok else "FAIL",
+        "score": 1.0 if ok else 0.0,
+        "metrics": {"predicted": predicted, "gold": GOLD, "raw_chars": len(str(data.get("raw") or ""))},
+    }

--- a/examples/scienceqa-mini/tasks/sqa-conductor/harness.py
+++ b/examples/scienceqa-mini/tasks/sqa-conductor/harness.py
@@ -1,0 +1,29 @@
+"""ScienceQA-mini harness: one MCQ invoke, publish parsed letter."""
+
+from __future__ import annotations
+
+import re
+
+from bora_sdk import Agent, HarnessContext, HarnessTerminal
+
+LETTER_RE = re.compile(r"\b([ABCD])\b")
+
+
+async def run(ctx: HarnessContext) -> HarnessTerminal:
+    question = ctx.params.require_str("question")
+    opts = ctx.params.get("options") or {}
+    lines = [f"{k}. {opts[k]}" for k in sorted(opts)]
+    prompt = (
+        "You are answering a multiple-choice science question.\n\n"
+        f"Question: {question}\n" + "\n".join(lines)
+        + "\n\nReply with ONLY the single letter (A, B, C or D) of the correct option."
+    )
+    agent = Agent(attempt_id=ctx.scope.attempt_id)
+    async with agent.session("solver", max_turns=2) as session:
+        resp = await session.invoke(prompt)
+    if not resp.get("ok"):
+        return HarnessTerminal.failed(str(resp.get("error") or "invoke_failed"))
+    text = str(resp.get("text") or "")
+    match = LETTER_RE.search(text.strip().upper())
+    ctx.publish_json("answer", {"raw": text, "letter": match.group(1) if match else None})
+    return HarnessTerminal.completed("scienceqa-mini")

--- a/examples/scienceqa-mini/tasks/sqa-conductor/task.yaml
+++ b/examples/scienceqa-mini/tasks/sqa-conductor/task.yaml
@@ -1,0 +1,36 @@
+format: bora.task/1
+task_id: sqa-conductor
+harness:
+  runtime: python
+  entrypoint: harness:run
+parameters:
+  question: Which of these materials is the best conductor of electricity?
+  options:
+    A: Rubber
+    B: Glass
+    C: Copper
+    D: Wood
+provider:
+  kind: local
+  assurance: l0
+agent_profiles:
+- id: solver
+limits:
+  wall_time_seconds: 300
+  agent_invocations: 2
+  environment_actions: 0
+artifacts:
+  publishable:
+  - id: answer
+    producer: harness
+    path: artifacts/answer.json
+    media_type: application/json
+evaluation:
+  runtime: python
+  entrypoint: evaluator:evaluate
+  network: none
+  inputs:
+  - artifact: answer
+    target: answer.json
+  output:
+    format: json

--- a/examples/scienceqa-mini/tasks/sqa-food-chain/evaluator.py
+++ b/examples/scienceqa-mini/tasks/sqa-food-chain/evaluator.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+GOLD = "A"
+
+
+def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:
+    data = json.loads(Path(inputs["artifacts"]["answer"]).read_text(encoding="utf-8"))
+    predicted = data.get("letter")
+    ok = predicted == GOLD
+    return {
+        "status": "PASS" if ok else "FAIL",
+        "score": 1.0 if ok else 0.0,
+        "metrics": {"predicted": predicted, "gold": GOLD, "raw_chars": len(str(data.get("raw") or ""))},
+    }

--- a/examples/scienceqa-mini/tasks/sqa-food-chain/harness.py
+++ b/examples/scienceqa-mini/tasks/sqa-food-chain/harness.py
@@ -1,0 +1,29 @@
+"""ScienceQA-mini harness: one MCQ invoke, publish parsed letter."""
+
+from __future__ import annotations
+
+import re
+
+from bora_sdk import Agent, HarnessContext, HarnessTerminal
+
+LETTER_RE = re.compile(r"\b([ABCD])\b")
+
+
+async def run(ctx: HarnessContext) -> HarnessTerminal:
+    question = ctx.params.require_str("question")
+    opts = ctx.params.get("options") or {}
+    lines = [f"{k}. {opts[k]}" for k in sorted(opts)]
+    prompt = (
+        "You are answering a multiple-choice science question.\n\n"
+        f"Question: {question}\n" + "\n".join(lines)
+        + "\n\nReply with ONLY the single letter (A, B, C or D) of the correct option."
+    )
+    agent = Agent(attempt_id=ctx.scope.attempt_id)
+    async with agent.session("solver", max_turns=2) as session:
+        resp = await session.invoke(prompt)
+    if not resp.get("ok"):
+        return HarnessTerminal.failed(str(resp.get("error") or "invoke_failed"))
+    text = str(resp.get("text") or "")
+    match = LETTER_RE.search(text.strip().upper())
+    ctx.publish_json("answer", {"raw": text, "letter": match.group(1) if match else None})
+    return HarnessTerminal.completed("scienceqa-mini")

--- a/examples/scienceqa-mini/tasks/sqa-food-chain/task.yaml
+++ b/examples/scienceqa-mini/tasks/sqa-food-chain/task.yaml
@@ -1,0 +1,36 @@
+format: bora.task/1
+task_id: sqa-food-chain
+harness:
+  runtime: python
+  entrypoint: harness:run
+parameters:
+  question: In a grassland food chain, which organism is a producer?
+  options:
+    A: Grass
+    B: Rabbit
+    C: Fox
+    D: Mushroom
+provider:
+  kind: local
+  assurance: l0
+agent_profiles:
+- id: solver
+limits:
+  wall_time_seconds: 300
+  agent_invocations: 2
+  environment_actions: 0
+artifacts:
+  publishable:
+  - id: answer
+    producer: harness
+    path: artifacts/answer.json
+    media_type: application/json
+evaluation:
+  runtime: python
+  entrypoint: evaluator:evaluate
+  network: none
+  inputs:
+  - artifact: answer
+    target: answer.json
+  output:
+    format: json

--- a/examples/scienceqa-mini/tasks/sqa-photosynthesis/evaluator.py
+++ b/examples/scienceqa-mini/tasks/sqa-photosynthesis/evaluator.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+GOLD = "B"
+
+
+def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:
+    data = json.loads(Path(inputs["artifacts"]["answer"]).read_text(encoding="utf-8"))
+    predicted = data.get("letter")
+    ok = predicted == GOLD
+    return {
+        "status": "PASS" if ok else "FAIL",
+        "score": 1.0 if ok else 0.0,
+        "metrics": {"predicted": predicted, "gold": GOLD, "raw_chars": len(str(data.get("raw") or ""))},
+    }

--- a/examples/scienceqa-mini/tasks/sqa-photosynthesis/harness.py
+++ b/examples/scienceqa-mini/tasks/sqa-photosynthesis/harness.py
@@ -1,0 +1,29 @@
+"""ScienceQA-mini harness: one MCQ invoke, publish parsed letter."""
+
+from __future__ import annotations
+
+import re
+
+from bora_sdk import Agent, HarnessContext, HarnessTerminal
+
+LETTER_RE = re.compile(r"\b([ABCD])\b")
+
+
+async def run(ctx: HarnessContext) -> HarnessTerminal:
+    question = ctx.params.require_str("question")
+    opts = ctx.params.get("options") or {}
+    lines = [f"{k}. {opts[k]}" for k in sorted(opts)]
+    prompt = (
+        "You are answering a multiple-choice science question.\n\n"
+        f"Question: {question}\n" + "\n".join(lines)
+        + "\n\nReply with ONLY the single letter (A, B, C or D) of the correct option."
+    )
+    agent = Agent(attempt_id=ctx.scope.attempt_id)
+    async with agent.session("solver", max_turns=2) as session:
+        resp = await session.invoke(prompt)
+    if not resp.get("ok"):
+        return HarnessTerminal.failed(str(resp.get("error") or "invoke_failed"))
+    text = str(resp.get("text") or "")
+    match = LETTER_RE.search(text.strip().upper())
+    ctx.publish_json("answer", {"raw": text, "letter": match.group(1) if match else None})
+    return HarnessTerminal.completed("scienceqa-mini")

--- a/examples/scienceqa-mini/tasks/sqa-photosynthesis/task.yaml
+++ b/examples/scienceqa-mini/tasks/sqa-photosynthesis/task.yaml
@@ -1,0 +1,36 @@
+format: bora.task/1
+task_id: sqa-photosynthesis
+harness:
+  runtime: python
+  entrypoint: harness:run
+parameters:
+  question: Which gas do plants primarily absorb from the air to perform photosynthesis?
+  options:
+    A: Oxygen
+    B: Carbon dioxide
+    C: Nitrogen
+    D: Hydrogen
+provider:
+  kind: local
+  assurance: l0
+agent_profiles:
+- id: solver
+limits:
+  wall_time_seconds: 300
+  agent_invocations: 2
+  environment_actions: 0
+artifacts:
+  publishable:
+  - id: answer
+    producer: harness
+    path: artifacts/answer.json
+    media_type: application/json
+evaluation:
+  runtime: python
+  entrypoint: evaluator:evaluate
+  network: none
+  inputs:
+  - artifact: answer
+    target: answer.json
+  output:
+    format: json

--- a/examples/scienceqa-mini/tasks/sqa-states-matter/evaluator.py
+++ b/examples/scienceqa-mini/tasks/sqa-states-matter/evaluator.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+GOLD = "B"
+
+
+def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:
+    data = json.loads(Path(inputs["artifacts"]["answer"]).read_text(encoding="utf-8"))
+    predicted = data.get("letter")
+    ok = predicted == GOLD
+    return {
+        "status": "PASS" if ok else "FAIL",
+        "score": 1.0 if ok else 0.0,
+        "metrics": {"predicted": predicted, "gold": GOLD, "raw_chars": len(str(data.get("raw") or ""))},
+    }

--- a/examples/scienceqa-mini/tasks/sqa-states-matter/harness.py
+++ b/examples/scienceqa-mini/tasks/sqa-states-matter/harness.py
@@ -1,0 +1,29 @@
+"""ScienceQA-mini harness: one MCQ invoke, publish parsed letter."""
+
+from __future__ import annotations
+
+import re
+
+from bora_sdk import Agent, HarnessContext, HarnessTerminal
+
+LETTER_RE = re.compile(r"\b([ABCD])\b")
+
+
+async def run(ctx: HarnessContext) -> HarnessTerminal:
+    question = ctx.params.require_str("question")
+    opts = ctx.params.get("options") or {}
+    lines = [f"{k}. {opts[k]}" for k in sorted(opts)]
+    prompt = (
+        "You are answering a multiple-choice science question.\n\n"
+        f"Question: {question}\n" + "\n".join(lines)
+        + "\n\nReply with ONLY the single letter (A, B, C or D) of the correct option."
+    )
+    agent = Agent(attempt_id=ctx.scope.attempt_id)
+    async with agent.session("solver", max_turns=2) as session:
+        resp = await session.invoke(prompt)
+    if not resp.get("ok"):
+        return HarnessTerminal.failed(str(resp.get("error") or "invoke_failed"))
+    text = str(resp.get("text") or "")
+    match = LETTER_RE.search(text.strip().upper())
+    ctx.publish_json("answer", {"raw": text, "letter": match.group(1) if match else None})
+    return HarnessTerminal.completed("scienceqa-mini")

--- a/examples/scienceqa-mini/tasks/sqa-states-matter/task.yaml
+++ b/examples/scienceqa-mini/tasks/sqa-states-matter/task.yaml
@@ -1,0 +1,37 @@
+format: bora.task/1
+task_id: sqa-states-matter
+harness:
+  runtime: python
+  entrypoint: harness:run
+parameters:
+  question: Which state of matter has a definite volume but takes the shape of its
+    container?
+  options:
+    A: Solid
+    B: Liquid
+    C: Gas
+    D: Plasma
+provider:
+  kind: local
+  assurance: l0
+agent_profiles:
+- id: solver
+limits:
+  wall_time_seconds: 300
+  agent_invocations: 2
+  environment_actions: 0
+artifacts:
+  publishable:
+  - id: answer
+    producer: harness
+    path: artifacts/answer.json
+    media_type: application/json
+evaluation:
+  runtime: python
+  entrypoint: evaluator:evaluate
+  network: none
+  inputs:
+  - artifact: answer
+    target: answer.json
+  output:
+    format: json

--- a/examples/webshop-mini/bora.yaml
+++ b/examples/webshop-mini/bora.yaml
@@ -1,0 +1,6 @@
+format: bora.database/1
+database_id: eval/webshop-mini
+version: 0.1.0
+description: WebShop-style simulated shopping mini suite (graded reward)
+tasks:
+  root: tasks

--- a/examples/webshop-mini/profiles.yaml
+++ b/examples/webshop-mini/profiles.yaml
@@ -1,0 +1,7 @@
+# Default job binding so `bora lock` works offline. Real evals bind a real
+# agent instead: `bora run <db> --agent <id>@<version>` (design/14).
+format: bora.profiles/1
+bindings:
+  solver:
+    executor: mock
+    model: none

--- a/examples/webshop-mini/tasks/ws-headphones/evaluator.py
+++ b/examples/webshop-mini/tasks/ws-headphones/evaluator.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+# Evaluator-only truth (WebShop-style graded reward).
+REQUIRED_ATTRS: list[str] = ['wireless', 'over-ear']
+REQUIRED_OPTIONS: dict[str, str] = {'color': 'black'}
+PRICE_CAP: float = 50.0
+
+
+def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:
+    data = json.loads(Path(inputs["artifacts"]["purchase"]).read_text(encoding="utf-8"))
+    purchase = data.get("purchase")
+    total = len(REQUIRED_ATTRS) + len(REQUIRED_OPTIONS) + 1  # +1 = price constraint
+    if not isinstance(purchase, dict):
+        return {"status": "FAIL", "score": 0.0,
+                "metrics": {"bought": False, "n_steps": data.get("n_steps")}}
+    attrs = {a.lower() for a in purchase.get("attributes") or []}
+    opts = {str(k).lower(): str(v).lower() for k, v in (purchase.get("options") or {}).items()}
+    matched = sum(1 for a in REQUIRED_ATTRS if a.lower() in attrs)
+    matched += sum(1 for k, v in REQUIRED_OPTIONS.items() if opts.get(k.lower()) == v.lower())
+    price = float(purchase.get("price") or 0.0)
+    price_ok = price <= PRICE_CAP
+    matched += 1 if price_ok else 0
+    reward = matched / total
+    return {
+        "status": "PASS" if reward == 1.0 else "FAIL",
+        "score": round(reward, 4),
+        "metrics": {
+            "bought": True, "item_id": purchase.get("item_id"),
+            "price": price, "price_ok": price_ok,
+            "matched": matched, "required": total,
+            "options_chosen": purchase.get("options"),
+            "n_steps": data.get("n_steps"),
+        },
+    }

--- a/examples/webshop-mini/tasks/ws-headphones/harness.py
+++ b/examples/webshop-mini/tasks/ws-headphones/harness.py
@@ -1,0 +1,158 @@
+"""WebShop-mini harness: simulated shop, search/click/select/buy loop."""
+
+from __future__ import annotations
+
+import re
+
+from bora_sdk import Agent, HarnessContext, HarnessTerminal
+
+CMD_RE = re.compile(
+    r"^\s*(search\s+(?P<q>.+)|click\s+(?P<item>[a-z0-9_-]+)"
+    r"|select\s+(?P<otype>[\w-]+)\s+(?P<oval>[\w. -]+)|back|buy)\s*$",
+    re.IGNORECASE,
+)
+
+
+class Shop:
+    def __init__(self, catalog: list[dict]) -> None:
+        self.catalog = {str(p["id"]): p for p in catalog}
+        self.results: list[str] = []
+        self.current: str | None = None
+        self.selected: dict[str, str] = {}
+        self.purchase: dict | None = None
+
+    def search(self, query: str) -> str:
+        terms = [t for t in re.split(r"[^a-z0-9.]+", query.lower()) if t]
+        scored = []
+        for pid, p in self.catalog.items():
+            hay = (p["title"] + " " + " ".join(p.get("attributes", []))).lower()
+            score = sum(1 for t in terms if t in hay)
+            if score:
+                scored.append((score, pid))
+        scored.sort(key=lambda x: (-x[0], x[1]))
+        self.results = [pid for _, pid in scored[:5]]
+        self.current = None
+        self.selected = {}
+        if not self.results:
+            return "No results. Try different keywords."
+        lines = ["Results:"]
+        for pid in self.results:
+            p = self.catalog[pid]
+            lines.append(f"  [{pid}] {p['title']} — ${p['price']:.2f}")
+        return "\n".join(lines)
+
+    def click(self, pid: str) -> str:
+        if pid not in self.catalog or (self.results and pid not in self.results):
+            return f"No item [{pid}] on this page."
+        self.current = pid
+        self.selected = {}
+        p = self.catalog[pid]
+        lines = [f"Item [{pid}] {p['title']} — ${p['price']:.2f}"]
+        lines.append("  attributes: " + ", ".join(p.get("attributes", [])))
+        for otype, vals in (p.get("options") or {}).items():
+            lines.append(f"  option {otype}: " + " | ".join(vals))
+        lines.append("Use: select <option> <value>, buy, or back.")
+        return "\n".join(lines)
+
+    def select(self, otype: str, oval: str) -> str:
+        if self.current is None:
+            return "Open an item first (click <id>)."
+        opts = self.catalog[self.current].get("options") or {}
+        if otype not in opts:
+            return f"No option {otype!r} for this item."
+        match = next((v for v in opts[otype] if v.lower() == oval.lower().strip()), None)
+        if match is None:
+            return f"Value {oval!r} not available for {otype}."
+        self.selected[otype] = match
+        return f"Selected {otype} = {match}."
+
+    def back(self) -> str:
+        self.current = None
+        self.selected = {}
+        if not self.results:
+            return "Search results are empty. Use search <keywords>."
+        lines = ["Results:"]
+        for pid in self.results:
+            p = self.catalog[pid]
+            lines.append(f"  [{pid}] {p['title']} — ${p['price']:.2f}")
+        return "\n".join(lines)
+
+    def buy(self) -> str:
+        if self.current is None:
+            return "Open an item first (click <id>)."
+        p = self.catalog[self.current]
+        self.purchase = {
+            "item_id": self.current,
+            "title": p["title"],
+            "price": p["price"],
+            "attributes": list(p.get("attributes", [])),
+            "options": dict(self.selected),
+        }
+        return f"Purchased [{self.current}] {p['title']} for ${p['price']:.2f}."
+
+    def step(self, cmd: str) -> str:
+        m = CMD_RE.match(cmd)
+        if not m:
+            return "Nothing happens. (Unknown command.)"
+        if m.group("q"):
+            return self.search(m.group("q"))
+        if m.group("item"):
+            return self.click(m.group("item").lower())
+        if m.group("otype"):
+            return self.select(m.group("otype").lower(), m.group("oval"))
+        head = cmd.strip().split()[0].lower()
+        if head == "back":
+            return self.back()
+        if head == "buy":
+            return self.buy()
+        return "Nothing happens."
+
+
+def _extract_command(text: str) -> str | None:
+    for line in text.splitlines():
+        line = line.strip().strip("`>*-").strip()
+        if line and CMD_RE.match(line):
+            return line
+    return None
+
+
+async def run(ctx: HarnessContext) -> HarnessTerminal:
+    instruction = ctx.params.require_str("instruction")
+    catalog = ctx.params.get("catalog") or []
+    max_steps = int(ctx.params.get("max_steps") or 12)
+    shop = Shop(list(catalog))
+    trace: list[dict[str, str]] = []
+
+    system = (
+        "You are shopping in a text web shop. Interact ONLY by replying with "
+        "exactly ONE command per turn: search <keywords> | click <item_id> | "
+        "select <option> <value> | back | buy. Select all required options "
+        "BEFORE buying. Reply with the bare command only.\n"
+        f"Shopping instruction: {instruction}\n\n"
+    )
+
+    agent = Agent(attempt_id=ctx.scope.attempt_id)
+    observation = "Welcome. Start with: search <keywords>."
+    async with agent.session("solver", max_turns=max_steps + 2) as session:
+        for _step in range(max_steps):
+            resp = await session.invoke(system + "Current page:\n" + observation)
+            if not resp.get("ok"):
+                return HarnessTerminal.failed(str(resp.get("error") or "invoke_failed"))
+            reply = str(resp.get("text") or "")
+            cmd = _extract_command(reply)
+            if cmd is None:
+                observation = "Nothing happens. Reply with exactly one bare command."
+                trace.append({"reply": reply[:400], "cmd": "", "result": observation})
+                continue
+            result = shop.step(cmd)
+            trace.append({"reply": reply[:400], "cmd": cmd, "result": result[:400]})
+            observation = result
+            if shop.purchase is not None:
+                break  # episode ends at buy — no idle turns (eval finding #5)
+
+    ctx.publish_json(
+        "purchase",
+        {"instruction": instruction, "purchase": shop.purchase, "steps": trace,
+         "n_steps": len(trace)},
+    )
+    return HarnessTerminal.completed("webshop-mini")

--- a/examples/webshop-mini/tasks/ws-headphones/task.yaml
+++ b/examples/webshop-mini/tasks/ws-headphones/task.yaml
@@ -1,0 +1,76 @@
+format: bora.task/1
+task_id: ws-headphones
+harness:
+  runtime: python
+  entrypoint: harness:run
+parameters:
+  instruction: Buy black wireless over-ear headphones under $50. Select the color
+    before buying.
+  catalog:
+  - id: h101
+    title: Wireless Over-Ear Headphones Pro
+    price: 79.99
+    attributes:
+    - wireless
+    - over-ear
+    - noise cancelling
+    options:
+      color:
+      - black
+      - silver
+  - id: h102
+    title: Wireless Over-Ear Headphones Lite
+    price: 39.99
+    attributes:
+    - wireless
+    - over-ear
+    - 40h battery
+    options:
+      color:
+      - black
+      - white
+  - id: h103
+    title: Wired Over-Ear Studio Headphones
+    price: 45.0
+    attributes:
+    - wired
+    - over-ear
+    - studio
+    options:
+      color:
+      - black
+  - id: h104
+    title: Wireless Earbuds Mini
+    price: 29.99
+    attributes:
+    - wireless
+    - in-ear
+    options:
+      color:
+      - black
+      - blue
+  max_steps: 10
+provider:
+  kind: local
+  assurance: l0
+agent_profiles:
+- id: solver
+limits:
+  wall_time_seconds: 900
+  agent_invocations: 14
+  environment_actions: 0
+artifacts:
+  publishable:
+  - id: purchase
+    producer: harness
+    path: artifacts/purchase.json
+    media_type: application/json
+evaluation:
+  runtime: python
+  entrypoint: evaluator:evaluate
+  network: none
+  inputs:
+  - artifact: purchase
+    target: purchase.json
+  output:
+    format: json

--- a/examples/webshop-mini/tasks/ws-mug/evaluator.py
+++ b/examples/webshop-mini/tasks/ws-mug/evaluator.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+# Evaluator-only truth (WebShop-style graded reward).
+REQUIRED_ATTRS: list[str] = ['ceramic', 'mug']
+REQUIRED_OPTIONS: dict[str, str] = {'size': '350ml'}
+PRICE_CAP: float = 15.0
+
+
+def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:
+    data = json.loads(Path(inputs["artifacts"]["purchase"]).read_text(encoding="utf-8"))
+    purchase = data.get("purchase")
+    total = len(REQUIRED_ATTRS) + len(REQUIRED_OPTIONS) + 1  # +1 = price constraint
+    if not isinstance(purchase, dict):
+        return {"status": "FAIL", "score": 0.0,
+                "metrics": {"bought": False, "n_steps": data.get("n_steps")}}
+    attrs = {a.lower() for a in purchase.get("attributes") or []}
+    opts = {str(k).lower(): str(v).lower() for k, v in (purchase.get("options") or {}).items()}
+    matched = sum(1 for a in REQUIRED_ATTRS if a.lower() in attrs)
+    matched += sum(1 for k, v in REQUIRED_OPTIONS.items() if opts.get(k.lower()) == v.lower())
+    price = float(purchase.get("price") or 0.0)
+    price_ok = price <= PRICE_CAP
+    matched += 1 if price_ok else 0
+    reward = matched / total
+    return {
+        "status": "PASS" if reward == 1.0 else "FAIL",
+        "score": round(reward, 4),
+        "metrics": {
+            "bought": True, "item_id": purchase.get("item_id"),
+            "price": price, "price_ok": price_ok,
+            "matched": matched, "required": total,
+            "options_chosen": purchase.get("options"),
+            "n_steps": data.get("n_steps"),
+        },
+    }

--- a/examples/webshop-mini/tasks/ws-mug/harness.py
+++ b/examples/webshop-mini/tasks/ws-mug/harness.py
@@ -1,0 +1,158 @@
+"""WebShop-mini harness: simulated shop, search/click/select/buy loop."""
+
+from __future__ import annotations
+
+import re
+
+from bora_sdk import Agent, HarnessContext, HarnessTerminal
+
+CMD_RE = re.compile(
+    r"^\s*(search\s+(?P<q>.+)|click\s+(?P<item>[a-z0-9_-]+)"
+    r"|select\s+(?P<otype>[\w-]+)\s+(?P<oval>[\w. -]+)|back|buy)\s*$",
+    re.IGNORECASE,
+)
+
+
+class Shop:
+    def __init__(self, catalog: list[dict]) -> None:
+        self.catalog = {str(p["id"]): p for p in catalog}
+        self.results: list[str] = []
+        self.current: str | None = None
+        self.selected: dict[str, str] = {}
+        self.purchase: dict | None = None
+
+    def search(self, query: str) -> str:
+        terms = [t for t in re.split(r"[^a-z0-9.]+", query.lower()) if t]
+        scored = []
+        for pid, p in self.catalog.items():
+            hay = (p["title"] + " " + " ".join(p.get("attributes", []))).lower()
+            score = sum(1 for t in terms if t in hay)
+            if score:
+                scored.append((score, pid))
+        scored.sort(key=lambda x: (-x[0], x[1]))
+        self.results = [pid for _, pid in scored[:5]]
+        self.current = None
+        self.selected = {}
+        if not self.results:
+            return "No results. Try different keywords."
+        lines = ["Results:"]
+        for pid in self.results:
+            p = self.catalog[pid]
+            lines.append(f"  [{pid}] {p['title']} — ${p['price']:.2f}")
+        return "\n".join(lines)
+
+    def click(self, pid: str) -> str:
+        if pid not in self.catalog or (self.results and pid not in self.results):
+            return f"No item [{pid}] on this page."
+        self.current = pid
+        self.selected = {}
+        p = self.catalog[pid]
+        lines = [f"Item [{pid}] {p['title']} — ${p['price']:.2f}"]
+        lines.append("  attributes: " + ", ".join(p.get("attributes", [])))
+        for otype, vals in (p.get("options") or {}).items():
+            lines.append(f"  option {otype}: " + " | ".join(vals))
+        lines.append("Use: select <option> <value>, buy, or back.")
+        return "\n".join(lines)
+
+    def select(self, otype: str, oval: str) -> str:
+        if self.current is None:
+            return "Open an item first (click <id>)."
+        opts = self.catalog[self.current].get("options") or {}
+        if otype not in opts:
+            return f"No option {otype!r} for this item."
+        match = next((v for v in opts[otype] if v.lower() == oval.lower().strip()), None)
+        if match is None:
+            return f"Value {oval!r} not available for {otype}."
+        self.selected[otype] = match
+        return f"Selected {otype} = {match}."
+
+    def back(self) -> str:
+        self.current = None
+        self.selected = {}
+        if not self.results:
+            return "Search results are empty. Use search <keywords>."
+        lines = ["Results:"]
+        for pid in self.results:
+            p = self.catalog[pid]
+            lines.append(f"  [{pid}] {p['title']} — ${p['price']:.2f}")
+        return "\n".join(lines)
+
+    def buy(self) -> str:
+        if self.current is None:
+            return "Open an item first (click <id>)."
+        p = self.catalog[self.current]
+        self.purchase = {
+            "item_id": self.current,
+            "title": p["title"],
+            "price": p["price"],
+            "attributes": list(p.get("attributes", [])),
+            "options": dict(self.selected),
+        }
+        return f"Purchased [{self.current}] {p['title']} for ${p['price']:.2f}."
+
+    def step(self, cmd: str) -> str:
+        m = CMD_RE.match(cmd)
+        if not m:
+            return "Nothing happens. (Unknown command.)"
+        if m.group("q"):
+            return self.search(m.group("q"))
+        if m.group("item"):
+            return self.click(m.group("item").lower())
+        if m.group("otype"):
+            return self.select(m.group("otype").lower(), m.group("oval"))
+        head = cmd.strip().split()[0].lower()
+        if head == "back":
+            return self.back()
+        if head == "buy":
+            return self.buy()
+        return "Nothing happens."
+
+
+def _extract_command(text: str) -> str | None:
+    for line in text.splitlines():
+        line = line.strip().strip("`>*-").strip()
+        if line and CMD_RE.match(line):
+            return line
+    return None
+
+
+async def run(ctx: HarnessContext) -> HarnessTerminal:
+    instruction = ctx.params.require_str("instruction")
+    catalog = ctx.params.get("catalog") or []
+    max_steps = int(ctx.params.get("max_steps") or 12)
+    shop = Shop(list(catalog))
+    trace: list[dict[str, str]] = []
+
+    system = (
+        "You are shopping in a text web shop. Interact ONLY by replying with "
+        "exactly ONE command per turn: search <keywords> | click <item_id> | "
+        "select <option> <value> | back | buy. Select all required options "
+        "BEFORE buying. Reply with the bare command only.\n"
+        f"Shopping instruction: {instruction}\n\n"
+    )
+
+    agent = Agent(attempt_id=ctx.scope.attempt_id)
+    observation = "Welcome. Start with: search <keywords>."
+    async with agent.session("solver", max_turns=max_steps + 2) as session:
+        for _step in range(max_steps):
+            resp = await session.invoke(system + "Current page:\n" + observation)
+            if not resp.get("ok"):
+                return HarnessTerminal.failed(str(resp.get("error") or "invoke_failed"))
+            reply = str(resp.get("text") or "")
+            cmd = _extract_command(reply)
+            if cmd is None:
+                observation = "Nothing happens. Reply with exactly one bare command."
+                trace.append({"reply": reply[:400], "cmd": "", "result": observation})
+                continue
+            result = shop.step(cmd)
+            trace.append({"reply": reply[:400], "cmd": cmd, "result": result[:400]})
+            observation = result
+            if shop.purchase is not None:
+                break  # episode ends at buy — no idle turns (eval finding #5)
+
+    ctx.publish_json(
+        "purchase",
+        {"instruction": instruction, "purchase": shop.purchase, "steps": trace,
+         "n_steps": len(trace)},
+    )
+    return HarnessTerminal.completed("webshop-mini")

--- a/examples/webshop-mini/tasks/ws-mug/task.yaml
+++ b/examples/webshop-mini/tasks/ws-mug/task.yaml
@@ -1,0 +1,72 @@
+format: bora.task/1
+task_id: ws-mug
+harness:
+  runtime: python
+  entrypoint: harness:run
+parameters:
+  instruction: Buy a ceramic coffee mug, 350ml size, under $15. Select the size before
+    buying.
+  catalog:
+  - id: m201
+    title: Ceramic Coffee Mug Classic
+    price: 9.99
+    attributes:
+    - ceramic
+    - mug
+    - dishwasher safe
+    options:
+      size:
+      - 250ml
+      - 350ml
+      - 500ml
+      color:
+      - white
+      - black
+  - id: m202
+    title: Ceramic Coffee Mug Artisan
+    price: 18.5
+    attributes:
+    - ceramic
+    - mug
+    - handmade
+    options:
+      size:
+      - 350ml
+      color:
+      - blue
+  - id: m203
+    title: Steel Travel Mug
+    price: 12.99
+    attributes:
+    - stainless steel
+    - mug
+    - insulated
+    options:
+      size:
+      - 350ml
+      - 450ml
+  max_steps: 10
+provider:
+  kind: local
+  assurance: l0
+agent_profiles:
+- id: solver
+limits:
+  wall_time_seconds: 900
+  agent_invocations: 14
+  environment_actions: 0
+artifacts:
+  publishable:
+  - id: purchase
+    producer: harness
+    path: artifacts/purchase.json
+    media_type: application/json
+evaluation:
+  runtime: python
+  entrypoint: evaluator:evaluate
+  network: none
+  inputs:
+  - artifact: purchase
+    target: purchase.json
+  output:
+    format: json

--- a/examples/webshop-mini/tasks/ws-tshirt/evaluator.py
+++ b/examples/webshop-mini/tasks/ws-tshirt/evaluator.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+# Evaluator-only truth (WebShop-style graded reward).
+REQUIRED_ATTRS: list[str] = ['cotton', 't-shirt']
+REQUIRED_OPTIONS: dict[str, str] = {'color': 'red'}
+PRICE_CAP: float = 20.0
+
+
+def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:
+    data = json.loads(Path(inputs["artifacts"]["purchase"]).read_text(encoding="utf-8"))
+    purchase = data.get("purchase")
+    total = len(REQUIRED_ATTRS) + len(REQUIRED_OPTIONS) + 1  # +1 = price constraint
+    if not isinstance(purchase, dict):
+        return {"status": "FAIL", "score": 0.0,
+                "metrics": {"bought": False, "n_steps": data.get("n_steps")}}
+    attrs = {a.lower() for a in purchase.get("attributes") or []}
+    opts = {str(k).lower(): str(v).lower() for k, v in (purchase.get("options") or {}).items()}
+    matched = sum(1 for a in REQUIRED_ATTRS if a.lower() in attrs)
+    matched += sum(1 for k, v in REQUIRED_OPTIONS.items() if opts.get(k.lower()) == v.lower())
+    price = float(purchase.get("price") or 0.0)
+    price_ok = price <= PRICE_CAP
+    matched += 1 if price_ok else 0
+    reward = matched / total
+    return {
+        "status": "PASS" if reward == 1.0 else "FAIL",
+        "score": round(reward, 4),
+        "metrics": {
+            "bought": True, "item_id": purchase.get("item_id"),
+            "price": price, "price_ok": price_ok,
+            "matched": matched, "required": total,
+            "options_chosen": purchase.get("options"),
+            "n_steps": data.get("n_steps"),
+        },
+    }

--- a/examples/webshop-mini/tasks/ws-tshirt/harness.py
+++ b/examples/webshop-mini/tasks/ws-tshirt/harness.py
@@ -1,0 +1,158 @@
+"""WebShop-mini harness: simulated shop, search/click/select/buy loop."""
+
+from __future__ import annotations
+
+import re
+
+from bora_sdk import Agent, HarnessContext, HarnessTerminal
+
+CMD_RE = re.compile(
+    r"^\s*(search\s+(?P<q>.+)|click\s+(?P<item>[a-z0-9_-]+)"
+    r"|select\s+(?P<otype>[\w-]+)\s+(?P<oval>[\w. -]+)|back|buy)\s*$",
+    re.IGNORECASE,
+)
+
+
+class Shop:
+    def __init__(self, catalog: list[dict]) -> None:
+        self.catalog = {str(p["id"]): p for p in catalog}
+        self.results: list[str] = []
+        self.current: str | None = None
+        self.selected: dict[str, str] = {}
+        self.purchase: dict | None = None
+
+    def search(self, query: str) -> str:
+        terms = [t for t in re.split(r"[^a-z0-9.]+", query.lower()) if t]
+        scored = []
+        for pid, p in self.catalog.items():
+            hay = (p["title"] + " " + " ".join(p.get("attributes", []))).lower()
+            score = sum(1 for t in terms if t in hay)
+            if score:
+                scored.append((score, pid))
+        scored.sort(key=lambda x: (-x[0], x[1]))
+        self.results = [pid for _, pid in scored[:5]]
+        self.current = None
+        self.selected = {}
+        if not self.results:
+            return "No results. Try different keywords."
+        lines = ["Results:"]
+        for pid in self.results:
+            p = self.catalog[pid]
+            lines.append(f"  [{pid}] {p['title']} — ${p['price']:.2f}")
+        return "\n".join(lines)
+
+    def click(self, pid: str) -> str:
+        if pid not in self.catalog or (self.results and pid not in self.results):
+            return f"No item [{pid}] on this page."
+        self.current = pid
+        self.selected = {}
+        p = self.catalog[pid]
+        lines = [f"Item [{pid}] {p['title']} — ${p['price']:.2f}"]
+        lines.append("  attributes: " + ", ".join(p.get("attributes", [])))
+        for otype, vals in (p.get("options") or {}).items():
+            lines.append(f"  option {otype}: " + " | ".join(vals))
+        lines.append("Use: select <option> <value>, buy, or back.")
+        return "\n".join(lines)
+
+    def select(self, otype: str, oval: str) -> str:
+        if self.current is None:
+            return "Open an item first (click <id>)."
+        opts = self.catalog[self.current].get("options") or {}
+        if otype not in opts:
+            return f"No option {otype!r} for this item."
+        match = next((v for v in opts[otype] if v.lower() == oval.lower().strip()), None)
+        if match is None:
+            return f"Value {oval!r} not available for {otype}."
+        self.selected[otype] = match
+        return f"Selected {otype} = {match}."
+
+    def back(self) -> str:
+        self.current = None
+        self.selected = {}
+        if not self.results:
+            return "Search results are empty. Use search <keywords>."
+        lines = ["Results:"]
+        for pid in self.results:
+            p = self.catalog[pid]
+            lines.append(f"  [{pid}] {p['title']} — ${p['price']:.2f}")
+        return "\n".join(lines)
+
+    def buy(self) -> str:
+        if self.current is None:
+            return "Open an item first (click <id>)."
+        p = self.catalog[self.current]
+        self.purchase = {
+            "item_id": self.current,
+            "title": p["title"],
+            "price": p["price"],
+            "attributes": list(p.get("attributes", [])),
+            "options": dict(self.selected),
+        }
+        return f"Purchased [{self.current}] {p['title']} for ${p['price']:.2f}."
+
+    def step(self, cmd: str) -> str:
+        m = CMD_RE.match(cmd)
+        if not m:
+            return "Nothing happens. (Unknown command.)"
+        if m.group("q"):
+            return self.search(m.group("q"))
+        if m.group("item"):
+            return self.click(m.group("item").lower())
+        if m.group("otype"):
+            return self.select(m.group("otype").lower(), m.group("oval"))
+        head = cmd.strip().split()[0].lower()
+        if head == "back":
+            return self.back()
+        if head == "buy":
+            return self.buy()
+        return "Nothing happens."
+
+
+def _extract_command(text: str) -> str | None:
+    for line in text.splitlines():
+        line = line.strip().strip("`>*-").strip()
+        if line and CMD_RE.match(line):
+            return line
+    return None
+
+
+async def run(ctx: HarnessContext) -> HarnessTerminal:
+    instruction = ctx.params.require_str("instruction")
+    catalog = ctx.params.get("catalog") or []
+    max_steps = int(ctx.params.get("max_steps") or 12)
+    shop = Shop(list(catalog))
+    trace: list[dict[str, str]] = []
+
+    system = (
+        "You are shopping in a text web shop. Interact ONLY by replying with "
+        "exactly ONE command per turn: search <keywords> | click <item_id> | "
+        "select <option> <value> | back | buy. Select all required options "
+        "BEFORE buying. Reply with the bare command only.\n"
+        f"Shopping instruction: {instruction}\n\n"
+    )
+
+    agent = Agent(attempt_id=ctx.scope.attempt_id)
+    observation = "Welcome. Start with: search <keywords>."
+    async with agent.session("solver", max_turns=max_steps + 2) as session:
+        for _step in range(max_steps):
+            resp = await session.invoke(system + "Current page:\n" + observation)
+            if not resp.get("ok"):
+                return HarnessTerminal.failed(str(resp.get("error") or "invoke_failed"))
+            reply = str(resp.get("text") or "")
+            cmd = _extract_command(reply)
+            if cmd is None:
+                observation = "Nothing happens. Reply with exactly one bare command."
+                trace.append({"reply": reply[:400], "cmd": "", "result": observation})
+                continue
+            result = shop.step(cmd)
+            trace.append({"reply": reply[:400], "cmd": cmd, "result": result[:400]})
+            observation = result
+            if shop.purchase is not None:
+                break  # episode ends at buy — no idle turns (eval finding #5)
+
+    ctx.publish_json(
+        "purchase",
+        {"instruction": instruction, "purchase": shop.purchase, "steps": trace,
+         "n_steps": len(trace)},
+    )
+    return HarnessTerminal.completed("webshop-mini")

--- a/examples/webshop-mini/tasks/ws-tshirt/task.yaml
+++ b/examples/webshop-mini/tasks/ws-tshirt/task.yaml
@@ -1,0 +1,92 @@
+format: bora.task/1
+task_id: ws-tshirt
+harness:
+  runtime: python
+  entrypoint: harness:run
+parameters:
+  instruction: Buy a red cotton t-shirt for less than $20. Select the color before
+    buying.
+  catalog:
+  - id: b001
+    title: Red Cotton T-Shirt Classic
+    price: 14.99
+    attributes:
+    - cotton
+    - t-shirt
+    - machine washable
+    options:
+      color:
+      - red
+      - blue
+      - white
+      size:
+      - s
+      - m
+      - l
+  - id: b002
+    title: Red Polyester Sport T-Shirt
+    price: 12.5
+    attributes:
+    - polyester
+    - t-shirt
+    - quick dry
+    options:
+      color:
+      - red
+      - black
+      size:
+      - m
+      - l
+  - id: b003
+    title: Premium Red Cotton T-Shirt
+    price: 25.0
+    attributes:
+    - cotton
+    - t-shirt
+    - premium
+    options:
+      color:
+      - red
+      size:
+      - s
+      - m
+      - l
+      - xl
+  - id: b004
+    title: Blue Cotton T-Shirt Classic
+    price: 13.99
+    attributes:
+    - cotton
+    - t-shirt
+    options:
+      color:
+      - blue
+      - white
+      size:
+      - s
+      - m
+  max_steps: 10
+provider:
+  kind: local
+  assurance: l0
+agent_profiles:
+- id: solver
+limits:
+  wall_time_seconds: 900
+  agent_invocations: 14
+  environment_actions: 0
+artifacts:
+  publishable:
+  - id: purchase
+    producer: harness
+    path: artifacts/purchase.json
+    media_type: application/json
+evaluation:
+  runtime: python
+  entrypoint: evaluator:evaluate
+  network: none
+  inputs:
+  - artifact: purchase
+    target: purchase.json
+  output:
+    format: json

--- a/services/registry/oauth_github.py
+++ b/services/registry/oauth_github.py
@@ -85,9 +85,7 @@ def request_device_code(*, client_id: str, scope: str = "read:user") -> DeviceCo
     )
     if "error" in data:
         raise GitHubOAuthError(str(data["error"]), str(data.get("error_description") or ""))
-    verification_uri = str(
-        data.get("verification_uri") or "https://github.com/login/device"
-    )
+    verification_uri = str(data.get("verification_uri") or "https://github.com/login/device")
     user_code = str(data["user_code"])
     # Prefer GitHub's complete URI when present; always ensure user_code + skip
     # account picker. Multi-account sessions hit /login/device/select_account and

--- a/services/registry/package_files.py
+++ b/services/registry/package_files.py
@@ -121,9 +121,7 @@ def build_index_from_archive(archive: bytes, *, package_digest: str) -> PackageF
                     d_entry = FileEntry(path=d, type="dir", size=0)
                     by_path[d] = d_entry
                     entries.append(d_entry)
-    return PackageFileIndex(
-        package_digest=package_digest, entries=entries, _by_path=by_path
-    )
+    return PackageFileIndex(package_digest=package_digest, entries=entries, _by_path=by_path)
 
 
 def get_or_build_index(archive: bytes, *, package_digest: str) -> PackageFileIndex:

--- a/services/registry/package_service.py
+++ b/services/registry/package_service.py
@@ -100,10 +100,10 @@ class PackageService:
                 http_status=400,
             )
         package_kind = str(meta.get("package_kind") or "database").strip().casefold()
-        if package_kind not in {"database", "plugin"}:
+        if package_kind not in {"database", "plugin", "agent"}:
             raise RegistryAppError(
                 "invalid_request",
-                "package_kind must be database or plugin",
+                "package_kind must be database, plugin or agent",
                 http_status=400,
             )
         self._validate_archive(
@@ -291,10 +291,10 @@ class PackageService:
     ) -> dict[str, Any]:
         if visibility is not None and visibility not in {"public", "private"}:
             raise RegistryAppError("invalid_request", "bad visibility", http_status=400)
-        if package_kind is not None and package_kind not in {"database", "plugin"}:
+        if package_kind is not None and package_kind not in {"database", "plugin", "agent"}:
             raise RegistryAppError(
                 "invalid_request",
-                "package_kind must be database or plugin",
+                "package_kind must be database, plugin or agent",
                 http_status=400,
             )
         rows = self.meta.list_releases(
@@ -342,7 +342,7 @@ class PackageService:
             if uploader and uploader == uid:
                 out.append(item)
                 continue
-            if kind != "plugin" and db_id in maintainable:
+            if kind == "database" and db_id in maintainable:
                 out.append(item)
         return out
 
@@ -377,6 +377,7 @@ class PackageService:
         if label:
             payload["display_name"] = label
         try:
+            from bora.registry.media_types import AGENT_MEDIA_TYPE
             from bora.registry.plugin_package import PLUGIN_MEDIA_TYPE
 
             if row.media_type == PLUGIN_MEDIA_TYPE:
@@ -384,6 +385,11 @@ class PackageService:
                 payload["package_kind"] = "plugin"
                 if data is not None:
                     payload["plugin_preview"] = _plugin_preview_from_archive(data)
+            elif row.media_type == AGENT_MEDIA_TYPE:
+                data = read_blob(self.blobs, row.blob_digest, prefix="packages")
+                payload["package_kind"] = "agent"
+                if data is not None:
+                    payload["agent_preview"] = _agent_preview_from_archive(data)
             else:
                 payload["package_kind"] = "database"
         except Exception:  # noqa: BLE001 — preview is best-effort
@@ -658,6 +664,30 @@ class PackageService:
                             http_status=400,
                         )
                     got = compute_plugin_digest(tmp_path)
+                elif package_kind == "agent":
+                    from bora.registry.agent_package import (
+                        AGENT_MEDIA_TYPE,
+                        assert_agent_package,
+                        compute_agent_digest,
+                    )
+
+                    if media_type != AGENT_MEDIA_TYPE:
+                        raise RegistryAppError(
+                            "invalid_format",
+                            f"agent media_type must be {AGENT_MEDIA_TYPE}",
+                            http_status=400,
+                        )
+                    try:
+                        assert_agent_package(tmp_path)
+                    except RegistryAppError:
+                        raise
+                    except Exception as exc:  # noqa: BLE001
+                        raise RegistryAppError(
+                            "invalid_format",
+                            f"not a valid bora.agent/1: {exc}",
+                            http_status=400,
+                        ) from exc
+                    got = compute_agent_digest(tmp_path)
                 else:
                     if (
                         (tmp_path / "plugin.yaml").is_file()
@@ -666,6 +696,14 @@ class PackageService:
                         raise RegistryAppError(
                             "invalid_format",
                             "plugin package must use package_kind=plugin",
+                            http_status=400,
+                        )
+                    if (tmp_path / "agent.yaml").is_file() and not (
+                        tmp_path / "bora.yaml"
+                    ).is_file():
+                        raise RegistryAppError(
+                            "invalid_format",
+                            "agent package must use package_kind=agent",
                             http_status=400,
                         )
                     got = compute_package_digest(tmp_path)
@@ -679,6 +717,34 @@ class PackageService:
             raise
         except Exception as exc:  # noqa: BLE001
             raise RegistryAppError("invalid_archive", str(exc), http_status=400) from exc
+
+
+def _agent_preview_from_archive(archive: bytes) -> dict[str, Any]:
+    """Secret-free agent detail preview (design/14): manifest + binding + files."""
+    from bora.agents.manifest import load_agent_manifest
+    from bora.config.profiles import project_job_overlay
+    from bora.registry.archive import extract_archive
+
+    with tempfile.TemporaryDirectory(prefix="bora-prev-") as tmp:
+        root = Path(tmp)
+        extract_archive(archive, root)
+        man = load_agent_manifest(root)
+        files = sorted(
+            p.relative_to(root).as_posix()
+            for p in root.rglob("*")
+            if p.is_file() and "__pycache__" not in p.parts
+        )
+        overlay = project_job_overlay({"agent": man.binding})
+        return {
+            "agent_id": man.agent_id,
+            "version": man.version,
+            "format": "bora.agent/1",
+            "label": man.label,
+            "description": man.description,
+            "tags": list(man.tags),
+            "binding": overlay["bindings"].get("agent", {}),
+            "files": files[:200],
+        }
 
 
 def _plugin_preview_from_archive(archive: bytes) -> dict[str, Any]:

--- a/services/registry/runtime_service.py
+++ b/services/registry/runtime_service.py
@@ -197,5 +197,9 @@ def _appearances_from_suite(
         overlays = _overlay_paths(raw)
         if overlays:
             row["overlays"] = overlays
+        # Provenance passthrough (design/14): never part of the rt_* identity.
+        agent_ref = raw.get("agent_ref")
+        if isinstance(agent_ref, str) and agent_ref.strip():
+            row["agent_ref"] = agent_ref.strip()
         out.append((row, raw))
     return out

--- a/services/registry/runtime_service.py
+++ b/services/registry/runtime_service.py
@@ -22,9 +22,7 @@ from bora.config.runtime_identity import (
 )
 
 
-def is_plaza_source_suite(
-    payload: Mapping[str, Any], official_ids: frozenset[str]
-) -> bool:
+def is_plaza_source_suite(payload: Mapping[str, Any], official_ids: frozenset[str]) -> bool:
     """Public complete release-bound suite on an official Dataset."""
     return (
         payload.get("visibility") == "public"

--- a/services/registry/store.py
+++ b/services/registry/store.py
@@ -1719,10 +1719,13 @@ class PostgresMetadataStore(MetadataStore):
 def package_kind_for_media_type(media_type: str) -> str:
     """Derive list/meta ``package_kind`` without opening the blob."""
     try:
+        from bora.registry.media_types import AGENT_MEDIA_TYPE
         from bora.registry.plugin_package import PLUGIN_MEDIA_TYPE
 
         if media_type == PLUGIN_MEDIA_TYPE:
             return "plugin"
+        if media_type == AGENT_MEDIA_TYPE:
+            return "agent"
     except Exception:  # noqa: BLE001 — kind is best-effort for clients
         pass
     return "database"

--- a/src/bora/agents/__init__.py
+++ b/src/bora/agents/__init__.py
@@ -1,0 +1,6 @@
+"""Local Agent (`bora.agent/1`) cache and manifest (design/14).
+
+An Agent is one versioned job binding plus display metadata. Install only
+writes the local cache; run-time use goes through the --agent projection
+into the existing profiles lane.
+"""

--- a/src/bora/agents/manifest.py
+++ b/src/bora/agents/manifest.py
@@ -1,0 +1,218 @@
+"""Parse and validate ``bora.agent/1`` (``agent.yaml``) — design/14.
+
+The ``binding`` block is exactly one ``bora.profiles/1`` binding and is
+validated by the same parser (key allowlist, options denylist, overlay path
+shape). ``binding.agent_ref`` is reserved for the --agent projection and
+rejected here. Every file in the package is secret-scanned fail-closed.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from bora.config.errors import (
+    ERROR_INVALID_FORMAT,
+    ERROR_INVALID_PACKAGE,
+    ERROR_INVALID_SCHEMA,
+    ConfigError,
+)
+from bora.config.overlay_files import scan_overlay_files
+from bora.config.profiles import PROFILES_FORMAT, parse_profiles_mapping
+
+AGENT_FILENAME = "agent.yaml"
+AGENT_FORMAT = "bora.agent/1"
+
+# Short id, or org/name Hub address (one slash), matching plugin id rules.
+_AGENT_ID_RE = re.compile(r"^(?:[a-z0-9][a-z0-9_-]*/)?[a-z0-9][a-z0-9_-]*$")
+
+_TOP_LEVEL_KEYS = frozenset(
+    {"format", "agent_id", "version", "label", "description", "tags", "binding"}
+)
+
+# Placeholder role used only to run the profiles binding validator.
+_VALIDATION_ROLE = "agent"
+
+
+@dataclass(frozen=True)
+class AgentManifest:
+    agent_id: str
+    version: str
+    binding: dict[str, Any]
+    label: str | None = None
+    description: str | None = None
+    tags: tuple[str, ...] = ()
+    root: Path | None = None  # package dir (None when loaded from a bare yaml)
+
+    def as_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "format": AGENT_FORMAT,
+            "agent_id": self.agent_id,
+            "version": self.version,
+            "binding": copy.deepcopy(self.binding),
+        }
+        if self.label:
+            out["label"] = self.label
+        if self.description:
+            out["description"] = self.description
+        if self.tags:
+            out["tags"] = list(self.tags)
+        return out
+
+
+def _optional_str(raw: Any, *, key: str, location: str) -> str | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, str) or not raw.strip():
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            f"{key} must be a non-empty string when set",
+            location=f"{location}:/{key}",
+        )
+    return raw.strip()
+
+
+def parse_agent_document(raw: Any, *, location: str = AGENT_FILENAME) -> AgentManifest:
+    """Validate a loaded ``agent.yaml`` mapping into an :class:`AgentManifest`."""
+    if not isinstance(raw, dict):
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            "agent document root must be a mapping",
+            location=location,
+        )
+    fmt = raw.get("format")
+    if fmt != AGENT_FORMAT:
+        raise ConfigError(
+            ERROR_INVALID_FORMAT,
+            f"agent format must be {AGENT_FORMAT}; got {fmt!r}",
+            location=f"{location}:/format",
+        )
+    unknown = set(raw) - _TOP_LEVEL_KEYS
+    if unknown:
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            f"unknown agent keys: {sorted(unknown)}",
+            location=location,
+        )
+
+    agent_id_raw = raw.get("agent_id")
+    if not isinstance(agent_id_raw, str) or not _AGENT_ID_RE.fullmatch(agent_id_raw.strip()):
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            "agent_id must match ^[a-z0-9][a-z0-9_-]*$ (optionally org/name)",
+            location=f"{location}:/agent_id",
+        )
+    agent_id = agent_id_raw.strip()
+
+    version_raw = raw.get("version")
+    if not isinstance(version_raw, str) or not version_raw.strip():
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            "version must be a non-empty string",
+            location=f"{location}:/version",
+        )
+    version = version_raw.strip()
+
+    label = _optional_str(raw.get("label"), key="label", location=location)
+    description = _optional_str(raw.get("description"), key="description", location=location)
+
+    tags_raw = raw.get("tags")
+    tags: tuple[str, ...] = ()
+    if tags_raw is not None:
+        if not isinstance(tags_raw, list) or not all(
+            isinstance(t, str) and t.strip() for t in tags_raw
+        ):
+            raise ConfigError(
+                ERROR_INVALID_SCHEMA,
+                "tags must be a list of non-empty strings",
+                location=f"{location}:/tags",
+            )
+        tags = tuple(t.strip() for t in tags_raw)
+
+    binding_raw = raw.get("binding")
+    if not isinstance(binding_raw, dict) or not binding_raw:
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            "binding must be a non-empty mapping (one bora.profiles/1 binding)",
+            location=f"{location}:/binding",
+        )
+    if "agent_ref" in binding_raw:
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            "binding.agent_ref is reserved (injected by --agent projection)",
+            location=f"{location}:/binding/agent_ref",
+        )
+    parsed = parse_profiles_mapping(
+        {"format": PROFILES_FORMAT, "bindings": {_VALIDATION_ROLE: binding_raw}},
+        location=f"{location}:/binding",
+    )
+    binding = parsed[_VALIDATION_ROLE]
+    if label and "label" not in binding:
+        binding["label"] = label
+
+    return AgentManifest(
+        agent_id=agent_id,
+        version=version,
+        binding=binding,
+        label=label,
+        description=description,
+        tags=tags,
+    )
+
+
+def _package_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in {"__pycache__", ".git", ".bora"}]
+        for name in filenames:
+            files.append(Path(dirpath) / name)
+    return sorted(files)
+
+
+def load_agent_manifest(path: Path) -> AgentManifest:
+    """Load ``agent.yaml`` from a package dir or a direct yaml path.
+
+    Fail closed on schema errors and on secret material anywhere in the
+    package (locator names are fine; values are not).
+    """
+    path = path.expanduser().resolve(strict=False)
+    if path.is_dir():
+        root: Path | None = path
+        yaml_path = path / AGENT_FILENAME
+    else:
+        root = None
+        yaml_path = path
+    if not yaml_path.is_file():
+        raise ConfigError(
+            ERROR_INVALID_PACKAGE,
+            f"agent manifest not found: {yaml_path}",
+            location=str(yaml_path),
+        )
+    try:
+        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            f"invalid YAML: {exc}",
+            location=str(yaml_path),
+        ) from exc
+    manifest = parse_agent_document(data, location=str(yaml_path))
+
+    scan_files = _package_files(root) if root is not None else [yaml_path]
+    scan_overlay_files(scan_files, location=str(yaml_path))
+
+    return AgentManifest(
+        agent_id=manifest.agent_id,
+        version=manifest.version,
+        binding=manifest.binding,
+        label=manifest.label,
+        description=manifest.description,
+        tags=manifest.tags,
+        root=root,
+    )

--- a/src/bora/agents/paths.py
+++ b/src/bora/agents/paths.py
@@ -1,0 +1,25 @@
+"""Local agent cache paths (design/14).
+
+Mirrors the plugins cache: ``$BORA_HOME/agents`` + ``index.json``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bora.plugins.paths import bora_home
+
+AGENTS_DIRNAME = "agents"
+INDEX_FILENAME = "index.json"
+
+
+def agents_root() -> Path:
+    return bora_home() / AGENTS_DIRNAME
+
+
+def index_path() -> Path:
+    return agents_root() / INDEX_FILENAME
+
+
+def package_dir(agent_id: str, version: str) -> Path:
+    return agents_root() / agent_id / version

--- a/src/bora/agents/store.py
+++ b/src/bora/agents/store.py
@@ -1,0 +1,239 @@
+"""Agent cache index + install/uninstall (design/14).
+
+Mirrors the plugins cache: install only writes ``$BORA_HOME/agents``; it
+never rewrites profiles / task.yaml. Index keys are the local id (short
+``agent_id`` recorded as ``local/<agent_id>``) or the Hub id ``org/name``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from bora.agents.manifest import AgentManifest, load_agent_manifest
+from bora.agents.paths import agents_root, index_path, package_dir
+from bora.config.errors import ERROR_INVALID_PACKAGE, ConfigError
+from bora.plugins.store import compute_tree_digest
+
+LOCAL_NAMESPACE = "local"
+
+
+@dataclass
+class AgentIndexEntry:
+    agent_id: str  # index id: local/<id> or org/name
+    version: str
+    digest: str
+    path: str  # relative to agents_root
+    format: str
+    label: str | None = None
+    tags: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "agent_id": self.agent_id,
+            "version": self.version,
+            "digest": self.digest,
+            "path": self.path,
+            "format": self.format,
+        }
+        if self.label:
+            out["label"] = self.label
+        if self.tags:
+            out["tags"] = list(self.tags)
+        return out
+
+
+@dataclass
+class AgentIndex:
+    agents: list[AgentIndexEntry] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"agents": [a.as_dict() for a in self.agents]}
+
+    def find(self, agent_id: str) -> AgentIndexEntry | None:
+        for a in self.agents:
+            if a.agent_id == agent_id:
+                return a
+        return None
+
+
+def load_index() -> AgentIndex:
+    path = index_path()
+    if not path.is_file():
+        return AgentIndex()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return AgentIndex()
+    rows = raw.get("agents") if isinstance(raw, dict) else None
+    if not isinstance(rows, list):
+        return AgentIndex()
+    entries: list[AgentIndexEntry] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        try:
+            entries.append(
+                AgentIndexEntry(
+                    agent_id=str(row["agent_id"]),
+                    version=str(row["version"]),
+                    digest=str(row["digest"]),
+                    path=str(row["path"]),
+                    format=str(row.get("format") or "bora.agent/1"),
+                    label=str(row["label"]) if row.get("label") else None,
+                    tags=[str(t) for t in row.get("tags") or []],
+                )
+            )
+        except KeyError:
+            continue
+    return AgentIndex(agents=entries)
+
+
+def save_index(index: AgentIndex) -> None:
+    root = agents_root()
+    root.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(index.as_dict(), indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(prefix=".index.", suffix=".json", dir=str(root))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, index_path())
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def default_index_id(manifest: AgentManifest) -> str:
+    """Local-path installs of a short id are namespaced ``local/<agent_id>``."""
+    if "/" in manifest.agent_id:
+        return manifest.agent_id
+    return f"{LOCAL_NAMESPACE}/{manifest.agent_id}"
+
+
+def install_from_path(source: Path, *, agent_id: str | None = None) -> AgentIndexEntry:
+    """Copy an agent package into the local cache and update the index.
+
+    Never modifies project profiles / bora.yaml / task.yaml. *agent_id*
+    overrides the index id (Hub install records ``org/name``). Fails closed
+    on manifest/secret errors before anything is written.
+    """
+    source = source.expanduser().resolve(strict=False)
+    if not source.is_dir():
+        raise ConfigError(
+            ERROR_INVALID_PACKAGE,
+            f"agent path is not a directory: {source}",
+            location=str(source),
+        )
+    manifest = load_agent_manifest(source)
+    index_id = (
+        agent_id.strip()
+        if isinstance(agent_id, str) and agent_id.strip()
+        else default_index_id(manifest)
+    )
+    digest = compute_tree_digest(source)
+    rel = f"{index_id}/{manifest.version}"
+    dest = package_dir(index_id, manifest.version)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    entry = AgentIndexEntry(
+        agent_id=index_id,
+        version=manifest.version,
+        digest=digest,
+        path=rel,
+        format="bora.agent/1",
+        label=manifest.label,
+        tags=list(manifest.tags),
+    )
+
+    if dest.is_dir():
+        if compute_tree_digest(dest) == digest:
+            _upsert_index(entry)
+            return entry
+        shutil.rmtree(dest)
+
+    tmp = Path(tempfile.mkdtemp(prefix=f".{index_id.replace('/', '.')}.", dir=str(dest.parent)))
+    try:
+        shutil.copytree(source, tmp / "pkg")
+        os.replace(tmp / "pkg", dest)
+    finally:
+        if tmp.is_dir():
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    if compute_tree_digest(dest) != digest:
+        shutil.rmtree(dest, ignore_errors=True)
+        raise ConfigError(
+            ERROR_INVALID_PACKAGE,
+            "digest mismatch after agent install",
+            location=str(dest),
+        )
+    _upsert_index(entry)
+    return entry
+
+
+def _upsert_index(entry: AgentIndexEntry) -> None:
+    index = load_index()
+    index.agents = [a for a in index.agents if a.agent_id != entry.agent_id]
+    index.agents.append(entry)
+    index.agents.sort(key=lambda a: a.agent_id)
+    save_index(index)
+
+
+def uninstall(agent_id: str) -> bool:
+    index = load_index()
+    entry = index.find(agent_id)
+    if entry is None:
+        return False
+    dest = agents_root() / entry.path
+    if dest.is_dir():
+        shutil.rmtree(dest)
+    parent = dest.parent
+    root = agents_root()
+    while parent != root and parent.is_dir() and not any(parent.iterdir()):
+        parent.rmdir()
+        parent = parent.parent
+    index.agents = [a for a in index.agents if a.agent_id != agent_id]
+    save_index(index)
+    return True
+
+
+def list_installed() -> list[AgentIndexEntry]:
+    return list(load_index().agents)
+
+
+def resolve_package_root(entry: AgentIndexEntry) -> Path:
+    return agents_root() / entry.path
+
+
+def resolve_installed_ref(agent_id: str, version: str) -> tuple[AgentIndexEntry, Path]:
+    """Resolve a pinned ``<id>@<version>`` against the local cache, fail closed."""
+    entry = load_index().find(agent_id)
+    if entry is None:
+        raise ConfigError(
+            ERROR_INVALID_PACKAGE,
+            f"agent not installed: {agent_id!r} (run: bora agent install …)",
+            location=agent_id,
+        )
+    if entry.version != version:
+        raise ConfigError(
+            ERROR_INVALID_PACKAGE,
+            f"agent {agent_id!r} installed at version {entry.version!r}, "
+            f"requested {version!r} (run: bora agent install)",
+            location=f"{agent_id}@{version}",
+        )
+    root = resolve_package_root(entry)
+    if not root.is_dir():
+        raise ConfigError(
+            ERROR_INVALID_PACKAGE,
+            f"agent cache missing on disk: {root}",
+            location=f"{agent_id}@{version}",
+        )
+    return entry, root

--- a/src/bora/application/agent_ops/__init__.py
+++ b/src/bora/application/agent_ops/__init__.py
@@ -1,0 +1,1 @@
+"""Agent object use cases: --agent projection, publish/install (design/14)."""

--- a/src/bora/application/agent_ops/install_remote.py
+++ b/src/bora/application/agent_ops/install_remote.py
@@ -1,0 +1,104 @@
+"""Install an agent from the Registry into the local agents cache (design/14)."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from bora.agents.store import AgentIndexEntry, install_from_path
+from bora.config.errors import ConfigError
+from bora.registry.archive import extract_archive
+from bora.registry.client import RegistryError
+from bora.registry.media_types import AGENT_MEDIA_TYPE
+
+
+class AgentInstallCommand:
+    def __init__(self, client_factory: Any) -> None:
+        self._client_factory = client_factory
+        self._tmp_dirs: list[tempfile.TemporaryDirectory[str]] = []
+
+    def install_agent_from_registry(
+        self,
+        locator: str,
+        *,
+        registry_url: str | None = None,
+        token: str | None = None,
+    ) -> dict[str, Any]:
+        """Locator forms: ``org/agent_id@version`` or ``org/agent_id@sha256:…``."""
+        if "@" not in locator:
+            raise ConfigError(
+                "invalid_ref",
+                "locator must be package_id@version or package_id@sha256:…",
+                location=locator,
+            )
+        package_id, ver_or_digest = locator.rsplit("@", 1)
+        package_id = package_id.strip()
+        ver_or_digest = ver_or_digest.strip()
+        if not package_id or not ver_or_digest:
+            raise ConfigError("invalid_ref", "empty package_id or version", location=locator)
+
+        client = self._client_factory(
+            registry_url=registry_url,
+            token=token,
+            require_token=True,
+        )
+        try:
+            extract_dir = self._download_agent(
+                client,
+                package_id=package_id,
+                version=None if ver_or_digest.startswith("sha256:") else ver_or_digest,
+                package_digest=ver_or_digest if ver_or_digest.startswith("sha256:") else None,
+                location=locator,
+            )
+            entry: AgentIndexEntry = install_from_path(extract_dir, agent_id=package_id)
+        except RegistryError as exc:
+            raise ConfigError(exc.code, exc.message, location="registry") from exc
+        finally:
+            self.cleanup_tmp()
+        summary = entry.as_dict()
+        summary["ok"] = True
+        summary["ref"] = f"{entry.agent_id}@{entry.version}"
+        summary["from"] = locator
+        return summary
+
+    def _download_agent(
+        self,
+        client: Any,
+        *,
+        package_id: str,
+        version: str | None,
+        package_digest: str | None,
+        location: str,
+    ) -> Path:
+        try:
+            if package_digest:
+                meta = client.get_metadata(database_id=package_id, package_digest=package_digest)
+            else:
+                meta = client.get_metadata(database_id=package_id, version=version)
+            if meta.media_type != AGENT_MEDIA_TYPE:
+                raise ConfigError(
+                    "invalid_package_kind",
+                    f"release is not an agent (media_type={meta.media_type})",
+                    location=location,
+                )
+            tmp = tempfile.TemporaryDirectory(prefix="bora-agent-dl-")
+            self._tmp_dirs.append(tmp)
+            archive_path = Path(tmp.name) / "agent.tar.gz"
+            client.fetch_content(
+                database_id=package_id,
+                package_digest=meta.package_digest,
+                dest=archive_path,
+            )
+        except RegistryError as exc:
+            raise ConfigError(exc.code, exc.message, location="registry") from exc
+        extract_dir = Path(tmp.name) / "pkg"
+        extract_dir.mkdir()
+        extract_archive(archive_path, extract_dir)
+        archive_path.unlink(missing_ok=True)
+        return extract_dir
+
+    def cleanup_tmp(self) -> None:
+        while self._tmp_dirs:
+            tmp = self._tmp_dirs.pop()
+            tmp.cleanup()

--- a/src/bora/application/agent_ops/publish.py
+++ b/src/bora/application/agent_ops/publish.py
@@ -1,0 +1,94 @@
+"""Publish a bora.agent/1 package to the Registry (design/14)."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from bora.agents.manifest import load_agent_manifest
+from bora.config.errors import ConfigError
+from bora.registry.agent_package import (
+    AGENT_MEDIA_TYPE,
+    build_agent_archive,
+    compute_agent_digest,
+)
+from bora.registry.client import RegistryError
+
+
+def hub_agent_package_id(agent_id: str, *, org: str) -> str:
+    """Hub address for publish: short id concatenates; namespaced must match *org*."""
+    org_id = org.strip()
+    if not org_id:
+        raise ConfigError("org_required", "agent publish requires --org", location="registry")
+    prefix, _, name = agent_id.rpartition("/")
+    if not prefix:
+        return f"{org_id}/{agent_id}"
+    if prefix != org_id:
+        raise ConfigError(
+            "agent_org_mismatch",
+            f"agent_id prefix {prefix!r} does not match upload org {org_id!r}",
+            location="agent.yaml:/agent_id",
+        )
+    return agent_id
+
+
+class AgentPublishCommand:
+    def __init__(self, client_factory: Any) -> None:
+        self._client_factory = client_factory
+
+    def publish_agent(
+        self,
+        agent_root: Path,
+        *,
+        public: bool = False,
+        org: str | None = None,
+        registry_url: str | None = None,
+        token: str | None = None,
+    ) -> dict[str, Any]:
+        root = agent_root.expanduser().resolve(strict=False)
+        manifest = load_agent_manifest(root)
+        package_id = hub_agent_package_id(manifest.agent_id, org=org or "")
+        package_digest = compute_agent_digest(root)
+        archive, blob_digest, size = build_agent_archive(root)
+
+        visibility = "public" if public else "private"
+        client = self._client_factory(
+            registry_url=registry_url,
+            token=token,
+            require_token=True,
+        )
+        with tempfile.TemporaryDirectory(prefix="bora-agent-") as tmp:
+            archive_path = Path(tmp) / "agent.tar.gz"
+            archive_path.write_bytes(archive)
+            try:
+                info = client.publish(
+                    database_id=package_id,
+                    version=manifest.version,
+                    package_digest=package_digest,
+                    blob_digest=blob_digest,
+                    size=size,
+                    media_type=AGENT_MEDIA_TYPE,
+                    visibility=visibility,
+                    archive=archive_path,
+                    org_id=(org or "").strip(),
+                    package_kind="agent",
+                )
+            except RegistryError as exc:
+                raise ConfigError(exc.code, exc.message, location="registry") from exc
+
+        return {
+            "ok": True,
+            "package_kind": "agent",
+            "agent_id": manifest.agent_id,
+            "package_id": info.database_id,
+            "version": info.version,
+            "visibility": info.visibility,
+            "package_digest": info.package_digest,
+            "blob_digest": info.blob_digest,
+            "size": info.size,
+            "media_type": info.media_type,
+            "ref": f"{info.database_id}@{info.version}",
+            "org_id": info.org_id or (org or "").strip(),
+            "label": manifest.label,
+        }

--- a/src/bora/application/agent_ops/resolve.py
+++ b/src/bora/application/agent_ops/resolve.py
@@ -1,0 +1,137 @@
+"""Project ``--agent`` specs into a ``bora.profiles/1`` document (design/14).
+
+Spec forms (repeatable):
+
+* ``<ref>``            — bind ALL role slots (wildcard ``"*"`` binding)
+* ``<role>=<ref>``     — bind one role; exact role wins over wildcard
+* ``<path>``           — local dir or ``agent.yaml`` (dev loop; ref = ``file:…@dev``)
+
+``<ref>`` is a pinned local-cache id: ``local/<id>@<version>`` or
+``org/name@<version>`` (short ``<id>@<version>`` falls back to ``local/<id>``).
+The synthesized document enters the existing ``profiles_path`` lane, so lock /
+job_overlay / fingerprint behave exactly as with a hand-written profiles file.
+``agent_ref`` (``<id>@<version>+sha256:<digest12>``) is injected per binding as
+provenance; it never enters suite fingerprint identity.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from bora.agents.manifest import AgentManifest, load_agent_manifest
+from bora.agents.paths import agents_root
+from bora.agents.store import LOCAL_NAMESPACE, resolve_installed_ref
+from bora.config.errors import ERROR_INVALID_SCHEMA, ConfigError
+from bora.config.profiles import (
+    PROFILES_FORMAT,
+    WILDCARD_ROLE,
+    parse_profiles_mapping,
+    write_profiles_yaml,
+)
+from bora.plugins.store import compute_tree_digest
+
+_ROLE_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
+_DIGEST_SHORT_HEX = 12
+
+PROJECTIONS_DIRNAME = ".projections"
+
+
+def _short_digest(digest: str) -> str:
+    if digest.startswith("sha256:"):
+        return "sha256:" + digest[len("sha256:") :][:_DIGEST_SHORT_HEX]
+    return digest[:_DIGEST_SHORT_HEX]
+
+
+def _looks_like_path(ref: str) -> bool:
+    if ref.startswith(("./", "../", "/", "~")):
+        return True
+    return Path(ref).exists()
+
+
+def _load_from_path(ref: str) -> tuple[AgentManifest, str]:
+    path = Path(ref).expanduser().resolve(strict=False)
+    manifest = load_agent_manifest(path)
+    if manifest.root is not None:
+        digest = compute_tree_digest(manifest.root)
+    else:
+        digest = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    return manifest, f"file:{path}@dev+{_short_digest(digest)}"
+
+
+def _load_from_cache(ref: str) -> tuple[AgentManifest, str]:
+    agent_id, _, version = ref.rpartition("@")
+    if not agent_id or not version:
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            "--agent ref must be <id>@<version> or a local path "
+            "(install first: bora agent install …)",
+            location=ref,
+        )
+    if version.startswith("sha256:"):
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            "--agent by digest requires registry install; pin @<version> locally",
+            location=ref,
+        )
+    try:
+        entry, root = resolve_installed_ref(agent_id, version)
+    except ConfigError:
+        if "/" in agent_id:
+            raise
+        entry, root = resolve_installed_ref(f"{LOCAL_NAMESPACE}/{agent_id}", version)
+    manifest = load_agent_manifest(root)
+    return manifest, f"{entry.agent_id}@{entry.version}+{_short_digest(entry.digest)}"
+
+
+def parse_agent_spec(raw: str) -> tuple[str, str]:
+    """Split one --agent value into ``(role_or_wildcard, ref)``."""
+    spec = raw.strip()
+    if not spec:
+        raise ConfigError(ERROR_INVALID_SCHEMA, "--agent must not be empty", location=raw)
+    role, sep, rest = spec.partition("=")
+    if sep and _ROLE_RE.fullmatch(role.strip()) and rest.strip():
+        return role.strip(), rest.strip()
+    return WILDCARD_ROLE, spec
+
+
+def bindings_from_agent_specs(specs: list[str]) -> dict[str, dict[str, Any]]:
+    """Resolve specs into a profiles bindings map with ``agent_ref`` injected."""
+    bindings: dict[str, dict[str, Any]] = {}
+    for raw in specs:
+        role, ref = parse_agent_spec(raw)
+        if role in bindings:
+            raise ConfigError(
+                ERROR_INVALID_SCHEMA,
+                f"duplicate --agent for role {role!r}",
+                location=raw,
+            )
+        manifest, agent_ref = (
+            _load_from_path(ref) if _looks_like_path(ref) else _load_from_cache(ref)
+        )
+        binding = copy.deepcopy(manifest.binding)
+        binding["agent_ref"] = agent_ref
+        bindings[role] = binding
+    return bindings
+
+
+def resolve_agent_specs(specs: list[str]) -> Path:
+    """Synthesize a ``bora.profiles/1`` file for the profiles lane; return its path.
+
+    Written content-addressed under ``$BORA_HOME/agents/.projections`` so the
+    exact document a run used stays inspectable and re-runnable (also works
+    when the Dataset itself is a registry ref with no local root).
+    """
+    bindings = bindings_from_agent_specs(specs)
+    document = {"format": PROFILES_FORMAT, "bindings": bindings}
+    # Re-parse for shape safety before anything reads the file.
+    parse_profiles_mapping(document, location="--agent")
+    canon = json.dumps(document, sort_keys=True, separators=(",", ":"))
+    name = hashlib.sha256(canon.encode("utf-8")).hexdigest()[:16]
+    out = agents_root() / PROJECTIONS_DIRNAME / f"{name}.yaml"
+    write_profiles_yaml(out, document)
+    return out

--- a/src/bora/application/composition.py
+++ b/src/bora/application/composition.py
@@ -132,6 +132,13 @@ def build_plugin_commands() -> Any:
     )()
 
 
+def build_agent_projection() -> Callable[[list[str]], Any]:
+    """--agent specs → synthesized profiles document path (design/14)."""
+    from bora.application.agent_ops.resolve import resolve_agent_specs
+
+    return resolve_agent_specs
+
+
 def build_registry_client(
     *,
     registry_url: str | None = None,

--- a/src/bora/application/composition.py
+++ b/src/bora/application/composition.py
@@ -139,6 +139,23 @@ def build_agent_projection() -> Callable[[list[str]], Any]:
     return resolve_agent_specs
 
 
+def build_agent_commands() -> Any:
+    from bora.application.agent_ops.install_remote import AgentInstallCommand
+    from bora.application.agent_ops.publish import AgentPublishCommand
+
+    install = AgentInstallCommand(client_factory=build_registry_client)
+    publish = AgentPublishCommand(client_factory=build_registry_client)
+    return type(
+        "AgentCommands",
+        (),
+        {
+            "install_agent_from_registry": install.install_agent_from_registry,
+            "cleanup_agent_tmp": install.cleanup_tmp,
+            "publish_agent": publish.publish_agent,
+        },
+    )()
+
+
 def build_registry_client(
     *,
     registry_url: str | None = None,

--- a/src/bora/application/suite/suite_config_fingerprint.py
+++ b/src/bora/application/suite/suite_config_fingerprint.py
@@ -278,12 +278,10 @@ def job_overlays_compatible(
             if not isinstance(binding, Mapping):
                 continue
             rid = str(role_id)
-            suite_b = suite_bindings.get(rid)
-            if not isinstance(suite_b, Mapping):
-                # Wildcard default binding covers any role id (design/14).
-                from bora.config.profiles import WILDCARD_ROLE
+            # Wildcard default binding covers any role id, field-wise (design/14).
+            from bora.config.profiles import effective_binding
 
-                suite_b = suite_bindings.get(WILDCARD_ROLE)
+            suite_b = effective_binding(suite_bindings, rid)
             if not isinstance(suite_b, Mapping):
                 # Task used a role not in suite profiles map → incompatible
                 return False
@@ -315,6 +313,39 @@ def derive_labels(actors: Sequence[Mapping[str, str]]) -> tuple[str, str]:
     return join_display_names(agents), join_display_names(models)
 
 
+def _expand_wildcard_overlay(
+    job_overlay: Mapping[str, Any],
+    per_task_overlays: Sequence[Mapping[str, Any] | None],
+) -> Mapping[str, Any]:
+    """Expand a ``"*"`` default binding onto the role ids the tasks used.
+
+    Identity rule (design/14): wildcard and explicit spellings of the same
+    bindings are the same job configuration. Without per-task roles to expand
+    against, the overlay is returned unchanged.
+    """
+    from bora.config.profiles import WILDCARD_ROLE, effective_binding
+
+    bindings = job_overlay.get("bindings")
+    if not isinstance(bindings, Mapping) or WILDCARD_ROLE not in bindings:
+        return job_overlay
+    role_ids: set[str] = set()
+    for ov in per_task_overlays:
+        if not isinstance(ov, Mapping):
+            continue
+        rows = ov.get("bindings")
+        if isinstance(rows, Mapping):
+            role_ids.update(str(r) for r in rows if str(r) != WILDCARD_ROLE)
+    role_ids.update(str(r) for r in bindings if str(r) != WILDCARD_ROLE)
+    if not role_ids:
+        return job_overlay
+    expanded: dict[str, Any] = {}
+    for rid in sorted(role_ids):
+        row = effective_binding(bindings, rid)
+        if row is not None:
+            expanded[rid] = row
+    return {**dict(job_overlay), "bindings": expanded}
+
+
 def compute_suite_config_fields(
     per_task_actors: Sequence[Sequence[Mapping[str, str]] | list[dict[str, str]]],
     *,
@@ -332,16 +363,20 @@ def compute_suite_config_fields(
     """
     # --- Preferred path: suite-level job binding (#59) -----------------------
     if isinstance(job_overlay, Mapping) and isinstance(job_overlay.get("bindings"), Mapping):
-        actors = actors_summary_from_job_overlay(job_overlay)
         overlays = list(per_task_overlays or [])
+        # Fingerprint identity must not depend on wildcard-vs-explicit spelling:
+        # expand "*" onto the roles the tasks actually used before digesting.
+        effective = _expand_wildcard_overlay(job_overlay, overlays)
+        actors = actors_summary_from_job_overlay(effective)
         homogeneous = job_overlays_compatible(job_overlay, overlays)
         agent_label, model_label = derive_labels(actors) if homogeneous else ("", "")
         return {
-            "config_fingerprint": fingerprint_for_job_overlay(job_overlay),
+            "config_fingerprint": fingerprint_for_job_overlay(effective),
             "config_homogeneous": homogeneous,
             "actors_summary": actors,
             "agent_label": agent_label,
             "model_label": model_label,
+            # Stored overlay keeps the operator-authored shape (re-run fidelity).
             "job_overlay": dict(job_overlay),
         }
 

--- a/src/bora/application/suite/suite_config_fingerprint.py
+++ b/src/bora/application/suite/suite_config_fingerprint.py
@@ -280,6 +280,11 @@ def job_overlays_compatible(
             rid = str(role_id)
             suite_b = suite_bindings.get(rid)
             if not isinstance(suite_b, Mapping):
+                # Wildcard default binding covers any role id (design/14).
+                from bora.config.profiles import WILDCARD_ROLE
+
+                suite_b = suite_bindings.get(WILDCARD_ROLE)
+            if not isinstance(suite_b, Mapping):
                 # Task used a role not in suite profiles map → incompatible
                 return False
             if _binding_role_key(binding) != _binding_role_key(suite_b):

--- a/src/bora/cli/cmd_agent.py
+++ b/src/bora/cli/cmd_agent.py
@@ -1,0 +1,160 @@
+"""CLI: ``bora agent install|list|show|uninstall`` (design/14).
+
+Install writes only the local cache ($BORA_HOME/agents) — never profiles /
+task.yaml. Run with ``bora run <dataset> --agent <id>@<version>``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+agent_app = typer.Typer(
+    name="agent",
+    help=(
+        "Manage local Agent definitions (bora.agent/1).\n\n"
+        "install writes only ~/.bora/agents (or $BORA_HOME/agents) — it does "
+        "NOT modify profiles.yaml / task.yaml. Bind at run time with "
+        "`bora run <dataset> --agent <id>@<version>` or `--agent <role>=<ref>`."
+    ),
+    no_args_is_help=True,
+)
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(agent_app, name="agent")
+
+
+AGENT_OPTION_HELP = (
+    "Bind an installed Agent (bora.agent/1) for this run; repeatable. "
+    "Forms: <id>@<version> (all roles), <role>=<ref> (one role), or a local "
+    "path to an agent dir / agent.yaml. Mutually exclusive with --profiles."
+)
+
+
+def resolve_agent_option(agent: list[str] | None, profiles: Path | None) -> Path | None:
+    """Shared --agent handling: mutual exclusion + projection into a profiles file."""
+    if not agent:
+        return profiles
+    if profiles is not None:
+        typer.echo(
+            "invalid_override: --agent and --profiles are mutually exclusive",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    from bora.application.composition import build_agent_projection
+    from bora.config.errors import ConfigError
+
+    try:
+        return build_agent_projection()(list(agent))
+    except ConfigError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=2) from exc
+
+
+@agent_app.command("install")
+def agent_install(
+    source: Annotated[
+        str,
+        typer.Argument(
+            help=(
+                "Local path to a bora.agent/1 directory "
+                "(registry locator org/agent_id@version arrives with registry support)"
+            )
+        ),
+    ],
+) -> None:
+    """Install an agent into the local cache (never edits profiles)."""
+    from bora.config.errors import ConfigError
+
+    src_path = Path(source)
+    if "@" in source and not src_path.exists():
+        typer.echo(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": "not_supported",
+                    "message": "registry install not available yet; pass a local path",
+                }
+            ),
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    from bora.agents.store import install_from_path
+
+    try:
+        entry = install_from_path(src_path)
+    except ConfigError as exc:
+        typer.echo(
+            json.dumps({"ok": False, "error": exc.error_code, "message": str(exc)}),
+            err=True,
+        )
+        raise typer.Exit(code=2) from exc
+    except OSError as exc:
+        typer.echo(json.dumps({"ok": False, "error": "io_error", "message": str(exc)}), err=True)
+        raise typer.Exit(code=2) from exc
+    payload = entry.as_dict()
+    payload["ok"] = True
+    payload["ref"] = f"{entry.agent_id}@{entry.version}"
+    typer.echo(json.dumps(payload, sort_keys=True))
+
+
+@agent_app.command("list")
+def agent_list() -> None:
+    """List installed agents from the local index."""
+    from bora.agents.store import list_installed
+
+    rows = [e.as_dict() for e in list_installed()]
+    typer.echo(json.dumps({"agents": rows, "ok": True}, sort_keys=True))
+
+
+@agent_app.command("show")
+def agent_show(
+    ref: Annotated[str, typer.Argument(help="Installed id (<id> or <id>@<version>)")],
+) -> None:
+    """Show one installed agent's manifest (secret-free by construction)."""
+    from bora.agents.manifest import load_agent_manifest
+    from bora.agents.store import load_index, resolve_installed_ref, resolve_package_root
+    from bora.config.errors import ConfigError
+
+    try:
+        agent_id, _, version = ref.rpartition("@")
+        if agent_id and version:
+            entry, root = resolve_installed_ref(agent_id, version)
+        else:
+            entry = load_index().find(ref)
+            if entry is None:
+                raise ConfigError("invalid_package", f"agent not installed: {ref!r}", location=ref)
+            root = resolve_package_root(entry)
+        manifest = load_agent_manifest(root)
+    except ConfigError as exc:
+        typer.echo(
+            json.dumps({"ok": False, "error": exc.error_code, "message": str(exc)}),
+            err=True,
+        )
+        raise typer.Exit(code=2) from exc
+    payload = manifest.as_dict()
+    payload["ok"] = True
+    payload["agent_id"] = entry.agent_id
+    payload["digest"] = entry.digest
+    typer.echo(json.dumps(payload, sort_keys=True))
+
+
+@agent_app.command("uninstall")
+def agent_uninstall(
+    agent_id: Annotated[str, typer.Argument(help="Installed id to remove from cache")],
+) -> None:
+    """Remove an agent from cache/index. Does not edit profiles."""
+    from bora.agents.store import uninstall
+
+    if not uninstall(agent_id):
+        typer.echo(
+            json.dumps({"agent_id": agent_id, "error": "agent_not_installed", "ok": False}),
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    typer.echo(json.dumps({"ok": True, "uninstalled": agent_id}, sort_keys=True))

--- a/src/bora/cli/cmd_agent.py
+++ b/src/bora/cli/cmd_agent.py
@@ -61,8 +61,8 @@ def agent_install(
         str,
         typer.Argument(
             help=(
-                "Local path to a bora.agent/1 directory "
-                "(registry locator org/agent_id@version arrives with registry support)"
+                "Local path to a bora.agent/1 directory, or registry locator "
+                "org/agent_id@version | org/agent_id@sha256:… (remote requires credentials)"
             )
         ),
     ],
@@ -72,17 +72,19 @@ def agent_install(
 
     src_path = Path(source)
     if "@" in source and not src_path.exists():
-        typer.echo(
-            json.dumps(
-                {
-                    "ok": False,
-                    "error": "not_supported",
-                    "message": "registry install not available yet; pass a local path",
-                }
-            ),
-            err=True,
-        )
-        raise typer.Exit(code=2)
+        from bora.application.composition import build_agent_commands
+
+        cmds = build_agent_commands()
+        try:
+            summary = cmds.install_agent_from_registry(source)
+        except ConfigError as exc:
+            typer.echo(
+                json.dumps({"ok": False, "error": exc.error_code, "message": str(exc)}),
+                err=True,
+            )
+            raise typer.Exit(code=2) from exc
+        typer.echo(json.dumps(summary, sort_keys=True))
+        return
 
     from bora.agents.store import install_from_path
 
@@ -101,6 +103,27 @@ def agent_install(
     payload["ok"] = True
     payload["ref"] = f"{entry.agent_id}@{entry.version}"
     typer.echo(json.dumps(payload, sort_keys=True))
+
+
+@agent_app.command("publish")
+def agent_publish(
+    source: Annotated[Path, typer.Argument(help="Local bora.agent/1 package directory")],
+    org: Annotated[str, typer.Option("--org", help="Organization id (required)")],
+    public: Annotated[bool, typer.Option("--public", help="Publish as public")] = False,
+) -> None:
+    """Publish an agent package to the Registry (package_kind=agent)."""
+    from bora.application.composition import build_agent_commands
+    from bora.config.errors import ConfigError
+
+    try:
+        summary = build_agent_commands().publish_agent(source, public=public, org=org)
+    except ConfigError as exc:
+        typer.echo(
+            json.dumps({"ok": False, "error": exc.error_code, "message": str(exc)}),
+            err=True,
+        )
+        raise typer.Exit(code=2) from exc
+    typer.echo(json.dumps(summary, sort_keys=True))
 
 
 @agent_app.command("list")

--- a/src/bora/cli/cmd_campaign_run.py
+++ b/src/bora/cli/cmd_campaign_run.py
@@ -8,6 +8,8 @@ from typing import Annotated
 
 import typer
 
+from bora.cli.cmd_agent import AGENT_OPTION_HELP, resolve_agent_option
+
 
 def register(app: typer.Typer) -> None:
     """Attach commands to the root Typer app."""
@@ -39,6 +41,10 @@ def register(app: typer.Typer) -> None:
                 help="Alternate profiles.yaml replacing Database-root job bindings.",
             ),
         ] = None,
+        agent: Annotated[
+            list[str] | None,
+            typer.Option("--agent", help=AGENT_OPTION_HELP),
+        ] = None,
     ) -> None:
         """Foreground serial campaign over a parameter matrix (v0.11)."""
         import asyncio
@@ -46,6 +52,7 @@ def register(app: typer.Typer) -> None:
         from bora.application.composition import build_campaign_runner
         from bora.config.errors import ConfigError
 
+        profiles = resolve_agent_option(agent, profiles)
         run_campaign = build_campaign_runner()
         try:
             summary = asyncio.run(
@@ -157,6 +164,10 @@ def register(app: typer.Typer) -> None:
                 help="Alternate profiles.yaml replacing Database-root job bindings.",
             ),
         ] = None,
+        agent: Annotated[
+            list[str] | None,
+            typer.Option("--agent", help=AGENT_OPTION_HELP),
+        ] = None,
         keep_workspace: Annotated[
             bool,
             typer.Option(
@@ -188,6 +199,7 @@ def register(app: typer.Typer) -> None:
             build_suite_runner,
         )
 
+        profiles = resolve_agent_option(agent, profiles)
         _suite = build_suite_runner()
         execute_suite_run = _suite.execute_suite_run
         plan_suite_run = _suite.plan_suite_run

--- a/src/bora/cli/cmd_view_tasks_lock.py
+++ b/src/bora/cli/cmd_view_tasks_lock.py
@@ -9,6 +9,7 @@ from typing import Annotated
 import typer
 
 from bora.application.composition import build_lock_command
+from bora.cli.cmd_agent import AGENT_OPTION_HELP
 from bora.config.errors import ConfigError
 
 
@@ -150,6 +151,10 @@ def register(app: typer.Typer) -> None:
                 ),
             ),
         ] = None,
+        agent: Annotated[
+            list[str] | None,
+            typer.Option("--agent", help=AGENT_OPTION_HELP),
+        ] = None,
         probe: Annotated[
             bool,
             typer.Option(
@@ -169,7 +174,9 @@ def register(app: typer.Typer) -> None:
                 err=True,
             )
             raise typer.Exit(code=2)
+        from bora.cli.cmd_agent import resolve_agent_option
 
+        profiles = resolve_agent_option(agent, profiles)
         try:
             if probe:
                 from bora.application.composition import build_probe_command

--- a/src/bora/cli/main.py
+++ b/src/bora/cli/main.py
@@ -14,6 +14,7 @@ from typing import Annotated
 import typer
 
 from bora.cli import (
+    cmd_agent,
     cmd_cache,
     cmd_campaign_run,
     cmd_cancel_submit,
@@ -64,6 +65,7 @@ cmd_evidence_status.register(app)
 cmd_cancel_submit.register(app)
 cmd_executors_publish_login.register(app)
 cmd_plugin.register(app)
+cmd_agent.register(app)
 cmd_registry.register(app)
 cmd_cache.register(app)
 cmd_results.register(app)

--- a/src/bora/config/profiles.py
+++ b/src/bora/config/profiles.py
@@ -294,7 +294,7 @@ def merge_bindings_onto_slots(
                 ERROR_MISSING_BINDING,
                 f"no job binding for role {role_id!r} "
                 f"(add bindings.{role_id} in Database {PROFILES_FILENAME} "
-                "or pass --profiles / binding overrides)",
+                "or pass --profiles / --agent / binding overrides)",
                 location=f"{loc}/id",
             )
         # Slot identity + non-binding fields, then binding fields on top.

--- a/src/bora/config/profiles.py
+++ b/src/bora/config/profiles.py
@@ -31,6 +31,8 @@ PROFILES_FILENAME = "profiles.yaml"
 PROFILES_FORMAT = "bora.profiles/1"
 
 # Fields that constitute job binding — forbidden on member task.yaml slots.
+# ``agent_ref`` is provenance injected by the --agent projection (design/14);
+# it rides job_overlay / lock but never suite fingerprint identity.
 BINDING_FIELD_KEYS = frozenset(
     {
         "executor",
@@ -41,8 +43,13 @@ BINDING_FIELD_KEYS = frozenset(
         "extensions",
         "label",
         "overlays",
+        "agent_ref",
     }
 )
+
+# Wildcard bindings key: default binding for any role id without an exact row
+# (design/14). Exact role id always wins; projection expands per real role.
+WILDCARD_ROLE = "*"
 
 # Allowlisted nested binding override leaves under /bindings/<role_id>/…
 _BINDING_OVERRIDE_LEAVES = frozenset(
@@ -189,7 +196,7 @@ def parse_profiles_mapping(
                 location=f"{location}:/bindings",
             )
         rid = role_id.strip()
-        if not _ROLE_ID_RE.fullmatch(rid):
+        if rid != WILDCARD_ROLE and not _ROLE_ID_RE.fullmatch(rid):
             raise ConfigError(
                 ERROR_INVALID_SCHEMA,
                 f"invalid binding role id: {rid!r}",
@@ -280,6 +287,8 @@ def merge_bindings_onto_slots(
             )
         role_id = pid.strip()
         binding = bindings.get(role_id)
+        if binding is None:
+            binding = bindings.get(WILDCARD_ROLE)
         if binding is None:
             raise ConfigError(
                 ERROR_MISSING_BINDING,
@@ -559,10 +568,13 @@ def project_job_overlay(
     out: dict[str, Any] = {}
     for rid in keys:
         raw = bindings.get(rid)
+        if raw is None and role_ids is not None:
+            # Wildcard default binding expands to the real role ids (design/14).
+            raw = bindings.get(WILDCARD_ROLE)
         if not isinstance(raw, Mapping):
             continue
         row: dict[str, Any] = {}
-        for k in ("executor", "model", "base_url", "api_key", "label"):
+        for k in ("executor", "model", "base_url", "api_key", "label", "agent_ref"):
             if k in raw and raw[k] is not None:
                 row[k] = raw[k]
         extensions = raw.get("extensions")

--- a/src/bora/config/profiles.py
+++ b/src/bora/config/profiles.py
@@ -47,9 +47,44 @@ BINDING_FIELD_KEYS = frozenset(
     }
 )
 
-# Wildcard bindings key: default binding for any role id without an exact row
-# (design/14). Exact role id always wins; projection expands per real role.
+# Wildcard bindings key: default binding for any role id (design/14). An exact
+# role row overrides the wildcard **field-wise** (missing fields fall back to
+# the wildcard), so binding overrides can tweak one field of a wildcard-bound
+# agent; projection expands per real role.
 WILDCARD_ROLE = "*"
+
+
+def effective_binding(
+    bindings: Mapping[str, Mapping[str, Any]],
+    role_id: str,
+) -> dict[str, Any] | None:
+    """Resolve one role's binding with wildcard field-level fallback.
+
+    Exact row fields win; fields absent on the exact row fall back to the
+    wildcard row (top-level fields only — ``options``/``extensions`` are
+    replaced wholesale by an exact row that sets them). ``None`` when neither
+    row exists.
+    """
+    exact = bindings.get(role_id)
+    wild = bindings.get(WILDCARD_ROLE) if role_id != WILDCARD_ROLE else None
+    if not isinstance(exact, Mapping):
+        exact = None
+    if not isinstance(wild, Mapping):
+        wild = None
+    if exact is None and wild is None:
+        return None
+    out: dict[str, Any] = {}
+    for source in (wild, exact):
+        if source is None:
+            continue
+        for key, val in source.items():
+            out[key] = copy.deepcopy(val)
+    # Provenance never inherits: a role with its own row is not "produced by"
+    # the wildcard's agent unless the exact row says so itself.
+    if exact is not None and "agent_ref" not in exact:
+        out.pop("agent_ref", None)
+    return out
+
 
 # Allowlisted nested binding override leaves under /bindings/<role_id>/…
 _BINDING_OVERRIDE_LEAVES = frozenset(
@@ -286,9 +321,7 @@ def merge_bindings_onto_slots(
                 location=f"{loc}/id",
             )
         role_id = pid.strip()
-        binding = bindings.get(role_id)
-        if binding is None:
-            binding = bindings.get(WILDCARD_ROLE)
+        binding = effective_binding(bindings, role_id)
         if binding is None:
             raise ConfigError(
                 ERROR_MISSING_BINDING,
@@ -567,10 +600,11 @@ def project_job_overlay(
     keys = role_ids if role_ids is not None else sorted(bindings.keys())
     out: dict[str, Any] = {}
     for rid in keys:
-        raw = bindings.get(rid)
-        if raw is None and role_ids is not None:
-            # Wildcard default binding expands to the real role ids (design/14).
-            raw = bindings.get(WILDCARD_ROLE)
+        if role_ids is not None:
+            # Wildcard expands (field-wise) onto the real role ids (design/14).
+            raw: Mapping[str, Any] | None = effective_binding(bindings, rid)
+        else:
+            raw = bindings.get(rid)
         if not isinstance(raw, Mapping):
             continue
         row: dict[str, Any] = {}

--- a/src/bora/evidence/store.py
+++ b/src/bora/evidence/store.py
@@ -140,6 +140,7 @@ class InvocationHandle:
         final_response: dict[str, Any] | None = None,
         error: str | None = None,
         latency_ms: float | None = None,
+        error_detail: str | None = None,
     ) -> None:
         """Atomically finalize metadata (+ optional final-response). Idempotent."""
         with self._lock:
@@ -164,6 +165,8 @@ class InvocationHandle:
                 "event_schema": "bora.trajectory.event/1",
                 "event_count": self._event_seq,
             }
+            if error_detail:
+                meta["error_detail"] = error_detail
             try:
                 # Redact first; fail closed only on residual secrets after redaction.
                 cleaned_meta = redact_value(meta, extra_sentinels=self.store.sentinels)

--- a/src/bora/plugins/contrib/acp/__init__.py
+++ b/src/bora/plugins/contrib/acp/__init__.py
@@ -71,6 +71,14 @@ class AcpExecutorSPI(ExecutorSPI):
                 "XDG_STATE_HOME": f"{home_s}/.local/state",
                 "XDG_DATA_HOME": f"{home_s}/.local/share",
             }
+            # Engines hard-fail when a pointed-to dir is missing (codex exits 1
+            # on absent CODEX_HOME); the attempt home exists but subdirs don't.
+            import contextlib
+            from pathlib import Path
+
+            for sub in (".codex", ".config", ".cache", ".local/state", ".local/share"):
+                with contextlib.suppress(OSError):
+                    Path(home_s, sub).mkdir(parents=True, exist_ok=True)
         workdir = _kwargs.get("workdir")
         workdir_s = str(workdir).strip() if workdir else None
         self._inner = AcpExecutor(

--- a/src/bora/plugins/contrib/acp/executor.py
+++ b/src/bora/plugins/contrib/acp/executor.py
@@ -139,6 +139,7 @@ class AcpExecutor(AgentExecutor):
         self._protocol_version: int | None = None
         self._actual_model: str | None = None
         self._actual_reasoning_effort: str | None = None
+        self._last_error_detail: str | None = None
         self._lock = threading.Lock()
         self._closed = False
         self._cm: Any = None  # async context manager for spawn
@@ -331,6 +332,22 @@ class AcpExecutor(AgentExecutor):
         )
         self._actual_reasoning_effort = desired
 
+    @staticmethod
+    def _exc_detail(exc: BaseException) -> str | None:
+        """Human-actionable detail from an ACP failure (RequestError.data first).
+
+        Adapters put the underlying cause in ``error.data.details`` (e.g. the
+        engine's stderr); losing it leaves operators with a bare error kind.
+        """
+        data = getattr(exc, "data", None)
+        if isinstance(data, dict):
+            for key in ("details", "detail", "message"):
+                val = data.get(key)
+                if isinstance(val, str) and val.strip():
+                    return val.strip()[:300]
+        text = str(exc).strip()
+        return text[:300] if text else None
+
     async def _prompt_once(self, prompt: str) -> AgentResult:
         import acp
 
@@ -357,11 +374,17 @@ class AcpExecutor(AgentExecutor):
                 err = "acp_unexpected_eof"
             else:
                 err = "acp_protocol_error"
+            detail = self._exc_detail(exc)
+            if detail:
+                self._client.record(
+                    {"type": "lifecycle", "phase": "error", "reason": err, "detail": detail}
+                )
             return self._result(
                 text="".join(self._client.text_chunks),
                 ok=False,
                 error=err,
                 stop=None,
+                error_detail=detail,
             )
 
         # Token authority: PromptResponse.usage (may be absent on older agents).
@@ -400,9 +423,10 @@ class AcpExecutor(AgentExecutor):
         ok: bool,
         error: str | None,
         stop: Any,
+        error_detail: str | None = None,
     ) -> AgentResult:
         structured = parse_validated_text_structured(text) if ok else None
-        meta = {
+        meta: dict[str, Any] = {
             "executor_kind": "acp",
             "acp_entry_id": self.entry_id,
             "acp_version": self.descriptor.acp_version,
@@ -416,6 +440,8 @@ class AcpExecutor(AgentExecutor):
             "stop_reason": str(stop) if stop is not None else None,
             "integration_mode": self.descriptor.integration_mode,
         }
+        if error_detail:
+            meta["error_detail"] = error_detail
         vendor_events = tuple(self._client.events) if self._client else ()
         events = tuple(acp_session_events_to_bora(vendor_events))
         # Dual-source normalize: tokens from PromptResponse.usage; cost/context
@@ -456,8 +482,11 @@ class AcpExecutor(AgentExecutor):
         try:
             self._run(self._spawn_and_init(cwd=cwd), timeout=min(timeout, 120.0))
         except RuntimeError as exc:
+            # Bare kind raised by _spawn_and_init; no extra detail to carry.
+            self._last_error_detail = None
             return str(exc) or "acp_protocol_error"
         except Exception as exc:  # noqa: BLE001
+            self._last_error_detail = self._exc_detail(exc)
             msg = str(exc).lower()
             if "auth" in msg:
                 return "acp_auth_required"
@@ -481,25 +510,29 @@ class AcpExecutor(AgentExecutor):
 
         err = self._ensure_session(workdir=workdir, timeout=timeout)
         if err is not None:
+            detail = self._last_error_detail
+            event: dict[str, Any] = {
+                "type": "lifecycle",
+                "phase": "failed",
+                "reason": err,
+                "source": "acp_adapter",
+            }
+            meta: dict[str, Any] = {
+                "executor_kind": "acp",
+                "acp_entry_id": self.entry_id,
+                "descriptor_digest": self.descriptor.descriptor_digest,
+            }
+            if detail:
+                event["detail"] = detail
+                meta["error_detail"] = detail
             return AgentResult(
                 model=self.model,
                 text="",
                 structured=None,
                 ok=False,
                 error=err,
-                events=(
-                    {
-                        "type": "lifecycle",
-                        "phase": "failed",
-                        "reason": err,
-                        "source": "acp_adapter",
-                    },
-                ),
-                metadata={
-                    "executor_kind": "acp",
-                    "acp_entry_id": self.entry_id,
-                    "descriptor_digest": self.descriptor.descriptor_digest,
-                },
+                events=(event,),
+                metadata=meta,
             )
 
         started = time.monotonic()

--- a/src/bora/registry/agent_package.py
+++ b/src/bora/registry/agent_package.py
@@ -1,0 +1,79 @@
+"""bora.agent/1 archive + digest helpers (design/14; mirrors plugin_package)."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import io
+import tarfile
+from pathlib import Path
+
+from bora.agents.manifest import AGENT_FORMAT, load_agent_manifest
+from bora.plugins.store import compute_tree_digest
+from bora.registry.media_types import AGENT_MEDIA_TYPE as AGENT_MEDIA_TYPE
+from bora.registry.plugin_package import member_paths_for_plugin as member_paths_for_agent
+
+__all__ = [
+    "AGENT_MEDIA_TYPE",
+    "assert_agent_package",
+    "build_agent_archive",
+    "compute_agent_digest",
+    "member_paths_for_agent",
+]
+
+
+def compute_agent_digest(root: Path) -> str:
+    """Package digest for agents — same tree algorithm as the local cache."""
+    return compute_tree_digest(root)
+
+
+def assert_agent_package(root: Path) -> None:
+    """Fail closed unless *root* is a valid, secret-free bora.agent/1 tree."""
+    load_agent_manifest(root)  # schema + package-wide secret scan
+    if (root / "bora.yaml").is_file() or (root / "plugin.yaml").is_file():
+        raise ValueError(f"agent package must not also carry a Database/plugin manifest ({root})")
+    _ = AGENT_FORMAT  # format pinned by load_agent_manifest
+
+
+def build_agent_archive(root: Path) -> tuple[bytes, str, int]:
+    """Return ``(archive_bytes, blob_digest, size)`` for an agent package root."""
+    root = root.expanduser().resolve(strict=False)
+    assert_agent_package(root)
+    paths = member_paths_for_agent(root)
+    tar_buf = io.BytesIO()
+    with tarfile.open(fileobj=tar_buf, mode="w", format=tarfile.PAX_FORMAT) as tar:
+        seen_dirs: set[str] = set()
+        for rel in paths:
+            parts = Path(rel).parts
+            for i in range(1, len(parts)):
+                d = "/".join(parts[:i])
+                if d in seen_dirs:
+                    continue
+                seen_dirs.add(d)
+                info = tarfile.TarInfo(name=d)
+                info.type = tarfile.DIRTYPE
+                info.mode = 0o755
+                info.mtime = 0
+                info.uid = 0
+                info.gid = 0
+                info.uname = ""
+                info.gname = ""
+                tar.addfile(info)
+            abs_path = root / rel
+            info = tarfile.TarInfo(name=rel)
+            info.size = abs_path.stat().st_size
+            info.mode = 0o644
+            info.mtime = 0
+            info.uid = 0
+            info.gid = 0
+            info.uname = ""
+            info.gname = ""
+            with abs_path.open("rb") as fh:
+                tar.addfile(info, fh)
+    raw_tar = tar_buf.getvalue()
+    gz_buf = io.BytesIO()
+    with gzip.GzipFile(fileobj=gz_buf, mode="wb", mtime=0) as gz:
+        gz.write(raw_tar)
+    archive = gz_buf.getvalue()
+    blob_digest = f"sha256:{hashlib.sha256(archive).hexdigest()}"
+    return archive, blob_digest, len(archive)

--- a/src/bora/registry/media_types.py
+++ b/src/bora/registry/media_types.py
@@ -4,5 +4,6 @@ from __future__ import annotations
 
 DATABASE_MEDIA_TYPE = "application/vnd.bora.database.v1.tar+gzip"
 PLUGIN_MEDIA_TYPE = "application/vnd.bora.plugin.v1.tar+gzip"
+AGENT_MEDIA_TYPE = "application/vnd.bora.agent.v1.tar+gzip"
 ATTEMPT_RESULT_MEDIA_TYPE = "application/vnd.bora.attempt-result.v1.tar+gzip"
 SUITE_RESULT_MEDIA_TYPE = "application/vnd.bora.suite-result.v1.tar+gzip"

--- a/src/bora/runtime/agent_service_evidence.py
+++ b/src/bora/runtime/agent_service_evidence.py
@@ -297,11 +297,18 @@ def seal_invoke_result(
                 latency_ms=latency_ms,
             )
         else:
+            detail = None
+            res_meta = getattr(result, "metadata", None)
+            if isinstance(res_meta, dict):
+                raw_detail = res_meta.get("error_detail")
+                if isinstance(raw_detail, str) and raw_detail.strip():
+                    detail = raw_detail.strip()
             handle.seal(
                 status=status,
                 final_response=None,
                 error=result.error,
                 latency_ms=latency_ms,
+                error_detail=detail,
             )
     except RedactionError:
         return "redaction_failed"

--- a/tests/agents/test_agent_manifest.py
+++ b/tests/agents/test_agent_manifest.py
@@ -1,0 +1,101 @@
+"""bora.agent/1 manifest parse + fail-closed secret scan (design/14)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bora.agents.manifest import AGENT_FILENAME, load_agent_manifest, parse_agent_document
+from bora.config.errors import ConfigError
+
+GOOD_DOC = {
+    "format": "bora.agent/1",
+    "agent_id": "mock-default",
+    "version": "0.1.0",
+    "label": "Mock Default",
+    "tags": ["ci"],
+    "binding": {
+        "executor": "mock",
+        "model": "none",
+    },
+}
+
+
+def _write_pkg(root: Path, doc_text: str) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / AGENT_FILENAME).write_text(doc_text, encoding="utf-8")
+    return root
+
+
+def test_parse_good_document() -> None:
+    m = parse_agent_document(dict(GOOD_DOC))
+    assert m.agent_id == "mock-default"
+    assert m.version == "0.1.0"
+    assert m.binding["executor"] == "mock"
+    # label sinks into binding.label when binding omits it
+    assert m.binding["label"] == "Mock Default"
+    assert m.tags == ("ci",)
+
+
+def test_unknown_top_key_fails() -> None:
+    doc = dict(GOOD_DOC)
+    doc["skills"] = ["x"]
+    with pytest.raises(ConfigError):
+        parse_agent_document(doc)
+
+
+def test_bad_format_fails() -> None:
+    doc = dict(GOOD_DOC)
+    doc["format"] = "bora.agent/2"
+    with pytest.raises(ConfigError):
+        parse_agent_document(doc)
+
+
+def test_reserved_agent_ref_rejected() -> None:
+    doc = dict(GOOD_DOC)
+    doc["binding"] = {"executor": "mock", "model": "none", "agent_ref": "x@1"}
+    with pytest.raises(ConfigError) as exc:
+        parse_agent_document(doc)
+    assert "agent_ref" in str(exc.value)
+
+
+def test_unknown_binding_key_rejected() -> None:
+    doc = dict(GOOD_DOC)
+    doc["binding"] = {"executor": "mock", "model": "none", "token": "sk-nope"}
+    with pytest.raises(ConfigError):
+        parse_agent_document(doc)
+
+
+def test_load_from_dir_and_bare_yaml(tmp_path: Path) -> None:
+    pkg = _write_pkg(
+        tmp_path / "agent-pkg",
+        "format: bora.agent/1\nagent_id: a1\nversion: '1.0'\n"
+        "binding: {executor: mock, model: none}\n",
+    )
+    m = load_agent_manifest(pkg)
+    assert m.root == pkg
+    m2 = load_agent_manifest(pkg / AGENT_FILENAME)
+    assert m2.root is None
+    assert m2.agent_id == "a1"
+
+
+def test_secret_in_package_fails_closed(tmp_path: Path) -> None:
+    pkg = _write_pkg(
+        tmp_path / "leaky",
+        "format: bora.agent/1\nagent_id: leaky\nversion: '1.0'\n"
+        "binding: {executor: mock, model: none}\n",
+    )
+    (pkg / "notes.txt").write_text("api_key = sk-abc123def456ghi789jkl000\n", encoding="utf-8")
+    with pytest.raises(ConfigError):
+        load_agent_manifest(pkg)
+
+
+def test_locator_name_is_clean(tmp_path: Path) -> None:
+    pkg = _write_pkg(
+        tmp_path / "locator",
+        "format: bora.agent/1\nagent_id: locator\nversion: '1.0'\n"
+        "binding: {executor: mock, model: none, api_key: '${OPENAI_API_KEY}'}\n",
+    )
+    m = load_agent_manifest(pkg)
+    assert m.binding["api_key"] == "${OPENAI_API_KEY}"

--- a/tests/agents/test_agent_resolve.py
+++ b/tests/agents/test_agent_resolve.py
@@ -1,0 +1,86 @@
+"""--agent spec parsing + projection into the profiles lane (design/14)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from bora.application.agent_ops.resolve import (
+    bindings_from_agent_specs,
+    parse_agent_spec,
+    resolve_agent_specs,
+)
+from bora.config.errors import ConfigError
+
+
+@pytest.fixture(autouse=True)
+def _bora_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "bora-home"
+    monkeypatch.setenv("BORA_HOME", str(home))
+    return home
+
+
+def _make_pkg(tmp_path: Path, agent_id: str = "mock-default") -> Path:
+    pkg = tmp_path / f"pkg-{agent_id}"
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "agent.yaml").write_text(
+        f"format: bora.agent/1\nagent_id: {agent_id}\nversion: '0.1.0'\n"
+        "label: T\nbinding: {executor: mock, model: none}\n",
+        encoding="utf-8",
+    )
+    return pkg
+
+
+def test_parse_agent_spec_forms() -> None:
+    assert parse_agent_spec("local/x@1.0") == ("*", "local/x@1.0")
+    assert parse_agent_spec("solver=local/x@1.0") == ("solver", "local/x@1.0")
+    assert parse_agent_spec("./dir/agent.yaml") == ("*", "./dir/agent.yaml")
+    # '=' inside a ref that is not a role assignment stays whole
+    assert parse_agent_spec("solver=./p/agent.yaml") == ("solver", "./p/agent.yaml")
+    with pytest.raises(ConfigError):
+        parse_agent_spec("  ")
+
+
+def test_bindings_from_path_spec(tmp_path: Path) -> None:
+    pkg = _make_pkg(tmp_path)
+    bindings = bindings_from_agent_specs([str(pkg)])
+    assert set(bindings) == {"*"}
+    row = bindings["*"]
+    assert row["executor"] == "mock"
+    assert row["agent_ref"].startswith("file:")
+    assert "+sha256:" in row["agent_ref"]
+
+
+def test_bindings_from_cache_ref_with_local_fallback(tmp_path: Path) -> None:
+    from bora.agents.store import install_from_path
+
+    install_from_path(_make_pkg(tmp_path))
+    for ref in ("local/mock-default@0.1.0", "mock-default@0.1.0"):
+        bindings = bindings_from_agent_specs([f"solver={ref}"])
+        assert bindings["solver"]["agent_ref"].startswith("local/mock-default@0.1.0+sha256:")
+
+
+def test_missing_cache_ref_fails_closed() -> None:
+    with pytest.raises(ConfigError):
+        bindings_from_agent_specs(["ghost@1.0"])
+
+
+def test_duplicate_role_fails_closed(tmp_path: Path) -> None:
+    pkg = _make_pkg(tmp_path)
+    with pytest.raises(ConfigError):
+        bindings_from_agent_specs([str(pkg), str(pkg)])
+    with pytest.raises(ConfigError):
+        bindings_from_agent_specs([f"solver={pkg}", f"solver={pkg}"])
+
+
+def test_resolve_writes_parseable_profiles_document(tmp_path: Path) -> None:
+    pkg = _make_pkg(tmp_path)
+    out = resolve_agent_specs([str(pkg), f"critic={pkg}"])
+    assert out.is_file()
+    doc = yaml.safe_load(out.read_text(encoding="utf-8"))
+    assert doc["format"] == "bora.profiles/1"
+    assert set(doc["bindings"]) == {"*", "critic"}
+    # Content-addressed: same specs → same path.
+    assert resolve_agent_specs([str(pkg), f"critic={pkg}"]) == out

--- a/tests/agents/test_agent_store.py
+++ b/tests/agents/test_agent_store.py
@@ -1,0 +1,78 @@
+"""Agent cache install/list/uninstall + pinned ref resolve (design/14)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bora.agents import store
+from bora.config.errors import ConfigError
+
+
+@pytest.fixture(autouse=True)
+def _bora_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "bora-home"
+    monkeypatch.setenv("BORA_HOME", str(home))
+    return home
+
+
+def _make_pkg(tmp_path: Path, agent_id: str = "mock-default", version: str = "0.1.0") -> Path:
+    pkg = tmp_path / f"pkg-{agent_id}"
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "agent.yaml").write_text(
+        f"format: bora.agent/1\nagent_id: {agent_id}\nversion: '{version}'\n"
+        "label: T\nbinding: {executor: mock, model: none}\n",
+        encoding="utf-8",
+    )
+    return pkg
+
+
+def test_install_list_resolve_roundtrip(tmp_path: Path) -> None:
+    pkg = _make_pkg(tmp_path)
+    entry = store.install_from_path(pkg)
+    assert entry.agent_id == "local/mock-default"
+    assert entry.version == "0.1.0"
+    assert entry.digest.startswith("sha256:")
+
+    rows = store.list_installed()
+    assert [r.agent_id for r in rows] == ["local/mock-default"]
+
+    got, root = store.resolve_installed_ref("local/mock-default", "0.1.0")
+    assert got.digest == entry.digest
+    assert (root / "agent.yaml").is_file()
+
+
+def test_install_idempotent(tmp_path: Path) -> None:
+    pkg = _make_pkg(tmp_path)
+    a = store.install_from_path(pkg)
+    b = store.install_from_path(pkg)
+    assert a.digest == b.digest
+    assert len(store.list_installed()) == 1
+
+
+def test_hub_id_override(tmp_path: Path) -> None:
+    pkg = _make_pkg(tmp_path)
+    entry = store.install_from_path(pkg, agent_id="acme/mock-default")
+    assert entry.agent_id == "acme/mock-default"
+    _, root = store.resolve_installed_ref("acme/mock-default", "0.1.0")
+    assert root.is_dir()
+
+
+def test_resolve_missing_fails_closed() -> None:
+    with pytest.raises(ConfigError):
+        store.resolve_installed_ref("local/nope", "1.0")
+
+
+def test_resolve_version_mismatch_fails_closed(tmp_path: Path) -> None:
+    store.install_from_path(_make_pkg(tmp_path))
+    with pytest.raises(ConfigError) as exc:
+        store.resolve_installed_ref("local/mock-default", "9.9")
+    assert "9.9" in str(exc.value)
+
+
+def test_uninstall(tmp_path: Path) -> None:
+    store.install_from_path(_make_pkg(tmp_path))
+    assert store.uninstall("local/mock-default") is True
+    assert store.list_installed() == []
+    assert store.uninstall("local/mock-default") is False

--- a/tests/agents/test_cli_agent_lifecycle.py
+++ b/tests/agents/test_cli_agent_lifecycle.py
@@ -1,0 +1,113 @@
+"""CLI: bora agent install/list/show/uninstall + lock --agent acceptance (design/14)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_AGENT = ROOT / "examples/agents/mock-default"
+DATABASE = ROOT / "examples/core"
+
+
+@pytest.fixture()
+def env(tmp_path: Path) -> dict[str, str]:
+    home = tmp_path / "bora-home"
+    home.mkdir()
+    return {
+        **os.environ,
+        "BORA_HOME": str(home),
+        "BORA_OFFLINE_AGENT": "1",
+        "BORA_SKIP_DOCKER": "1",
+    }
+
+
+def _cli(env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "bora.cli.main", *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_agent_install_list_show_uninstall(env: dict[str, str]) -> None:
+    proc = _cli(env, "agent", "install", str(EXAMPLE_AGENT))
+    assert proc.returncode == 0, proc.stderr
+    data = json.loads(proc.stdout)
+    assert data["ok"] is True
+    assert data["ref"] == "local/mock-default@0.1.0"
+
+    listed = json.loads(_cli(env, "agent", "list").stdout)
+    assert [a["agent_id"] for a in listed["agents"]] == ["local/mock-default"]
+
+    shown = json.loads(_cli(env, "agent", "show", "local/mock-default@0.1.0").stdout)
+    assert shown["binding"]["executor"] == "mock"
+    assert shown["digest"].startswith("sha256:")
+
+    assert _cli(env, "agent", "uninstall", "local/mock-default").returncode == 0
+    assert json.loads(_cli(env, "agent", "list").stdout)["agents"] == []
+
+
+def test_agent_and_profiles_mutually_exclusive(env: dict[str, str]) -> None:
+    proc = _cli(
+        env,
+        "lock",
+        str(DATABASE),
+        "--task",
+        "sdk-agent-session",
+        "--agent",
+        str(EXAMPLE_AGENT),
+        "--profiles",
+        str(DATABASE / "profiles.yaml"),
+    )
+    assert proc.returncode == 2
+    assert "mutually exclusive" in proc.stderr
+
+
+def _lock_summary(env: dict[str, str], *extra: str) -> dict[str, Any]:
+    proc = _cli(env, "lock", str(DATABASE), "--task", "sdk-agent-session", *extra)
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def test_lock_with_agent_records_agent_ref_and_matches_profiles_lane(
+    env: dict[str, str], tmp_path: Path
+) -> None:
+    assert _cli(env, "agent", "install", str(EXAMPLE_AGENT)).returncode == 0
+
+    summary = _lock_summary(env, "--agent", "local/mock-default@0.1.0")
+    bindings = summary["job_overlay"]["bindings"]
+    refs = {row.get("agent_ref") for row in bindings.values()}
+    assert len(refs) == 1
+    (ref,) = refs
+    assert ref.startswith("local/mock-default@0.1.0+sha256:")
+
+    # Same run twice → deterministic digest.
+    again = _lock_summary(env, "--agent", "local/mock-default@0.1.0")
+    assert again["digest"] == summary["digest"]
+
+    # Equivalent hand-written profiles file (same bindings incl. agent_ref)
+    # must produce the identical lock digest — the lanes are the same lane.
+    import yaml
+
+    profiles_doc = {"format": "bora.profiles/1", "bindings": {}}
+    for role, row in bindings.items():
+        clone = dict(row)
+        api_key = clone.get("api_key")
+        if isinstance(api_key, str) and api_key and not api_key.startswith("${"):
+            clone["api_key"] = f"${{{api_key}}}"
+        profiles_doc["bindings"][role] = clone
+    profiles_path = tmp_path / "equiv-profiles.yaml"
+    profiles_path.write_text(yaml.safe_dump(profiles_doc, sort_keys=False), encoding="utf-8")
+
+    via_profiles = _lock_summary(env, "--profiles", str(profiles_path))
+    assert via_profiles["digest"] == summary["digest"]

--- a/tests/agents/test_eval_mini_examples_lock.py
+++ b/tests/agents/test_eval_mini_examples_lock.py
@@ -1,0 +1,75 @@
+"""Eval-mini example Databases lock offline (mock default binding + --agent lane)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+CASES = [
+    ("examples/scienceqa-mini", "sqa-photosynthesis"),
+    ("examples/alfworld-mini", "alf-drawer-key"),
+    ("examples/webshop-mini", "ws-tshirt"),
+]
+
+
+@pytest.fixture()
+def env(tmp_path: Path) -> dict[str, str]:
+    home = tmp_path / "bora-home"
+    home.mkdir()
+    return {
+        **os.environ,
+        "BORA_HOME": str(home),
+        "BORA_OFFLINE_AGENT": "1",
+        "BORA_SKIP_DOCKER": "1",
+    }
+
+
+def _lock(env: dict[str, str], db: str, task: str, *extra: str) -> dict:
+    proc = subprocess.run(
+        [sys.executable, "-m", "bora.cli.main", "lock", str(ROOT / db), "--task", task, *extra],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert proc.returncode == 0, f"{db}/{task}: {proc.stderr}"
+    return json.loads(proc.stdout)
+
+
+@pytest.mark.parametrize(("db", "task"), CASES)
+def test_lock_with_database_profiles(env: dict[str, str], db: str, task: str) -> None:
+    summary = _lock(env, db, task)
+    binding = summary["job_overlay"]["bindings"]["solver"]
+    assert binding["executor"] == "mock"
+
+
+@pytest.mark.parametrize(("db", "task"), CASES)
+def test_lock_with_example_agent(env: dict[str, str], db: str, task: str) -> None:
+    install = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "bora.cli.main",
+            "agent",
+            "install",
+            str(ROOT / "examples/agents/cc-default"),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert install.returncode == 0, install.stderr
+    summary = _lock(env, db, task, "--agent", "local/cc-default@0.1.0")
+    binding = summary["job_overlay"]["bindings"]["solver"]
+    assert binding["agent_ref"].startswith("local/cc-default@0.1.0+sha256:")
+    assert binding["executor"] == "acp"

--- a/tests/agents/test_profiles_wildcard_agent_ref.py
+++ b/tests/agents/test_profiles_wildcard_agent_ref.py
@@ -98,3 +98,51 @@ def test_suite_compat_and_labels_with_wildcard_binding() -> None:
     fields = compute_suite_config_fields([], job_overlay=suite_overlay, per_task_overlays=per_task)
     assert fields["config_homogeneous"] is True
     assert fields["agent_label"] == "Claude Code (entry default)"
+
+
+def test_wildcard_and_explicit_spellings_share_fingerprint() -> None:
+    """Identity must not depend on '*'-vs-explicit spelling (design/14)."""
+    from bora.application.suite.suite_config_fingerprint import compute_suite_config_fields
+
+    binding = {
+        "executor": "acp",
+        "model": "entry-default",
+        "extensions": [{"plugin": "acp", "options": {"entry": "claude-code"}}],
+    }
+    per_task = [{"bindings": {"solver": dict(binding)}}]
+    via_wildcard = compute_suite_config_fields(
+        [], job_overlay={"bindings": {"*": binding}}, per_task_overlays=per_task
+    )
+    via_explicit = compute_suite_config_fields(
+        [], job_overlay={"bindings": {"solver": dict(binding)}}, per_task_overlays=per_task
+    )
+    assert via_wildcard["config_fingerprint"] == via_explicit["config_fingerprint"]
+    assert [a["profile_id"] for a in via_wildcard["actors_summary"]] == ["solver"]
+
+
+def test_exact_row_overrides_wildcard_field_wise() -> None:
+    """--set on one field of a wildcard-bound agent must not drop the rest."""
+    from bora.config.profiles import apply_binding_override, effective_binding
+
+    bindings = parse_profiles_mapping(
+        {
+            "format": "bora.profiles/1",
+            "bindings": {
+                "*": {
+                    "executor": "acp",
+                    "model": "entry-default",
+                    "extensions": [{"plugin": "acp", "options": {"entry": "claude-code"}}],
+                }
+            },
+        }
+    )
+    apply_binding_override(bindings, "/bindings/solver/model", "claude-opus-5")
+    merged = merge_bindings_onto_slots([{"id": "solver"}, {"id": "critic"}], bindings)
+    by_id = {row["id"]: row for row in merged}
+    assert by_id["solver"]["model"] == "claude-opus-5"  # override wins
+    assert by_id["solver"]["executor"] == "acp"  # inherited from wildcard
+    assert by_id["solver"]["extensions"][0]["options"]["entry"] == "claude-code"
+    assert by_id["critic"]["model"] == "entry-default"  # untouched fallback
+
+    eff = effective_binding(bindings, "solver")
+    assert eff is not None and eff["model"] == "claude-opus-5" and eff["executor"] == "acp"

--- a/tests/agents/test_profiles_wildcard_agent_ref.py
+++ b/tests/agents/test_profiles_wildcard_agent_ref.py
@@ -1,0 +1,74 @@
+"""Wildcard "*" default binding + agent_ref passthrough in profiles (design/14)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bora.config.errors import ConfigError
+from bora.config.profiles import (
+    job_overlay_to_profiles_document,
+    merge_bindings_onto_slots,
+    parse_profiles_mapping,
+    project_job_overlay,
+)
+
+WILDCARD_DOC = {
+    "format": "bora.profiles/1",
+    "bindings": {
+        "*": {"executor": "mock", "model": "none", "agent_ref": "local/m@0.1.0+sha256:abc"},
+        "critic": {"executor": "mock", "model": "other"},
+    },
+}
+
+
+def test_parse_accepts_wildcard_key() -> None:
+    bindings = parse_profiles_mapping(WILDCARD_DOC)
+    assert set(bindings) == {"*", "critic"}
+
+
+def test_parse_still_rejects_bad_role_ids() -> None:
+    doc = {"format": "bora.profiles/1", "bindings": {"**": {"executor": "mock", "model": "x"}}}
+    with pytest.raises(ConfigError):
+        parse_profiles_mapping(doc)
+
+
+def test_merge_exact_wins_wildcard_falls_back() -> None:
+    bindings = parse_profiles_mapping(WILDCARD_DOC)
+    merged = merge_bindings_onto_slots([{"id": "solver"}, {"id": "critic"}], bindings)
+    by_id = {row["id"]: row for row in merged}
+    assert by_id["solver"]["model"] == "none"  # wildcard fallback
+    assert by_id["solver"]["agent_ref"] == "local/m@0.1.0+sha256:abc"
+    assert by_id["critic"]["model"] == "other"  # exact wins
+    assert "agent_ref" not in by_id["critic"]
+
+
+def test_merge_without_wildcard_still_fails_closed() -> None:
+    bindings = parse_profiles_mapping(
+        {"format": "bora.profiles/1", "bindings": {"critic": {"executor": "mock", "model": "x"}}}
+    )
+    with pytest.raises(ConfigError):
+        merge_bindings_onto_slots([{"id": "solver"}], bindings)
+
+
+def test_project_expands_wildcard_to_real_roles() -> None:
+    bindings = parse_profiles_mapping(WILDCARD_DOC)
+    overlay = project_job_overlay(bindings, role_ids=["solver", "critic"])
+    rows = overlay["bindings"]
+    assert set(rows) == {"solver", "critic"}
+    assert rows["solver"]["agent_ref"] == "local/m@0.1.0+sha256:abc"
+    assert rows["critic"]["model"] == "other"
+    assert "*" not in rows
+
+
+def test_agent_ref_round_trips_via_profiles_document() -> None:
+    bindings = parse_profiles_mapping(WILDCARD_DOC)
+    overlay = project_job_overlay(bindings, role_ids=["solver"])
+    doc = job_overlay_to_profiles_document(overlay)
+    assert doc["bindings"]["solver"]["agent_ref"] == "local/m@0.1.0+sha256:abc"
+
+
+def test_task_yaml_slots_reject_agent_ref_inline() -> None:
+    from bora.config.profiles import assert_slots_have_no_inline_binding
+
+    with pytest.raises(ConfigError):
+        assert_slots_have_no_inline_binding([{"id": "solver", "agent_ref": "x@1"}])

--- a/tests/agents/test_profiles_wildcard_agent_ref.py
+++ b/tests/agents/test_profiles_wildcard_agent_ref.py
@@ -72,3 +72,29 @@ def test_task_yaml_slots_reject_agent_ref_inline() -> None:
 
     with pytest.raises(ConfigError):
         assert_slots_have_no_inline_binding([{"id": "solver", "agent_ref": "x@1"}])
+
+
+def test_suite_compat_and_labels_with_wildcard_binding() -> None:
+    """Found via live eval: '*' suite binding blanked labels / homogeneity."""
+    from bora.application.suite.suite_config_fingerprint import (
+        compute_suite_config_fields,
+        job_overlays_compatible,
+    )
+
+    binding = {
+        "executor": "acp",
+        "model": "entry-default",
+        "label": "Claude Code (entry default)",
+        "extensions": [{"plugin": "acp", "options": {"entry": "claude-code"}}],
+    }
+    suite_overlay = {"bindings": {"*": binding}}
+    per_task = [{"bindings": {"solver": dict(binding)}}]
+
+    assert job_overlays_compatible(suite_overlay, per_task) is True
+    # A conflicting model for the same role still breaks compatibility.
+    conflicting = [{"bindings": {"solver": {**binding, "model": "other"}}}]
+    assert job_overlays_compatible(suite_overlay, conflicting) is False
+
+    fields = compute_suite_config_fields([], job_overlay=suite_overlay, per_task_overlays=per_task)
+    assert fields["config_homogeneous"] is True
+    assert fields["agent_label"] == "Claude Code (entry default)"

--- a/tests/plugins/test_acp_error_detail.py
+++ b/tests/plugins/test_acp_error_detail.py
@@ -38,3 +38,19 @@ def test_exc_detail_truncates_long_payloads() -> None:
     exc = _RequestErrorLike("Internal error", {"details": "x" * 1000})
     detail = AcpExecutor._exc_detail(exc)
     assert detail is not None and len(detail) == 300
+
+
+def test_spi_creates_pointed_home_subdirs(tmp_path) -> None:
+    """codex exits 1 when CODEX_HOME points at a missing dir (live-eval find)."""
+    from bora.plugins.contrib.acp import AcpExecutorSPI
+
+    home = tmp_path / "attempt-home"
+    home.mkdir()
+    AcpExecutorSPI(
+        options={"entry": "codex"},
+        profile_id="solver",
+        model="entry-default",
+        home=str(home),
+    )
+    for sub in (".codex", ".config", ".cache", ".local/state", ".local/share"):
+        assert (home / sub).is_dir(), sub

--- a/tests/plugins/test_acp_error_detail.py
+++ b/tests/plugins/test_acp_error_detail.py
@@ -1,0 +1,40 @@
+"""ACP failure detail must reach evidence, not just a bare error kind.
+
+Found via live eval: claude-agent-acp returned error.data.details
+("--dangerously-skip-permissions cannot be used with root/sudo…") but the
+executor surfaced only ``acp_protocol_error``.
+"""
+
+from __future__ import annotations
+
+from bora.plugins.contrib.acp.executor import AcpExecutor
+
+
+class _RequestErrorLike(Exception):
+    def __init__(self, message: str, data: object) -> None:
+        super().__init__(message)
+        self.data = data
+
+
+def test_exc_detail_prefers_request_error_data() -> None:
+    exc = _RequestErrorLike(
+        "Internal error",
+        {"details": "Claude Code process exited with code 1. stderr: root refused"},
+    )
+    detail = AcpExecutor._exc_detail(exc)
+    assert detail is not None
+    assert "root refused" in detail
+
+
+def test_exc_detail_falls_back_to_message_keys_and_str() -> None:
+    assert AcpExecutor._exc_detail(_RequestErrorLike("x", {"message": "adapter said no"})) == (
+        "adapter said no"
+    )
+    assert AcpExecutor._exc_detail(RuntimeError("plain failure")) == "plain failure"
+    assert AcpExecutor._exc_detail(RuntimeError("")) is None
+
+
+def test_exc_detail_truncates_long_payloads() -> None:
+    exc = _RequestErrorLike("Internal error", {"details": "x" * 1000})
+    detail = AcpExecutor._exc_detail(exc)
+    assert detail is not None and len(detail) == 300

--- a/tests/registry/test_agent_package_e2e.py
+++ b/tests/registry/test_agent_package_e2e.py
@@ -1,0 +1,147 @@
+"""design/14: publish agent → preview → list filter → install; secrets rejected."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import threading
+import urllib.request
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+from services.registry.app import build_default_state, make_handler
+
+from bora.application.composition import build_agent_commands
+from bora.registry.client import RegistryClient
+from bora.registry.media_types import AGENT_MEDIA_TYPE
+
+_agents = build_agent_commands()
+install_agent_from_registry = _agents.install_agent_from_registry
+publish_agent = _agents.publish_agent
+
+REPO = Path(__file__).resolve().parents[2]
+AGENT_FIXTURE = REPO / "examples" / "agents" / "mock-default"
+TEST_ORG = "test"
+
+
+@pytest.fixture()
+def registry_server(tmp_path: Path):
+    data = tmp_path / "reg-data"
+    state, token = build_default_state(data, bootstrap_token="test-token-agent", memory_blob=True)
+    handler = make_handler(state)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{port}"
+    yield {"url": url, "token": token, "state": state}
+    server.shutdown()
+
+
+@pytest.fixture()
+def env(registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    monkeypatch.setenv("BORA_REGISTRY_URL", registry_server["url"])
+    monkeypatch.setenv("BORA_REGISTRY_TOKEN", registry_server["token"])
+    home = tmp_path / "bora-home"
+    home.mkdir()
+    monkeypatch.setenv("BORA_HOME", str(home))
+    client = RegistryClient(registry_server["url"], token=registry_server["token"])
+    with contextlib.suppress(Exception):  # already created
+        client.create_org(name=TEST_ORG, display_name="Test Org")
+    return {"url": registry_server["url"], "token": registry_server["token"], "home": str(home)}
+
+
+def _get(url: str, token: str, path: str) -> dict:
+    req = urllib.request.Request(url + path, headers={"Authorization": f"Bearer {token}"})
+    with urllib.request.urlopen(req) as resp:  # noqa: S310
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def test_publish_agent_preview_list_and_install(env: dict[str, str]) -> None:
+    summary = publish_agent(AGENT_FIXTURE, public=False, org=TEST_ORG)
+    assert summary["ok"] is True
+    assert summary["package_kind"] == "agent"
+    assert summary["media_type"] == AGENT_MEDIA_TYPE
+    assert summary["package_id"] == f"{TEST_ORG}/mock-default"
+
+    body = _get(
+        env["url"],
+        env["token"],
+        f"/v1/packages/{summary['package_id']}/versions/{summary['version']}",
+    )
+    assert body.get("package_kind") == "agent"
+    preview = body.get("agent_preview") or {}
+    assert preview.get("agent_id") == "mock-default"
+    assert preview.get("label") == "Mock Default"
+    assert preview.get("binding", {}).get("executor") == "mock"
+    assert "agent.yaml" in (preview.get("files") or [])
+
+    listed = _get(env["url"], env["token"], "/v1/packages?package_kind=agent")
+    items = listed.get("items") or []
+    assert any(i.get("database_id") == summary["package_id"] for i in items)
+    assert all(i.get("package_kind") == "agent" for i in items)
+
+    db_listed = _get(env["url"], env["token"], "/v1/packages?package_kind=database")
+    assert not any(
+        i.get("database_id") == summary["package_id"] for i in (db_listed.get("items") or [])
+    )
+
+    installed = install_agent_from_registry(summary["ref"])
+    assert installed["ok"] is True
+    assert installed["agent_id"] == f"{TEST_ORG}/mock-default"
+    assert installed["digest"].startswith("sha256:")
+    assert (Path(env["home"]) / "agents" / "index.json").is_file()
+
+    # Install by digest round-trips too.
+    by_digest = install_agent_from_registry(f"{summary['package_id']}@{summary['package_digest']}")
+    assert by_digest["ok"] is True
+
+
+def test_reject_secret_bearing_agent(env: dict[str, str], tmp_path: Path) -> None:
+    from bora.config.errors import ConfigError
+
+    pkg = tmp_path / "leaky-agent"
+    pkg.mkdir()
+    (pkg / "agent.yaml").write_text(
+        "format: bora.agent/1\nagent_id: leaky\nversion: '1.0'\n"
+        "binding: {executor: mock, model: none}\n",
+        encoding="utf-8",
+    )
+    (pkg / "notes.txt").write_text("api_key = sk-abc123def456ghi789jkl000\n", encoding="utf-8")
+    with pytest.raises(ConfigError):
+        publish_agent(pkg, public=False, org=TEST_ORG)
+
+
+def test_reject_agent_yaml_as_database(env: dict[str, str], tmp_path: Path) -> None:
+    """agent.yaml trees must not slip through as package_kind=database.
+
+    The client already fails closed locally (no bora.yaml); the server guard
+    in ``_validate_archive`` is exercised directly as defense in depth.
+    """
+    import tarfile
+
+    from services.registry.http_api import RegistryAppError
+    from services.registry.package_service import PackageService
+
+    pkg = tmp_path / "sneaky"
+    pkg.mkdir()
+    (pkg / "agent.yaml").write_text(
+        "format: bora.agent/1\nagent_id: sneaky\nversion: '1.0'\n"
+        "binding: {executor: mock, model: none}\n",
+        encoding="utf-8",
+    )
+    # Hand-rolled tarball: bora.registry.archive validates database trees.
+    archive_path = tmp_path / "sneaky.tar.gz"
+    with tarfile.open(archive_path, "w:gz") as tar:
+        tar.add(pkg / "agent.yaml", arcname="agent.yaml")
+
+    svc = PackageService.__new__(PackageService)  # _validate_archive uses no self state
+    with pytest.raises(RegistryAppError) as exc:
+        svc._validate_archive(
+            archive_path,
+            package_kind="database",
+            media_type="application/vnd.bora.database.v1.tar+gzip",
+            package_digest="sha256:" + "0" * 64,  # guard fires before digest compare
+        )
+    assert "package_kind=agent" in str(exc.value)


### PR DESCRIPTION
## 摘要

Make **Agent** a first-class, publishable, pullable object (HuggingFace-hub style). An Agent is one versioned `bora.profiles/1` binding (executor / model / options / extensions / locators) plus display metadata. At run time it projects into a synthesized profiles document and enters the **existing** `profiles_path` lane — no new branch below Config Core; lock digest / `job_overlay` / suite fingerprint semantics unchanged.

Design authority added first per repo rules: `docs/design/14-agent-hub.md` (+ sync rows in `AGENTS.md`, `ARCHITECTURE.md`, `docs/design/README.md`).

What's in:

- **Config**: wildcard `"*"` default-binding key in `bora.profiles/1` (exact role id wins); `agent_ref` as a reserved binding key — recorded in `job_overlay` / lock digest as provenance, **excluded** from suite fingerprint `_ACTOR_KEYS` and plaza `rt_*` identity.
- **Agents core**: `bora.agent/1` manifest parse with fail-closed package-wide secret scan (reuses the overlay scanner); local cache `$BORA_HOME/agents` mirroring the plugins cache.
- **CLI**: `bora agent install|list|show|uninstall|publish`; repeatable `--agent <ref> | <role>=<ref> | <local path>` on `lock` / `run` / `campaign`, mutually exclusive with `--profiles`.
- **Registry**: `package_kind=agent` on the generic `/v1/packages` lane (no new routes); server-side manifest validation + secret scan + secret-free `agent_preview`; cross-kind fail-closed guards (`agent.yaml` cannot ship as database/plugin and vice versa); media type `application/vnd.bora.agent.v1.tar+gzip`; remote install pinned by `@version` / `@sha256:` only.
- **Hub SPA**: Agents catalog + detail pages (shared components and design tokens); Runtime plaza appearances pass `agent_ref` through and the detail page links to the Agent.
- Example package `examples/agents/mock-default` (mock executor, CI-safe).

## 关联

- Issue: #146
- Evidence level: `runnable-mvp` on the mock-executor lock/run lane only (public smokes below); no broader claim.

## 验证

```bash
uv run ruff format --check src tests && uv run ruff check src tests && uv run pyright   # clean
export BORA_OFFLINE_AGENT=1 BORA_SKIP_DOCKER=1 BORA_SKIP_REAL_CODEX=1 BORA_SKIP_REAL_PI=1 BORA_SKIP_REAL_OPENCODE=1 BORA_SKIP_REAL_ACP=1
uv run pytest tests/agents tests/config tests/plugins tests/architecture -q             # pass
uv sync --frozen --extra registry && uv run pytest tests/registry -q                    # 196 passed
pnpm --dir apps/hub install --frozen-lockfile && pnpm --dir apps/hub lint && pnpm --dir apps/hub build  # pass

# e2e smokes
uv run bora agent install examples/agents/mock-default
uv run bora lock examples/core --task sdk-agent-session --agent local/mock-default@0.1.0
#   → job_overlay.bindings.*.agent_ref set; digest identical to the equivalent --profiles run
uv run bora run examples/core --task x --agent a --profiles b   # → exit 2 (mutually exclusive)
```

Note: the few `python-core` failures outside the CI ignore list reproduce on a clean `main` checkout in this container (pre-existing environment issues: docker/pgid-dependent tests), unrelated to this change.

## Checklist

- [x] 未把 credential / token 写入 yaml、lock、evidence、示例 (agents additionally get a fail-closed secret scan at parse/install/publish)
- [x] 未把 trajectory / `HarnessTerminal.completed` 当作 PASS (agents carry no scoring authority)
- [x] 产品/机制变更已同步最高权威 (design/14 first, then AGENTS/ARCHITECTURE/code; tracked in #146)
- [x] 有回归或公开 smoke (tests/agents 30, tests/registry agent e2e, lock-lane digest-equality acceptance); fixture 未单独冒充 `runnable-mvp`

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDMQXtiVxucQpvfxVx7413)_