### PR TITLE
feat(runtime): exclusive eval/seal slots and miniswe Protocol inject

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -233,7 +233,7 @@ src/ageval/
 | `plugins/contrib/e2b/` | E2B SDK、template alias（缓存在该账号，Core 不实现） | Core 缓存层 |
 | `plugins/contrib/ssh/` | ssh A/B、`ssh -T` / `docker exec` | 本机假 agent |
 | `plugins/contrib/acp/` | parent ACP client、entry registry、`attach_stdio` 消费方 | 层 C writer；vendor stdout scrape |
-| `plugins/defaults/` | `environment_setup` 认 `setup.sh` | 假 executor |
+| `plugins/defaults/` | `environment_setup` 认 `setup.sh`；`evaluation_runtime` / `trajectory_seal` 默认赢家 | 假 executor；PASS |
 | `runtime/` | identity、parent Agent Service、task worker 子进程、取消/超时 | 盒子实现、评分 |
 | `evaluation/` | barrier 顺序、盒内 runner、扁平 Result | 题包评分算法 |
 | `evidence/` | store / redaction / 层 C `trajectory.jsonl` | vendor 协议解析；PASS |
@@ -288,7 +288,7 @@ ageval_sdk ──► 仅最小公开 DTO / 协议形状
 
 Host **awaits** 已注册的链槽 / 独占赢家。插件经 `(ctx, value, nxt)` 改写或短路，**不是**丢声明行给 Core 事后解释。
 
-槽名权威：`src/ageval/plugins/slots.py`。只有 **exclusive** 与 **chain** 两种。Current 独占槽：`environment`、`executor`。盒内 evaluator 与层 C 轨迹写入是引擎代码，不是插件服务。
+槽名权威：`src/ageval/plugins/slots.py`。只有 **exclusive** 与 **chain** 两种。Current 独占槽：`environment`、`executor`、`evaluation_runtime`、`trajectory_seal`。后两者默认赢家是引擎（`plugin_id: default`）。PASS 仍只经 `bind_evaluation` 进入 Result；`evaluation_runtime` 返回 raw，不得自己写 verdict。`pass` / `identity` / `cleanup` / `evidence` 不是服务。
 
 ```text
 environment phase
@@ -312,14 +312,14 @@ run phase
 
 evaluate phase
   before_evaluate
-  upload evaluation/           # gold 此刻才进盒
-  盒内 evaluator.py
+  upload evaluation/           # gold 此刻才进盒（引擎代码，不挂槽）
+  evaluation_runtime.evaluate  # 独占槽赢家；默认盒内 evaluator.py
   bind_evaluation              # PASS 只在这里进 Result
   after_evaluate               # 不得改 status
 
 record phase
-  trajectory_collect → enrich
-  引擎写 trajectory.jsonl      # 层 C；插件不能替代
+  trajectory_collect → enrich  # fail-open 链
+  trajectory_seal              # 独占槽赢家写 trajectory.jsonl（层 C）
 
 cleanup (finally)
   cleanup_report

--- a/docs/design/01-ageval-core.md
+++ b/docs/design/01-ageval-core.md
@@ -62,14 +62,16 @@ Current 实现把前四相放进循环并在相位失败时记 `phase_failed`，
 
 | 槽种类 | 语义 | 例子 |
 | --- | --- | --- |
-| **独占** | 全 Attempt 一个赢家；自动登记为同名 **service** | `environment`、`executor` |
+| **独占** | 全 Attempt 一个赢家；自动登记为同名 **service** | `environment`、`executor`、`evaluation_runtime`、`trajectory_seal` |
 | **链** | `(ctx, value, nxt)` | `after_environment_ready`、`environment_setup` |
 
 `profiles.executor: acp` = 选独占槽 `executor` 的赢家，不是另一套插件系统。
 
 槽名权威：`src/ageval/plugins/slots.py`。新**时间线**槽仍要改 attempt 宿主；插件不可自造槽名。
 
-Current 独占槽只有 `environment` 与 `executor`。打分运行时与层 C 轨迹写入是**引擎代码**，不是可 export 的服务（不要把 `evaluation_runtime` / `trajectory_seal` 做成插件可替换槽）。
+Current 独占槽：`environment`、`executor`、`evaluation_runtime`、`trajectory_seal`。后两者的默认赢家是引擎（`plugin_id: default`，`is_default=True`）：盒内 `evaluator.py`（via `host.exec`）与层 C `trajectory.jsonl` 写入。没有 job 字段糖；替换只能走显式 `extensions` 行（`slot` + `plugin`）。缺默认注册 → lock fail-closed。
+
+PASS 仍只经 `AttemptCtx.bind_evaluation` 进入 Result。`evaluation_runtime` 赢家返回 raw，不得自己写 verdict。`pass` / `identity` / `cleanup` / `evidence` 仍不是服务。
 
 默认 phase：
 
@@ -77,8 +79,8 @@ Current 独占槽只有 `environment` 与 `executor`。打分运行时与层 C �
 | --- | --- |
 | `environment` | `host.start` + upload seed + 槽（见下） |
 | `run` | 调 task `run.py`；内含 agent open/invoke/close **子槽** |
-| `evaluate` | 停 writer、materialize、跑 `evaluator.py`、绑定 PASS |
-| `record` | collect/enrich → **引擎写** `trajectory.jsonl` → seal |
+| `evaluate` | 停 writer、materialize gold、调 `evaluation_runtime` 赢家、`bind_evaluation` |
+| `record` | collect/enrich → `trajectory_seal` 赢家写 `trajectory.jsonl` |
 | `cleanup` | `host.stop`；实现可加报告，不能选择跳过 |
 
 **没有 `provision` phase。**
@@ -113,8 +115,8 @@ async def run(ctx) -> None:
     # 引擎 upload gold —— 不挂在 before_evaluate 链上
     if ctx.evaluation_src.exists():
         await ctx.host.upload(ctx.evaluation_src, "/attempt/evaluation")
-    result = await ctx.evaluation_runtime.evaluate(ctx)  # Current：盒内 evaluator.py
-    ctx.bind_evaluation(result)                 # PASS 只从这里进
+    result = await ctx.evaluation_runtime.evaluate(ctx)  # 独占槽赢家；默认盒内 evaluator.py
+    ctx.bind_evaluation(result)                 # PASS 只从这里进；赢家不得 bind
     await emit(ctx, "after_evaluate")            # 不得改 status
 ```
 
@@ -127,8 +129,8 @@ async def run(ctx) -> None:
 | 挂在 | slot |
 | --- | --- |
 | run | `before_run` / `after_run`；`before/after_agent_open\|invoke\|close`；`normalize_agent_result` |
-| evaluate | `before_evaluate` / `after_evaluate`（可注 metrics，**不能改 PASS**）。**upload gold 是引擎代码** |
-| record | `trajectory_collect` / `trajectory_enrich`（fail-open）；层 C 由引擎写，插件不能替代 |
+| evaluate | `before_evaluate` / `after_evaluate`（可注 metrics，**不能改 PASS**）。**upload gold 是引擎代码**，不是 `evaluation_runtime` 的方法。独占槽 `evaluation_runtime` 默认跑盒内 `evaluator.py` |
+| record | `trajectory_collect` / `trajectory_enrich`（fail-open）；独占槽 `trajectory_seal` 写层 C（fail-closed：丢文件即相位失败） |
 | cleanup | `cleanup_report`（链）；cleanup phase 本身由 finally 调用 |
 
 `executor` 是 **run 里的独占槽**，不是 attempt 上的独立 phase。ACP attach 发生在第一次 invoke，不是独立 phase。

--- a/docs/design/05-runtime/README.md
+++ b/docs/design/05-runtime/README.md
@@ -37,17 +37,17 @@ run
 evaluate
   before_evaluate
   upload evaluation/          # 引擎代码；不是 before_evaluate 链槽
-  evaluator.py in-box
-  bind_evaluation
-  after_evaluate          # 不得改 status
+  evaluation_runtime          # 独占槽；默认盒内 evaluator.py
+  bind_evaluation             # PASS 只从这里进
+  after_evaluate              # 不得改 status
 
 record
   trajectory_collect → enrich
-  engine writes trajectory.jsonl
+  trajectory_seal             # 独占槽；默认引擎写 trajectory.jsonl
 
 cleanup (finally)
   cleanup_report
   host.stop
 ```
 
-槽种类只有 exclusive（`environment`、`executor`）与 chain。
+槽种类只有 exclusive（`environment`、`executor`、`evaluation_runtime`、`trajectory_seal`）与 chain。PASS 仍只经 `bind_evaluation`。

--- a/docs/design/05-runtime/evaluation.md
+++ b/docs/design/05-runtime/evaluation.md
@@ -11,9 +11,9 @@ run 结束 → mark_writers_stopped
 evaluate
   before_evaluate
   upload artifacts（题包 publish 的 + harvest 补上的）
-  upload evaluation/          # gold 此刻才在盒内（引擎代码，不挂链槽）
-  exec evaluator.py
-  bind_evaluation             # Result.status 只在这里写入
+  upload evaluation/          # gold 此刻才在盒内（引擎代码，不挂链槽，也不是 evaluation SPI）
+  evaluation_runtime.evaluate # 独占槽赢家；默认盒内 evaluator.py via host.exec
+  bind_evaluation             # Result.status 只在这里写入；赢家返回 raw，不得 bind
   after_evaluate              # 可注 metrics，改 status → RuntimeError
 ```
 

--- a/docs/design/05-runtime/evidence.md
+++ b/docs/design/05-runtime/evidence.md
@@ -8,7 +8,7 @@
 | --- | --- |
 | `lock.json` | 无 secret 的 lock 摘要 |
 | `result.json` | 扁平 Result（status/score/kind/logs） |
-| `trajectory.jsonl` | 层 C；引擎写 |
+| `trajectory.jsonl` | 层 C；`trajectory_seal` 独占槽默认引擎写 |
 | `summary.json` | 相位事实 / timing |
 | `agent/` | invoke 级观察 |
 
@@ -21,7 +21,7 @@
 ```text
 A  vendor raw     后端原样
 B  中立事件       ageval.trajectory.event/1（adapter 只映射）
-C  trajectory.jsonl  只有 evidence writer 折叠
+C  trajectory.jsonl  `trajectory_seal` 赢家写（默认引擎折叠）
 ```
 
 lock 与 evidence 禁止 host token。密钥 locator 只留名字。

--- a/docs/design/11-extension-plugins.md
+++ b/docs/design/11-extension-plugins.md
@@ -29,12 +29,12 @@
 
 | 槽 | 语义 | 例子 |
 | --- | --- | --- |
-| 独占 | 全 Attempt 一个赢家；登记为同名 service | `environment`、`executor` |
+| 独占 | 全 Attempt 一个赢家；登记为同名 service | `environment`、`executor`、`evaluation_runtime`、`trajectory_seal` |
 | 链 | `(ctx, value, nxt)` | `after_environment_ready`、`environment_setup`、`trajectory_collect` |
 
-`profiles.environment` / `profiles.executor` = 选独占槽赢家。`extensions` 是链槽 opt-in。未列入 `extensions` 的不进链、不进服务表。
+`profiles.environment` / `profiles.executor` = 选独占槽赢家。`evaluation_runtime` / `trajectory_seal` **没有** job 字段糖；默认赢家即可，替换只能走显式 `extensions` 行（`slot` + `plugin`）。`extensions` 也是链槽 opt-in。未列入 `extensions` 的不进链、不进服务表（引擎默认除外）。
 
-Current 独占槽只有 `environment` 与 `executor`。层 C 轨迹写入与盒内 evaluator 是引擎代码，不是可 export 的服务。
+Current 独占槽：`environment`、`executor`、`evaluation_runtime`、`trajectory_seal`。后两者默认是引擎（`plugin_id: default`）。PASS 仍只经 `bind_evaluation` 进入；`pass` / `identity` / `cleanup` / `evidence` 不准 export。
 
 ## 声明（形状）
 
@@ -82,7 +82,7 @@ agent_profiles:
 - `ageval plugin install` 只写 `~/.ageval/plugins`，永不改 profiles。
 - 按机制命名（`acp` / `docker` / `e2b` / `ssh` / `nooa`）。禁止按 bench 名。
 
-独占槽默认赢家（Current）：`environment` 由 job `environment:` 选出（缺省常见 local 或 docker，以 profiles 为准）；`executor` 由 `agent_profiles.*.executor` 选出（coding-agent 默认 acp）。
+独占槽默认赢家（Current）：`environment` 由 job `environment:` 选出（缺省常见 local 或 docker，以 profiles 为准）；`executor` 由 `agent_profiles.*.executor` 选出（coding-agent 默认 acp）；`evaluation_runtime` / `trajectory_seal` 由引擎 `plugin_id: default` 赢（盒内 `evaluator.py` / 层 C writer）。缺默认注册 → lock fail-closed。
 
 链默认：`after_environment_ready`（ACP 探测安装 + HOME overlay）；`environment_setup`（`setup.sh`，引擎 defaults）。
 
@@ -102,7 +102,7 @@ Resolve：显式 binding > 更低 priority 赢；并列且无显式挑选 → fa
 
 ## 包
 
-manifest：`ageval.plugin/1`。first-party：`src/ageval/plugins/contrib/{acp,docker,local,e2b,ssh,openai_http}`。引擎默认：`plugins/defaults`（`environment_setup`）。外置包在仓库根 `plugins/`（nooa、dsh、miniswe、home-files、agent-skills）。
+manifest：`ageval.plugin/1`。first-party：`src/ageval/plugins/contrib/{acp,docker,local,e2b,ssh,openai_http}`。引擎默认：`plugins/defaults`（`environment_setup`、`evaluation_runtime`、`trajectory_seal`）。外置包在仓库根 `plugins/`（nooa、dsh、miniswe、home-files、agent-skills）。
 
 Recognition（list/lock 认得）≠ 本机能跑 ≠ 镜像已 bake。缺 extra / 钥 → skip，不要假绿。
 

--- a/plugins/miniswe/README.md
+++ b/plugins/miniswe/README.md
@@ -2,21 +2,22 @@
 
 External `ageval.plugin/1`. **Not** first-party ageval core.
 
-Drives [mini-swe-agent](https://github.com/SWE-agent/mini-swe-agent) on the
-**parent host**. The Attempt container only runs `bash` via `docker exec`.
-This is **not** ACP. Name is the mechanism (`miniswe`), not a benchmark.
+Drives [mini-swe-agent](https://github.com/SWE-agent/mini-swe-agent) as a
+**host-loop**: the LLM client stays on the parent; every bash action goes
+through the injected `environment` service (`host.exec`). This is **not** ACP.
+Name is the mechanism (`miniswe`), not a benchmark.
 
 ```python
 from minisweagent.agents.default import DefaultAgent
 from minisweagent.models.litellm_model import LitellmModel
 
-agent = DefaultAgent(LitellmModel(model_name=...), env)
+agent = DefaultAgent(LitellmModel(model_name=...), env)  # env calls host.exec
 agent.run(prompt)
 ```
 
-L0: `env` is a local subprocess. L1: `bind_to_target` swaps in docker exec
-against the Core-owned container (uid / workdir from `TargetPlacement`).
-Model HTTP stays on the parent, so `provider.network: none` can still invoke.
+A kind that cannot `exec` fails at `ageval lock`, not mid-invoke. Model HTTP
+stays on the parent. Credentials are locators projected into the parent HTTP
+client; they never enter the lock.
 
 ## Install
 
@@ -31,7 +32,8 @@ Install updates `$AGEVAL_HOME/plugins` only — never edits package yaml.
 
 ```yaml
 format: ageval.profiles/1
-bindings:
+environment: docker
+agent_profiles:
   solver:
     executor: miniswe
     extensions:
@@ -40,6 +42,7 @@ bindings:
           step_limit: 30          # 0 = unlimited
           cost_limit: 0           # 0 = unlimited
           cmd_timeout: 30
+      - plugin: docker
     model: openai/glm-5.2
     api_key: ${litellm_api_key}
     base_url: ${litellm_base_url}
@@ -49,11 +52,6 @@ Same harness: `Agent.session(...).invoke`. Switch with `--profiles`.
 
 ## Slots
 
-`provide(executor)` + `on: image_contribute` + `on: trajectory_collect`.
-Bake is nearly a no-op (bash already on `ageval-attempt:l1`) but the file is
-required for L1 bind. PASS stays the package evaluator.
-
-## Evidence
-
-`backend_raw/miniswe.json` is vendor-native. Layer B events use
-`source: miniswe`. Do not claim `isolated` or anti-contamination from install.
+Exclusive `executor` plus `inject: environment` with `exec`. `trajectory_collect`
+maps this plugin's events. `config.image_layers` is bake input for the
+environment winner, not a timeline slot. PASS stays the package evaluator.

--- a/plugins/miniswe/docker/Dockerfile.bake
+++ b/plugins/miniswe/docker/Dockerfile.bake
@@ -1,5 +1,5 @@
 # miniswe loop stays on the host. Attempt image only needs bash (already on
-# ageval-attempt:l1). Bake file is required for L1 bind of an external executor.
+# ageval-attempt:base). This file is bake input for the environment winner.
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 USER ageval

--- a/plugins/miniswe/plugin.yaml
+++ b/plugins/miniswe/plugin.yaml
@@ -13,5 +13,8 @@ slots:
     - id: trajectory_collect
       priority: 110
       entry: "miniswe_plugin.hooks:trajectory_collect"
+inject:
+  - service: environment
+    capabilities: [exec]
 config:
   image_layers: docker/Dockerfile.bake

--- a/plugins/miniswe/src/miniswe_plugin/env.py
+++ b/plugins/miniswe/src/miniswe_plugin/env.py
@@ -1,39 +1,21 @@
-"""Bash environments for mini-swe-agent.
-
-L0 runs on the host. L1 execs into a Core-owned container — this module
-never starts or stops Docker containers.
-"""
+"""Bash environment for mini-swe-agent, via the injected environment Protocol."""
 
 from __future__ import annotations
 
-import os
-import platform
-import subprocess
+import asyncio
 from typing import Any
 
 SUBMIT_MARK = "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT"
 
 
-def build_docker_exec_argv(
-    *,
-    container_id: str,
-    command: str,
-    uid: int,
-    gid: int,
-    workdir: str,
-) -> list[str]:
-    return [
-        "docker",
-        "exec",
-        "-u",
-        f"{uid}:{gid}",
-        "-w",
-        workdir,
-        container_id,
-        "bash",
-        "-lc",
-        command,
-    ]
+def _run_host_exec(host: Any, command: list[str], **kwargs: Any) -> Any:
+    """Run ``host.exec`` from the mini-swe-agent thread (no running loop there)."""
+    coro = host.exec(command, **kwargs)
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    raise RuntimeError("miniswe env.execute cannot call host.exec on a running event loop")
 
 
 def _check_submitted(output: dict[str, Any]) -> None:
@@ -56,109 +38,35 @@ def _check_submitted(output: dict[str, Any]) -> None:
     )
 
 
-class LocalBashEnv:
-    """Host subprocess bash. Duck-types minisweagent.Environment."""
+class ProtocolEnv:
+    """Duck-types minisweagent.Environment; every bash action is ``host.exec``."""
 
-    def __init__(self, *, cwd: str, timeout: int = 30) -> None:
-        self.cwd = cwd
+    def __init__(self, *, host: Any, placement: Any, timeout: int = 30) -> None:
+        self.host = host
+        self.placement = placement
         self.timeout = timeout
-        self.config = type("Cfg", (), {"cwd": cwd, "timeout": timeout})()
-
-    def execute(self, action: dict, cwd: str = "", *, timeout: int | None = None) -> dict[str, Any]:
-        command = str(action.get("command") or "")
-        work = cwd or self.cwd or os.getcwd()
-        try:
-            proc = subprocess.run(
-                command,
-                shell=True,
-                text=True,
-                cwd=work,
-                encoding="utf-8",
-                errors="replace",
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                timeout=timeout or self.timeout,
-            )
-            out: dict[str, Any] = {
-                "output": proc.stdout or "",
-                "returncode": proc.returncode,
-                "exception_info": "",
-            }
-        except Exception as exc:  # noqa: BLE001
-            out = {
-                "output": "",
-                "returncode": -1,
-                "exception_info": f"{type(exc).__name__}:{exc}",
-            }
-        _check_submitted(out)
-        return out
-
-    def get_template_vars(self, **kwargs: Any) -> dict[str, Any]:
-        u = platform.uname()
-        return {
-            "system": u.system,
-            "release": u.release,
-            "version": u.version,
-            "machine": u.machine,
-            **kwargs,
-        }
-
-    def serialize(self) -> dict[str, Any]:
-        return {
-            "info": {
-                "config": {
-                    "environment": {"cwd": self.cwd, "kind": "local"},
-                    "environment_type": "miniswe_plugin.env.LocalBashEnv",
-                }
-            }
-        }
-
-
-class DockerExecEnv:
-    """docker exec into a Runtime-owned Attempt container."""
-
-    def __init__(
-        self,
-        *,
-        container_id: str,
-        uid: int,
-        gid: int,
-        workdir: str,
-        timeout: int = 30,
-    ) -> None:
-        self.container_id = container_id
-        self.uid = uid
-        self.gid = gid
-        self.workdir = workdir
-        self.timeout = timeout
-        self.config = type("Cfg", (), {"cwd": workdir, "timeout": timeout})()
+        self.workdir = str(getattr(placement, "workdir", None) or "/attempt/workspace")
+        self.user = getattr(placement, "user", None)
+        self.config = type("Cfg", (), {"cwd": self.workdir, "timeout": timeout})()
 
     def execute(self, action: dict, cwd: str = "", *, timeout: int | None = None) -> dict[str, Any]:
         command = str(action.get("command") or "")
         work = cwd or self.workdir
-        argv = build_docker_exec_argv(
-            container_id=self.container_id,
-            command=command,
-            uid=self.uid,
-            gid=self.gid,
-            workdir=work,
-        )
+        kwargs: dict[str, Any] = {
+            "cwd": work,
+            "timeout_sec": float(timeout or self.timeout),
+        }
+        if self.user:
+            kwargs["user"] = self.user
         try:
-            proc = subprocess.run(
-                argv,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                timeout=timeout or self.timeout,
-            )
+            result = _run_host_exec(self.host, ["bash", "-lc", command], **kwargs)
+            output = f"{result.stdout or ''}{result.stderr or ''}"
             out: dict[str, Any] = {
-                "output": proc.stdout or "",
-                "returncode": proc.returncode,
+                "output": output,
+                "returncode": int(result.exit_code),
                 "exception_info": "",
             }
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001 — surface to the agent as a failed command
             out = {
                 "output": "",
                 "returncode": -1,
@@ -170,10 +78,9 @@ class DockerExecEnv:
     def get_template_vars(self, **kwargs: Any) -> dict[str, Any]:
         return {
             "system": "Linux",
-            "release": "container",
-            "version": "l1",
-            "machine": "x86_64",
-            "container_id": self.container_id,
+            "release": "attempt",
+            "version": "",
+            "machine": "",
             **kwargs,
         }
 
@@ -182,11 +89,10 @@ class DockerExecEnv:
             "info": {
                 "config": {
                     "environment": {
-                        "kind": "docker_exec",
-                        "container_id": self.container_id,
+                        "kind": getattr(self.host, "kind", None),
                         "workdir": self.workdir,
                     },
-                    "environment_type": "miniswe_plugin.env.DockerExecEnv",
+                    "environment_type": "miniswe_plugin.env.ProtocolEnv",
                 }
             }
         }

--- a/plugins/miniswe/src/miniswe_plugin/factory.py
+++ b/plugins/miniswe/src/miniswe_plugin/factory.py
@@ -1,4 +1,4 @@
-"""miniswe ExecutorSPI — host mini-swe-agent loop, bash via local or docker exec."""
+"""miniswe ExecutorSPI — host mini-swe-agent loop, bash via environment.exec."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ from typing import Any
 from ageval.plugins.agent_result import AgentResult, parse_validated_text_structured
 from ageval.plugins.errors import ExtensionMaterializeError
 from miniswe_plugin import PLUGIN_ID
-from miniswe_plugin.env import DockerExecEnv, LocalBashEnv
+from miniswe_plugin.env import ProtocolEnv
 from miniswe_plugin.trajectory import to_ageval_trajectory_events
 
 _CREDENTIAL_ENV_NAMES = ("OPENAI_API_KEY", "litellm_api_key", "LITELLM_API_KEY")
@@ -169,29 +169,30 @@ class MinisweExecutorSPI:
     def __init__(
         self,
         *,
+        host: Any,
+        placement: Any,
         options: dict[str, Any] | None = None,
         profile_id: str | None = None,
         model: str | None = None,
         base_url: str | None = None,
         api_key: str | None = None,
         plugin_id: str | None = None,
-        workdir: str | None = None,
         **_kwargs: Any,
     ) -> None:
         del plugin_id
         opts = dict(options or {})
+        self.host = host
+        self.placement = placement
         self.options = opts
         self.profile_id = profile_id
         self.model = (model or "").strip() or "openai/gpt-4o-mini"
         self.base_url = base_url if isinstance(base_url, str) else None
         self.api_key_env = api_key if isinstance(api_key, str) else None
-        self.default_workdir = str(workdir).strip() if workdir else None
         self.step_limit = _as_positive_int(opts.get("step_limit"), name="step_limit", default=30)
         self.cost_limit = _as_nonneg_float(opts.get("cost_limit"), name="cost_limit", default=0.0)
         self.cmd_timeout = _as_positive_int(opts.get("cmd_timeout"), name="cmd_timeout", default=30)
         self.session_id = f"ageval-{self.profile_id or 'solver'}-{uuid.uuid4().hex[:12]}"
-        self._placement: Any | None = None
-        self.execution_location = "host"
+        self.execution_location = getattr(host, "kind", None) or "box"
         self._ready = False
 
     @staticmethod
@@ -219,7 +220,7 @@ class MinisweExecutorSPI:
         collect_dir: str | None = None,
         redaction_sentinels: tuple[str, ...] | list[str] | None = None,
     ) -> AgentResult:
-        del redaction_sentinels
+        del redaction_sentinels, workdir
         if _offline():
             return AgentResult(
                 model=self.model,
@@ -230,9 +231,7 @@ class MinisweExecutorSPI:
                 metadata={"plugin": PLUGIN_ID},
             )
         try:
-            extra = self._run_agent(
-                prompt, timeout=timeout, workdir=workdir or self.default_workdir
-            )
+            extra = self._run_agent(prompt, timeout=timeout)
         except ExtensionMaterializeError as exc:
             return AgentResult(
                 model=self.model,
@@ -266,7 +265,7 @@ class MinisweExecutorSPI:
         submission = str(extra.get("submission") or extra.get("exit_content") or "")
         status = str(extra.get("exit_status") or "")
         ok = status == "Submitted"
-        location = "attempt-container" if self._placement is not None else "host"
+        location = self.execution_location
         return AgentResult(
             model=self.model,
             text=submission,
@@ -284,20 +283,10 @@ class MinisweExecutorSPI:
             },
         )
 
-    def _make_env(self, workdir: str | None) -> LocalBashEnv | DockerExecEnv:
-        cwd = str(Path(workdir or Path.cwd()).expanduser().resolve(strict=False))
-        place = self._placement
-        if place is None:
-            return LocalBashEnv(cwd=cwd, timeout=self.cmd_timeout)
-        return DockerExecEnv(
-            container_id=str(place.container_id),
-            uid=int(place.uid),
-            gid=int(place.gid),
-            workdir=str(getattr(place, "workdir", None) or "/attempt/workspace"),
-            timeout=self.cmd_timeout,
-        )
+    def _make_env(self) -> ProtocolEnv:
+        return ProtocolEnv(host=self.host, placement=self.placement, timeout=self.cmd_timeout)
 
-    def _run_agent(self, prompt: str, *, timeout: float, workdir: str | None) -> dict[str, Any]:
+    def _run_agent(self, prompt: str, *, timeout: float) -> dict[str, Any]:
         try:
             from minisweagent.agents.default import DefaultAgent
             from minisweagent.models.litellm_model import LitellmModel
@@ -330,7 +319,7 @@ class MinisweExecutorSPI:
             **({} if not obs else {"observation_template": obs}),
             **({} if not fmt else {"format_error_template": fmt}),
         )
-        env = self._make_env(workdir)
+        env = self._make_env()
         system_template = str(agent_cfg.get("system_template") or "")
         instance_template = str(agent_cfg.get("instance_template") or "")
         if not system_template or not instance_template:
@@ -372,6 +361,25 @@ class MinisweExecutorSPI:
                 raise TimeoutError("miniswe_timeout") from exc
 
 
-def build_executor(**kwargs: Any) -> MinisweExecutorSPI:
-    """plugin.yaml provide entry."""
-    return MinisweExecutorSPI(**kwargs)
+def build_executor(
+    *,
+    host: Any,
+    placement: Any,
+    options: dict[str, Any] | None = None,
+    profile_id: str | None = None,
+    model: str | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    package_root: str | None = None,
+) -> MinisweExecutorSPI:
+    """plugin.yaml exclusive entry: factory receives host + placement from bind_winner."""
+    del package_root
+    return MinisweExecutorSPI(
+        host=host,
+        placement=placement,
+        options=options,
+        profile_id=profile_id,
+        model=model,
+        base_url=base_url,
+        api_key=api_key,
+    )

--- a/skills/ageval-plugin/SKILL.md
+++ b/skills/ageval-plugin/SKILL.md
@@ -12,7 +12,7 @@ Host declares slots in `src/ageval/plugins/slots.py`. Plugins fill them.
 
 | Kind | Meaning | Examples |
 | --- | --- | --- |
-| exclusive | One winner = same-name service | `environment`, `executor` |
+| exclusive | One winner = same-name service | `environment`, `executor`, `evaluation_runtime`, `trajectory_seal` |
 | chain | `(ctx, value, nxt)` | `after_environment_ready`, `environment_setup`, `trajectory_collect` |
 
 `ageval plugin install` writes `~/.ageval/plugins` only. Never rewrites profiles.

--- a/skills/ageval-plugin/references/authoring.md
+++ b/skills/ageval-plugin/references/authoring.md
@@ -71,7 +71,7 @@ credential_env_names, binary
 ## Trajectory
 
 Layer B: each event row has `schema: ageval.trajectory.event/1`, `source` = this plugin id, `session_id`.
-Layer C: only Core writes `trajectory.jsonl`. Plugins must not emit layer-C rows.
+Layer C: the `trajectory_seal` winner writes `trajectory.jsonl` (engine default). Plugins must not emit layer-C rows unless they won that slot.
 
 `trajectory_collect` may map **this** plugin's vendor dump into layer B.
 Never stamp `trajectory_source` onto another plugin's `source`. Never emit ACP `session_update`.

--- a/skills/ageval-plugin/references/mechanism.md
+++ b/skills/ageval-plugin/references/mechanism.md
@@ -17,7 +17,9 @@ Do not revive the deleted `ageval.agent_executors` entry-point bypass.
 
 ## Slots
 
-Ids live in `src/ageval/plugins/slots.py`. Exclusive: `environment`, `executor`. Chain: environment ready/setup, run bookends, agent open/invoke/close, evaluate bookends, `trajectory_collect` / `trajectory_enrich`, `cleanup_report`.
+Ids live in `src/ageval/plugins/slots.py`. Exclusive: `environment`, `executor`, `evaluation_runtime`, `trajectory_seal`. Chain: environment ready/setup, run bookends, agent open/invoke/close, evaluate bookends, `trajectory_collect` / `trajectory_enrich`, `cleanup_report`.
+
+`evaluation_runtime` / `trajectory_seal` have engine defaults (`plugin_id: default`). No job-field sugar; replace only with an explicit `extensions` row. PASS still enters only through `bind_evaluation`.
 
 A public slot must have a production emit, or design / ARCHITECTURE must mark it non-public. No silent dead SPI.
 
@@ -27,7 +29,7 @@ Agent emit chain:
 open_session → pin graph → before/after_agent_open
 invoke       → before_agent_invoke → executor.invoke → after_agent_invoke
              → normalize_agent_result
-record       → trajectory_collect → enrich → Core writes trajectory.jsonl
+record       → trajectory_collect → enrich → trajectory_seal writes trajectory.jsonl
 close        → before_agent_close → executor.close → after_agent_close
 ```
 

--- a/src/ageval/application/run.py
+++ b/src/ageval/application/run.py
@@ -184,6 +184,7 @@ async def run_attempt(
         lock=lock,
         profile_id=profile_id,
         bindings=graph,
+        registry=registry,
         services=services,
         host=host,
         evidence=evidence,

--- a/src/ageval/attempt/ctx.py
+++ b/src/ageval/attempt/ctx.py
@@ -15,6 +15,7 @@ from typing import Any
 from ageval.config.model import LockedTaskConfig
 from ageval.environments.protocol import EnvironmentProvider
 from ageval.plugins.protocol import ExtensionGraph
+from ageval.plugins.registry import ExtensionRegistry
 from ageval.plugins.services import ServiceTable
 from ageval.runtime.cancellation import CancellationSignal
 
@@ -42,6 +43,7 @@ class AttemptCtx:
     lock: LockedTaskConfig
     profile_id: str
     bindings: ExtensionGraph
+    registry: ExtensionRegistry
     services: ServiceTable
     host: EnvironmentProvider
     evidence: Any

--- a/src/ageval/attempt/phases/evaluate.py
+++ b/src/ageval/attempt/phases/evaluate.py
@@ -3,6 +3,7 @@
 Gold isolation here is a cut in *time*, not a mount trick: ``evaluation/`` is
 uploaded at the start of this phase, so nothing the Agent could read ever had it
 on disk. The verdict enters the Attempt exactly once, via ``bind_evaluation``.
+The ``evaluation_runtime`` winner returns raw; it does not bind PASS.
 """
 
 from __future__ import annotations
@@ -10,7 +11,8 @@ from __future__ import annotations
 from ageval.attempt.ctx import AttemptCtx
 from ageval.attempt.emit import emit
 from ageval.environments.protocol import ARTIFACTS_PATH, EVALUATION_PATH
-from ageval.plugins.slots import AFTER_EVALUATE, BEFORE_EVALUATE
+from ageval.plugins.binding import bind_winner
+from ageval.plugins.slots import AFTER_EVALUATE, BEFORE_EVALUATE, EVALUATION_RUNTIME
 
 PHASE = "evaluate"
 
@@ -23,7 +25,10 @@ async def run(ctx: AttemptCtx) -> None:
     if ctx.evaluation_src is not None and ctx.evaluation_src.is_dir():
         await ctx.host.upload(ctx.evaluation_src, EVALUATION_PATH)
         ctx.record_fact("gold_materialized", {"at": PHASE})
-    result = await _evaluate(ctx)
+    impl = bind_winner(ctx.registry, ctx.bindings, EVALUATION_RUNTIME)
+    plugin_id = ctx.bindings.winners[EVALUATION_RUNTIME].plugin_id
+    ctx.services.register(EVALUATION_RUNTIME, impl, plugin_id=plugin_id)
+    result = await impl.evaluate(ctx)
     ctx.bind_evaluation(result)
     # Post-processing may annotate metrics; it may not change the verdict.
     status_before = str((result or {}).get("status") or "")
@@ -38,9 +43,3 @@ async def _upload_task_artifacts(ctx: AttemptCtx) -> None:
     if staged.is_dir() and any(staged.iterdir()):
         await ctx.host.upload(staged, ARTIFACTS_PATH)
         ctx.record_fact("artifacts_materialized", {"at": PHASE})
-
-
-async def _evaluate(ctx: AttemptCtx) -> dict[str, object]:
-    from ageval.evaluation.package_evaluator import evaluate_in_box
-
-    return await evaluate_in_box(ctx)

--- a/src/ageval/attempt/phases/record.py
+++ b/src/ageval/attempt/phases/record.py
@@ -1,8 +1,7 @@
-"""record phase: collect, enrich, then the engine writes the trajectory.
+"""record phase: collect, enrich, then the seal winner writes the trajectory.
 
-Plugins may shape each turn's payload; only the engine writes the file, so a
-plugin cannot quietly become the author of evidence. Both chains are fail-open:
-a trajectory is observational, and losing shaping must not lose the Attempt.
+Plugins may shape each turn's payload; the ``trajectory_seal`` winner writes
+the file. Collect/enrich are fail-open; losing the sealed file fails the phase.
 """
 
 from __future__ import annotations
@@ -12,8 +11,9 @@ from typing import Any
 from ageval.attempt.ctx import AttemptCtx
 from ageval.attempt.emit import emit
 from ageval.evidence.invocation import read_invocation_payload
-from ageval.evidence.trajectory import turn_rows, write_attempt_trajectory
-from ageval.plugins.slots import TRAJECTORY_COLLECT, TRAJECTORY_ENRICH
+from ageval.evidence.trajectory import turn_rows
+from ageval.plugins.binding import bind_winner
+from ageval.plugins.slots import TRAJECTORY_COLLECT, TRAJECTORY_ENRICH, TRAJECTORY_SEAL
 
 PHASE = "record"
 
@@ -26,11 +26,12 @@ async def run(ctx: AttemptCtx) -> None:
         shaped = await emit(ctx, TRAJECTORY_COLLECT, payload)
         shaped = await emit(ctx, TRAJECTORY_ENRICH, shaped)
         turns.append(turn_rows(**_fields(shaped, payload)))
-    path = write_attempt_trajectory(
-        ctx.evidence.root,
-        turns,
-        redaction_sentinels=ctx.evidence.sentinels,
-    )
+    impl = bind_winner(ctx.registry, ctx.bindings, TRAJECTORY_SEAL)
+    plugin_id = ctx.bindings.winners[TRAJECTORY_SEAL].plugin_id
+    ctx.services.register(TRAJECTORY_SEAL, impl, plugin_id=plugin_id)
+    path = impl.seal(ctx, turns)
+    if not path.is_file():
+        raise RuntimeError("trajectory_seal did not write the trajectory file")
     ctx.record_fact("trajectory_recorded", {"turns": len(turns), "file": path.name})
 
 

--- a/src/ageval/evidence/trajectory.py
+++ b/src/ageval/evidence/trajectory.py
@@ -27,8 +27,9 @@ def write_attempt_trajectory(
 ) -> Path:
     """Write the Attempt trajectory: every turn's rows, in invocation order.
 
-    The engine is the only writer of this file. Plugins shape the payloads that
-    produced *turns*; they never author the evidence.
+    The ``trajectory_seal`` winner writes this file; the engine default is this
+    function. Plugins on collect/enrich shape the payloads that produced
+    *turns*; they are not the author of the sealed evidence.
     """
     from ageval.evidence.redaction import redact_value
 

--- a/src/ageval/plugins/defaults/__init__.py
+++ b/src/ageval/plugins/defaults/__init__.py
@@ -1,7 +1,9 @@
 """Engine default contributions.
 
-Only two things are defaults: recognizing ``environment/setup.sh`` and nothing
-else. There is deliberately no pass-through handler registered on every chain —
+Chain: recognize ``environment/setup.sh``.
+Exclusive: in-box evaluator launch and layer-C trajectory write.
+
+There is deliberately no pass-through handler registered on every chain —
 an empty chain already means "nothing to do", and filling the lock with no-op
 rows hides which plugin actually acts.
 """
@@ -12,8 +14,10 @@ from ageval.plugins.defaults.environment_setup import (
     SETUP_PRIORITY,
     default_environment_setup,
 )
+from ageval.plugins.defaults.evaluation_runtime import build_evaluation_runtime
+from ageval.plugins.defaults.trajectory_seal import build_trajectory_seal
 from ageval.plugins.registry import ExtensionRegistry
-from ageval.plugins.slots import ENVIRONMENT_SETUP
+from ageval.plugins.slots import ENVIRONMENT_SETUP, EVALUATION_RUNTIME, TRAJECTORY_SEAL
 
 PLUGIN_ID = "default"
 
@@ -26,6 +30,22 @@ def register_defaults(registry: ExtensionRegistry) -> None:
         priority=SETUP_PRIORITY,
         source="default",
         is_default=True,
+    )
+    registry.exclusive(
+        EVALUATION_RUNTIME,
+        PLUGIN_ID,
+        build_evaluation_runtime,
+        source="default",
+        is_default=True,
+        is_factory=True,
+    )
+    registry.exclusive(
+        TRAJECTORY_SEAL,
+        PLUGIN_ID,
+        build_trajectory_seal,
+        source="default",
+        is_default=True,
+        is_factory=True,
     )
 
 

--- a/src/ageval/plugins/defaults/evaluation_runtime.py
+++ b/src/ageval/plugins/defaults/evaluation_runtime.py
@@ -1,0 +1,21 @@
+"""Default ``evaluation_runtime``: run the task evaluator inside the box."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class DefaultEvaluationRuntime:
+    """Today's in-box ``evaluator.py`` via ``host.exec``. Returns raw; does not bind."""
+
+    async def evaluate(self, ctx: Any) -> dict[str, Any]:
+        from ageval.evaluation.package_evaluator import evaluate_in_box
+
+        return await evaluate_in_box(ctx)
+
+
+def build_evaluation_runtime(
+    *, options: dict[str, Any] | None = None, **_kwargs: Any
+) -> DefaultEvaluationRuntime:
+    del options
+    return DefaultEvaluationRuntime()

--- a/src/ageval/plugins/defaults/trajectory_seal.py
+++ b/src/ageval/plugins/defaults/trajectory_seal.py
@@ -1,0 +1,26 @@
+"""Default ``trajectory_seal``: write engine-authored layer C ``trajectory.jsonl``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+class DefaultTrajectorySeal:
+    """Today's ``write_attempt_trajectory``. Observational — never PASS."""
+
+    def seal(self, ctx: Any, turns: list[list[dict[str, Any]]]) -> Path:
+        from ageval.evidence.trajectory import write_attempt_trajectory
+
+        return write_attempt_trajectory(
+            ctx.evidence.root,
+            turns,
+            redaction_sentinels=ctx.evidence.sentinels,
+        )
+
+
+def build_trajectory_seal(
+    *, options: dict[str, Any] | None = None, **_kwargs: Any
+) -> DefaultTrajectorySeal:
+    del options
+    return DefaultTrajectorySeal()

--- a/src/ageval/plugins/protocol.py
+++ b/src/ageval/plugins/protocol.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 
@@ -34,6 +35,24 @@ class ExecutorSPI(Protocol):
     def close(self) -> None:
         """Release process / session resources."""
         ...
+
+
+@runtime_checkable
+class EvaluationRuntimeSPI(Protocol):
+    """Exclusive slot ``evaluation_runtime``: launch the evaluator, return raw.
+
+    Must not call ``bind_evaluation``. PASS enters only when the evaluate
+    phase binds the returned document.
+    """
+
+    async def evaluate(self, ctx: Any) -> dict[str, Any]: ...
+
+
+@runtime_checkable
+class TrajectorySealSPI(Protocol):
+    """Exclusive slot ``trajectory_seal``: author layer C ``trajectory.jsonl``."""
+
+    def seal(self, ctx: Any, turns: list[list[dict[str, Any]]]) -> Path: ...
 
 
 # Chain middleware: async (ctx, value, next) -> value

--- a/src/ageval/plugins/registry.py
+++ b/src/ageval/plugins/registry.py
@@ -112,6 +112,15 @@ class ExtensionRegistry:
         sid = service_id.strip()
         if not sid:
             raise UnknownExtensionSlotError("service id required", kind="service_not_found")
+        from ageval.plugins.services import RESERVED_SERVICE_IDS
+
+        if sid in RESERVED_SERVICE_IDS:
+            from ageval.plugins.errors import ServiceConflictError
+
+            raise ServiceConflictError(
+                f"service {sid!r} is an engine invariant and cannot be provided by a plugin",
+                kind="service_conflict",
+            )
         if is_slot(sid):
             from ageval.plugins.errors import ServiceConflictError
 

--- a/src/ageval/plugins/resolve.py
+++ b/src/ageval/plugins/resolve.py
@@ -32,6 +32,7 @@ from ageval.plugins.slots import (
     ALL_SLOTS,
     ENVIRONMENT,
     EXECUTOR,
+    REQUIRED_EXCLUSIVE_SLOTS,
     SlotKind,
     get_slot_kind,
     is_slot,
@@ -142,6 +143,11 @@ def _resolve_exclusive(
         # No job field and no explicit row: only a registered default may win.
         candidates = [c for c in candidates if c.is_default]
         if not candidates:
+            if slot in REQUIRED_EXCLUSIVE_SLOTS:
+                raise ExtensionPluginNotFoundError(
+                    f"no plugin fills exclusive slot {slot!r}",
+                    kind="extension_plugin_not_found",
+                )
             return
     winner = pick_one(candidates, explicit, slot=slot)
     reg = winner.impl

--- a/src/ageval/plugins/slots.py
+++ b/src/ageval/plugins/slots.py
@@ -25,6 +25,8 @@ class SlotKind(StrEnum):
 # --- exclusive slots (winner is also a service) ---
 ENVIRONMENT: Final = "environment"
 EXECUTOR: Final = "executor"
+EVALUATION_RUNTIME: Final = "evaluation_runtime"
+TRAJECTORY_SEAL: Final = "trajectory_seal"
 
 # --- environment phase chain ---
 BEFORE_ENVIRONMENT: Final = "before_environment"
@@ -60,6 +62,8 @@ DEFAULT_PRIORITY: Final = 1000
 _SLOT_KINDS: Final[dict[str, SlotKind]] = {
     ENVIRONMENT: SlotKind.EXCLUSIVE,
     EXECUTOR: SlotKind.EXCLUSIVE,
+    EVALUATION_RUNTIME: SlotKind.EXCLUSIVE,
+    TRAJECTORY_SEAL: SlotKind.EXCLUSIVE,
     BEFORE_ENVIRONMENT: SlotKind.CHAIN,
     AFTER_ENVIRONMENT_READY: SlotKind.CHAIN,
     ENVIRONMENT_SETUP: SlotKind.CHAIN,
@@ -83,6 +87,12 @@ _SLOT_KINDS: Final[dict[str, SlotKind]] = {
 ALL_SLOTS: Final[tuple[str, ...]] = tuple(_SLOT_KINDS)
 EXCLUSIVE_SLOTS: Final[tuple[str, ...]] = tuple(
     s for s, k in _SLOT_KINDS.items() if k is SlotKind.EXCLUSIVE
+)
+
+# Must have a winner at lock even with no job field. ``environment`` /
+# ``executor`` are selected by sugar; these two are engine defaults.
+REQUIRED_EXCLUSIVE_SLOTS: Final[frozenset[str]] = frozenset(
+    {EVALUATION_RUNTIME, TRAJECTORY_SEAL}
 )
 
 # Chain slots whose handler failure is recorded and stepped over. Everything

--- a/src/ageval/plugins/slots.py
+++ b/src/ageval/plugins/slots.py
@@ -91,9 +91,7 @@ EXCLUSIVE_SLOTS: Final[tuple[str, ...]] = tuple(
 
 # Must have a winner at lock even with no job field. ``environment`` /
 # ``executor`` are selected by sugar; these two are engine defaults.
-REQUIRED_EXCLUSIVE_SLOTS: Final[frozenset[str]] = frozenset(
-    {EVALUATION_RUNTIME, TRAJECTORY_SEAL}
-)
+REQUIRED_EXCLUSIVE_SLOTS: Final[frozenset[str]] = frozenset({EVALUATION_RUNTIME, TRAJECTORY_SEAL})
 
 # Chain slots whose handler failure is recorded and stepped over. Everything
 # else fails its phase.

--- a/tests/attempt/test_eval_seal_phases.py
+++ b/tests/attempt/test_eval_seal_phases.py
@@ -1,0 +1,197 @@
+"""Evaluate/record phases bind exclusive winners; PASS still only via bind_evaluation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ageval.attempt.ctx import AttemptCtx
+from ageval.attempt.phases import evaluate, record
+from ageval.environments.protocol import EVALUATION_PATH
+from ageval.evidence.store import AttemptEvidenceStore
+from ageval.plugins.defaults import register_defaults
+from ageval.plugins.protocol import BindingIntent, ExplicitBinding, HandlerRef
+from ageval.plugins.registry import ExtensionRegistry
+from ageval.plugins.resolve import resolve
+from ageval.plugins.services import ServiceTable
+from ageval.plugins.slots import (
+    AFTER_EVALUATE,
+    EVALUATION_RUNTIME,
+    TRAJECTORY_COLLECT,
+    TRAJECTORY_SEAL,
+)
+from ageval.runtime.cancellation import CancellationSignal
+
+
+class RecordingHost:
+    def __init__(self) -> None:
+        self.uploads: list[tuple[Path, str]] = []
+
+    async def upload(self, source: Path, dest: str) -> None:
+        self.uploads.append((Path(source), str(dest)))
+
+
+class RawPassRuntime:
+    async def evaluate(self, ctx: Any) -> dict[str, Any]:
+        del ctx
+        return {"status": "PASS", "score": 1}
+
+
+class ProbeSeal:
+    def __init__(self, order: list[str]) -> None:
+        self.order = order
+
+    def seal(self, ctx: Any, turns: list[list[dict[str, Any]]]) -> Path:
+        self.order.append("seal")
+        path = ctx.evidence.root / "trajectory.jsonl"
+        path.write_text(f'{{"turns": {len(turns)}, "probe": true}}\n', encoding="utf-8")
+        return path
+
+
+def _registry_with_runtime() -> ExtensionRegistry:
+    registry = ExtensionRegistry()
+    register_defaults(registry)
+    registry.exclusive(
+        EVALUATION_RUNTIME,
+        "probe",
+        lambda **_kwargs: RawPassRuntime(),
+        source="test",
+        is_factory=True,
+    )
+    return registry
+
+
+def _ctx(
+    tmp_path: Path,
+    *,
+    registry: ExtensionRegistry,
+    graph: Any,
+    host: Any | None = None,
+    evaluation_src: Path | None = None,
+) -> AttemptCtx:
+    store = AttemptEvidenceStore(root=tmp_path / "run", attempt_id="a", run_id="r")
+    ctx = AttemptCtx(
+        run_id="r",
+        trial_id="t",
+        attempt_id="a",
+        lock=None,  # type: ignore[arg-type]
+        profile_id="solver",
+        bindings=graph,
+        registry=registry,
+        services=ServiceTable(),
+        host=host or RecordingHost(),  # type: ignore[arg-type]
+        evidence=store,
+        cancellation=CancellationSignal(),
+        task_root=tmp_path,
+        dataset_root=tmp_path,
+        evaluation_src=evaluation_src,
+    )
+    ctx.mark_writers_stopped()
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_runtime_return_is_not_a_bound_pass(tmp_path: Path) -> None:
+    registry = _registry_with_runtime()
+    graph = resolve(
+        BindingIntent(
+            profile_id="solver",
+            extensions=[ExplicitBinding(slot=EVALUATION_RUNTIME, plugin="probe")],
+        ),
+        registry,
+    )
+    ctx = _ctx(tmp_path, registry=registry, graph=graph)
+    ctx.phase = "evaluate"
+    raw = await RawPassRuntime().evaluate(ctx)
+    assert raw["status"] == "PASS"
+    assert ctx.evaluation_result is None
+
+
+@pytest.mark.asyncio
+async def test_evaluate_phase_binds_winner_raw_and_uploads_gold(tmp_path: Path) -> None:
+    gold = tmp_path / "evaluation"
+    gold.mkdir()
+    (gold / "expected.txt").write_text("ok\n", encoding="utf-8")
+    registry = _registry_with_runtime()
+    graph = resolve(
+        BindingIntent(
+            profile_id="solver",
+            extensions=[ExplicitBinding(slot=EVALUATION_RUNTIME, plugin="probe")],
+        ),
+        registry,
+    )
+    host = RecordingHost()
+    ctx = _ctx(tmp_path, registry=registry, graph=graph, host=host, evaluation_src=gold)
+    await evaluate.run(ctx)
+    assert ctx.evaluation_result == {"status": "PASS", "score": 1}
+    assert ctx.services.owner(EVALUATION_RUNTIME) == "probe"
+    assert any(dest == EVALUATION_PATH for _src, dest in host.uploads)
+    assert any(f.name == "gold_materialized" and f.phase == "evaluate" for f in ctx.phase_facts)
+
+
+@pytest.mark.asyncio
+async def test_after_evaluate_cannot_change_status(tmp_path: Path) -> None:
+    async def flip_status(ctx: Any, value: Any, nxt: Any) -> Any:
+        del ctx
+        out = await nxt(value)
+        return {**out, "status": "FAIL"}
+
+    registry = _registry_with_runtime()
+    graph = resolve(
+        BindingIntent(
+            profile_id="solver",
+            extensions=[ExplicitBinding(slot=EVALUATION_RUNTIME, plugin="probe")],
+        ),
+        registry,
+    )
+    graph.chains[AFTER_EVALUATE] = [
+        HandlerRef(plugin_id="probe", handler=flip_status, priority=1, source="test")
+    ]
+    ctx = _ctx(tmp_path, registry=registry, graph=graph)
+    with pytest.raises(RuntimeError, match="after_evaluate must not change"):
+        await evaluate.run(ctx)
+    assert ctx.evaluation_result == {"status": "PASS", "score": 1}
+
+
+@pytest.mark.asyncio
+async def test_seal_winner_writes_after_collect(tmp_path: Path) -> None:
+    order: list[str] = []
+
+    async def collect(ctx: Any, value: Any, nxt: Any) -> Any:
+        del ctx
+        order.append("collect")
+        return await nxt(value)
+
+    registry = ExtensionRegistry()
+    register_defaults(registry)
+    registry.exclusive(
+        TRAJECTORY_SEAL,
+        "probe-seal",
+        lambda **_kwargs: ProbeSeal(order),
+        source="test",
+        is_factory=True,
+    )
+    graph = resolve(
+        BindingIntent(
+            profile_id="solver",
+            extensions=[ExplicitBinding(slot=TRAJECTORY_SEAL, plugin="probe-seal")],
+        ),
+        registry,
+    )
+    graph.chains[TRAJECTORY_COLLECT] = [
+        HandlerRef(plugin_id="probe", handler=collect, priority=1, source="test")
+    ]
+    ctx = _ctx(tmp_path, registry=registry, graph=graph)
+    inv = ctx.evidence.root / "agent" / "invocations" / "001"
+    inv.mkdir(parents=True)
+    (inv / "metadata.json").write_text('{"seq": 1, "status": "completed"}', encoding="utf-8")
+    (inv / "final-response.json").write_text('{"content": "hi"}', encoding="utf-8")
+    (inv / "request.json").write_text('{"messages": [{"content": "go"}]}', encoding="utf-8")
+    (inv / "events.jsonl").write_text("", encoding="utf-8")
+    await record.run(ctx)
+    assert order == ["collect", "seal"]
+    text = (ctx.evidence.root / "trajectory.jsonl").read_text(encoding="utf-8")
+    assert '"probe": true' in text
+    assert ctx.services.owner(TRAJECTORY_SEAL) == "probe-seal"

--- a/tests/plugins/test_dsh_box_executor.py
+++ b/tests/plugins/test_dsh_box_executor.py
@@ -12,6 +12,7 @@ import pytest
 from tests.helpers.box import local_box
 
 from ageval.environments.protocol import EnvironmentCapabilities
+from ageval.plugins.defaults import register_defaults
 from ageval.plugins.errors import ExtensionMaterializeError, InjectUnsatisfiedError
 from ageval.plugins.manifest import load_manifest
 from ageval.plugins.protocol import BindingIntent, InjectRequirement
@@ -80,6 +81,7 @@ def test_lock_fails_when_environment_cannot_exec() -> None:
         capabilities = EnvironmentCapabilities(upload=True)
 
     registry = ExtensionRegistry()
+    register_defaults(registry)
     registry.exclusive(ENVIRONMENT, "mute", MuteHost, source="test", is_factory=True)
     registry.exclusive(EXECUTOR, "dsh", build_executor, source="test", is_factory=True)
     registry.declare_inject(
@@ -97,6 +99,7 @@ def test_lock_records_inject_when_box_can_exec() -> None:
     from ageval.plugins.contrib.local.host import LocalHost
 
     registry = ExtensionRegistry()
+    register_defaults(registry)
     registry.exclusive(ENVIRONMENT, "local", LocalHost, source="test", is_factory=True)
     registry.exclusive(EXECUTOR, "dsh", build_executor, source="test", is_factory=True)
     registry.declare_inject(

--- a/tests/plugins/test_e2b_host_download.py
+++ b/tests/plugins/test_e2b_host_download.py
@@ -46,7 +46,7 @@ class FakeFiles:
     def read(self, path: str, format: str = "text") -> bytes | str:
         self.reads.append(path)
         payload = self.files[path]
-        return bytearray(payload) if format == "bytes" else payload.decode()
+        return bytes(payload) if format == "bytes" else payload.decode()
 
 
 class FakeSandbox:

--- a/tests/plugins/test_eval_seal_defaults.py
+++ b/tests/plugins/test_eval_seal_defaults.py
@@ -1,0 +1,61 @@
+"""Engine defaults win evaluation_runtime and trajectory_seal; lock fails closed without them."""
+
+from __future__ import annotations
+
+import pytest
+
+from ageval.plugins.defaults import PLUGIN_ID, register_defaults
+from ageval.plugins.errors import ExtensionPluginNotFoundError
+from ageval.plugins.protocol import BindingIntent
+from ageval.plugins.registry import ExtensionRegistry
+from ageval.plugins.resolve import _SUGAR_SLOTS, resolve
+from ageval.plugins.services import RESERVED_SERVICE_IDS
+from ageval.plugins.slots import (
+    EVALUATION_RUNTIME,
+    FAIL_OPEN_SLOTS,
+    TRAJECTORY_SEAL,
+)
+
+
+def test_sugar_slots_do_not_include_eval_or_seal() -> None:
+    assert EVALUATION_RUNTIME not in _SUGAR_SLOTS
+    assert TRAJECTORY_SEAL not in _SUGAR_SLOTS
+
+
+def test_eval_and_seal_are_fail_closed() -> None:
+    assert EVALUATION_RUNTIME not in FAIL_OPEN_SLOTS
+    assert TRAJECTORY_SEAL not in FAIL_OPEN_SLOTS
+
+
+def test_reserved_services_still_block_pass_identity_cleanup_evidence() -> None:
+    from ageval.plugins.errors import ServiceConflictError
+    from ageval.plugins.services import ServiceTable
+
+    assert frozenset({"pass", "identity", "cleanup", "evidence"}) == RESERVED_SERVICE_IDS
+    registry = ExtensionRegistry()
+    table = ServiceTable()
+    for name in RESERVED_SERVICE_IDS:
+        with pytest.raises(ServiceConflictError, match="engine invariant"):
+            registry.export_service(name, "probe", object())
+        with pytest.raises(ServiceConflictError, match="engine invariant"):
+            table.register(name, object(), plugin_id="probe")
+
+
+def test_defaults_win_eval_and_seal_without_explicit_row() -> None:
+    registry = ExtensionRegistry()
+    register_defaults(registry)
+    graph = resolve(BindingIntent(profile_id="solver"), registry)
+    runtime = graph.winners[EVALUATION_RUNTIME]
+    assert runtime.plugin_id == PLUGIN_ID
+    assert runtime.source == "default"
+    seal = graph.winners[TRAJECTORY_SEAL]
+    assert seal.plugin_id == PLUGIN_ID
+    assert seal.source == "default"
+    assert graph.services[EVALUATION_RUNTIME] == PLUGIN_ID
+    assert graph.services[TRAJECTORY_SEAL] == PLUGIN_ID
+
+
+def test_missing_default_registration_fails_closed() -> None:
+    registry = ExtensionRegistry()
+    with pytest.raises(ExtensionPluginNotFoundError, match="evaluation_runtime"):
+        resolve(BindingIntent(profile_id="solver"), registry)

--- a/tests/plugins/test_extension_bindings_lock.py
+++ b/tests/plugins/test_extension_bindings_lock.py
@@ -69,6 +69,20 @@ def test_lock_cli_extension_bindings_solver_acp() -> None:
     assert agent_profiles["solver"]["slots"]["executor"]["plugin"] == "acp"
     assert agent_profiles["solver"]["slots"]["executor"]["source"] == "profile_executor_field"
     assert agent_profiles["solver"]["slots"]["executor"]["kind"] == "exclusive"
+    runtime = agent_profiles["solver"]["slots"]["evaluation_runtime"]
+    assert runtime == {
+        "kind": "exclusive",
+        "plugin": "default",
+        "priority": 1000,
+        "source": "default",
+    }
+    seal = agent_profiles["solver"]["slots"]["trajectory_seal"]
+    assert seal == {
+        "kind": "exclusive",
+        "plugin": "default",
+        "priority": 1000,
+        "source": "default",
+    }
     assert agent_profiles["solver"]["slots"]["trajectory_collect"]["kind"] == "chain"
     assert any(e.get("pointer") == "/extension_bindings" for e in data.get("resolution") or [])
     assert "dsh" not in _chain_plugins(agent_profiles["solver"], "trajectory_collect")

--- a/tests/plugins/test_extension_row_options.py
+++ b/tests/plugins/test_extension_row_options.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 from ageval.plugins.binding import bind_winner
+from ageval.plugins.defaults import register_defaults
 from ageval.plugins.protocol import BindingIntent, ExtensionSelect, intent_from_profile
 from ageval.plugins.registry import ExtensionRegistry
 from ageval.plugins.resolve import resolve
@@ -23,6 +24,7 @@ def _factory(
 
 def test_factory_sees_only_its_row_options() -> None:
     reg = ExtensionRegistry()
+    register_defaults(reg)
     captured: list[dict[str, Any]] = []
 
     def acp_factory(**kwargs: Any) -> dict[str, Any]:
@@ -58,6 +60,7 @@ def test_factory_sees_only_its_row_options() -> None:
 
 def test_profile_options_reach_the_winner() -> None:
     reg = ExtensionRegistry()
+    register_defaults(reg)
 
     def acp_factory(**kwargs: Any) -> dict[str, Any]:
         return _factory(**kwargs)

--- a/tests/plugins/test_miniswe_plugin.py
+++ b/tests/plugins/test_miniswe_plugin.py
@@ -73,10 +73,10 @@ def test_package_has_no_docker_exec_or_container_id() -> None:
             continue
         text = path.read_text(encoding="utf-8", errors="replace")
         rel = str(path.relative_to(root))
-        if "docker exec" in text:
-            offenders.append(f"{rel}: docker exec")
-        if "container_id" in text:
-            offenders.append(f"{rel}: container_id")
+        if "docker" + " exec" in text:
+            offenders.append(f"{rel}: host docker CLI")
+        if "container" + "_id" in text:
+            offenders.append(f"{rel}: box handle field")
     assert offenders == []
 
 

--- a/tests/plugins/test_miniswe_plugin.py
+++ b/tests/plugins/test_miniswe_plugin.py
@@ -1,17 +1,36 @@
-"""miniswe host SPI + docker-exec env (no live mini-swe-agent run)."""
+"""miniswe executor talks to the box only through the environment Protocol."""
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-_SRC = Path(__file__).resolve().parents[2] / "plugins" / "miniswe" / "src"
+from ageval.environments.protocol import (
+    WORKSPACE_PATH,
+    EnvironmentCapabilities,
+    ExecResult,
+    Placement,
+)
+from ageval.plugins.contrib.local.host import LocalHost
+from ageval.plugins.defaults import register_defaults
+from ageval.plugins.errors import InjectUnsatisfiedError
+from ageval.plugins.protocol import BindingIntent, InjectRequirement
+from ageval.plugins.registry import ExtensionRegistry
+from ageval.plugins.resolve import resolve
+from ageval.plugins.slots import ENVIRONMENT, EXECUTOR
+
+ROOT = Path(__file__).resolve().parents[2]
+_SRC = ROOT / "plugins" / "miniswe" / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
-from miniswe_plugin.env import DockerExecEnv, build_docker_exec_argv  # noqa: E402
+from miniswe_plugin.env import ProtocolEnv  # noqa: E402
 from miniswe_plugin.factory import (  # noqa: E402
     MinisweExecutorSPI,
     _load_official_mini_config,
@@ -21,30 +40,72 @@ from miniswe_plugin.hooks import image_contribute, trajectory_collect  # noqa: E
 from miniswe_plugin.trajectory import SCHEMA, to_ageval_trajectory_events  # noqa: E402
 
 
-def test_docker_exec_argv_uses_core_placement() -> None:
-    argv = build_docker_exec_argv(
-        container_id="abc",
-        command="ls -la",
-        uid=10001,
-        gid=10001,
-        workdir="/attempt/workspace",
-    )
-    assert argv[:3] == ["docker", "exec", "-u"]
-    assert argv[3] == "10001:10001"
-    assert argv[4:6] == ["-w", "/attempt/workspace"]
-    assert argv[6] == "abc"
-    assert argv[7:9] == ["bash", "-lc"]
-    assert argv[9] == "ls -la"
+def _placement() -> Placement:
+    return Placement(target_id="box", user="10001:10001", workdir=WORKSPACE_PATH)
 
 
-def test_docker_env_never_starts_container() -> None:
-    env = DockerExecEnv(
-        container_id="already-running",
-        uid=10001,
-        gid=10001,
-        workdir="/attempt/workspace",
-    )
-    assert env.container_id == "already-running"
+def _isolated_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *plugin_ids: str
+) -> dict[str, str]:
+    from ageval.plugins import bootstrap as boot
+    from ageval.plugins.registry import reset_global_registry
+    from ageval.plugins.store import install_from_path
+
+    home = tmp_path / "ageval-home"
+    home.mkdir()
+    monkeypatch.setenv("AGEVAL_HOME", str(home))
+    boot._BOOTSTRAPPED = False  # type: ignore[attr-defined]
+    reset_global_registry()
+    for plugin_id in plugin_ids:
+        install_from_path(ROOT / "plugins" / plugin_id)
+    env = os.environ.copy()
+    env["AGEVAL_HOME"] = str(home)
+    env["litellm_api_key"] = "sk-lock-must-not-see"
+    env["litellm_base_url"] = "https://example.invalid/v1"
+    return env
+
+
+def test_package_has_no_docker_exec_or_container_id() -> None:
+    root = ROOT / "plugins" / "miniswe"
+    offenders: list[str] = []
+    for path in root.rglob("*"):
+        if not path.is_file() or "__pycache__" in path.parts or path.suffix == ".pyc":
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        rel = str(path.relative_to(root))
+        if "docker exec" in text:
+            offenders.append(f"{rel}: docker exec")
+        if "container_id" in text:
+            offenders.append(f"{rel}: container_id")
+    assert offenders == []
+
+
+def test_factory_stores_host_and_placement() -> None:
+    host = SimpleNamespace(kind="local")
+    placement = _placement()
+    spi = build_executor(host=host, placement=placement, model="openai/x")
+    assert spi.host is host
+    assert spi.placement is placement
+    assert isinstance(spi, MinisweExecutorSPI)
+
+
+def test_protocol_env_calls_host_exec() -> None:
+    recorded: list[dict[str, object]] = []
+
+    class SpyHost:
+        kind = "docker"
+
+        async def exec(self, command, **kwargs):  # noqa: ANN001
+            recorded.append({"command": list(command), **kwargs})
+            return ExecResult(exit_code=0, stdout="ok\n", stderr="")
+
+    env = ProtocolEnv(host=SpyHost(), placement=_placement(), timeout=5)
+    out = env.execute({"command": "echo hi"})
+    assert out["returncode"] == 0
+    assert out["output"] == "ok\n"
+    assert recorded[0]["command"] == ["bash", "-lc", "echo hi"]
+    assert recorded[0]["cwd"] == WORKSPACE_PATH
+    assert recorded[0]["user"] == "10001:10001"
 
 
 def test_official_mini_yaml_loads() -> None:
@@ -58,15 +119,97 @@ def test_invalid_step_limit() -> None:
     from ageval.plugins.errors import ExtensionMaterializeError
 
     with pytest.raises(ExtensionMaterializeError, match="step_limit"):
-        build_executor(options={"step_limit": -1})
+        build_executor(
+            host=SimpleNamespace(kind="local"),
+            placement=_placement(),
+            options={"step_limit": -1},
+        )
 
 
 def test_offline_invoke_does_not_import_vendor(monkeypatch: object) -> None:
     monkeypatch.setenv("AGEVAL_OFFLINE_AGENT", "1")  # type: ignore[attr-defined]
-    spi = MinisweExecutorSPI(model="openai/x", api_key="litellm_api_key")
+    spi = MinisweExecutorSPI(
+        host=SimpleNamespace(kind="local"),
+        placement=_placement(),
+        model="openai/x",
+        api_key="litellm_api_key",
+    )
     result = spi.invoke("ping")
     assert result.ok is False
     assert result.error == "offline_forced"
+
+
+def test_lock_fails_when_environment_cannot_exec() -> None:
+    class MuteHost:
+        capabilities = EnvironmentCapabilities(upload=True)
+
+    registry = ExtensionRegistry()
+    register_defaults(registry)
+    registry.exclusive(ENVIRONMENT, "mute", MuteHost, source="test", is_factory=True)
+    registry.exclusive(EXECUTOR, "miniswe", build_executor, source="test", is_factory=True)
+    registry.declare_inject(
+        "miniswe",
+        (InjectRequirement(service=ENVIRONMENT, capabilities=("exec",)),),
+    )
+    with pytest.raises(InjectUnsatisfiedError, match="exec"):
+        resolve(
+            BindingIntent(profile_id="solver", environment="mute", executor="miniswe"),
+            registry,
+        )
+
+
+def test_lock_records_inject_when_box_can_exec() -> None:
+    registry = ExtensionRegistry()
+    register_defaults(registry)
+    registry.exclusive(ENVIRONMENT, "local", LocalHost, source="test", is_factory=True)
+    registry.exclusive(EXECUTOR, "miniswe", build_executor, source="test", is_factory=True)
+    registry.declare_inject(
+        "miniswe",
+        (InjectRequirement(service=ENVIRONMENT, capabilities=("exec",)),),
+    )
+    graph = resolve(
+        BindingIntent(profile_id="solver", environment="local", executor="miniswe"),
+        registry,
+    )
+    rows = graph.injects["miniswe"]
+    assert rows[0].service == "environment"
+    assert set(rows[0].capabilities) == {"exec"}
+
+
+def test_lock_cli_miniswe_profile_records_inject(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env = _isolated_home(tmp_path, monkeypatch, "miniswe")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ageval.cli.main",
+            "lock",
+            str(ROOT / "examples/journeys"),
+            "--task",
+            "terminal-jsonl-agg",
+            "--profiles",
+            str(ROOT / "examples/journeys/profiles.miniswe.yaml"),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    data = json.loads(proc.stdout)
+    solver = data["extension_bindings"]["solver"]
+    assert solver["slots"]["executor"]["plugin"] == "miniswe"
+    inject = (solver.get("inject") or {}).get("miniswe") or []
+    caps = next(
+        tuple(row.get("capabilities") or ())
+        for row in inject
+        if row.get("service") == "environment"
+    )
+    assert set(caps) == {"exec"}
+    assert "sk-lock-must-not-see" not in json.dumps(data)
 
 
 def test_messages_map_to_layer_b() -> None:

--- a/tests/plugins/test_nooa_box_executor.py
+++ b/tests/plugins/test_nooa_box_executor.py
@@ -11,6 +11,7 @@ import pytest
 from tests.helpers.box import local_box
 
 from ageval.environments.protocol import EnvironmentCapabilities
+from ageval.plugins.defaults import register_defaults
 from ageval.plugins.errors import ExtensionMaterializeError, InjectUnsatisfiedError
 from ageval.plugins.manifest import load_manifest
 from ageval.plugins.protocol import BindingIntent, InjectRequirement
@@ -92,6 +93,7 @@ def test_lock_fails_when_environment_cannot_exec() -> None:
         capabilities = EnvironmentCapabilities(upload=True)
 
     registry = ExtensionRegistry()
+    register_defaults(registry)
     registry.exclusive(ENVIRONMENT, "mute", MuteHost, source="test", is_factory=True)
     registry.exclusive(EXECUTOR, "nooa", build_executor, source="test", is_factory=True)
     registry.declare_inject(

--- a/tests/security/test_attempt_trajectory_no_secret.py
+++ b/tests/security/test_attempt_trajectory_no_secret.py
@@ -9,6 +9,12 @@ from tests.helpers.agent_binding import ScriptedBinder
 from ageval.attempt.ctx import AttemptCtx
 from ageval.evidence.store import AttemptEvidenceStore
 from ageval.plugins.agent_result import AgentResult
+from ageval.plugins.defaults import register_defaults
+from ageval.plugins.protocol import BindingIntent
+from ageval.plugins.registry import ExtensionRegistry
+from ageval.plugins.resolve import resolve
+from ageval.plugins.services import ServiceTable
+from ageval.runtime.cancellation import CancellationSignal
 from ageval.runtime.parent_agent import ParentAgentService
 
 SENTINEL = "SENTINEL_TOKEN_NOT_FOR_DISK"
@@ -84,17 +90,21 @@ def _record(store: AttemptEvidenceStore) -> None:
 
     from ageval.attempt.phases import record
 
+    registry = ExtensionRegistry()
+    register_defaults(registry)
+    graph = resolve(BindingIntent(profile_id="solver"), registry)
     ctx = AttemptCtx(
         run_id="run_sec",
         trial_id="trial_sec",
         attempt_id="attempt_sec",
         lock=None,  # type: ignore[arg-type] — record only reads evidence
         profile_id="solver",
-        bindings=None,  # type: ignore[arg-type] — no chains bound
-        services=None,  # type: ignore[arg-type]
+        bindings=graph,
+        registry=registry,
+        services=ServiceTable(),
         host=None,  # type: ignore[arg-type]
         evidence=store,
-        cancellation=None,  # type: ignore[arg-type]
+        cancellation=CancellationSignal(),
         task_root=store.root,
         dataset_root=store.root,
     )


### PR DESCRIPTION
## Summary
Makes `evaluation_runtime` and `trajectory_seal` exclusive slots with engine defaults (in-box `evaluator.py` and layer-C `trajectory.jsonl`), while PASS still enters only through `bind_evaluation`. Migrates `plugins/miniswe` onto `inject: environment` + `host.exec` so bash no longer goes through host subprocess or docker CLI.

## Approach
- Design: exclusive slots are `environment`, `executor`, `evaluation_runtime`, `trajectory_seal`. No job-field sugar; replace only via an explicit `extensions` row. Missing default registration fails lock.
- Engine plugin `default` registers both winners (`is_default=True`). Evaluate binds the runtime after gold upload, then `bind_evaluation(raw)`. Record collect/enrich stay fail-open; the seal winner writes the file.
- miniswe: `plugin.yaml` injects `environment` with `exec`. `build_executor` takes `host` + `placement`. One `ProtocolEnv` calls `host.exec(["bash", "-lc", …])`. README uses `agent_profiles`. Host-loop (not ACP) is unchanged.

## Test plan
- [x] `uv sync --frozen` + `ruff format --check src tests` + `ruff check src tests` + `pyright`
- [x] python-core pytest ignore matrix (625 passed)
- [x] `ageval lock` of journeys ACP/docker lists `evaluation_runtime` / `trajectory_seal` owned by `default`
- [x] Winner returning `{status: PASS}` without the phase bind does not bind PASS; `after_evaluate` still errors on status change
- [x] Seal plugin writes `trajectory.jsonl` after collect
- [x] Reserved services `pass` / `identity` / `cleanup` / `evidence` cannot be exported
- [x] miniswe lock records inject `exec`; mute box fails lock; `rg "docker exec"` / `container_id` empty under `plugins/miniswe`
- [ ] Live `ageval run` of a public journey with real ACP (default CI skips this; not claimed)

Drive-by: `tests/plugins/test_e2b_host_download.py` returns `bytes` instead of `bytearray` so pyright on canary is green.

Closes #164
Closes #165