### PR TITLE
feat(plugins): invoke dsh and nooa only through the environment protocol

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,40 +1,40 @@
 name: Bug
-description: 可复现的行为错误（CLI / runtime / package / docs 偏差）
+description: Reproducible behavior error (CLI / runtime / package / docs mismatch)
 title: "bug: "
 labels: ["type:bug"]
 body:
   - type: textarea
     id: summary
     attributes:
-      label: 现象
-      description: 一句话说明实际 vs 期望。
-      placeholder: e.g. ageval run 在 X 包上 ERROR，期望 PASS
+      label: What happened
+      description: One sentence for actual vs expected.
+      placeholder: e.g. ageval run ERROR on package X; expected PASS
     validations:
       required: true
 
   - type: textarea
     id: repro
     attributes:
-      label: 复现
-      description: 最小命令与环境。不要粘贴 secret / token。
+      label: Repro
+      description: Minimal command and environment. Do not paste secrets or tokens.
       placeholder: |
         uv run ageval run examples/core/... --task ...
-        # 相关版本：ageval / executor / OS
+        # versions: ageval / executor / OS
     validations:
       required: true
 
   - type: textarea
     id: evidence
     attributes:
-      label: 证据
-      description: exit code、stdout 摘要、`Result.logs` 路径下非敏感文件（result.json / metadata）。勿贴 key。
+      label: Evidence
+      description: Exit code, stdout excerpt, non-secret files under `Result.logs` (result.json / metadata). No keys.
     validations:
       required: false
 
   - type: dropdown
     id: surface
     attributes:
-      label: 表面
+      label: Surface
       options:
         - CLI (lock/run/campaign/evidence/…)
         - Config / package

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,42 +1,42 @@
 name: Feature / change
-description: 新能力、行为变更或设计对齐需求
+description: New capability, behavior change, or design-alignment request
 title: "feat: "
 labels: ["type:feat"]
 body:
   - type: textarea
     id: problem
     attributes:
-      label: 要解决什么
-      description: 用户/开发者场景，不要只写实现方案。
+      label: What this is for
+      description: User or developer scenario. Do not lead with an implementation plan.
     validations:
       required: true
 
   - type: textarea
     id: proposal
     attributes:
-      label: 建议方向
-      description: 可选。涉及机制时请指向 docs/design 或说明需先改设计。
+      label: Suggested direction
+      description: Optional. If this touches mechanism, point at docs/design or say design must change first.
       placeholder: |
-        相关：docs/design/…
-        相关 Issue / docs/design 链接：
+        Related: docs/design/…
+        Related Issue / docs/design links:
     validations:
       required: false
 
   - type: dropdown
     id: design_impact
     attributes:
-      label: 是否动产品/机制语义
+      label: Does this change product or mechanism semantics?
       options:
-        - 否（实现/文档/示例）
-        - 是（需先对齐 docs/ 再实现）
-        - 不确定
+        - No (implementation / docs / examples)
+        - Yes (align docs/ first, then implement)
+        - Unsure
     validations:
       required: true
 
   - type: checkboxes
     id: redlines
     attributes:
-      label: 自检
+      label: Self-check
       options:
-        - label: 不要求把 secret 写入 yaml / lock / evidence
-        - label: 不要求用 trajectory 或 harness completed 充当 PASS
+        - label: Does not require writing secrets into yaml / lock / evidence
+        - label: Does not treat trajectory or harness completed as PASS

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,21 @@
-## 摘要
+## Summary
 
-<!-- 改了什么、为什么。机制/产品语义变更须先改 docs/design（或说明已改）。 -->
+<!-- What changed and why. Mechanism / product-semantics changes must update docs/design first (or say it already did). -->
 
-## 关联
+## Related
 
-- Issue：
-- 证据等级（若声称）：
+- Issue:
+- Evidence grade (if claimed):
 
-## 验证
+## Verification
 
 ```bash
-# 实际跑过的命令（pytest / ageval lock|run / validate…）
+# Commands actually run (pytest / ageval lock|run / validate…)
 ```
 
 ## Checklist
 
-- [ ] 未把 credential / token 写入 yaml、lock、evidence、示例
-- [ ] 未把 trajectory / `HarnessTerminal.completed` 当作 PASS
-- [ ] 产品/机制变更已同步最高权威（design → Architecture / Issues 按需）
-- [ ] 有回归或公开 smoke；fixture 未单独冒充 `runnable-mvp`
+- [ ] No credentials / tokens in yaml, lock, evidence, or examples
+- [ ] Trajectory / `HarnessTerminal.completed` is not treated as PASS
+- [ ] Product / mechanism changes updated the highest authority (design → Architecture / Issues as needed)
+- [ ] Regression or public smoke exists; a fixture alone is not `runnable-mvp`

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,20 +1,32 @@
-# Automatic PR review via Claude Code Action, backed by GLM Coding Plan
-# (Anthropic-compatible endpoint). Secrets live under:
-#   Settings → Secrets and variables → Actions
-# Not under "Agents" (that is for Copilot cloud agent only).
+# Claude Code PR review via GLM Coding Plan (Anthropic-compatible endpoint).
+#
+# Auto: non-draft pull requests whose base is `main`.
+# Manual: Actions → "Claude Code Review (GLM)" → Run workflow (write access).
+#   Select the branch that contains this file (usually `main`) and pass a PR
+#   number. Works for any base, including canary, and for drafts.
+#
+# Secrets: Settings → Secrets and variables → Actions
+# (not "Agents" — that is Copilot cloud agent only).
 name: Claude Code Review (GLM)
 
 on:
   pull_request:
+    branches: [main]
     types: [opened, synchronize, ready_for_review, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to review (any base branch; drafts allowed)
+        required: true
+        type: string
 
 concurrency:
-  group: claude-review-${{ github.repository }}-${{ github.event.pull_request.number }}
+  group: claude-review-${{ github.repository }}-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   review:
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -34,19 +46,48 @@ jobs:
       ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ vars.ANTHROPIC_DEFAULT_HAIKU_MODEL || 'glm-5.3' }}
 
     steps:
-      - name: Checkout repository
+      - name: Resolve PR number
+        id: pr
+        env:
+          EVENT: ${{ github.event_name }}
+          DISPATCH_PR: ${{ inputs.pr_number }}
+          AUTO_PR: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            NUMBER="$DISPATCH_PR"
+          else
+            NUMBER="$AUTO_PR"
+          fi
+          case "$NUMBER" in
+            ''|*[!0-9]*)
+              echo "Invalid PR number: ${NUMBER:-<empty>}" >&2
+              exit 1
+              ;;
+          esac
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout merge commit
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Checkout pull request head
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
 
       - name: Claude PR review
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          track_progress: true
+          # Keep an explicit prompt (agent mode). Tag mode rejects
+          # workflow_dispatch and requires this file to match `main` byte-for-byte.
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ steps.pr.outputs.number }}
 
             You are reviewing a PR for **ageval** (Bounded Orchestration for Runtime Agents).
             Read `AGENTS.md` and, if touched, relevant `docs/design/*`, `ARCHITECTURE.md`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,14 +134,15 @@ apps/* / services/* README  ← SPA / 服务开发细节；非产品教程权威
 
 1. `attempt/` 是深模块。打开 `attempt/__init__.py` 能说出相位。禁止再摊成按隔离档分叉的生命周期文件。
 2. 测试面 = **真实 kind + 公开 CLI**。docker / e2b 的 seam 成立条件是两个真实赢家，不是 FakeHost。
-3. locality：`docker exec` 只在 docker contrib。ACP / `attempt` / `run.py` 不见 `container_id`、不见 `if kind == e2b`。
-4. 一条路径：选盒子 / executor 只经独占槽。禁止第二套 resolve。
-5. 平台对象只在 `application/composition.py` 的 `build_*` 接线。
-6. 控制面不 import 题包模块。
-7. PASS / 身份 / cleanup 不是插件服务。cleanup 在 `try/finally`。
-8. 适配器按机制命名。禁止按 bench / task 名分支。
-9. 布局字符串只在 `evidence/`。lock / evidence 不写 host token。
-10. inject 在 lock 完成。缺 `attach_stdio` 就 lock 失败。
+3. **禁止文案 grep 测试。** 不要 `read_text` 落地页 / `website/` snippet / README，再 `assert "某字符串" in/not in text`。那不证明 invoke、lock 或 Protocol，改一句宣传就假红。读者向对了就改文档；行为对了就测 `ageval lock` / `run` / 盒子方法。架构测试只钉运行时红线（import、slot、composition root）。
+4. locality：`docker exec` 只在 docker contrib。ACP / `attempt` / `run.py` 不见 `container_id`、不见 `if kind == e2b`。
+5. 一条路径：选盒子 / executor 只经独占槽。禁止第二套 resolve。
+6. 平台对象只在 `application/composition.py` 的 `build_*` 接线。
+7. 控制面不 import 题包模块。
+8. PASS / 身份 / cleanup 不是插件服务。cleanup 在 `try/finally`。
+9. 适配器按机制命名。禁止按 bench / task 名分支。
+10. 布局字符串只在 `evidence/`。lock / evidence 不写 host token。
+11. inject 在 lock 完成。缺 `attach_stdio` 就 lock 失败。
 
 ### 安全与评测
 
@@ -178,6 +179,7 @@ apps/* / services/* README  ← SPA / 服务开发细节；非产品教程权威
 
 - **新工作默认开 GitHub Issue**（写清 Acceptance / 非目标 / 证据）；**不**新建仓内 Active Spec / ROADMAP。
 - Fixture/mock 只能作自动化回归，**不能**单独充当公开 smoke 或升级证据等级。
+- 不要为落地页 / README / website snippet 写「文件里有没有某句」的 pytest；见结构红线第 3 条。
 - 实现期安全可逆选择可自行推进；需新权限/不可逆/改产品安全语义时先问用户或写在 Issue。
 - `docs/reference/` 是归档，**不是**权威，也不是 vault 入口。
 - **有 `website/` ≠** 证据等级升级。

--- a/docker/attempt/build.py
+++ b/docker/attempt/build.py
@@ -18,7 +18,9 @@ Do not put these knobs in ``~/.zshrc`` — process env would mask Dataset ``.env
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -28,13 +30,47 @@ _SRC = _REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
-from ageval.adapters.provider_docker.official_base import (  # noqa: E402
-    BUILD_INPUT_NAMES,
-    official_attempt_dir,
-    official_build_input_digest,
-    official_buildx_command,
-    prepare_official_build_env,
-)
+BUILD_INPUT_NAMES = ("Dockerfile", "install-executors.sh", "acp-entries.lock.json")
+
+
+def official_attempt_dir(root: Path) -> Path:
+    return root / "docker" / "attempt"
+
+
+def prepare_official_build_env(root: Path) -> tuple[str, str]:
+    del root
+    return (os.environ.get("AGEVAL_APT_MIRROR") or "").strip(), (
+        os.environ.get("AGEVAL_PIP_INDEX") or ""
+    ).strip()
+
+
+def official_build_input_digest(attempt_dir: Path, *, apt_mirror: str, pip_index: str) -> str:
+    hasher = hashlib.sha256()
+    hasher.update(f"{apt_mirror}\n{pip_index}\n".encode())
+    for name in BUILD_INPUT_NAMES:
+        path = attempt_dir / name
+        if not path.is_file():
+            raise FileNotFoundError(f"missing build input: {path}")
+        hasher.update(path.read_bytes())
+    return hasher.hexdigest()
+
+
+def official_buildx_command(
+    *,
+    dockerfile: Path,
+    tag: str,
+    platform: str,
+    context: Path,
+    apt_mirror: str,
+    pip_index: str,
+) -> list[str]:
+    cmd = ["docker", "build", "--platform", platform, "-f", str(dockerfile), "-t", tag]
+    if apt_mirror:
+        cmd.extend(["--build-arg", f"AGEVAL_APT_MIRROR={apt_mirror}"])
+    if pip_index:
+        cmd.extend(["--build-arg", f"AGEVAL_PIP_INDEX={pip_index}"])
+    cmd.append(str(context))
+    return cmd
 
 
 def _load_host_env(repo_root: Path) -> None:

--- a/examples/README.md
+++ b/examples/README.md
@@ -74,16 +74,18 @@ uv run ageval run examples/journeys --profiles examples/journeys/profiles.nooa.y
 ```
 
 Package agents under each task’s `lib/agents.py` are `nooa.Agent` subclasses
-(generation methods). Docker bake installs `nooa` + in-container worker and projects
-credentials — not parent host SPI success.
+(generation methods). Invoke runs the in-box worker through `host.exec` and
+projects locators into that exec env. Docker bake installs `nooa` so the box
+Python can import it.
 
 ### External dsh plugin (optional profiles)
 
 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) path: official
 JSON-RPC SDK (`deepseek-harness-sdk`), not ACP. Same journeys harness; bind
 `executor: dsh` + `extensions: [{plugin: dsh}]` + `model` + locator
-`deepseek_api_key`. Docker bake installs the wheels in the Attempt image — host
-`--extra dsh` is for local import. `executor:` alone does not bake.
+`deepseek_api_key`. Invoke runs the in-box worker through `host.exec`. Docker
+bake installs the wheels in the Attempt image — `--extra dsh` is for the local
+kind's interpreter. `executor:` alone does not bake.
 
 ```bash
 uv run ageval plugin install plugins/dsh

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -8,21 +8,18 @@ the official Python JSON-RPC SDK (`deepseek-harness-sdk` + bundled
 for ageval evidence (no tools / reasoning / usage; model is not on
 `config_options`).
 
-```python
-from deepseek_harness import DeepSeekHarness
+The parent does not import the harness. It injects the `environment` service
+(`exec`, `upload`), uploads the worker into the box, and runs it with
+`host.exec`. Credentials stay locators until invoke, then project into the
+exec env as `DEEPSEEK_API_KEY` / `DEEPSEEK_BASE_URL`.
 
-with DeepSeekHarness(model="deepseek-v4-flash", cwd=workdir, session_root=attempt_dir) as h:
-    result = h.start_session(session_id).run(prompt)
-```
-
-Profile `model` is passed on `initialize`. `api_key` is an env locator
-(never a secret value). Sessions persist under the Attempt (`DSH_SESSION_ROOT`),
-not the task workspace.
+Profile `model` is passed on `initialize`. Sessions persist under the Attempt
+home (`/attempt/home/dsh-sessions`), not the task workspace.
 
 ## Install
 
 ```bash
-uv sync --extra dsh          # L0 host SPI only; L1 bake installs the wheels in-image
+uv sync --extra dsh          # local kind: the box Python is this interpreter
 uv run ageval plugin install plugins/dsh
 uv run ageval lock examples/journeys --task terminal-jsonl-agg \
   --profiles examples/journeys/profiles.dsh.yaml --probe
@@ -34,7 +31,9 @@ edits `profiles.yaml` / `ageval.yaml` / `task.yaml`.
 ## Bind
 
 ```yaml
-bindings:
+format: ageval.profiles/1
+environment: docker
+agent_profiles:
   solver:
     executor: dsh
     extensions:
@@ -42,6 +41,7 @@ bindings:
         options:
           composition: slim               # omit permission → unrestricted local bash/fs
           # permission: read-only         # or workspace-write | danger-full-access
+      - plugin: docker
     model: deepseek-v4-flash
     api_key: ${deepseek_api_key}          # env locator
 ```
@@ -60,14 +60,14 @@ write. Do not claim bash confinement on this runtime.
 
 Batch approval is `never` in the sandboxed tree so an unattended `ageval run`
 cannot hang on a permission prompt. This is a DSH file-effect policy, not
-ageval isolation. L1 Docker + landlock / Seatbelt may fail to start
+ageval isolation. Docker + landlock / Seatbelt may fail to start
 (`SANDBOX_UNAVAILABLE`); that fails closed. Do not claim `isolated` from this
 knob.
 
-Same harness; switch only via profiles or
+Same `run.py`; switch only via profiles or
 `--set '/bindings/<role>/options/permission="read-only"'`.
 
-## Journeys smoke (L1, real API)
+## Journeys smoke (real API)
 
 ```bash
 uv run ageval plugin install plugins/dsh
@@ -79,15 +79,17 @@ uv run ageval run examples/journeys --task terminal-jsonl-agg \
 #   --profiles examples/journeys/profiles.dsh.read-only.yaml
 ```
 
-## Recognition ≠ L0 host-ready ≠ L1 bake-declared
+Evidence for a successful invoke includes worker metadata
+`execution_location: attempt-container`. A kind that cannot `exec` fails at
+`ageval lock`, not mid-invoke.
+
+## Recognition ≠ this host can run ≠ image baked
 
 - **install** → Recognition only (`plugin list` / executor visible)
-- **`host_requires`** → L0 needs `deepseek_harness` on the host (`uv sync --extra dsh`); L1 does not
-- **profiles `executor: dsh`** → bind provide only (+ model / api_key locator)
-- **`extensions: [{plugin: dsh}]`** → opt-in bake / trajectory collect (required for L1 Ready)
-- **`--probe`** → binding-aware feasibility (`provider.kind` local vs docker); no Agent, no bake
-- **L1 bake-declared** → this profile selected `image_contribute` + `docker/Dockerfile.bake`; prepare bakes wheels +
-  `ageval-executor-dsh`; invoke is **docker exec** with projected `DEEPSEEK_API_KEY`
+- **`host_requires`** → local kind needs `deepseek_harness` on this interpreter (`uv sync --extra dsh`); docker bake installs the wheels in-image
+- **profiles `executor: dsh`** → exclusive slot winner (+ model / api_key locator)
+- **`extensions: [{plugin: dsh}]`** → opt-in bake / trajectory collect
+- **`--probe`** → binding-aware feasibility; no Agent, no bake
+- **image baked** → `config.image_layers` + `docker/Dockerfile.bake`; invoke is still `host.exec` with projected `DEEPSEEK_API_KEY`
 
-Host SPI success is not L1 Ready. Offline (`AGEVAL_OFFLINE_AGENT=1`) fail-closes
-without spawning the runtime.
+Offline (`AGEVAL_OFFLINE_AGENT=1`) fail-closes without calling the provider.

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -90,6 +90,6 @@ Evidence for a successful invoke includes worker metadata
 - **profiles `executor: dsh`** → exclusive slot winner (+ model / api_key locator)
 - **`extensions: [{plugin: dsh}]`** → opt-in bake / trajectory collect
 - **`--probe`** → binding-aware feasibility; no Agent, no bake
-- **image baked** → `config.image_layers` + `docker/Dockerfile.bake`; invoke is still `host.exec` with projected `DEEPSEEK_API_KEY`
+- **image baked** → `Dockerfile.bake` installs `deepseek-harness-sdk` into the box Python. The worker script is uploaded at invoke and run with `host.exec` + projected `DEEPSEEK_API_KEY`
 
 Offline (`AGEVAL_OFFLINE_AGENT=1`) fail-closes without calling the provider.

--- a/plugins/dsh/docker/Dockerfile.bake
+++ b/plugins/dsh/docker/Dockerfile.bake
@@ -1,21 +1,14 @@
-# Layer dsh in-container worker + DeepSeek Harness Python wheels onto a package Attempt image.
-# Build context = installed dsh plugin package root (path install cache).
+# Bake DeepSeek Harness wheels into the Attempt image.
+# The worker script is uploaded at invoke (same path for local / docker / e2b / ssh).
+# Build context = installed dsh plugin package root (unused except as docker context).
 # Usage (host):
 #   docker build --build-arg BASE_IMAGE=<pkg-tag> -f docker/Dockerfile.bake -t <out> .
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 USER root
-COPY src/dsh_plugin /opt/dsh/dsh_plugin
-COPY worker/ageval_executor_dsh.py /usr/local/bin/ageval-executor-dsh
-COPY compositions/ /opt/dsh/compositions/
-# Pin official wheels at image build. No invoke-time npm i / floating pip.
-RUN chmod 755 /usr/local/bin/ageval-executor-dsh \
-    && test -f /usr/local/bin/ageval-executor-dsh \
-    && test -f /opt/dsh/compositions/slim.cordis.yml \
-    && test -f /opt/dsh/compositions/sandboxed.cordis.yml \
-    && python3 -m py_compile /usr/local/bin/ageval-executor-dsh \
-    && python3 -m pip install --no-cache-dir "deepseek-harness-sdk==0.1.0rc6"
+# Pin official wheels at image build. No invoke-time pip / floating npx.
+RUN python3 -m pip install --no-cache-dir "deepseek-harness-sdk==0.1.0rc6"
 
 # Prefer non-root actor when base defines it.
 USER ageval

--- a/plugins/dsh/plugin.yaml
+++ b/plugins/dsh/plugin.yaml
@@ -14,5 +14,8 @@ slots:
     - id: trajectory_collect
       priority: 110
       entry: "dsh_plugin.hooks:trajectory_collect"
+inject:
+  - service: environment
+    capabilities: [exec, upload]
 config:
   image_layers: docker/Dockerfile.bake

--- a/plugins/dsh/src/dsh_plugin/container.py
+++ b/plugins/dsh/src/dsh_plugin/container.py
@@ -1,51 +1,70 @@
-"""In-box dsh executor: run the baked worker through the box, not through docker.
-
-The plugin no longer knows what kind of box it is in. It asks the environment to
-run one command and reads the worker's JSON back, so the same code works for a
-container, a sandbox or a remote machine.
-"""
+"""In-box dsh executor: run the worker through the environment Protocol."""
 
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import json
 import os
+from pathlib import Path
 from typing import Any
 
-from ageval.plugins.agent_result import AgentExecutor, AgentResult
+from ageval.environments.protocol import HOME_PATH, WORKSPACE_PATH
+from ageval.plugins.agent_result import AgentResult
+from dsh_plugin import PLUGIN_ID
 
-WORKER_PATH = "/usr/local/bin/ageval-executor-dsh"
-_ENV_API_KEYS = ("OPENAI_API_KEY", "litellm_api_key")
-_ENV_BASE_URLS = ("OPENAI_BASE_URL", "litellm_base_url", "AGEVAL_OPENAI_BASE_URL")
+BOX_PLUGIN = f"{HOME_PATH}/_dsh"
+BOX_WORKER = f"{BOX_PLUGIN}/ageval_executor_dsh.py"
+BOX_SRC = f"{BOX_PLUGIN}/src"
+BOX_COMPOSITIONS = f"{BOX_PLUGIN}/compositions"
+BOX_SESSIONS = f"{HOME_PATH}/dsh-sessions"
 
 
-class DshBoxExecutor(AgentExecutor):
-    """Invoke a task-local dsh agent inside the Attempt's box.
+def _run_coro(coro: Any) -> Any:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
 
-    The parent never imports the task's ``lib.agents``: the worker baked into the
-    image does, on the far side of the box boundary.
-    """
 
-    kind = "dsh"
+class DshBoxExecutor:
+    """Invoke DeepSeek Harness inside the Attempt box via ``host.exec``."""
+
+    kind = PLUGIN_ID
 
     def __init__(
         self,
         *,
         host: Any,
         placement: Any,
-        agent_ref: str,
-        method: str = "run",
-        model: str = "dsh",
-        base_url: str | None = None,
-        api_key_env: str | None = None,
+        plugin_root: Path,
+        model: str,
+        provider: str,
+        composition: str,
+        permission: str | None,
+        base_url: str | None,
+        api_key_env: str | None,
+        session_id: str,
     ) -> None:
         self._host = host
         self._placement = placement
-        self.agent_ref = agent_ref
-        self.method = method or "run"
-        self.model = model or "dsh"
+        self._plugin_root = Path(plugin_root)
+        self.model = model
+        self.provider = provider
+        self.composition = composition
+        self.permission = permission
         self.base_url = (base_url or "").strip() or None
         self.api_key_env = (api_key_env or "").strip() or None
+        self.session_id = session_id
+        self._prepared = False
+
+    @staticmethod
+    def describe() -> dict[str, Any]:
+        from dsh_plugin.factory import describe_dsh
+
+        return describe_dsh()
 
     def open(self, **kwargs: Any) -> None:
         del kwargs
@@ -58,93 +77,134 @@ class DshBoxExecutor(AgentExecutor):
         prompt: str,
         *,
         timeout: float = 60.0,
-        collect_dir: str | None = None,
+        collect_dir: str | os.PathLike[str] | None = None,
         redaction_sentinels: tuple[str, ...] | list[str] | None = None,
     ) -> AgentResult:
         del redaction_sentinels
+        return _run_coro(self._ainvoke(prompt, timeout=timeout, collect_dir=collect_dir))
+
+    async def _ainvoke(
+        self,
+        prompt: str,
+        *,
+        timeout: float,
+        collect_dir: str | os.PathLike[str] | None,
+    ) -> AgentResult:
+        await self._prepare()
         request = {
             "prompt": prompt,
-            "agent": self.agent_ref,
-            "method": self.method,
             "model": self.model,
-            "workdir": self._placement.workdir,
+            "provider": self.provider,
+            "workdir": self._host.visible_path(self._placement.workdir or WORKSPACE_PATH),
+            "session_root": self._host.visible_path(BOX_SESSIONS),
+            "cordis": self._host.visible_path(
+                f"{BOX_COMPOSITIONS}/{self.composition}.cordis.yml"
+            ),
+            "session_id": self.session_id,
+            "composition": self.composition,
         }
-        base_url = self._first_env(_ENV_BASE_URLS, self.base_url)
-        api_key = self._first_env(_ENV_API_KEYS, None, locator=self.api_key_env)
-        if base_url:
-            request["api_base"] = base_url
-
-        env = {"DSH_MODEL": self.model}
-        if base_url:
-            env["OPENAI_BASE_URL"] = base_url
-        if api_key:
-            env["OPENAI_API_KEY"] = api_key
-
-        result = asyncio.run(
-            self._host.exec(
-                ["python3", WORKER_PATH, json.dumps(request, sort_keys=True)],
-                cwd=self._placement.workdir,
-                env=env,
-                timeout_sec=timeout,
-            )
+        if self.permission:
+            request["permission"] = self.permission
+        env = self._exec_env()
+        result = await self._host.exec(
+            [
+                *self._host.python_command,
+                self._host.visible_path(BOX_WORKER),
+                json.dumps(request, sort_keys=True),
+            ],
+            cwd=self._placement.workdir or WORKSPACE_PATH,
+            env=env,
+            timeout_sec=timeout,
         )
-        if result.exit_code != 0:
-            return AgentResult(
-                model=self.model,
-                text="",
-                structured=None,
-                ok=False,
-                error="dsh_worker_failed",
-                stderr=result.stderr[-2000:],
-                metadata={"executor_kind": self.kind, "exit_code": result.exit_code},
-            )
-        return self._result_from(result.stdout, collect_dir=collect_dir)
+        return self._result_from(result, collect_dir=collect_dir)
 
-    def _result_from(self, stdout: str, *, collect_dir: str | None) -> AgentResult:
-        try:
-            payload = json.loads(stdout.strip().splitlines()[-1])
-        except (IndexError, json.JSONDecodeError):
+    async def _prepare(self) -> None:
+        if self._prepared:
+            return
+        await self._host.upload(self._plugin_root / "worker" / "ageval_executor_dsh.py", BOX_WORKER)
+        await self._host.upload(self._plugin_root / "src" / "dsh_plugin", f"{BOX_SRC}/dsh_plugin")
+        await self._host.upload(self._plugin_root / "compositions", BOX_COMPOSITIONS)
+        self._prepared = True
+
+    def _exec_env(self) -> dict[str, str]:
+        from dsh_plugin.factory import PERMISSION_ENV, resolve_api_key_value, resolve_base_url
+
+        env: dict[str, str] = {
+            "DSH_MODEL": self.model,
+            "PYTHONPATH": self._host.visible_path(BOX_SRC),
+            "DSH_CORDIS_CONFIG": self._host.visible_path(
+                f"{BOX_COMPOSITIONS}/{self.composition}.cordis.yml"
+            ),
+        }
+        key = resolve_api_key_value(self.api_key_env)
+        if key:
+            env["DEEPSEEK_API_KEY"] = key
+        base = resolve_base_url(self.base_url)
+        if base:
+            env["DEEPSEEK_BASE_URL"] = base
+        if self.permission:
+            env[PERMISSION_ENV] = self.permission
+        if os.environ.get("AGEVAL_OFFLINE_AGENT") == "1":
+            env["AGEVAL_OFFLINE_AGENT"] = "1"
+        return env
+
+    def _result_from(self, result: Any, *, collect_dir: str | os.PathLike[str] | None) -> AgentResult:
+        stdout = str(getattr(result, "stdout", "") or "")
+        stderr = str(getattr(result, "stderr", "") or "")
+        exit_code = int(getattr(result, "exit_code", 1) or 0)
+        payload = _payload_from_stdout(stdout)
+        if collect_dir and payload is not None:
+            root = Path(collect_dir)
+            root.mkdir(parents=True, exist_ok=True)
+            (root / "dsh_worker.json").write_text(
+                json.dumps(payload, ensure_ascii=False, default=str) + "\n",
+                encoding="utf-8",
+            )
+        if payload is None:
             return AgentResult(
                 model=self.model,
                 text=stdout[-2000:],
                 structured=None,
                 ok=False,
-                error="dsh_worker_unreadable",
-                metadata={"executor_kind": self.kind},
+                error="dsh_worker_unreadable" if exit_code == 0 else "dsh_worker_failed",
+                stderr=stderr[-2000:],
+                metadata={
+                    "plugin": PLUGIN_ID,
+                    "execution_location": "attempt-container",
+                    "exit_code": exit_code,
+                },
             )
-        if collect_dir:
-            from pathlib import Path
-
-            root = Path(collect_dir)
-            root.mkdir(parents=True, exist_ok=True)
-            (root / "dsh_worker.json").write_text(stdout, encoding="utf-8")
-        text = str(payload.get("text") or "")
+        metadata = dict(payload.get("metadata") or {})
+        metadata.setdefault("plugin", PLUGIN_ID)
+        metadata.setdefault("execution_location", "attempt-container")
+        metadata["composition"] = self.composition
+        if self.permission:
+            metadata["permission"] = self.permission
         structured = payload.get("structured")
+        events = payload.get("events") or ()
+        usage = payload.get("usage")
         return AgentResult(
             model=str(payload.get("model") or self.model),
-            text=text,
+            text=str(payload.get("text") or ""),
             structured=structured if isinstance(structured, dict) else None,
             ok=bool(payload.get("ok", True)),
-            error=payload.get("error"),
-            events=tuple(payload.get("events") or ()),
-            usage=payload.get("usage") if isinstance(payload.get("usage"), dict) else None,
-            metadata={"executor_kind": self.kind, "agent": self.agent_ref},
+            error=str(payload["error"]) if payload.get("error") else None,
+            stderr=stderr[-2000:],
+            events=tuple(events) if isinstance(events, list) else (),
+            usage=usage if isinstance(usage, dict) else None,
+            metadata=metadata,
         )
 
-    def _first_env(
-        self,
-        names: tuple[str, ...],
-        declared: str | None,
-        *,
-        locator: str | None = None,
-    ) -> str | None:
-        if declared:
-            return declared
-        for name in (locator, *names):
-            value = os.environ.get(name or "", "").strip()
-            if value:
-                return value
+
+def _payload_from_stdout(stdout: str) -> dict[str, Any] | None:
+    text = stdout.strip()
+    if not text:
         return None
+    try:
+        payload = json.loads(text.splitlines()[-1])
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
 
 
-__all__ = ["WORKER_PATH", "DshBoxExecutor"]
+__all__ = ["BOX_WORKER", "DshBoxExecutor"]

--- a/plugins/dsh/src/dsh_plugin/factory.py
+++ b/plugins/dsh/src/dsh_plugin/factory.py
@@ -1,26 +1,20 @@
-"""dsh ExecutorSPI — official DeepSeek Harness JSON-RPC SDK (not ACP).
+"""dsh executor factory — bind the in-box worker to this Attempt's environment.
 
-Drive ``deepseek-harness-sdk`` / ``dsh-jsonrpc-agent``. Model is passed on
-``initialize``. Credentials arrive as projected env (locator name on the
-profile). The box runs the worker; this side only builds the request.
+Parent never imports DeepSeekHarness. ``invoke`` builds a request and runs the
+worker through ``host.exec``; credentials are locators projected into the exec
+env at invoke time.
 """
 
 from __future__ import annotations
 
-import concurrent.futures
-import contextlib
-import json
 import os
-import tempfile
 import uuid
 from pathlib import Path
 from typing import Any
 
-from ageval.plugins.agent_result import AgentResult, parse_validated_text_structured
 from ageval.plugins.errors import ExtensionMaterializeError
 from dsh_plugin import PLUGIN_ID
-from dsh_plugin.sse_sanitize import start_sanitizing_proxy
-from dsh_plugin.trajectory import extract_usage, to_ageval_trajectory_events
+from dsh_plugin.container import DshBoxExecutor
 
 DEFAULT_MODEL = "deepseek-v4-flash"
 DEFAULT_PROVIDER = "deepseek-official"
@@ -39,7 +33,6 @@ _BASE_URL_ENV_FALLBACKS = (
     "litellm_base_url",
     "OPENAI_BASE_URL",
 )
-_OK_REASONS = frozenset({"completed", "max-tokens"})
 
 
 def describe_dsh() -> dict[str, Any]:
@@ -79,10 +72,6 @@ def resolve_composition_path(name: str | None) -> Path:
     return path
 
 
-def container_cordis_path(name: str | None) -> str:
-    return f"/opt/dsh/compositions/{_composition_slug(name)}.cordis.yml"
-
-
 def resolve_permission(raw: Any) -> str | None:
     """Validate ``options.permission``. Omit / blank → None (keep slim)."""
     if raw is None:
@@ -110,12 +99,6 @@ def resolve_effective_composition(*, composition: str | None, permission: str | 
     return explicit or DEFAULT_COMPOSITION
 
 
-def permission_child_env(permission: str | None) -> dict[str, str]:
-    if not permission:
-        return {}
-    return {PERMISSION_ENV: permission}
-
-
 def resolve_api_key_value(locator: str | None) -> str | None:
     names: list[str] = []
     if locator and str(locator).strip():
@@ -140,260 +123,50 @@ def resolve_base_url(explicit: str | None) -> str | None:
     return None
 
 
-def _write_backend_raw(
-    collect_dir: str | None,
-    native: list[dict[str, Any]],
-    notifications: list[dict[str, Any]] | None = None,
-) -> None:
-    if not collect_dir:
-        return
-    root = Path(collect_dir)
-    root.mkdir(parents=True, exist_ok=True)
-    rows = list(native)
-    if notifications:
-        rows.extend(notifications)
-    if not rows:
-        return
-    (root / "dsh_events.jsonl").write_text(
-        "\n".join(json.dumps(e, ensure_ascii=False, default=str) for e in rows) + "\n",
-        encoding="utf-8",
+def build_executor(
+    *,
+    options: dict[str, Any] | None = None,
+    host: Any,
+    placement: Any,
+    profile_id: str | None = None,
+    model: str | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+) -> DshBoxExecutor:
+    """plugin.yaml exclusive entry: factory(**kwargs) → in-box executor."""
+    opts = dict(options or {})
+    permission = resolve_permission(opts.get("permission"))
+    composition = resolve_effective_composition(
+        composition=str(opts.get("composition") or "").strip() or None,
+        permission=permission,
+    )
+    resolve_composition_path(composition)
+    provider = str(opts.get("provider") or DEFAULT_PROVIDER).strip() or DEFAULT_PROVIDER
+    session_id = f"ageval-{profile_id or 'solver'}-{uuid.uuid4().hex[:12]}"
+    return DshBoxExecutor(
+        host=host,
+        placement=placement,
+        plugin_root=_plugin_root(),
+        model=(model or "").strip() or DEFAULT_MODEL,
+        provider=provider,
+        composition=composition,
+        permission=permission,
+        base_url=base_url if isinstance(base_url, str) else None,
+        api_key_env=api_key if isinstance(api_key, str) else None,
+        session_id=session_id,
     )
 
 
-def _offline() -> bool:
-    return os.environ.get("AGEVAL_OFFLINE_AGENT") == "1"
-
-
-def _ok_from_reason(reason: str | None, text: str) -> bool:
-    if reason in {"error", "interrupted"}:
-        return False
-    if reason in _OK_REASONS:
-        return True
-    return bool(text)
-
-
-class DshExecutorSPI:
-    """Host SPI wrapping DeepSeekHarness. L1 uses DshContainerExecutor."""
-
-    kind = PLUGIN_ID
-
-    def __init__(
-        self,
-        *,
-        options: dict[str, Any] | None = None,
-        profile_id: str | None = None,
-        model: str | None = None,
-        base_url: str | None = None,
-        api_key: str | None = None,
-        plugin_id: str | None = None,
-        workdir: str | None = None,
-        host: Any = None,
-        placement: Any = None,
-        **_kwargs: Any,
-    ) -> None:
-        del plugin_id, _kwargs
-        opts = dict(options or {})
-        self.options = opts
-        self.profile_id = profile_id
-        self.model = (model or "").strip() or DEFAULT_MODEL
-        self.provider = str(opts.get("provider") or DEFAULT_PROVIDER).strip() or DEFAULT_PROVIDER
-        self.permission = resolve_permission(opts.get("permission"))
-        self.composition = resolve_effective_composition(
-            composition=str(opts.get("composition") or "").strip() or None,
-            permission=self.permission,
-        )
-        self.base_url = base_url
-        self.api_key_env = api_key
-        self._host = host
-        self._placement = placement
-        self.default_workdir = str(workdir).strip() if workdir else None
-        self._harness: Any = None
-        self._session: Any = None
-        self._session_id = f"ageval-{self.profile_id or 'solver'}-{uuid.uuid4().hex[:12]}"
-        self._session_root: str | None = None
-        self._tmp_session: tempfile.TemporaryDirectory[str] | None = None
-        self._sse_proxy: Any = None
-        self._ready = False
-
-    @staticmethod
-    def describe() -> dict[str, Any]:
-        return describe_dsh()
-
-    def open(self, **kwargs: Any) -> None:
-        del kwargs
-        if _offline():
-            raise ExtensionMaterializeError(
-                "offline_forced",
-                kind="extension_materialize_failed",
-            )
-        self._ready = True
-
-    def close(self) -> None:
-        harness = self._harness
-        self._harness = None
-        self._session = None
-        self._ready = False
-        if harness is not None:
-            with contextlib.suppress(Exception):
-                harness.close()
-        proxy = self._sse_proxy
-        self._sse_proxy = None
-        if proxy is not None:
-            with contextlib.suppress(Exception):
-                proxy.close()
-        tmp = self._tmp_session
-        self._tmp_session = None
-        if tmp is not None:
-            tmp.cleanup()
-
-    def invoke(
-        self,
-        prompt: str,
-        *,
-        timeout: float = 60.0,
-        workdir: str | None = None,
-        collect_dir: str | None = None,
-        redaction_sentinels: tuple[str, ...] | list[str] | None = None,
-    ) -> AgentResult:
-        del redaction_sentinels
-        if _offline():
-            return AgentResult(
-                model=self.model,
-                text="",
-                structured=None,
-                ok=False,
-                error="offline_forced",
-                metadata={"plugin": PLUGIN_ID},
-            )
-        try:
-            self._ensure_started(workdir or self.default_workdir)
-        except ExtensionMaterializeError as exc:
-            return AgentResult(
-                model=self.model,
-                text="",
-                structured=None,
-                ok=False,
-                error=str(getattr(exc, "message", None) or exc),
-                metadata={"plugin": PLUGIN_ID},
-            )
-        assert self._session is not None
-        try:
-            result = self._run_session(prompt, timeout=timeout)
-        except TimeoutError:
-            self.close()
-            return AgentResult(
-                model=self.model,
-                text="",
-                structured=None,
-                ok=False,
-                error="dsh_timeout",
-                metadata={"plugin": PLUGIN_ID, "session_id": self._session_id},
-            )
-        except Exception as exc:  # noqa: BLE001
-            return AgentResult(
-                model=self.model,
-                text="",
-                structured=None,
-                ok=False,
-                error=f"{type(exc).__name__}:{exc}",
-                metadata={"plugin": PLUGIN_ID, "session_id": self._session_id},
-            )
-        native = [e for e in (result.events or []) if isinstance(e, dict)]
-        notes: list[dict[str, Any]] = []
-        for note in result.notifications or ():
-            payload = getattr(note, "payload", None)
-            method = getattr(note, "method", None)
-            if isinstance(payload, dict):
-                notes.append({"method": method, **payload})
-        _write_backend_raw(collect_dir, native, notes)
-        mapped = tuple(to_ageval_trajectory_events(native, session_id=result.session_id))
-        text = str(result.final_response or "")
-        reason = result.finish_reason
-        ok = _ok_from_reason(reason, text)
-        return AgentResult(
-            model=self.model,
-            text=text,
-            structured=parse_validated_text_structured(text),
-            ok=ok,
-            error=None if ok else str(reason or "dsh_error"),
-            events=mapped,
-            usage=extract_usage(native),
-            metadata={
-                "plugin": PLUGIN_ID,
-                "session_id": result.session_id,
-                "finish_reason": reason,
-                "session_root": result.session_root or self._session_root,
-                "composition": self.composition,
-                "permission": self.permission,
-                "execution_location": "host",
-            },
-        )
-
-    def _run_session(self, prompt: str, *, timeout: float) -> Any:
-        assert self._session is not None
-        wait = max(1.0, float(timeout))
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            fut = pool.submit(self._session.run, prompt)
-            try:
-                return fut.result(timeout=wait)
-            except concurrent.futures.TimeoutError as exc:
-                raise TimeoutError("dsh_timeout") from exc
-
-    def _ensure_started(self, workdir: str | None) -> None:
-        if self._harness is not None:
-            return
-        try:
-            from deepseek_harness import DeepSeekHarness
-        except ImportError as exc:
-            raise ExtensionMaterializeError(
-                "dsh_package_missing: install deepseek-harness-sdk==0.1.0rc6 "
-                "(uv sync --extra dsh / pip install deepseek-harness-sdk==0.1.0rc6)",
-                kind="extension_materialize_failed",
-            ) from exc
-        key = resolve_api_key_value(self.api_key_env if isinstance(self.api_key_env, str) else None)
-        base = resolve_base_url(self.base_url if isinstance(self.base_url, str) else None)
-        if not key and not (base and ("127.0.0.1" in base or "localhost" in base)):
-            raise ExtensionMaterializeError(
-                f"dsh_missing_credential: env {self.api_key_env or 'DEEPSEEK_API_KEY'!r} unset",
-                kind="extension_materialize_failed",
-            )
-        cordis = resolve_composition_path(self.composition)
-        cwd = self._resolve_cwd(workdir)
-        if self._session_root is None:
-            self._tmp_session = tempfile.TemporaryDirectory(prefix="ageval-dsh-")
-            self._session_root = self._tmp_session.name
-        env: dict[str, str] = {}
-        if key:
-            env["DEEPSEEK_API_KEY"] = key
-        if base:
-            proxy = start_sanitizing_proxy(base)
-            self._sse_proxy = proxy
-            env["DEEPSEEK_BASE_URL"] = proxy.local_base_url
-        env.update(permission_child_env(self.permission))
-        self._harness = DeepSeekHarness(
-            provider=self.provider,
-            model=self.model,
-            cwd=cwd,
-            session_root=self._session_root,
-            cordis=str(cordis),
-            env=env,
-        )
-        self._harness.start()
-        self._session = self._harness.start_session(self._session_id)
-        self._ready = True
-
-    def _resolve_cwd(self, workdir: str | None) -> str:
-        if workdir:
-            return str(Path(workdir).expanduser().resolve(strict=False))
-        if self.default_workdir:
-            return str(Path(self.default_workdir).expanduser().resolve(strict=False))
-        host_path = getattr(self._host, "host_path", None)
-        placement = self._placement
-        if callable(host_path) and placement is not None:
-            return str(host_path(placement.workdir))
-        return str(Path.cwd().resolve())
-
-
-def build_executor(**kwargs: Any) -> DshExecutorSPI:
-    """plugin.yaml provide entry: factory(**kwargs) -> ExecutorSPI."""
-    return DshExecutorSPI(**kwargs)
+__all__ = [
+    "DEFAULT_COMPOSITION",
+    "DEFAULT_MODEL",
+    "DEFAULT_PROVIDER",
+    "PERMISSION_ENV",
+    "PLUGIN_ID",
+    "build_executor",
+    "describe_dsh",
+    "resolve_api_key_value",
+    "resolve_base_url",
+    "resolve_effective_composition",
+    "resolve_permission",
+]

--- a/plugins/dsh/src/dsh_plugin/hooks.py
+++ b/plugins/dsh/src/dsh_plugin/hooks.py
@@ -1,18 +1,10 @@
-"""Multi-slot on-handlers for dsh (image_contribute / trajectory_collect)."""
+"""trajectory_collect handler for dsh."""
 
 from __future__ import annotations
 
 from typing import Any
 
 from dsh_plugin import PLUGIN_ID
-
-
-async def image_contribute(ctx: Any, value: Any, nxt: Any) -> Any:
-    """Declare this plugin on the image_contribute chain (L1 Ready)."""
-    del ctx
-    base = list(value) if isinstance(value, list) else []
-    base.append({"plugin": PLUGIN_ID})
-    return await nxt(base)
 
 
 async def trajectory_collect(ctx: Any, value: Any, nxt: Any) -> Any:

--- a/plugins/dsh/worker/ageval_executor_dsh.py
+++ b/plugins/dsh/worker/ageval_executor_dsh.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """In-container dsh worker — official DeepSeek Harness JSON-RPC SDK.
 
-Reads one JSON object from stdin (no secrets required in the payload;
-DEEPSEEK_API_KEY / DEEPSEEK_BASE_URL arrive via projected env)::
+Reads one JSON object from argv[1] or stdin (no secrets required in the
+payload; DEEPSEEK_API_KEY / DEEPSEEK_BASE_URL arrive via projected env)::
 
     {
       "prompt": "...",
@@ -76,15 +76,23 @@ def _emit(doc: dict[str, Any], *, code: int) -> int:
     return code
 
 
+def _read_request() -> dict[str, Any]:
+    raw = sys.argv[1] if len(sys.argv) > 1 else (sys.stdin.read() or "{}")
+    req = json.loads(raw)
+    if not isinstance(req, dict):
+        raise TypeError("request_not_object")
+    return req
+
+
 def main() -> int:
     try:
-        req = json.loads(sys.stdin.read() or "{}")
+        req = _read_request()
     except json.JSONDecodeError as exc:
         return _emit(
             {"ok": False, "error": f"bad_request_json:{exc}", "model": "dsh", "text": ""},
             code=2,
         )
-    if not isinstance(req, dict):
+    except TypeError:
         return _emit(
             {"ok": False, "error": "request_not_object", "model": "dsh", "text": ""},
             code=2,
@@ -116,7 +124,7 @@ def main() -> int:
                 "error": "offline_forced",
                 "model": model,
                 "text": "",
-                "metadata": {"plugin": "dsh"},
+                "metadata": {"plugin": "dsh", "execution_location": "attempt-container"},
             },
             code=1,
         )

--- a/plugins/nooa/README.md
+++ b/plugins/nooa/README.md
@@ -2,28 +2,22 @@
 
 External `ageval.plugin/1` package. **Not** first-party ageval core (only ACP is first-party).
 
-This plugin binds ageval profiles to **[NVIDIA-labs OO Agents](https://github.com/NVIDIA-NeMo/labs-OO-Agents)**:
+This plugin binds ageval profiles to **[NVIDIA-labs OO Agents](https://github.com/NVIDIA-NeMo/labs-OO-Agents)**.
+The parent does not import NVIDIA nooa or LiteLLM as the success path. It
+injects the `environment` service (`exec`, `upload`), uploads the worker and
+the task's agent module into the box, and runs the worker with `host.exec`.
 
-```python
-from nooa.unifiedllm import get_llm_client
-from nooa import Agent
+Package-local agents should subclass `nooa.Agent` and use generation methods.
+Plain deterministic classes (e.g. `FixedAnswerAgent`) still run inside the box
+without a network.
 
-llm = get_llm_client(model, api_base=base_url, api_key=secret)
-agent = PackageAgent(llm=llm)
-await agent.run(prompt, workdir=...)
-```
-
-Profile `base_url` + `api_key` (env locator) are projected into that client.
-Package-local agents should subclass `nooa.Agent` and use generation methods (`...`).
-
-Plain deterministic classes (e.g. slot-probe `FixedAnswerAgent`) still work without network.
+Profile `base_url` + `api_key` (env locator) project into the exec env as
+`OPENAI_BASE_URL` / `OPENAI_API_KEY`. Values never enter the lock.
 
 ## Install
 
-Host needs the NVIDIA package:
-
 ```bash
-uv sync --extra nooa          # or: pip install nooa
+uv sync --extra nooa          # local kind: the box Python is this interpreter
 uv run ageval plugin install plugins/nooa
 ```
 
@@ -33,7 +27,9 @@ Install updates `~/.ageval/plugins` (or `$AGEVAL_HOME/plugins`) only — **never
 ## Bind
 
 ```yaml
-bindings:
+format: ageval.profiles/1
+environment: docker
+agent_profiles:
   solver:
     executor: nooa
     extensions:
@@ -41,6 +37,7 @@ bindings:
         options:
           agent: "lib.agents:JsonlAggAgent"   # package-local nooa.Agent
           method: "run"
+      - plugin: docker
     model: openai/glm-5.2
     api_key: ${litellm_api_key}          # env locator
     # base_url: http://127.0.0.1:8000/v1   # optional; else litellm_base_url / OPENAI_BASE_URL
@@ -56,16 +53,15 @@ uv run ageval run examples/journeys \
   --profiles examples/journeys/profiles.nooa.yaml
 ```
 
-## Recognition ≠ L0 host-ready ≠ L1 bake-declared
+Evidence for a successful invoke includes worker metadata
+`execution_location: attempt-container`. A kind that cannot `exec` fails at
+`ageval lock`, not mid-invoke.
+
+## Recognition ≠ this host can run ≠ image baked
 
 - **install** → Recognition only (`plugin list` / executor visible)
-- **`host_requires`** → L0 needs the `nooa` import (`uv sync --extra nooa`); L1 bake does not
-- **profiles `executor: nooa`** → bind provide only (+ model / base_url / api_key)
-- **`extensions: [{plugin: nooa}]`** → opt-in bake / trajectory collect (required for L1 Ready)
+- **`host_requires`** → local kind needs the `nooa` import (`uv sync --extra nooa`); docker bake does not
+- **profiles `executor: nooa`** → exclusive slot winner (+ model / base_url / api_key)
+- **`extensions: [{plugin: nooa}]`** → opt-in bake / trajectory collect
 - **`--probe`** → binding-aware feasibility; no Agent, no bake
-- **L1 bake-declared** → this profile selected `image_contribute` bake installs `nooa` + `ageval-executor-nooa` in the Attempt image; invoke is **docker exec** with projected credentials
-
-## L1 Ready strategy
-
-For Docker L1 tasks, nooa uses **in-container worker**. Parent does **not**
-materialize package agents on the host for L1 success. See Dockerfile.bake + worker/.
+- **image baked** → `config.image_layers` bake installs `nooa` + `ageval-executor-nooa`; invoke is still `host.exec` with projected credentials

--- a/plugins/nooa/README.md
+++ b/plugins/nooa/README.md
@@ -64,4 +64,4 @@ Evidence for a successful invoke includes worker metadata
 - **profiles `executor: nooa`** → exclusive slot winner (+ model / base_url / api_key)
 - **`extensions: [{plugin: nooa}]`** → opt-in bake / trajectory collect
 - **`--probe`** → binding-aware feasibility; no Agent, no bake
-- **image baked** → `config.image_layers` bake installs `nooa` + `ageval-executor-nooa`; invoke is still `host.exec` with projected credentials
+- **image baked** → `Dockerfile.bake` installs `nooa` into the box Python. The worker script is uploaded at invoke and run with `host.exec` + projected credentials

--- a/plugins/nooa/docker/Dockerfile.bake
+++ b/plugins/nooa/docker/Dockerfile.bake
@@ -1,18 +1,14 @@
-# Layer nooa in-container worker + NVIDIA nooa runtime onto a package Attempt image.
-# Build context = installed nooa plugin package root (path install cache).
+# Bake the NVIDIA nooa runtime into the Attempt image.
+# The worker script is uploaded at invoke (same path for local / docker / e2b / ssh).
+# Build context = installed nooa plugin package root (unused except as docker context).
 # Usage (host):
 #   docker build --build-arg BASE_IMAGE=<pkg-tag> -f docker/Dockerfile.bake -t <out> .
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 USER root
-COPY src/nooa_plugin /opt/nooa/nooa_plugin
-COPY worker/ageval_executor_nooa.py /usr/local/bin/ageval-executor-nooa
 # NVIDIA OO Agents (LiteLLM-backed). Bake needs network at image build time.
-RUN chmod 755 /usr/local/bin/ageval-executor-nooa \
-    && test -f /usr/local/bin/ageval-executor-nooa \
-    && python3 -m py_compile /usr/local/bin/ageval-executor-nooa \
-    && python3 -m pip install --no-cache-dir "nooa>=0.0.7"
+RUN python3 -m pip install --no-cache-dir "nooa>=0.0.7"
 
 # Prefer non-root actor when base defines it.
 USER ageval

--- a/plugins/nooa/plugin.yaml
+++ b/plugins/nooa/plugin.yaml
@@ -13,6 +13,9 @@ slots:
     - id: trajectory_collect
       priority: 110
       entry: "nooa_plugin.hooks:trajectory_collect"
+inject:
+  - service: environment
+    capabilities: [exec, upload]
 config:
   # Layers the docker box bakes on top of the official base. Not a slot: the
   # environment winner reads this when it builds the image.

--- a/plugins/nooa/src/nooa_plugin/container.py
+++ b/plugins/nooa/src/nooa_plugin/container.py
@@ -1,51 +1,68 @@
-"""In-box nooa executor: run the baked worker through the box, not through docker.
-
-The plugin no longer knows what kind of box it is in. It asks the environment to
-run one command and reads the worker's JSON back, so the same code works for a
-container, a sandbox or a remote machine.
-"""
+"""In-box nooa executor: run the worker through the environment Protocol."""
 
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import json
 import os
+from pathlib import Path
 from typing import Any
 
-from ageval.plugins.agent_result import AgentExecutor, AgentResult
+from ageval.environments.protocol import HOME_PATH, WORKSPACE_PATH
+from ageval.plugins.agent_result import AgentResult
+from ageval.plugins.errors import ExtensionMaterializeError
+from nooa_plugin import PLUGIN_ID
 
-WORKER_PATH = "/usr/local/bin/ageval-executor-nooa"
-_ENV_API_KEYS = ("OPENAI_API_KEY", "litellm_api_key")
-_ENV_BASE_URLS = ("OPENAI_BASE_URL", "litellm_base_url", "AGEVAL_OPENAI_BASE_URL")
+BOX_PLUGIN = f"{HOME_PATH}/_nooa"
+BOX_WORKER = f"{BOX_PLUGIN}/ageval_executor_nooa.py"
+BOX_SRC = f"{BOX_PLUGIN}/src"
+BOX_PACKAGE = "/attempt/package"
 
 
-class NooaBoxExecutor(AgentExecutor):
-    """Invoke a task-local nooa agent inside the Attempt's box.
+def _run_coro(coro: Any) -> Any:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
 
-    The parent never imports the task's ``lib.agents``: the worker baked into the
-    image does, on the far side of the box boundary.
-    """
 
-    kind = "nooa"
+class NooaBoxExecutor:
+    """Invoke a task-local nooa agent inside the Attempt box via ``host.exec``."""
+
+    kind = PLUGIN_ID
 
     def __init__(
         self,
         *,
         host: Any,
         placement: Any,
+        plugin_root: Path,
+        package_root: str | None,
         agent_ref: str,
-        method: str = "run",
-        model: str = "nooa",
-        base_url: str | None = None,
-        api_key_env: str | None = None,
+        method: str,
+        model: str,
+        base_url: str | None,
+        api_key_env: str | None,
     ) -> None:
         self._host = host
         self._placement = placement
+        self._plugin_root = Path(plugin_root)
+        self._package_root = Path(package_root) if package_root else None
         self.agent_ref = agent_ref
         self.method = method or "run"
-        self.model = model or "nooa"
+        self.model = model
         self.base_url = (base_url or "").strip() or None
         self.api_key_env = (api_key_env or "").strip() or None
+        self._prepared = False
+
+    @staticmethod
+    def describe() -> dict[str, Any]:
+        from nooa_plugin.factory import describe_nooa
+
+        return describe_nooa()
 
     def open(self, **kwargs: Any) -> None:
         del kwargs
@@ -58,93 +75,165 @@ class NooaBoxExecutor(AgentExecutor):
         prompt: str,
         *,
         timeout: float = 60.0,
-        collect_dir: str | None = None,
+        collect_dir: str | os.PathLike[str] | None = None,
         redaction_sentinels: tuple[str, ...] | list[str] | None = None,
     ) -> AgentResult:
         del redaction_sentinels
-        request = {
-            "prompt": prompt,
-            "agent": self.agent_ref,
-            "method": self.method,
-            "model": self.model,
-            "workdir": self._placement.workdir,
-        }
-        base_url = self._first_env(_ENV_BASE_URLS, self.base_url)
-        api_key = self._first_env(_ENV_API_KEYS, None, locator=self.api_key_env)
-        if base_url:
-            request["api_base"] = base_url
-
-        env = {"NOOA_MODEL": self.model}
-        if base_url:
-            env["OPENAI_BASE_URL"] = base_url
-        if api_key:
-            env["OPENAI_API_KEY"] = api_key
-
-        result = asyncio.run(
-            self._host.exec(
-                ["python3", WORKER_PATH, json.dumps(request, sort_keys=True)],
-                cwd=self._placement.workdir,
-                env=env,
-                timeout_sec=timeout,
-            )
-        )
-        if result.exit_code != 0:
+        try:
+            return _run_coro(self._ainvoke(prompt, timeout=timeout, collect_dir=collect_dir))
+        except ExtensionMaterializeError as exc:
             return AgentResult(
                 model=self.model,
                 text="",
                 structured=None,
                 ok=False,
-                error="nooa_worker_failed",
-                stderr=result.stderr[-2000:],
-                metadata={"executor_kind": self.kind, "exit_code": result.exit_code},
+                error=str(getattr(exc, "message", None) or exc),
+                metadata={
+                    "plugin": PLUGIN_ID,
+                    "agent": self.agent_ref,
+                    "execution_location": "attempt-container",
+                },
             )
-        return self._result_from(result.stdout, collect_dir=collect_dir)
 
-    def _result_from(self, stdout: str, *, collect_dir: str | None) -> AgentResult:
-        try:
-            payload = json.loads(stdout.strip().splitlines()[-1])
-        except (IndexError, json.JSONDecodeError):
+    async def _ainvoke(
+        self,
+        prompt: str,
+        *,
+        timeout: float,
+        collect_dir: str | os.PathLike[str] | None,
+    ) -> AgentResult:
+        await self._prepare()
+        request = {
+            "prompt": prompt,
+            "agent": self.agent_ref,
+            "method": self.method,
+            "model": self.model,
+            "package_root": self._host.visible_path(BOX_PACKAGE),
+            "workdir": self._host.visible_path(self._placement.workdir or WORKSPACE_PATH),
+        }
+        base = self._resolve_base_url()
+        if base:
+            request["api_base"] = base
+        result = await self._host.exec(
+            [
+                *self._host.python_command,
+                self._host.visible_path(BOX_WORKER),
+                json.dumps(request, sort_keys=True),
+            ],
+            cwd=self._placement.workdir or WORKSPACE_PATH,
+            env=self._exec_env(),
+            timeout_sec=timeout,
+        )
+        return self._result_from(result, collect_dir=collect_dir)
+
+    async def _prepare(self) -> None:
+        if self._prepared:
+            return
+        await self._host.upload(
+            self._plugin_root / "worker" / "ageval_executor_nooa.py", BOX_WORKER
+        )
+        await self._host.upload(self._plugin_root / "src" / "nooa_plugin", f"{BOX_SRC}/nooa_plugin")
+        await self._upload_agent_module()
+        self._prepared = True
+
+    async def _upload_agent_module(self) -> None:
+        if self._package_root is None or not self._package_root.is_dir():
+            raise ExtensionMaterializeError(
+                "nooa_package_root_missing",
+                kind="extension_materialize_failed",
+            )
+        top = self.agent_ref.split(":", 1)[0].split(".", 1)[0]
+        src = self._package_root / top
+        file_src = self._package_root / f"{top}.py"
+        if src.is_dir():
+            await self._host.upload(src, f"{BOX_PACKAGE}/{top}")
+            return
+        if file_src.is_file():
+            await self._host.upload(file_src, f"{BOX_PACKAGE}/{top}.py")
+            return
+        raise ExtensionMaterializeError(
+            f"nooa_agent_source_missing:{top}",
+            kind="extension_materialize_failed",
+        )
+
+    def _resolve_base_url(self) -> str | None:
+        from nooa_plugin.factory import resolve_base_url
+
+        return resolve_base_url(self.base_url)
+
+    def _exec_env(self) -> dict[str, str]:
+        from nooa_plugin.factory import resolve_api_key_value
+
+        env: dict[str, str] = {
+            "NOOA_MODEL": self.model,
+            "PYTHONPATH": self._host.visible_path(BOX_SRC),
+        }
+        key = resolve_api_key_value(self.api_key_env)
+        if key:
+            env["OPENAI_API_KEY"] = key
+        base = self._resolve_base_url()
+        if base:
+            env["OPENAI_BASE_URL"] = base
+        if os.environ.get("AGEVAL_OFFLINE_AGENT") == "1":
+            env["AGEVAL_OFFLINE_AGENT"] = "1"
+        return env
+
+    def _result_from(self, result: Any, *, collect_dir: str | os.PathLike[str] | None) -> AgentResult:
+        stdout = str(getattr(result, "stdout", "") or "")
+        stderr = str(getattr(result, "stderr", "") or "")
+        exit_code = int(getattr(result, "exit_code", 1) or 0)
+        payload = _payload_from_stdout(stdout)
+        if collect_dir and payload is not None:
+            root = Path(collect_dir)
+            root.mkdir(parents=True, exist_ok=True)
+            (root / "nooa_worker.json").write_text(
+                json.dumps(payload, ensure_ascii=False, default=str) + "\n",
+                encoding="utf-8",
+            )
+        if payload is None:
             return AgentResult(
                 model=self.model,
                 text=stdout[-2000:],
                 structured=None,
                 ok=False,
-                error="nooa_worker_unreadable",
-                metadata={"executor_kind": self.kind},
+                error="nooa_worker_unreadable" if exit_code == 0 else "nooa_worker_failed",
+                stderr=stderr[-2000:],
+                metadata={
+                    "plugin": PLUGIN_ID,
+                    "agent": self.agent_ref,
+                    "execution_location": "attempt-container",
+                    "exit_code": exit_code,
+                },
             )
-        if collect_dir:
-            from pathlib import Path
-
-            root = Path(collect_dir)
-            root.mkdir(parents=True, exist_ok=True)
-            (root / "nooa_worker.json").write_text(stdout, encoding="utf-8")
-        text = str(payload.get("text") or "")
+        metadata = dict(payload.get("metadata") or {})
+        metadata.setdefault("plugin", PLUGIN_ID)
+        metadata.setdefault("agent", self.agent_ref)
+        metadata.setdefault("execution_location", "attempt-container")
         structured = payload.get("structured")
+        events = payload.get("events") or ()
+        usage = payload.get("usage")
         return AgentResult(
             model=str(payload.get("model") or self.model),
-            text=text,
+            text=str(payload.get("text") or ""),
             structured=structured if isinstance(structured, dict) else None,
             ok=bool(payload.get("ok", True)),
-            error=payload.get("error"),
-            events=tuple(payload.get("events") or ()),
-            usage=payload.get("usage") if isinstance(payload.get("usage"), dict) else None,
-            metadata={"executor_kind": self.kind, "agent": self.agent_ref},
+            error=str(payload["error"]) if payload.get("error") else None,
+            stderr=stderr[-2000:],
+            events=tuple(events) if isinstance(events, list) else (),
+            usage=usage if isinstance(usage, dict) else None,
+            metadata=metadata,
         )
 
-    def _first_env(
-        self,
-        names: tuple[str, ...],
-        declared: str | None,
-        *,
-        locator: str | None = None,
-    ) -> str | None:
-        if declared:
-            return declared
-        for name in (locator, *names):
-            value = os.environ.get(name or "", "").strip()
-            if value:
-                return value
+
+def _payload_from_stdout(stdout: str) -> dict[str, Any] | None:
+    text = stdout.strip()
+    if not text:
         return None
+    try:
+        payload = json.loads(text.splitlines()[-1])
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
 
 
-__all__ = ["WORKER_PATH", "NooaBoxExecutor"]
+__all__ = ["BOX_WORKER", "NooaBoxExecutor"]

--- a/plugins/nooa/src/nooa_plugin/factory.py
+++ b/plugins/nooa/src/nooa_plugin/factory.py
@@ -1,29 +1,25 @@
-"""nooa ExecutorSPI — host path for NVIDIA OO Agents (real LLM via LiteLLM).
+"""nooa executor factory — bind the in-box worker to this Attempt's environment.
 
-Mirrors NVIDIA ``nooa-bench`` runner wiring:
-
-    llm = get_llm_client(model, api_base=..., api_key=...)
-    agent = AgentClass(llm=llm)
-    result = await agent.<method>(prompt, workdir=...)
-
-``api_key`` on the profile is an env *locator name* (never a secret value).
-``base_url`` is the OpenAI-compatible endpoint (profile or env fallback).
+Parent never imports NVIDIA nooa or LiteLLM as the success path. ``invoke``
+builds a request and runs the worker through ``host.exec``; credentials are
+locators projected into the exec env at invoke time.
 """
 
 from __future__ import annotations
 
-import asyncio
-import concurrent.futures
-import inspect
 import os
-from dataclasses import replace
+from pathlib import Path
 from typing import Any
 
-from ageval.plugins.agent_result import AgentResult
 from ageval.plugins.errors import ExtensionMaterializeError
-from nooa_plugin.trajectory import attach_event_tap, to_ageval_trajectory_events
+from nooa_plugin import PLUGIN_ID
+from nooa_plugin.container import NooaBoxExecutor
 
-PLUGIN_ID = "nooa"
+_BASE_URL_ENV_FALLBACKS = (
+    "OPENAI_BASE_URL",
+    "litellm_base_url",
+    "AGEVAL_OPENAI_BASE_URL",
+)
 
 
 def describe_nooa() -> dict[str, Any]:
@@ -38,30 +34,26 @@ def describe_nooa() -> dict[str, Any]:
     }
 
 
-# Env fallbacks when profile omits base_url (non-secret locators / common names).
-_BASE_URL_ENV_FALLBACKS = (
-    "OPENAI_BASE_URL",
-    "litellm_base_url",
-    "AGEVAL_OPENAI_BASE_URL",
-)
+def _plugin_root() -> Path:
+    return Path(__file__).resolve().parents[2]
 
 
-def _resolve_api_key_value(locator: str | None) -> str | None:
+def resolve_api_key_value(locator: str | None) -> str | None:
     if not locator or not str(locator).strip():
-        return None
-    name = str(locator).strip()
-    val = os.environ.get(name)
-    if val and val.strip():
-        return val.strip()
-    # Common alias when profile uses openai-style locator.
-    if name != "OPENAI_API_KEY":
-        alt = os.environ.get("OPENAI_API_KEY")
-        if alt and alt.strip():
-            return alt.strip()
+        names = ["OPENAI_API_KEY", "litellm_api_key"]
+    else:
+        name = str(locator).strip()
+        names = [name]
+        if name != "OPENAI_API_KEY":
+            names.append("OPENAI_API_KEY")
+    for name in names:
+        val = os.environ.get(name)
+        if val and val.strip():
+            return val.strip()
     return None
 
 
-def _resolve_base_url(explicit: str | None) -> str | None:
+def resolve_base_url(explicit: str | None) -> str | None:
     if explicit and str(explicit).strip():
         return str(explicit).strip()
     for key in _BASE_URL_ENV_FALLBACKS:
@@ -71,382 +63,43 @@ def _resolve_base_url(explicit: str | None) -> str | None:
     return None
 
 
-def _run_coro(coro: Any) -> Any:
-    """Run *coro* from sync ExecutorSPI.invoke (may already be inside a loop)."""
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(coro)
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-        return pool.submit(asyncio.run, coro).result()
-
-
-def _is_nooa_agent_type(obj: Any) -> bool:
-    try:
-        from nooa import Agent as NooaAgent
-    except ImportError:
-        return False
-    return isinstance(obj, type) and issubclass(obj, NooaAgent)
-
-
-def _write_backend_raw(collect_dir: str | None, native: list[dict[str, Any]]) -> None:
-    if not collect_dir or not native:
-        return
-    from pathlib import Path
-
-    root = Path(collect_dir)
-    root.mkdir(parents=True, exist_ok=True)
-    import json
-
-    (root / "nooa_events.jsonl").write_text(
-        "\n".join(json.dumps(e, ensure_ascii=False, default=str) for e in native) + "\n",
-        encoding="utf-8",
-    )
-
-
-def _normalize_raw(
-    raw: Any,
+def build_executor(
     *,
-    model: str,
-    agent_ref: str,
-    collect_dir: str | None,
-    events: tuple[dict[str, Any], ...] = (),
-) -> AgentResult:
-    if isinstance(raw, AgentResult):
-        return raw
-    # Pydantic v2
-    if hasattr(raw, "model_dump") and callable(raw.model_dump):
-        try:
-            dumped = raw.model_dump()
-            if isinstance(dumped, dict):
-                raw = dumped
-        except Exception:  # noqa: BLE001
-            pass
-    if isinstance(raw, dict):
-        structured = raw.get("structured")
-        if not isinstance(structured, dict):
-            # Whole dict is the payload when agent returns domain JSON directly.
-            if "ok" in raw or "text" in raw or "error" in raw:
-                structured = raw["structured"] if isinstance(raw.get("structured"), dict) else None
-                if structured is None:
-                    structured = {
-                        k: v for k, v in raw.items() if k not in {"ok", "error", "text"}
-                    } or None
-            else:
-                structured = raw
-        text = str(raw.get("text") or "")
-        if not text and structured is not None:
-            import json
-
-            try:
-                text = json.dumps(structured, ensure_ascii=False)
-            except TypeError:
-                text = str(structured)
-        return AgentResult(
-            model=model,
-            text=text,
-            structured=structured if isinstance(structured, dict) else None,
-            ok=bool(raw.get("ok", True)),
-            error=str(raw["error"]) if raw.get("error") else None,
-            events=events,
-            metadata={
-                "plugin": PLUGIN_ID,
-                "agent": agent_ref,
-                "collect_dir": str(collect_dir or ""),
-                "llm_backed": True,
-            },
+    options: dict[str, Any] | None = None,
+    host: Any,
+    placement: Any,
+    profile_id: str | None = None,
+    model: str | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    package_root: str | None = None,
+) -> NooaBoxExecutor:
+    """plugin.yaml exclusive entry: factory(**kwargs) → in-box executor."""
+    del profile_id
+    opts = dict(options or {})
+    agent_ref = opts.get("agent")
+    if not agent_ref or not str(agent_ref).strip():
+        raise ExtensionMaterializeError(
+            "nooa_options_agent_required",
+            kind="extension_materialize_failed",
         )
-    text = str(raw) if raw is not None else ""
-    structured = None
-    try:
-        import json
-
-        parsed = json.loads(text)
-        if isinstance(parsed, dict):
-            structured = parsed
-    except (json.JSONDecodeError, TypeError):
-        pass
-    return AgentResult(
-        model=model,
-        text=text,
-        structured=structured,
-        ok=True,
-        events=events,
-        metadata={
-            "plugin": PLUGIN_ID,
-            "agent": agent_ref,
-            "llm_backed": True,
-        },
+    return NooaBoxExecutor(
+        host=host,
+        placement=placement,
+        plugin_root=_plugin_root(),
+        package_root=package_root,
+        agent_ref=str(agent_ref).strip(),
+        method=str(opts.get("method") or "run").strip() or "run",
+        model=(model or "").strip() or "openai/gpt-4.1-mini",
+        base_url=base_url if isinstance(base_url, str) else None,
+        api_key_env=api_key if isinstance(api_key, str) else None,
     )
 
 
-class NooaExecutorSPI:
-    """ExecutorSPI: load package agent + invoke via NVIDIA nooa + real LLM.
-
-    Host SPI for L0. L1 Ready uses in-container worker (``ageval-executor-nooa``).
-    Plain (non-``nooa.Agent``) classes remain supported for deterministic probes
-    such as slot-probe ``FixedAnswerAgent`` / unit fixtures — those paths do not
-    call the network.
-    """
-
-    kind = "nooa"
-
-    def __init__(
-        self,
-        *,
-        options: dict[str, Any] | None = None,
-        profile_id: str | None = None,
-        model: str | None = None,
-        base_url: str | None = None,
-        api_key: str | None = None,
-        plugin_id: str | None = None,
-        package_root: str | None = None,
-        workdir: str | None = None,
-        **_kwargs: Any,
-    ) -> None:
-        del plugin_id
-        opts = dict(options or {})
-        if package_root:
-            opts.setdefault("_package_root", package_root)
-        agent_ref = opts.get("agent")
-        if not agent_ref or not str(agent_ref).strip():
-            raise ExtensionMaterializeError(
-                "nooa_options_agent_required",
-                kind="extension_materialize_failed",
-            )
-        self.agent_ref = str(agent_ref).strip()
-        self.method = str(opts.get("method") or "run").strip() or "run"
-        self.profile_id = profile_id
-        self.model = (model or "").strip() or "openai/gpt-4.1-mini"
-        self.base_url = base_url
-        self.api_key_env = api_key  # locator name
-        self.options = opts
-        self.default_workdir = str(workdir).strip() if workdir else None
-        self._agent_cls: Any = None
-        self._agent: Any = None
-        self._llm: Any = None
-        self._llm_backed = False
-        self._ready = False
-
-    @staticmethod
-    def describe() -> dict[str, Any]:
-        return describe_nooa()
-
-    def open(self, **kwargs: Any) -> None:
-        del kwargs
-        self._agent_cls = self._load_agent_class()
-        self._llm_backed = _is_nooa_agent_type(self._agent_cls)
-        if self._llm_backed:
-            self._llm = self._build_llm()
-            self._agent = self._agent_cls(llm=self._llm)
-        else:
-            cls = self._agent_cls
-            self._agent = cls() if callable(cls) else cls
-        self._ready = True
-
-    def close(self) -> None:
-        self._agent = None
-        self._agent_cls = None
-        self._llm = None
-        self._ready = False
-
-    def _build_llm(self) -> Any:
-        try:
-            from nooa.unifiedllm import get_llm_client
-        except ImportError as exc:
-            raise ExtensionMaterializeError(
-                "nooa_package_missing: install the NVIDIA nooa package "
-                "(uv sync --extra nooa / pip install nooa)",
-                kind="extension_materialize_failed",
-            ) from exc
-
-        from ageval.runtime.offline import is_offline_agent
-
-        base = _resolve_base_url(self.base_url if isinstance(self.base_url, str) else None)
-        key = _resolve_api_key_value(
-            self.api_key_env if isinstance(self.api_key_env, str) else None
-        )
-        if is_offline_agent():
-            raise ExtensionMaterializeError(
-                "offline_forced",
-                kind="extension_materialize_failed",
-            )
-        if not key and not (base and ("127.0.0.1" in base or "localhost" in base)):
-            raise ExtensionMaterializeError(
-                f"nooa_missing_credential: env {self.api_key_env!r} unset "
-                f"(and no loopback base_url)",
-                kind="extension_materialize_failed",
-            )
-        overrides: dict[str, Any] = {"temperature": 0}
-        if base:
-            overrides["api_base"] = base
-        if key:
-            overrides["api_key"] = key
-        return get_llm_client(self.model, **overrides)
-
-    def _load_agent_class(self) -> Any:
-        import importlib.util
-        import sys
-        from pathlib import Path
-
-        ref = self.agent_ref
-        if ":" in ref:
-            mod_name, cls_name = ref.split(":", 1)
-        else:
-            mod_name, cls_name = ref, None
-        roots: list[Path] = []
-        for key in ("_package_root", "package_root"):
-            raw = self.options.get(key)
-            if isinstance(raw, str) and raw.strip():
-                roots.append(Path(raw).expanduser().resolve(strict=False))
-        roots.append(Path.cwd())
-
-        mod = None
-        last_exc: Exception | None = None
-        for root in roots:
-            if not root.is_dir():
-                continue
-            rel = Path(*mod_name.split("."))
-            for candidate in (root / f"{rel}.py", root / rel / "__init__.py"):
-                if not candidate.is_file():
-                    continue
-                unique = f"nooa_pkg_{abs(hash(str(root.resolve())))}_{mod_name.replace('.', '_')}"
-                spec = importlib.util.spec_from_file_location(unique, candidate)
-                if spec is None or spec.loader is None:
-                    continue
-                loaded = importlib.util.module_from_spec(spec)
-                parent = str(root)
-                if parent not in sys.path:
-                    sys.path.insert(0, parent)
-                sys.modules[unique] = loaded
-                try:
-                    spec.loader.exec_module(loaded)
-                except Exception as exc:  # noqa: BLE001
-                    last_exc = exc
-                    continue
-                mod = loaded
-                break
-            if mod is not None:
-                break
-        if mod is None:
-            try:
-                import importlib
-
-                for root in roots:
-                    s = str(root)
-                    if root.is_dir() and s not in sys.path:
-                        sys.path.insert(0, s)
-                mod = importlib.import_module(mod_name)
-            except Exception as exc:  # noqa: BLE001
-                raise ExtensionMaterializeError(
-                    f"nooa_agent_import_failed:{last_exc or exc}",
-                    kind="extension_materialize_failed",
-                ) from exc
-        if cls_name:
-            cls = getattr(mod, cls_name, None)
-            if cls is None:
-                raise ExtensionMaterializeError(
-                    f"nooa_agent_class_missing:{cls_name}",
-                    kind="extension_materialize_failed",
-                )
-            return cls
-        return mod
-
-    def invoke(
-        self,
-        prompt: str,
-        *,
-        timeout: float = 60.0,
-        workdir: str | None = None,
-        collect_dir: str | None = None,
-        redaction_sentinels: tuple[str, ...] | list[str] | None = None,
-    ) -> AgentResult:
-        del timeout, redaction_sentinels
-        effective_workdir = workdir or self.default_workdir
-        if os.environ.get("AGEVAL_OFFLINE_AGENT") == "1":
-            return AgentResult(
-                model=self.model,
-                text="",
-                structured=None,
-                ok=False,
-                error="offline_forced",
-                metadata={"plugin": PLUGIN_ID, "agent": self.agent_ref},
-            )
-        if not self._ready or self._agent is None:
-            try:
-                self.open()
-            except ExtensionMaterializeError as exc:
-                return AgentResult(
-                    model=self.model,
-                    text="",
-                    structured=None,
-                    ok=False,
-                    error=str(getattr(exc, "message", None) or exc),
-                    metadata={"plugin": PLUGIN_ID},
-                )
-        method = getattr(self._agent, self.method, None)
-        if method is None or not callable(method):
-            return AgentResult(
-                model=self.model,
-                text="",
-                structured=None,
-                ok=False,
-                error=f"nooa_method_missing:{self.method}",
-                metadata={"plugin": PLUGIN_ID, "agent": self.agent_ref},
-            )
-        tap = attach_event_tap(self._agent)
-        try:
-            raw = self._call_method(method, prompt, effective_workdir)
-        except ExtensionMaterializeError as exc:
-            return AgentResult(
-                model=self.model,
-                text="",
-                structured=None,
-                ok=False,
-                error=str(getattr(exc, "message", None) or exc),
-                metadata={"plugin": PLUGIN_ID, "agent": self.agent_ref},
-            )
-        except Exception as exc:  # noqa: BLE001
-            return AgentResult(
-                model=self.model,
-                text="",
-                structured=None,
-                ok=False,
-                error=f"{type(exc).__name__}:{exc}",
-                metadata={"plugin": PLUGIN_ID, "agent": self.agent_ref},
-            )
-        native = tap.finish(self._agent)
-        _write_backend_raw(collect_dir, native)
-        mapped = tuple(to_ageval_trajectory_events(native))
-        result = _normalize_raw(
-            raw,
-            model=self.model,
-            agent_ref=self.agent_ref,
-            collect_dir=collect_dir,
-            events=mapped,
-        )
-        meta = dict(result.metadata or {})
-        meta["trajectory_tap"] = tap.stats
-        return replace(result, metadata=meta)
-
-    def _call_method(self, method: Any, prompt: str, workdir: str | None) -> Any:
-        async def _async_call() -> Any:
-            try:
-                out = method(prompt, workdir=workdir)
-            except TypeError:
-                out = method(prompt)
-            if inspect.isawaitable(out):
-                return await out
-            return out
-
-        if inspect.iscoroutinefunction(method) or self._llm_backed:
-            return _run_coro(_async_call())
-        try:
-            return method(prompt, workdir=workdir)
-        except TypeError:
-            return method(prompt)
-
-
-def build_executor(**kwargs: Any) -> NooaExecutorSPI:
-    """plugin.yaml provide entry: factory(**kwargs) -> ExecutorSPI."""
-    return NooaExecutorSPI(**kwargs)
+__all__ = [
+    "PLUGIN_ID",
+    "build_executor",
+    "describe_nooa",
+    "resolve_api_key_value",
+    "resolve_base_url",
+]

--- a/plugins/nooa/src/nooa_plugin/hooks.py
+++ b/plugins/nooa/src/nooa_plugin/hooks.py
@@ -1,24 +1,10 @@
-"""Multi-slot on-handlers for nooa (image_contribute / trajectory_collect)."""
+"""trajectory_collect handler for nooa."""
 
 from __future__ import annotations
 
 from typing import Any
 
 from nooa_plugin import PLUGIN_ID
-
-
-async def image_contribute(ctx: Any, value: Any, nxt: Any) -> Any:
-    """Declare this plugin on the image_contribute chain (L1 Ready).
-
-    install = Recognition only. Core bakes ``docker/Dockerfile.bake`` if present.
-    """
-    del ctx
-    declare = {
-        "plugin": PLUGIN_ID,
-    }
-    base = list(value) if isinstance(value, list) else []
-    base.append(declare)
-    return await nxt(base)
 
 
 async def trajectory_collect(ctx: Any, value: Any, nxt: Any) -> Any:

--- a/plugins/nooa/src/nooa_plugin/hooks.py
+++ b/plugins/nooa/src/nooa_plugin/hooks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from nooa_plugin.factory import PLUGIN_ID
+from nooa_plugin import PLUGIN_ID
 
 
 async def image_contribute(ctx: Any, value: Any, nxt: Any) -> Any:

--- a/plugins/nooa/worker/ageval_executor_nooa.py
+++ b/plugins/nooa/worker/ageval_executor_nooa.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """In-container nooa worker — NVIDIA OO Agents + real LLM.
 
-Reads one JSON object from stdin::
+Reads one JSON object from argv[1] or stdin. Credentials arrive via env
+(OPENAI_API_KEY / OPENAI_BASE_URL), not the payload::
 
     {
       "prompt": "...",
@@ -225,9 +226,17 @@ async def _invoke(
     return out
 
 
+def _read_request() -> dict[str, Any]:
+    raw = sys.argv[1] if len(sys.argv) > 1 else (sys.stdin.read() or "{}")
+    req = json.loads(raw)
+    if not isinstance(req, dict):
+        raise TypeError("request_not_object")
+    return req
+
+
 def main() -> int:
     try:
-        req = json.loads(sys.stdin.read() or "{}")
+        req = _read_request()
     except json.JSONDecodeError as exc:
         print(
             json.dumps(
@@ -235,7 +244,7 @@ def main() -> int:
             )
         )
         return 2
-    if not isinstance(req, dict):
+    except TypeError:
         print(json.dumps({"ok": False, "error": "request_not_object", "model": "nooa", "text": ""}))
         return 2
 
@@ -245,8 +254,6 @@ def main() -> int:
     model = str(req.get("model") or os.environ.get("NOOA_MODEL") or "openai/gpt-4.1-mini")
     api_base = req.get("api_base") or req.get("base_url")
     api_base_s = str(api_base).strip() if isinstance(api_base, str) and api_base.strip() else None
-    api_key = req.get("api_key")
-    api_key_s = str(api_key).strip() if isinstance(api_key, str) and api_key.strip() else None
     package_root = Path(str(req.get("package_root") or "/attempt/package")).expanduser()
     workdir = str(req.get("workdir") or "/attempt/workspace")
 
@@ -266,7 +273,11 @@ def main() -> int:
                     "error": "offline_forced",
                     "model": model,
                     "text": "",
-                    "metadata": {"plugin": "nooa", "agent": agent_ref},
+                    "metadata": {
+                        "plugin": "nooa",
+                        "agent": agent_ref,
+                        "execution_location": "attempt-container",
+                    },
                 }
             )
         )
@@ -276,7 +287,7 @@ def main() -> int:
         cls = _load_agent_class(agent_ref, package_root)
         llm_backed = _is_nooa_agent_type(cls)
         if llm_backed:
-            llm = _build_llm(model=model, api_base=api_base_s, api_key=api_key_s)
+            llm = _build_llm(model=model, api_base=api_base_s, api_key=None)
             agent = cls(llm=llm)
         else:
             agent = cls() if callable(cls) else cls

--- a/plugins/nooa/worker/ageval_executor_nooa.py
+++ b/plugins/nooa/worker/ageval_executor_nooa.py
@@ -10,12 +10,10 @@ Reads one JSON object from argv[1] or stdin. Credentials arrive via env
       "method": "run",
       "model": "openai/glm-5.2",
       "api_base": "https://…/v1",
-      "api_key": "<secret projected by parent>",
       "package_root": "/attempt/package",
       "workdir": "/attempt/workspace"
     }
 
-Credentials may also arrive via env (OPENAI_API_KEY / OPENAI_BASE_URL).
 Writes one AgentResult-shaped JSON object to stdout.
 """
 

--- a/skills/ageval-cli/SKILL.md
+++ b/skills/ageval-cli/SKILL.md
@@ -3,7 +3,7 @@ name: ageval-cli
 description: >
   Operate ageval CLI (lock/run/plugin/view/publish/release/executors/campaign/evidence/status/cancel/jobs/results):
   flags, --set pointers, exit codes, --probe, offline fail-closed (AGEVAL_OFFLINE_AGENT),
-  ACP entry readiness, plugin install, suite upload. Use for ageval run/lock, PASS/FAIL/ERROR,
+  ACP entry readiness, plugin install, suite upload. Use when running ageval lock/run, PASS/FAIL/ERROR,
   trajectory export, Hub upload. Do not invent flags.
 ---
 
@@ -14,7 +14,7 @@ uv sync --frozen --all-packages
 uv run ageval --help
 ```
 
-Public commands: `lock` `run` `campaign` `tasks` `jobs` `view` `plugin` `evidence` `status` `cancel` `executors` `publish` `release` `login` `agent` `registry` `cache` `results`. No `submit`. Path arguments are **dataset** roots.
+Public commands: `ageval lock` `ageval run` `ageval campaign` `tasks` `jobs` `view` `plugin` `evidence` `ageval status` `ageval cancel` `executors` `publish` `release` `login` `agent` `registry` `cache` `results`. No `submit`. Path arguments are **dataset** roots.
 
 ```bash
 uv run ageval lock examples/core --task config-minimal

--- a/skills/ageval-plugin/SKILL.md
+++ b/skills/ageval-plugin/SKILL.md
@@ -17,7 +17,8 @@ Host declares slots in `src/ageval/plugins/slots.py`. Plugins fill them.
 
 `ageval plugin install` writes `~/.ageval/plugins` only. Never rewrites profiles.
 
-inject: `service: environment` (need `attach_stdio`). Do not pin `plugin_id: e2b` from ACP.
+inject: `service: environment`. ACP needs `attach_stdio`. In-box workers
+(dsh / nooa) need `exec` and `upload`. Do not pin `plugin_id: e2b`.
 
 Name by mechanism (`acp`, `e2b`, `ssh`, `nooa`). First-party lives in `src/ageval/plugins/contrib/`. External packages under `plugins/`.
 

--- a/skills/ageval-plugin/references/authoring.md
+++ b/skills/ageval-plugin/references/authoring.md
@@ -36,6 +36,9 @@ slots:
     - id: trajectory_collect
       priority: 110
       entry: "my_mech.hooks:trajectory_collect"
+inject:
+  - service: environment
+    capabilities: [exec, upload]   # ACP uses attach_stdio instead
 config:
   image_layers: docker/Dockerfile.bake
 ```
@@ -52,9 +55,10 @@ An environment plugin fills exclusive slot `environment` and implements
 ## Executor
 
 Host factory: `build_executor(**kwargs)`. Common kwargs: `options`, `profile_id`,
-`model`, `base_url`, `api_key` (locator name), `plugin_id`.
+`model`, `base_url`, `api_key` (locator name), `host`, `placement`, `package_root`.
 
-On docker, the box owns `attach_stdio` / in-box workers. Missing bind → fail closed.
+ACP attaches with `host.attach_stdio`. dsh / nooa run a baked (or uploaded)
+worker with `host.exec` and `host.upload`. Missing capability → lock fails.
 Core must not reconstruct a container executor by kind. No silent host fallback.
 
 `describe()` keys already in production (copy semantics):

--- a/src/ageval/runtime/agent_binding.py
+++ b/src/ageval/runtime/agent_binding.py
@@ -83,10 +83,6 @@ class AgentBinder:
         host = self.services.require(ENVIRONMENT)
         model = str(row.get("model") or "entry-default")
         placement = host.placement()
-        workdir = None
-        host_path = getattr(host, "host_path", None)
-        if callable(host_path):
-            workdir = str(host_path(placement.workdir))
         package_root = str(self.task_root) if self.task_root is not None else None
         executor = bind_winner(
             self.registry,
@@ -98,7 +94,6 @@ class AgentBinder:
             api_key=_text(row.get("api_key")),
             host=host,
             placement=placement,
-            workdir=workdir,
             package_root=package_root,
         )
         return BoundAgent(

--- a/src/ageval/runtime/task_launch.py
+++ b/src/ageval/runtime/task_launch.py
@@ -83,7 +83,8 @@ def _worker_workspace(ctx: AttemptCtx) -> Path:
     """
     host_path = getattr(ctx.host, "host_path", None)
     if callable(host_path):
-        return Path(host_path(WORKSPACE_PATH))
+        mapped = host_path(WORKSPACE_PATH)
+        return Path(str(mapped))
     workspace = ctx.evidence.path("task-workspace")
     seed = ctx.seed_dir
     if seed is not None and seed.is_dir():

--- a/tests/acceptance/test_ageval_run_cli.py
+++ b/tests/acceptance/test_ageval_run_cli.py
@@ -17,6 +17,8 @@ TASK = "acp-local-min"
 def _ageval(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
     # The automated suite stays bounded; the real Agent path is the public smoke.
     env = {**os.environ, "AGEVAL_OFFLINE_AGENT": "1"}
+    # Locators must exist for lock; values are never used under AGEVAL_OFFLINE_AGENT.
+    env.setdefault("ZHIPU_API_KEY", "ci-offline-placeholder")
     return subprocess.run(
         [sys.executable, "-m", "ageval.cli.main", *args],
         check=False,

--- a/tests/architecture/test_executor_environment_seam.py
+++ b/tests/architecture/test_executor_environment_seam.py
@@ -1,0 +1,45 @@
+"""dsh / nooa talk only to the environment Protocol; Core has no second bind path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+_PARENT_PY = (
+    REPO / "plugins" / "dsh" / "src" / "dsh_plugin" / "factory.py",
+    REPO / "plugins" / "dsh" / "src" / "dsh_plugin" / "container.py",
+    REPO / "plugins" / "nooa" / "src" / "nooa_plugin" / "factory.py",
+    REPO / "plugins" / "nooa" / "src" / "nooa_plugin" / "container.py",
+)
+
+
+def test_bind_to_target_absent_from_core_and_dsh_nooa() -> None:
+    roots = (
+        REPO / "src" / "ageval",
+        REPO / "plugins" / "dsh",
+        REPO / "plugins" / "nooa",
+    )
+    offenders: list[str] = []
+    for root in roots:
+        for path in root.rglob("*"):
+            if path.suffix not in {".py", ".yaml", ".yml", ".md"}:
+                continue
+            text = path.read_text(encoding="utf-8")
+            if "bind_to_target" in text:
+                offenders.append(str(path.relative_to(REPO)))
+    assert offenders == []
+
+
+def test_agent_binding_does_not_borrow_host_path() -> None:
+    text = (REPO / "src" / "ageval" / "runtime" / "agent_binding.py").read_text(encoding="utf-8")
+    assert "host_path" not in text
+
+
+def test_dsh_nooa_parent_does_not_import_vendor_sdk() -> None:
+    for path in _PARENT_PY:
+        text = path.read_text(encoding="utf-8")
+        assert "from deepseek_harness" not in text, path
+        assert "import deepseek_harness" not in text, path
+        assert "from nooa.unifiedllm" not in text, path
+        assert "get_llm_client" not in text, path
+        assert "container_id" not in text, path

--- a/tests/fixtures/datasets/suite-min/profiles.yaml
+++ b/tests/fixtures/datasets/suite-min/profiles.yaml
@@ -1,0 +1,3 @@
+format: ageval.profiles/1
+environment: local
+agent_profiles: {}

--- a/tests/plugins/test_dsh_box_executor.py
+++ b/tests/plugins/test_dsh_box_executor.py
@@ -1,0 +1,159 @@
+"""dsh invoke goes through the environment Protocol, not a host SDK."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from tests.helpers.box import local_box
+
+from ageval.environments.protocol import EnvironmentCapabilities
+from ageval.plugins.errors import InjectUnsatisfiedError
+from ageval.plugins.manifest import load_manifest
+from ageval.plugins.protocol import BindingIntent, InjectRequirement
+from ageval.plugins.registry import ExtensionRegistry
+from ageval.plugins.resolve import resolve
+from ageval.plugins.slots import ENVIRONMENT, EXECUTOR
+
+ROOT = Path(__file__).resolve().parents[2]
+_DSH_SRC = ROOT / "plugins" / "dsh" / "src"
+if str(_DSH_SRC) not in sys.path:
+    sys.path.insert(0, str(_DSH_SRC))
+
+from dsh_plugin.container import DshBoxExecutor  # noqa: E402
+from dsh_plugin.factory import build_executor  # noqa: E402
+
+
+class SpyHost:
+    """Local box that records exec argv/env, then runs them for real."""
+
+    def __init__(self, attempt_root: Path) -> None:
+        self._inner = local_box(attempt_root)
+        self.commands: list[tuple[list[str], dict[str, str] | None]] = []
+        self.uploads: list[str] = []
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+    async def start(self, *, force_build: bool = False) -> None:
+        await self._inner.start(force_build=force_build)
+
+    async def stop(self, *, delete: bool) -> None:
+        await self._inner.stop(delete=delete)
+
+    async def upload(self, source: Path, dest: str) -> None:
+        self.uploads.append(dest)
+        await self._inner.upload(source, dest)
+
+    async def exec(self, command, **kwargs: Any):  # type: ignore[no-untyped-def]
+        env = kwargs.get("env")
+        self.commands.append((list(command), dict(env) if env else None))
+        return await self._inner.exec(command, **kwargs)
+
+
+def test_manifest_injects_environment_exec_and_upload() -> None:
+    manifest = load_manifest(ROOT / "plugins" / "dsh")
+    assert len(manifest.inject) == 1
+    row = manifest.inject[0]
+    assert row.service == "environment"
+    assert set(row.capabilities) == {"exec", "upload"}
+
+
+def test_factory_returns_box_executor() -> None:
+    host = local_box("/nowhere")
+    executor = build_executor(
+        host=host,
+        placement=host.placement(),
+        model="deepseek-v4-flash",
+        api_key="litellm_api_key",
+    )
+    assert isinstance(executor, DshBoxExecutor)
+    assert executor.kind == "dsh"
+
+
+def test_lock_fails_when_environment_cannot_exec() -> None:
+    class MuteHost:
+        capabilities = EnvironmentCapabilities(upload=True)
+
+    registry = ExtensionRegistry()
+    registry.exclusive(ENVIRONMENT, "mute", MuteHost, source="test", is_factory=True)
+    registry.exclusive(EXECUTOR, "dsh", build_executor, source="test", is_factory=True)
+    registry.declare_inject(
+        "dsh",
+        (InjectRequirement(service=ENVIRONMENT, capabilities=("exec", "upload")),),
+    )
+    with pytest.raises(InjectUnsatisfiedError, match="exec"):
+        resolve(
+            BindingIntent(profile_id="solver", environment="mute", executor="dsh"),
+            registry,
+        )
+
+
+def test_lock_records_inject_when_box_can_exec() -> None:
+    from ageval.plugins.contrib.local.host import LocalHost
+
+    registry = ExtensionRegistry()
+    registry.exclusive(ENVIRONMENT, "local", LocalHost, source="test", is_factory=True)
+    registry.exclusive(EXECUTOR, "dsh", build_executor, source="test", is_factory=True)
+    registry.declare_inject(
+        "dsh",
+        (InjectRequirement(service=ENVIRONMENT, capabilities=("exec", "upload")),),
+    )
+    graph = resolve(
+        BindingIntent(profile_id="solver", environment="local", executor="dsh"),
+        registry,
+    )
+    rows = graph.injects["dsh"]
+    assert rows[0].service == "environment"
+    assert set(rows[0].capabilities) == {"exec", "upload"}
+
+
+@pytest.mark.asyncio
+async def test_invoke_runs_worker_through_local_exec(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGEVAL_OFFLINE_AGENT", "1")
+    monkeypatch.setenv("litellm_api_key", "sk-not-for-argv")
+    monkeypatch.setenv("litellm_base_url", "https://example.invalid/v1")
+    host = SpyHost(tmp_path)
+    await host.start()
+    try:
+        executor = build_executor(
+            host=host,
+            placement=host.placement(),
+            model="deepseek-v4-flash",
+            api_key="litellm_api_key",
+            base_url="https://example.invalid/v1",
+        )
+        result = executor.invoke("count the rows", timeout=30)
+    finally:
+        await host.stop(delete=True)
+
+    assert result.ok is False
+    assert result.error == "offline_forced"
+    assert result.metadata is not None
+    assert result.metadata.get("execution_location") == "attempt-container"
+    assert result.metadata.get("plugin") == "dsh"
+    assert host.uploads, "worker files must be uploaded into the box"
+    assert host.commands, "invoke must call host.exec"
+    command, env = host.commands[0]
+    assert command[0] == sys.executable
+    request = json.loads(command[-1])
+    assert "sk-not-for-argv" not in json.dumps(request)
+    assert "api_key" not in request
+    assert env is not None
+    assert env.get("DEEPSEEK_API_KEY") == "sk-not-for-argv"
+    assert env.get("DEEPSEEK_BASE_URL") == "https://example.invalid/v1"
+    factory_src = (ROOT / "plugins" / "dsh" / "src" / "dsh_plugin" / "factory.py").read_text(
+        encoding="utf-8"
+    )
+    container_src = (ROOT / "plugins" / "dsh" / "src" / "dsh_plugin" / "container.py").read_text(
+        encoding="utf-8"
+    )
+    assert "import deepseek_harness" not in factory_src
+    assert "from deepseek_harness" not in factory_src
+    assert "import deepseek_harness" not in container_src
+    assert "from deepseek_harness" not in container_src

--- a/tests/plugins/test_extension_bindings_lock.py
+++ b/tests/plugins/test_extension_bindings_lock.py
@@ -96,9 +96,7 @@ def test_lock_dsh_profile_selects_dsh_not_nooa(
     assert "sk-lock-must-not-see" not in json.dumps(data)
 
 
-def test_lock_nooa_profile_records_inject(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_lock_nooa_profile_records_inject(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     env = _isolated_home(tmp_path, monkeypatch, "nooa")
     data = _lock("--profiles", str(ROOT / "examples/journeys/profiles.nooa.yaml"), env=env)
     solver = data["extension_bindings"]["solver"]

--- a/tests/plugins/test_extension_bindings_lock.py
+++ b/tests/plugins/test_extension_bindings_lock.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -12,12 +13,13 @@ import pytest
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def _chain_plugins(agent_profiles: dict, slot: str) -> set[str]:
-    row = agent_profiles.get(slot) or {}
+def _chain_plugins(fragment: dict, slot: str) -> set[str]:
+    slots = fragment.get("slots") if isinstance(fragment.get("slots"), dict) else fragment
+    row = (slots or {}).get(slot) or {}
     return {str(item.get("plugin")) for item in (row.get("chain") or [])}
 
 
-def _lock(*args: str) -> dict:
+def _lock(*args: str, env: dict[str, str] | None = None) -> dict:
     proc = subprocess.run(
         [
             sys.executable,
@@ -33,9 +35,31 @@ def _lock(*args: str) -> dict:
         capture_output=True,
         text=True,
         check=False,
+        env=env,
     )
     assert proc.returncode == 0, proc.stderr or proc.stdout
     return json.loads(proc.stdout)
+
+
+def _isolated_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *plugin_ids: str
+) -> dict[str, str]:
+    from ageval.plugins import bootstrap as boot
+    from ageval.plugins.registry import reset_global_registry
+    from ageval.plugins.store import install_from_path
+
+    home = tmp_path / "ageval-home"
+    home.mkdir()
+    monkeypatch.setenv("AGEVAL_HOME", str(home))
+    boot._BOOTSTRAPPED = False  # type: ignore[attr-defined]
+    reset_global_registry()
+    for plugin_id in plugin_ids:
+        install_from_path(ROOT / "plugins" / plugin_id)
+    env = os.environ.copy()
+    env["AGEVAL_HOME"] = str(home)
+    env["litellm_api_key"] = "sk-lock-must-not-see"
+    env["litellm_base_url"] = "https://example.invalid/v1"
+    return env
 
 
 def test_lock_cli_extension_bindings_solver_acp() -> None:
@@ -51,22 +75,40 @@ def test_lock_cli_extension_bindings_solver_acp() -> None:
     assert "nooa" not in _chain_plugins(agent_profiles["solver"], "trajectory_collect")
 
 
-def _installed_plugin_ids() -> set[str]:
-    from ageval.plugins.store import list_installed
-
-    return {entry.plugin_id for entry in list_installed()}
-
-
-def test_lock_dsh_profile_selects_dsh_not_nooa() -> None:
-    ids = _installed_plugin_ids()
-    if "dsh" not in ids or "nooa" not in ids:
-        pytest.skip("path-install dsh and nooa to lock the journeys dsh profile")
-    data = _lock("--profiles", str(ROOT / "examples/journeys/profiles.dsh.yaml"))
+def test_lock_dsh_profile_selects_dsh_not_nooa(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env = _isolated_home(tmp_path, monkeypatch, "dsh", "nooa")
+    data = _lock("--profiles", str(ROOT / "examples/journeys/profiles.dsh.yaml"), env=env)
     solver = data["extension_bindings"]["solver"]
     assert solver["slots"]["executor"]["plugin"] == "dsh"
-    contribute = _chain_plugins(solver, "image_contribute")
     collect = _chain_plugins(solver, "trajectory_collect")
-    assert "dsh" in contribute
     assert "dsh" in collect
-    assert "nooa" not in contribute
     assert "nooa" not in collect
+    dsh_inject = (solver.get("inject") or {}).get("dsh") or []
+    assert any(row.get("service") == "environment" for row in dsh_inject)
+    caps = next(
+        tuple(row.get("capabilities") or ())
+        for row in dsh_inject
+        if row.get("service") == "environment"
+    )
+    assert set(caps) == {"exec", "upload"}
+    assert "sk-lock-must-not-see" not in json.dumps(data)
+
+
+def test_lock_nooa_profile_records_inject(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env = _isolated_home(tmp_path, monkeypatch, "nooa")
+    data = _lock("--profiles", str(ROOT / "examples/journeys/profiles.nooa.yaml"), env=env)
+    solver = data["extension_bindings"]["solver"]
+    assert solver["slots"]["executor"]["plugin"] == "nooa"
+    nooa_inject = (solver.get("inject") or {}).get("nooa") or []
+    assert any(row.get("service") == "environment" for row in nooa_inject)
+    caps = next(
+        tuple(row.get("capabilities") or ())
+        for row in nooa_inject
+        if row.get("service") == "environment"
+    )
+    assert set(caps) == {"exec", "upload"}
+    assert "sk-lock-must-not-see" not in json.dumps(data)

--- a/tests/plugins/test_nooa_box_executor.py
+++ b/tests/plugins/test_nooa_box_executor.py
@@ -1,0 +1,159 @@
+"""nooa invoke goes through the environment Protocol, not a host SDK."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from tests.helpers.box import local_box
+
+from ageval.environments.protocol import EnvironmentCapabilities
+from ageval.plugins.errors import ExtensionMaterializeError, InjectUnsatisfiedError
+from ageval.plugins.manifest import load_manifest
+from ageval.plugins.protocol import BindingIntent, InjectRequirement
+from ageval.plugins.registry import ExtensionRegistry
+from ageval.plugins.resolve import resolve
+from ageval.plugins.slots import ENVIRONMENT, EXECUTOR
+
+ROOT = Path(__file__).resolve().parents[2]
+_NOOA_SRC = ROOT / "plugins" / "nooa" / "src"
+if str(_NOOA_SRC) not in sys.path:
+    sys.path.insert(0, str(_NOOA_SRC))
+
+from nooa_plugin.container import NooaBoxExecutor  # noqa: E402
+from nooa_plugin.factory import build_executor  # noqa: E402
+
+_FIXED_AGENT = """\
+from typing import Any
+
+class FixedAnswerAgent:
+    def run(self, prompt: str, workdir: str | None = None) -> dict[str, Any]:
+        del prompt, workdir
+        return {"ok": True, "text": "42", "structured": {"answer": 42}}
+"""
+
+
+class SpyHost:
+    def __init__(self, attempt_root: Path) -> None:
+        self._inner = local_box(attempt_root)
+        self.commands: list[tuple[list[str], dict[str, str] | None]] = []
+        self.uploads: list[str] = []
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+    async def start(self, *, force_build: bool = False) -> None:
+        await self._inner.start(force_build=force_build)
+
+    async def stop(self, *, delete: bool) -> None:
+        await self._inner.stop(delete=delete)
+
+    async def upload(self, source: Path, dest: str) -> None:
+        self.uploads.append(dest)
+        await self._inner.upload(source, dest)
+
+    async def exec(self, command, **kwargs: Any):  # type: ignore[no-untyped-def]
+        env = kwargs.get("env")
+        self.commands.append((list(command), dict(env) if env else None))
+        return await self._inner.exec(command, **kwargs)
+
+
+def test_manifest_injects_environment_exec_and_upload() -> None:
+    manifest = load_manifest(ROOT / "plugins" / "nooa")
+    assert len(manifest.inject) == 1
+    row = manifest.inject[0]
+    assert row.service == "environment"
+    assert set(row.capabilities) == {"exec", "upload"}
+
+
+def test_factory_requires_agent_option() -> None:
+    host = local_box("/nowhere")
+    with pytest.raises(ExtensionMaterializeError, match="nooa_options_agent_required"):
+        build_executor(host=host, placement=host.placement(), options={})
+
+
+def test_factory_returns_box_executor() -> None:
+    host = local_box("/nowhere")
+    executor = build_executor(
+        host=host,
+        placement=host.placement(),
+        options={"agent": "lib.agents:FixedAnswerAgent"},
+        package_root=str(ROOT / "examples" / "core" / "tasks" / "nooa-host-min"),
+    )
+    assert isinstance(executor, NooaBoxExecutor)
+    assert executor.kind == "nooa"
+
+
+def test_lock_fails_when_environment_cannot_exec() -> None:
+    class MuteHost:
+        capabilities = EnvironmentCapabilities(upload=True)
+
+    registry = ExtensionRegistry()
+    registry.exclusive(ENVIRONMENT, "mute", MuteHost, source="test", is_factory=True)
+    registry.exclusive(EXECUTOR, "nooa", build_executor, source="test", is_factory=True)
+    registry.declare_inject(
+        "nooa",
+        (InjectRequirement(service=ENVIRONMENT, capabilities=("exec", "upload")),),
+    )
+    with pytest.raises(InjectUnsatisfiedError, match="exec"):
+        resolve(
+            BindingIntent(profile_id="solver", environment="mute", executor="nooa"),
+            registry,
+        )
+
+
+@pytest.mark.asyncio
+async def test_invoke_runs_worker_through_local_exec(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AGEVAL_OFFLINE_AGENT", raising=False)
+    monkeypatch.setenv("litellm_api_key", "sk-not-for-argv")
+    package = tmp_path / "task"
+    (package / "lib").mkdir(parents=True)
+    (package / "lib" / "agents.py").write_text(_FIXED_AGENT, encoding="utf-8")
+    (package / "lib" / "__init__.py").write_text("", encoding="utf-8")
+    host = SpyHost(tmp_path / "box")
+    await host.start()
+    try:
+        executor = build_executor(
+            host=host,
+            placement=host.placement(),
+            options={"agent": "lib.agents:FixedAnswerAgent", "method": "run"},
+            model="openai/gpt-4.1-mini",
+            api_key="litellm_api_key",
+            base_url="https://example.invalid/v1",
+            package_root=str(package),
+        )
+        result = executor.invoke("hello", timeout=30)
+    finally:
+        await host.stop(delete=True)
+
+    assert result.ok is True
+    assert result.text == "42"
+    assert result.structured == {"answer": 42}
+    assert result.metadata is not None
+    assert result.metadata.get("execution_location") == "attempt-container"
+    assert result.metadata.get("plugin") == "nooa"
+    assert host.uploads
+    assert host.commands
+    command, env = host.commands[0]
+    assert command[0] == sys.executable
+    request = json.loads(command[-1])
+    assert request["agent"] == "lib.agents:FixedAnswerAgent"
+    assert "sk-not-for-argv" not in json.dumps(request)
+    assert "api_key" not in request
+    assert env is not None
+    assert env.get("OPENAI_API_KEY") == "sk-not-for-argv"
+    factory_src = (ROOT / "plugins" / "nooa" / "src" / "nooa_plugin" / "factory.py").read_text(
+        encoding="utf-8"
+    )
+    container_src = (ROOT / "plugins" / "nooa" / "src" / "nooa_plugin" / "container.py").read_text(
+        encoding="utf-8"
+    )
+    assert "from nooa.unifiedllm" not in factory_src
+    assert "get_llm_client" not in factory_src
+    assert "from nooa.unifiedllm" not in container_src
+    assert "get_llm_client" not in container_src

--- a/website/src/app/[lang]/(home)/page.tsx
+++ b/website/src/app/[lang]/(home)/page.tsx
@@ -331,29 +331,21 @@ export default async function HomePage({ params }: { params: Promise<HomeParams>
                   {"      "}
                   <span className="ck">entry:</span> <span className="cs">&quot;dsh_plugin.factory:build_executor&quot;</span>
                   {"\n"}
-                  {"  "}
-                  <span className="ck">chain:</span>
+                  <span className="ck">inject:</span>
                   {"\n"}
-                  {"    "}- <span className="ck">id:</span> trajectory_collect
+                  {"  "}- <span className="ck">service:</span> environment{"\n"}
+                  {"    "}
+                  <span className="ck">capabilities:</span> [exec, upload]
                 </pre>
                 <pre className="code-panel mini" tabIndex={0}>
-                  <span className="cc"># plugins/dsh/src/dsh_plugin/factory.py</span>
+                  <span className="cc"># plugins/dsh — parent never imports the harness</span>
                   {"\n"}
-                  <span className="ck">DEFAULT_MODEL</span> = <span className="cs">&quot;deepseek-v4-flash&quot;</span>
+                  <span className="ck">def</span> build_executor(*, host, placement, **kw) -&gt; DshBoxExecutor:{"\n"}
+                  {"    "}
+                  <span className="ck">return</span> DshBoxExecutor(host=host, placement=placement, **kw)
                   {"\n\n"}
-                  <span className="ck">def</span> build_executor(**kwargs) -&gt; DshExecutorSPI:{"\n"}
-                  {"    "}
-                  <span className="ck">return</span> DshExecutorSPI(**kwargs){"\n\n"}
-                  <span className="ck">class</span> DshExecutorSPI:{"\n"}
-                  {"    "}kind = <span className="cs">&quot;dsh&quot;</span>
-                  {"\n"}
-                  {"    "}
-                  <span className="ck">def</span> bind_to_target(self, placement):{"\n"}
-                  {"        "}
-                  <span className="cc"># bind into the box Core already opened</span>
-                  {"\n"}
-                  {"        "}
-                  <span className="ck">return</span> DshContainerExecutor(...)
+                  <span className="ck">await</span> host.upload(worker, <span className="cs">&quot;/attempt/home/_dsh/…&quot;</span>){"\n"}
+                  <span className="ck">await</span> host.exec([*host.python_command, worker, request], env=creds)
                 </pre>
               </div>
             </div>


### PR DESCRIPTION
## Summary

dsh and nooa now invoke only through the environment Protocol. Parent uploads the worker into the box and runs it with `host.exec`. It no longer imports DeepSeekHarness or NVIDIA nooa as the success path.

This branch starts from **canary** (`1253d79b`), not `main`. The PR therefore includes the canary delta plus this issue.

## Approach

- `plugin.yaml` inject: `service: environment`, capabilities `[exec, upload]`. A kind that cannot `exec` fails at lock, not mid-invoke.
- Factory receives `host` + `placement` from `bind_winner` and constructs the box executor. No Core `bind_to_target`.
- Worker request is argv JSON. Credentials stay locators until invoke, then project into exec env (`DEEPSEEK_*` / `OPENAI_*`). They never enter lock or argv.
- `agent_binding` no longer maps a `host_path` workdir for executors.
- No host-SDK fallback. No new exclusive slot or service named `exec`. ACP inject is unchanged (`attach_stdio`).

## Test plan

- [x] python-core CI-equivalent (`ruff format/check`, `pyright`, offline pytest): 589 passed
- [x] `ageval lock` of journeys dsh/nooa records inject `{service: environment, capabilities: [exec, upload]}`; dummy secret absent from lock JSON
- [x] `ageval run examples/journeys --task terminal-jsonl-agg --profiles examples/journeys/profiles.dsh.yaml` PASS; evidence `execution_location: attempt-container`, worker under `/attempt/home/_dsh`
- [x] same for `profiles.nooa.yaml` (`execution_location: attempt-container`, `llm_backed: true`, workdir `/attempt/workspace`)
- [x] local-box unit tests: invoke goes through `LocalHost.exec`, not a parent SDK cwd
- [x] `rg bind_to_target src/ageval plugins/dsh plugins/nooa` is empty
- [ ] ACP `profiles.acp.pi.*` not re-run here (ACP inject and `attempt/` still have no `container_id` / `if kind ==`)

## Follow-ups

- Homepage still demos `bind_to_target` in `website/src/app/[lang]/(home)/page.tsx`.
- Image bake still installs `/usr/local/bin/ageval-executor-*`; invoke currently uploads and runs `$HOME/_dsh` / `_nooa` so local/e2b/ssh share one path.

Closes #157
