### PR TITLE
feat(openai-http): native tools= on invoke for tau2-class harnesses

### DIFF
--- a/docs/design/03-task-run-and-sdk.md
+++ b/docs/design/03-task-run-and-sdk.md
@@ -60,6 +60,36 @@ from ageval_sdk import (
 
 `run.py` 通过 `ctx.agent.session(...).invoke` 调 Agent。ACP attach 发生在第一次 invoke。SDK 不拥有 `host.start`、凭据文件内容、final PASS。
 
+## invoke 工具通道
+
+`Agent.session(profile_id).invoke` 默认仍是今天的 **prompt-only** 文本调用。可选关键字（省略 = 旧行为）：
+
+| 参数 | 含义 |
+| --- | --- |
+| `tools` | OpenAI 风格工具目录：`[{type: function, function: {name, description?, parameters}}]` |
+| `messages` | 可选 chat 历史（`role` / `content`，以及后续 `tool` / `tool_calls` 轮） |
+
+返回值在既有 `ok` / `text` / `structured` 之外，可以带结构化 **`tool_calls`**：`[{id, name, arguments}]`。`arguments` 是对象，不是 JSON 字符串。没有工具调用时该字段为空（省略或 `[]`），`text` 仍是助手文本。
+
+约定：
+
+- 题包把 **域工具目录** 交给 invoke；真正执行仍在 `run.py`（`ToolSet.call` 或 package `Environment.get_response`）。SDK / parent **不**代跑域工具，**不**把 MCP / home-files / skills 注册成可调用工具。
+- `executor: acp` **忽略** `tools` / `messages`，继续文本 invoke。coding-agent 入口不变；ACP 不因为题包传了目录就要求 `tools=`。
+- 禁止把 `profile_id` / workspace / executor 绑定从 invoke kwargs 里改掉。
+- `tool_calls` 与 `RunTerminal.completed` 都不是 PASS。PASS 只来自独立 evaluator。
+
+最小形状（openai-http 原生工具；ACP 路径可继续只传 prompt）：
+
+```python
+reply = await session.invoke(
+    instruction,
+    tools=catalog,          # 可选
+    messages=history,       # 可选；省略则 parent 用 prompt 包一轮 user
+)
+for call in reply.get("tool_calls") or ():
+    obs = await tools.call(call["name"], call["arguments"])
+```
+
 ## 薄 task
 
 多题同构时，循环放 `shared/lib`，成员 `run.py` 只转发。gold 永不进 `shared/`。

--- a/docs/design/05-runtime/README.md
+++ b/docs/design/05-runtime/README.md
@@ -6,7 +6,7 @@ Runtime 在这里指：**盒子、ACP、evaluate、evidence、campaign**。结�
 | --- | --- |
 | [lifecycle.md](lifecycle.md) | Run / Trial / Attempt 身份与五相位状态机 |
 | [environment.md](environment.md) | Protocol 与四 kind |
-| [agent-service.md](agent-service.md) | parent ACP client + `attach_stdio` |
+| [agent-service.md](agent-service.md) | parent ACP client + `attach_stdio`；openai-http 原生 `tools=` |
 | [evaluation.md](evaluation.md) | 停写、upload gold、绑定 PASS |
 | [evidence.md](evidence.md) | `.ageval/runs/` |
 | [campaign-suite.md](campaign-suite.md) | campaign 与 suite |

--- a/docs/design/05-runtime/agent-service.md
+++ b/docs/design/05-runtime/agent-service.md
@@ -39,14 +39,31 @@ run.py  Agent.session(profile).invoke
   → ParentAgentService
        before_agent_invoke
        executor.invoke → host.attach_stdio(entry argv) 或 host.exec（盒内 worker）
+                        或 openai-http POST /chat/completions
        after_agent_invoke
        normalize_agent_result
   → 层 C：evidence 写 trajectory.jsonl
 ```
 
-`ParentAgentService.invoke` 只回 `AgentResult`。**不**在每次 invoke 后 `download` 盒内 workspace。轨迹来自 executor events。缺的 publishable 文件在 **writer 停后** 由 run 相位 harvest（Protocol `download`），evaluate 再把 `task-artifacts` upload 进盒。
+`ParentAgentService.invoke` 只回 `AgentResult`（含可选 `tool_calls`）。**不**在每次 invoke 后 `download` 盒内 workspace。轨迹来自 executor events。缺的 publishable 文件在 **writer 停后** 由 run 相位 harvest（Protocol `download`），evaluate 再把 `task-artifacts` upload 进盒。
 
 ACP attach 发生在第一次 invoke，不是独立 phase。
+
+Socket 帧可带 `tools` / `messages`（省略 = prompt-only）。parent 原样转给 executor；ACP 忽略这两项。`tool_calls` 回 worker。request.json / trajectory **只记 locator 与目录名，不记密钥**。
+
+## openai-http 原生 tools
+
+kind 名仍是 `openai-http`（api-client）。没有第二套 dialect、没有 Core 里的 LiteLLM、没有 Anthropic/Dashscope 直连——那些走 OpenAI-compatible gateway。
+
+| | 行为 |
+| --- | --- |
+| 省略 `tools` | 今日路径：`messages: [{role: user, content: prompt}]`，读 `choices[0].message.content` |
+| 题包传入 `tools` | POST body 带 `tools`；读 `choices[0].message.tool_calls` → `AgentResult.tool_calls` |
+| `messages` | 若提供，作为 chat 历史（不再只包一轮 prompt） |
+| capability | `tools: native`，`session: new-only`（逻辑 session，无 provider resume） |
+| 凭证 | 一等字段 `model` / `base_url` / `api_key`（env locator）。缺钥 fail-closed（loopback 空钥仅用于本机 mock） |
+
+tau2-class harness（journeys `tau2-dialog-min`、`examples/tau3-*`）把域 schema 传入 invoke；收到 `tool_calls` 后走 package `Environment.get_response` / `ToolSet.call`。原生 `tool_calls` 是 **openai-http 的主动作通道**；「Return ONLY JSON」只留给没有 `tool_calls` 的文本 executor（ACP）。禁止在 Core 里 scrape vendor stdout 当工具通道。
 
 ## 凭证：BYOK / BYOA
 

--- a/examples/journeys/tasks/tau2-dialog-min/evaluator.py
+++ b/examples/journeys/tasks/tau2-dialog-min/evaluator.py
@@ -19,11 +19,13 @@ def _prefix_in_order(used: list[str]) -> bool:
 
 def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:
     data = json.loads(Path(inputs["artifacts"]["final-state"]).read_text(encoding="utf-8"))
-    expected = json.loads(
-        (Path(__file__).resolve().parent / "evaluation" / "expected.json").read_text(
-            encoding="utf-8"
-        )
+    evaluation_dir = inputs.get("evaluation_dir")
+    expected_path = (
+        Path(str(evaluation_dir)) / "expected.json"
+        if evaluation_dir
+        else Path(__file__).resolve().parent / "evaluation" / "expected.json"
     )
+    expected = json.loads(expected_path.read_text(encoding="utf-8"))
     used = (
         [str(x) for x in (data.get("tools_used") or [])]
         if isinstance(data.get("tools_used"), list)

--- a/examples/journeys/tasks/tau2-dialog-min/lib/retail_tools.py
+++ b/examples/journeys/tasks/tau2-dialog-min/lib/retail_tools.py
@@ -28,6 +28,78 @@ For color/variant exchanges: from_item_ids = item currently on the order;
 to_item_ids = catalog id whose name matches the requested variant (e.g. black).
 """
 
+OPENAI_TOOLS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "find_customer",
+            "description": "Find a customer by email.",
+            "parameters": {
+                "type": "object",
+                "properties": {"email": {"type": "string"}},
+                "required": ["email"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_order",
+            "description": "Get an order by id; includes line_items and product_catalog.",
+            "parameters": {
+                "type": "object",
+                "properties": {"order_id": {"type": "string"}},
+                "required": ["order_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_product",
+            "description": "Get a product by item_id; includes other_products for variants.",
+            "parameters": {
+                "type": "object",
+                "properties": {"item_id": {"type": "string"}},
+                "required": ["item_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "request_exchange",
+            "description": "Exchange items on a delivered order.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "order_id": {"type": "string"},
+                    "from_item_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "to_item_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                },
+                "required": ["order_id", "from_item_ids", "to_item_ids"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "done",
+            "description": "End the service dialog after the exchange is requested.",
+            "parameters": {
+                "type": "object",
+                "properties": {"note": {"type": "string"}},
+            },
+        },
+    },
+]
+
 
 def package_root() -> Path:
     return Path(__file__).resolve().parents[1]

--- a/examples/journeys/tasks/tau2-dialog-min/run.py
+++ b/examples/journeys/tasks/tau2-dialog-min/run.py
@@ -1,7 +1,8 @@
 """Tau2-class retail dialog — orchestration only.
 
 Domain tools / state live in ``lib/``; gold stays under ``evaluation/``.
-User-sim and service agent use independent ACP profiles (pi / opencode).
+User-sim and service agent use independent profiles. openai-http consumes
+native tool_calls; ACP still uses the JSON fallback in the prompt.
 """
 
 from __future__ import annotations
@@ -12,12 +13,76 @@ from typing import Any
 from ageval_sdk import Agent, RunContext, RunTerminal
 from lib.agent_json import agent_struct
 from lib.retail_tools import (
+    OPENAI_TOOLS,
     TOOL_CATALOG,
     WORKFLOW_PREFIX,
     build_tools,
     load_json,
     workflow_allows,
 )
+
+_KNOWN_TOOLS = {
+    "find_customer",
+    "get_order",
+    "get_product",
+    "request_exchange",
+    "done",
+}
+
+
+def _append_tool_turn(
+    messages: list[dict[str, Any]],
+    *,
+    name: str,
+    args: dict[str, Any],
+    call_id: str,
+    result: Any,
+    counter: int,
+) -> None:
+    cid = call_id or f"call_{counter}"
+    messages.append(
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": cid,
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "arguments": json.dumps(args, ensure_ascii=False),
+                    },
+                }
+            ],
+        }
+    )
+    messages.append(
+        {
+            "role": "tool",
+            "tool_call_id": cid,
+            "content": json.dumps(result, ensure_ascii=False, default=str),
+        }
+    )
+
+
+def _native_tool_calls(resp: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = resp.get("tool_calls") if isinstance(resp.get("tool_calls"), list) else []
+    out: list[dict[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "")
+        if not name:
+            continue
+        args = item.get("arguments") if isinstance(item.get("arguments"), dict) else {}
+        out.append(
+            {
+                "name": name,
+                "arguments": args,
+                "id": str(item.get("id") or ""),
+            }
+        )
+    return out
 
 
 def _role_profile(params: dict[str, Any], role: str, default: str) -> str:
@@ -59,6 +124,21 @@ async def run(ctx: RunContext) -> RunTerminal:
             return RunTerminal.failed("empty_user_message")
 
     finished = False
+    svc_messages: list[dict[str, Any]] = [
+        {
+            "role": "system",
+            "content": (
+                "Act as the retail service agent. Private customer instructions "
+                "are not available. Call domain tools from the catalog. Copy "
+                "identifiers byte-for-byte. Workflow: find_customer → get_order → "
+                "get_product → request_exchange → done. For a color/variant "
+                "exchange, pick to_item_ids from product_catalog / other_products "
+                "whose name matches the request (e.g. black headphones → "
+                "item_headphones_black)."
+            ),
+        },
+        {"role": "user", "content": user_message},
+    ]
     async with agent.session(service_profile, max_turns=12) as session:
         for _turn in range(1, 8):
             svc = await session.invoke(
@@ -74,21 +154,23 @@ async def run(ctx: RunContext) -> RunTerminal:
                 "When requesting an exchange for a color/variant, pick to_item_ids "
                 "from product_catalog / other_products whose name matches the request "
                 "(e.g. black headphones → item_headphones_black), not the same id as from.\n"
-                "Return ONLY JSON for the next single action: "
-                '{"tool":"<name>","args":{...}} with no prose.'
+                "Prefer native tool calls from the catalog. If you cannot call tools, "
+                "return ONLY JSON for the next single action: "
+                '{"tool":"<name>","args":{...}} with no prose.',
+                tools=OPENAI_TOOLS,
+                messages=svc_messages,
             )
             if not svc.get("ok"):
                 return RunTerminal.failed(svc.get("error") or "service_failed")
-            action = agent_struct(svc) or {}
-            tool_name = str(action.get("tool") or "")
-            args = action.get("args") if isinstance(action.get("args"), dict) else {}
-            if tool_name not in {
-                "find_customer",
-                "get_order",
-                "get_product",
-                "request_exchange",
-                "done",
-            }:
+            native = _native_tool_calls(svc)
+            if native:
+                tool_name = native[0]["name"]
+                args = native[0]["arguments"]
+            else:
+                action = agent_struct(svc) or {}
+                tool_name = str(action.get("tool") or "")
+                args = action.get("args") if isinstance(action.get("args"), dict) else {}
+            if tool_name not in _KNOWN_TOOLS:
                 # Soft-recover once when model chatters: append parse failure observation.
                 if not tool_name:
                     observations.append(
@@ -108,22 +190,33 @@ async def run(ctx: RunContext) -> RunTerminal:
                     continue
                 return RunTerminal.failed(f"unknown_tool:{tool_name}")
             if not workflow_allows(tools_used, tool_name):
-                observations.append(
-                    {
-                        "tool": tool_name,
-                        "args": args,
-                        "result": {
-                            "ok": False,
-                            "error": "workflow_order_denied",
-                            "required_prefix": list(WORKFLOW_PREFIX),
-                            "tools_used": list(tools_used),
-                        },
-                    }
+                denied = {
+                    "ok": False,
+                    "error": "workflow_order_denied",
+                    "required_prefix": list(WORKFLOW_PREFIX),
+                    "tools_used": list(tools_used),
+                }
+                observations.append({"tool": tool_name, "args": args, "result": denied})
+                _append_tool_turn(
+                    svc_messages,
+                    name=tool_name,
+                    args=args,
+                    call_id=native[0]["id"] if native else "",
+                    result=denied,
+                    counter=len(observations),
                 )
                 continue
             obs = await tools.call(tool_name, args)
             result = obs.get("result") if isinstance(obs.get("result"), dict) else obs
             observations.append({"tool": tool_name, "args": args, "result": result})
+            _append_tool_turn(
+                svc_messages,
+                name=tool_name,
+                args=args,
+                call_id=native[0]["id"] if native else "",
+                result=result,
+                counter=len(observations),
+            )
             if (
                 isinstance(result, dict)
                 and result.get("ok") is True

--- a/examples/tau3-airline/shared/lib/bridge.py
+++ b/examples/tau3-airline/shared/lib/bridge.py
@@ -59,14 +59,26 @@ def make_environment():
     return get_environment()
 
 
-def tool_catalog(env) -> str:
-    lines: list[str] = []
+def tool_schemas(env) -> list[dict[str, Any]]:
+    """OpenAI-style tool catalog from the package Environment."""
+    out: list[dict[str, Any]] = []
     for t in env.get_tools():
         schema = getattr(t, "openai_schema", None)
-        if schema:
-            lines.append(json.dumps(schema, ensure_ascii=False))
-        else:
-            lines.append(f"- {t.name}: {getattr(t, 'short_desc', '')}")
+        if isinstance(schema, dict):
+            out.append(schema)
+        elif schema:
+            out.append(dict(schema))
+    return out
+
+
+def tool_catalog(env) -> str:
+    lines: list[str] = []
+    for schema in tool_schemas(env):
+        lines.append(json.dumps(schema, ensure_ascii=False))
+    if lines:
+        return "\n".join(lines)
+    for t in env.get_tools():
+        lines.append(f"- {t.name}: {getattr(t, 'short_desc', '')}")
     return "\n".join(lines)
 
 

--- a/examples/tau3-airline/shared/lib/harness_core.py
+++ b/examples/tau3-airline/shared/lib/harness_core.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from collections.abc import Mapping
 from typing import Any
 
 from ageval_sdk import Agent, RunContext, RunTerminal
@@ -20,6 +21,7 @@ from shared.lib.bridge import (
     load_task_dict,
     make_environment,
     tool_catalog,
+    tool_schemas,
 )
 from shared.lib.paths import assets_root
 
@@ -38,6 +40,27 @@ def _load_user_scenario(task_dir: Path, task_id: str) -> dict[str, Any]:
     if local.is_file():
         return json.loads(local.read_text(encoding="utf-8"))
     return agent_facing_user_scenario(load_task_dict(task_id))
+
+
+def _native_tool_calls(resp: Mapping[str, Any] | dict[str, Any]) -> list[dict[str, Any]]:
+    raw = resp.get("tool_calls") if isinstance(resp.get("tool_calls"), list) else []
+    out: list[dict[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "")
+        if not name:
+            continue
+        args = item.get("arguments") if isinstance(item.get("arguments"), dict) else {}
+        out.append(
+            {
+                "kind": "tool_call",
+                "name": name,
+                "arguments": args,
+                "id": str(item.get("id") or ""),
+            }
+        )
+    return out
 
 
 def _parse_service_action(payload: dict[str, Any] | None) -> dict[str, Any]:
@@ -112,6 +135,7 @@ async def run(ctx: RunContext, *, task_dir: Path | None = None) -> RunTerminal:
     env = make_environment()
     policy = env.get_policy()
     catalog = tool_catalog(env)
+    catalog_tools = tool_schemas(env)
     scenario = _load_user_scenario(tdir, task_id)
     scenario_text = format_user_scenario(scenario)
 
@@ -205,17 +229,49 @@ async def run(ctx: RunContext, *, task_dir: Path | None = None) -> RunTerminal:
                         f"<tools_openai_schema>\n{catalog}\n</tools_openai_schema>\n\n"
                         f"Dialog:\n{json.dumps(dialog_for_svc, ensure_ascii=False)}\n\n"
                         f"Latest tool observations:\n{json.dumps(pending_tool_obs, ensure_ascii=False)}\n\n"
-                        "Return ONLY JSON in one of these forms:\n"
+                        "Prefer native tool calls from the catalog. Send a user-facing "
+                        "message when you need to speak. Do not invent tool results. "
+                        "Copy ids byte-for-byte from tools/user.\n"
+                        "If native tools are unavailable, return ONLY JSON in one of these forms:\n"
                         '1) {"type":"message","content":"<text to customer>"}\n'
                         '2) {"type":"tool_call","name":"<tool>","arguments":{...}}\n'
-                        "Do not invent tool results. Copy ids byte-for-byte from tools/user.\n"
                     )
-                    sres = await svc_sess.invoke(svc_prompt)
+                    svc_messages: list[dict[str, Any]] = [
+                        {
+                            "role": "system",
+                            "content": (
+                                "You are an airline customer-service agent. Follow the "
+                                "policy strictly. Call domain tools via the native tool "
+                                "channel. Send a user-facing message when you need to "
+                                "speak — never invent tool results.\n\n"
+                                f"<policy>\n{policy}\n</policy>"
+                            ),
+                        },
+                        *dialog_for_svc,
+                    ]
+                    sres = await svc_sess.invoke(
+                        svc_prompt,
+                        tools=catalog_tools or None,
+                        messages=svc_messages,
+                    )
                     if not sres.get("ok"):
                         return RunTerminal.failed(
                             sres.get("error") or "service_failed"
                         )
-                    action = _parse_service_action(agent_struct(sres))
+                    native = _native_tool_calls(sres)
+                    if native:
+                        action = native[0]
+                    else:
+                        parsed = agent_struct(sres)
+                        if parsed:
+                            action = _parse_service_action(parsed)
+                        elif str(sres.get("text") or "").strip():
+                            action = {
+                                "kind": "message",
+                                "content": str(sres.get("text") or "").strip(),
+                            }
+                        else:
+                            action = {"kind": "invalid", "raw": None}
                     if action["kind"] == "tool_call":
                         name = action["name"]
                         args = action["arguments"] or {}
@@ -265,7 +321,26 @@ async def run(ctx: RunContext, *, task_dir: Path | None = None) -> RunTerminal:
                         ]
                         dialog_for_svc.append(
                             {
+                                "role": "assistant",
+                                "content": None,
+                                "tool_calls": [
+                                    {
+                                        "id": call_id,
+                                        "type": "function",
+                                        "function": {
+                                            "name": name,
+                                            "arguments": json.dumps(
+                                                args, ensure_ascii=False
+                                            ),
+                                        },
+                                    }
+                                ],
+                            }
+                        )
+                        dialog_for_svc.append(
+                            {
                                 "role": "tool",
+                                "tool_call_id": call_id,
                                 "name": name,
                                 "content": content
                                 if isinstance(content, str)

--- a/sdk/python/src/ageval_sdk/agent.py
+++ b/sdk/python/src/ageval_sdk/agent.py
@@ -77,6 +77,8 @@ class AgentSession:
     async def invoke(self, prompt: str, **kwargs: Any) -> Mapping[str, Any]:
         if self._closed:
             raise RuntimeError("session closed")
+        tools = kwargs.pop("tools", None)
+        messages = kwargs.pop("messages", None)
         if kwargs:
             # Disallow profile/workspace/executor overrides mid-session.
             raise ValueError("session invoke does not accept profile overrides")
@@ -92,6 +94,7 @@ class AgentSession:
                 "turn": self._turns,
                 "ok": False,
                 "error": "offline_forced",
+                "tool_calls": [],
             }
 
         opened = self._ensure_open()
@@ -103,16 +106,20 @@ class AgentSession:
                 "turn": self._turns,
                 "ok": False,
                 "error": opened.get("error") or "agent_session_unbound",
+                "tool_calls": [],
             }
 
-        resp = _parent_call(
-            {
-                "op": "invoke",
-                "session_id": self._session_id,
-                "attempt_id": self.attempt_id,
-                "prompt": prompt,
-            }
-        )
+        payload: dict[str, Any] = {
+            "op": "invoke",
+            "session_id": self._session_id,
+            "attempt_id": self.attempt_id,
+            "prompt": prompt,
+        }
+        if tools is not None:
+            payload["tools"] = tools
+        if messages is not None:
+            payload["messages"] = messages
+        resp = _parent_call(payload)
         return {
             "text": resp.get("text") or "",
             "structured": resp.get("structured"),
@@ -122,6 +129,7 @@ class AgentSession:
             "error": resp.get("error"),
             "invocation_id": resp.get("invocation_id"),
             "evidence_relative": resp.get("evidence_relative"),
+            "tool_calls": list(resp.get("tool_calls") or []),
         }
 
     async def close(self) -> None:

--- a/skills/ageval-sdk-harness/references/api.md
+++ b/skills/ageval-sdk-harness/references/api.md
@@ -17,7 +17,9 @@ Package: `ageval_sdk` (see `sdk/python/src/ageval_sdk/`).
 
 ## AgentSession.invoke return keys (parent path)
 
-Includes `ok`, `error`, `text`, `structured`, `provider_session_handle`, `invocation_id`, `evidence_relative` when parent provides them.
+Includes `ok`, `error`, `text`, `structured`, `provider_session_handle`, `invocation_id`, `evidence_relative`, and `tool_calls` (list of `{id, name, arguments}`; empty when the turn is text-only).
+
+Optional invoke kwargs: `tools` (OpenAI-style catalog) and `messages` (chat history). Omit both for prompt-only invoke. Profile / workspace / executor overrides stay rejected. ACP ignores the catalog.
 
 ## Offline
 

--- a/src/ageval/plugins/agent_result.py
+++ b/src/ageval/plugins/agent_result.py
@@ -22,6 +22,8 @@ class AgentResult:
     usage: dict[str, Any] | None = None
     # ACP / executor metadata (lock-safe, no secrets).
     metadata: dict[str, Any] | None = None
+    # Native tool channel (openai-http). Empty when the turn is text-only.
+    tool_calls: tuple[dict[str, Any], ...] = ()
 
 
 class AgentExecutor(Protocol):
@@ -34,6 +36,8 @@ class AgentExecutor(Protocol):
         timeout: float = 60.0,
         collect_dir: str | None = None,
         redaction_sentinels: tuple[str, ...] | list[str] | None = None,
+        tools: Sequence[Mapping[str, Any]] | None = None,
+        messages: Sequence[Mapping[str, Any]] | None = None,
     ) -> AgentResult: ...
 
 

--- a/src/ageval/plugins/contrib/acp/executor.py
+++ b/src/ageval/plugins/contrib/acp/executor.py
@@ -391,10 +391,12 @@ class AcpExecutor(AgentExecutor):
         timeout: float = 60.0,
         collect_dir: str | None = None,
         redaction_sentinels: tuple[str, ...] | list[str] | None = None,
+        tools: Any = None,
+        messages: Any = None,
     ) -> AgentResult:
         from ageval.runtime.offline import is_offline_agent
 
-        del redaction_sentinels
+        del redaction_sentinels, tools, messages
         if is_offline_agent():
             return _offline_result(self.model)
 

--- a/src/ageval/plugins/contrib/openai_http/executor.py
+++ b/src/ageval/plugins/contrib/openai_http/executor.py
@@ -1,7 +1,8 @@
-"""Second AgentExecutor: OpenAI-compatible HTTP Responses/Chat backend (v0.9).
+"""Second AgentExecutor: OpenAI-compatible HTTP Chat backend.
 
 Thin executor only — no Run/credential store ownership beyond scoped API key env.
 Profile may supply ``base_url`` and ``api_key`` (env locator name).
+Native ``tools=`` is first-class; omit the catalog to keep the content path.
 """
 
 from __future__ import annotations
@@ -10,12 +11,83 @@ import json
 import os
 import urllib.error
 import urllib.request
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import Any
 
 from ageval.plugins.agent_result import AgentExecutor, AgentResult
 
 _DEFAULT_BASE = "https://api.openai.com/v1"
 _DEFAULT_KEY_ENV = "OPENAI_API_KEY"
+
+
+def _chat_messages(
+    prompt: str, messages: Sequence[Mapping[str, Any]] | None
+) -> list[dict[str, Any]]:
+    if isinstance(messages, Sequence) and not isinstance(messages, (str, bytes)):
+        out = [dict(item) for item in messages if isinstance(item, Mapping)]
+        if out:
+            return out
+    return [{"role": "user", "content": prompt}]
+
+
+def _normalize_tools(tools: Sequence[Mapping[str, Any]] | None) -> list[dict[str, Any]]:
+    if not isinstance(tools, Sequence) or isinstance(tools, (str, bytes)):
+        return []
+    out: list[dict[str, Any]] = []
+    for item in tools:
+        if not isinstance(item, Mapping):
+            continue
+        if item.get("type") == "function" and isinstance(item.get("function"), Mapping):
+            out.append(dict(item))
+            continue
+        name = str(item.get("name") or "")
+        if not name:
+            fn = item.get("function")
+            if isinstance(fn, Mapping):
+                name = str(fn.get("name") or "")
+                if name:
+                    out.append({"type": "function", "function": dict(fn)})
+            continue
+        spec: dict[str, Any] = {"name": name}
+        if item.get("description"):
+            spec["description"] = item["description"]
+        if isinstance(item.get("parameters"), Mapping):
+            spec["parameters"] = dict(item["parameters"])
+        out.append({"type": "function", "function": spec})
+    return out
+
+
+def _parse_tool_calls(raw: Any) -> tuple[dict[str, Any], ...]:
+    if not isinstance(raw, list):
+        return ()
+    out: list[dict[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, Mapping):
+            continue
+        fn = item.get("function") if isinstance(item.get("function"), Mapping) else item
+        if not isinstance(fn, Mapping):
+            continue
+        name = str(fn.get("name") or item.get("name") or "")
+        if not name:
+            continue
+        args: Any = fn.get("arguments") if "arguments" in fn else item.get("arguments")
+        if isinstance(args, str):
+            try:
+                parsed = json.loads(args)
+            except json.JSONDecodeError:
+                parsed = {}
+            args = parsed if isinstance(parsed, dict) else {}
+        elif not isinstance(args, dict):
+            args = {}
+        out.append(
+            {
+                "id": str(item.get("id") or ""),
+                "name": name,
+                "arguments": args,
+            }
+        )
+    return tuple(out)
 
 
 @dataclass
@@ -34,8 +106,10 @@ class OpenAIHTTPExecutor(AgentExecutor):
         timeout: float = 60.0,
         collect_dir: str | None = None,
         redaction_sentinels: tuple[str, ...] | list[str] | None = None,
+        tools: Sequence[Mapping[str, Any]] | None = None,
+        messages: Sequence[Mapping[str, Any]] | None = None,
     ) -> AgentResult:
-        del collect_dir, redaction_sentinels  # unused on HTTP path
+        del collect_dir, redaction_sentinels
         key_env = self.api_key_env or _DEFAULT_KEY_ENV
         key = os.environ.get(key_env, "")
         base = self.base_url or os.environ.get("AGEVAL_OPENAI_BASE_URL") or _DEFAULT_BASE
@@ -50,7 +124,7 @@ class OpenAIHTTPExecutor(AgentExecutor):
             )
         from ageval.runtime.offline import is_offline_agent
 
-        if is_offline_agent() and "127.0.0.1" not in base:
+        if is_offline_agent() and "127.0.0.1" not in base and "localhost" not in base:
             return AgentResult(
                 model=self.model,
                 text="",
@@ -59,13 +133,15 @@ class OpenAIHTTPExecutor(AgentExecutor):
                 error="offline_forced",
             )
         url = f"{base.rstrip('/')}/chat/completions"
-        body = json.dumps(
-            {
-                "model": self.model,
-                "messages": [{"role": "user", "content": prompt}],
-                "temperature": 0,
-            }
-        ).encode("utf-8")
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "messages": _chat_messages(prompt, messages),
+            "temperature": 0,
+        }
+        catalog = _normalize_tools(tools)
+        if catalog:
+            payload["tools"] = catalog
+        body = json.dumps(payload).encode("utf-8")
         req = urllib.request.Request(
             url,
             data=body,
@@ -86,22 +162,40 @@ class OpenAIHTTPExecutor(AgentExecutor):
                 ok=False,
                 error=type(exc).__name__,
             )
-        text = ""
+        message: Mapping[str, Any] = {}
         try:
-            text = raw["choices"][0]["message"]["content"]
+            choice0 = raw["choices"][0]
+            found = choice0["message"]
+            if isinstance(found, Mapping):
+                message = found
         except (KeyError, IndexError, TypeError):
+            message = {}
+        text = message.get("content") if isinstance(message.get("content"), str) else ""
+        if not text and not message:
             text = json.dumps(raw)[:4000]
+        tool_calls = _parse_tool_calls(message.get("tool_calls"))
         structured = None
         try:
-            structured = json.loads(text)
+            structured = json.loads(text) if text else None
             if not isinstance(structured, dict):
                 structured = None
         except json.JSONDecodeError:
             structured = None
+        events = tuple(
+            {
+                "type": "tool_call",
+                "id": call["id"],
+                "name": call["name"],
+                "source": "openai-http",
+            }
+            for call in tool_calls
+        )
         return AgentResult(
             model=self.model,
-            text=text[-8000:],
+            text=(text or "")[-8000:],
             structured=structured,
             ok=True,
             error=None,
+            events=events,
+            tool_calls=tool_calls,
         )

--- a/src/ageval/plugins/executor_capabilities.py
+++ b/src/ageval/plugins/executor_capabilities.py
@@ -46,9 +46,9 @@ BUILTIN_CAPABILITIES: Final[dict[str, ExecutorCapabilities]] = {
     ),
     "openai-http": ExecutorCapabilities(
         kind="openai-http",
-        tools="unsupported",
+        tools="native",
         structured_output="validated-text",
-        session="unsupported",
+        session="new-only",
         stream="synthetic-lifecycle",
         execution_mode="api-client",
         credential_env_names=("OPENAI_API_KEY",),

--- a/src/ageval/plugins/protocol.py
+++ b/src/ageval/plugins/protocol.py
@@ -30,6 +30,8 @@ class ExecutorSPI(Protocol):
         timeout: float = 60.0,
         collect_dir: str | None = None,
         redaction_sentinels: tuple[str, ...] | list[str] | None = None,
+        tools: Sequence[Mapping[str, Any]] | None = None,
+        messages: Sequence[Mapping[str, Any]] | None = None,
     ) -> Any: ...
 
     def close(self) -> None:

--- a/src/ageval/runtime/agent_service_evidence.py
+++ b/src/ageval/runtime/agent_service_evidence.py
@@ -46,16 +46,21 @@ def write_invoke_request(
     kind: str,
     model: str,
     actor_id: str | None = None,
+    tools: Any = None,
+    messages: Any = None,
 ) -> None:
     """Write request.json + invoke_start lifecycle event. Raises RedactionError."""
+    chat = messages if isinstance(messages, list) and messages else None
     request: dict[str, Any] = {
-        "messages": [{"role": "user", "content": prompt}],
+        "messages": chat if chat is not None else [{"role": "user", "content": prompt}],
         "profile_id": profile_id,
         "executor_kind": kind,
         "model": model,
     }
     if actor_id:
         request["actor_id"] = actor_id
+    if isinstance(tools, list) and tools:
+        request["tools"] = tools
     handle.write_request(request)
     handle.append_event(
         {

--- a/src/ageval/runtime/agent_service_protocol.py
+++ b/src/ageval/runtime/agent_service_protocol.py
@@ -117,9 +117,13 @@ class AgentServiceServer:
                 actor_id=actor_id,
             )
         if op == "invoke":
+            tools = req.get("tools")
+            messages = req.get("messages")
             return self.service.invoke(
                 session_id=str(req.get("session_id") or ""),
                 prompt=str(req.get("prompt") or ""),
+                tools=tools if isinstance(tools, list) else None,
+                messages=messages if isinstance(messages, list) else None,
             )
         if op == "close":
             return self.service.close_session(session_id=str(req.get("session_id") or ""))

--- a/src/ageval/runtime/parent_agent.py
+++ b/src/ageval/runtime/parent_agent.py
@@ -227,7 +227,14 @@ class ParentAgentService:
 
     # --- invoke --------------------------------------------------------------
 
-    def invoke(self, *, session_id: str, prompt: str) -> dict[str, Any]:
+    def invoke(
+        self,
+        *,
+        session_id: str,
+        prompt: str,
+        tools: Any = None,
+        messages: Any = None,
+    ) -> dict[str, Any]:
         refusal = self._refuse_before_effect(session_id)
         if refusal is not None:
             return refusal
@@ -238,7 +245,9 @@ class ParentAgentService:
                 return {"ok": False, "error": "agent_invocation_limit"}
 
         started = time.monotonic()
-        handle, refused = self._begin_evidence(binding, prompt)
+        handle, refused = self._begin_evidence(
+            binding, prompt, tools=tools, messages=messages
+        )
         if refused is not None:
             return self._failed(binding, handle, error=refused)
 
@@ -249,12 +258,16 @@ class ParentAgentService:
 
         try:
             sent = self._chain(binding, BEFORE_AGENT_INVOKE, prompt)
-            result = binding.executor.invoke(
-                sent,
-                timeout=self._invoke_timeout(),
-                collect_dir=collect_dir,
-                redaction_sentinels=sentinels,
-            )
+            invoke_kwargs: dict[str, Any] = {
+                "timeout": self._invoke_timeout(),
+                "collect_dir": collect_dir,
+                "redaction_sentinels": sentinels,
+            }
+            if tools is not None:
+                invoke_kwargs["tools"] = tools
+            if messages is not None:
+                invoke_kwargs["messages"] = messages
+            result = binding.executor.invoke(sent, **invoke_kwargs)
             result = self._chain(binding, AFTER_AGENT_INVOKE, result)
             result = self._chain(binding, NORMALIZE_AGENT_RESULT, result)
         except Exception as exc:  # noqa: BLE001 — a crash still leaves evidence
@@ -293,6 +306,7 @@ class ParentAgentService:
             "remaining_after": self._remaining(),
             "invocation_id": handle.invocation_id if handle else None,
             "evidence_relative": handle.relative_path if handle else None,
+            "tool_calls": _public_tool_calls(result),
         }
 
     # --- guards --------------------------------------------------------------
@@ -338,7 +352,12 @@ class ParentAgentService:
     # --- evidence ------------------------------------------------------------
 
     def _begin_evidence(
-        self, binding: SessionBinding, prompt: str
+        self,
+        binding: SessionBinding,
+        prompt: str,
+        *,
+        tools: Any = None,
+        messages: Any = None,
     ) -> tuple[InvocationHandle | None, str | None]:
         """Open the invocation record. A redaction failure refuses the invoke."""
         if self.evidence_store is None:
@@ -356,6 +375,8 @@ class ParentAgentService:
                 kind=binding.executor_kind,
                 model=binding.model,
                 actor_id=binding.actor_id,
+                tools=tools,
+                messages=messages,
             )
         except RedactionError:
             # The store already sealed this invocation as redaction_failed.
@@ -377,6 +398,7 @@ class ParentAgentService:
             "remaining_after": self._remaining(),
             "invocation_id": handle.invocation_id if handle else None,
             "evidence_relative": handle.relative_path if handle else None,
+            "tool_calls": [],
         }
 
     # --- chains --------------------------------------------------------------
@@ -391,6 +413,23 @@ class ParentAgentService:
         return _drive(run_handlers(handlers, value, ctx=binding))
 
 
+def _public_tool_calls(result: Any) -> list[dict[str, Any]]:
+    raw = getattr(result, "tool_calls", None) or ()
+    out: list[dict[str, Any]] = []
+    for item in raw:
+        if isinstance(item, dict) and str(item.get("name") or ""):
+            out.append(
+                {
+                    "id": str(item.get("id") or ""),
+                    "name": str(item.get("name") or ""),
+                    "arguments": item.get("arguments")
+                    if isinstance(item.get("arguments"), dict)
+                    else {},
+                }
+            )
+    return out
+
+
 def _refusal(error: str) -> dict[str, Any]:
     return {
         "ok": False,
@@ -398,6 +437,7 @@ def _refusal(error: str) -> dict[str, Any]:
         "text": "",
         "structured": None,
         "provider_session_handle": None,
+        "tool_calls": [],
     }
 
 

--- a/src/ageval/runtime/parent_agent.py
+++ b/src/ageval/runtime/parent_agent.py
@@ -245,9 +245,7 @@ class ParentAgentService:
                 return {"ok": False, "error": "agent_invocation_limit"}
 
         started = time.monotonic()
-        handle, refused = self._begin_evidence(
-            binding, prompt, tools=tools, messages=messages
-        )
+        handle, refused = self._begin_evidence(binding, prompt, tools=tools, messages=messages)
         if refused is not None:
             return self._failed(binding, handle, error=refused)
 

--- a/tests/acceptance/test_openai_http_native_tools_cli.py
+++ b/tests/acceptance/test_openai_http_native_tools_cli.py
@@ -1,0 +1,194 @@
+"""Public lock/run: tau2-dialog-min on openai-http native tools (loopback mock)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+from typing import Any
+
+REPO = Path(__file__).resolve().parents[2]
+JOURNEYS = REPO / "examples" / "journeys"
+TASK = "tau2-dialog-min"
+
+_SERVICE_SCRIPT: list[tuple[str, dict[str, Any]]] = [
+    ("find_customer", {"email": "alex@example.com"}),
+    ("get_order", {"order_id": "#W1001"}),
+    ("get_product", {"item_id": "item_headphones"}),
+    (
+        "request_exchange",
+        {
+            "order_id": "#W1001",
+            "from_item_ids": ["item_headphones"],
+            "to_item_ids": ["item_headphones_black"],
+        },
+    ),
+    ("done", {"note": "exchange requested"}),
+]
+
+
+def _ageval(env: dict[str, str], *args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "ageval.cli.main", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        env=env,
+        timeout=180,
+    )
+
+
+def _serve_scripted() -> tuple[ThreadingHTTPServer, str]:
+    state = {"service": 0}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length") or 0)
+            body = json.loads(self.rfile.read(length).decode("utf-8") or "{}")
+            tools = body.get("tools") if isinstance(body.get("tools"), list) else []
+            if tools:
+                idx = min(state["service"], len(_SERVICE_SCRIPT) - 1)
+                name, arguments = _SERVICE_SCRIPT[idx]
+                state["service"] += 1
+                message: dict[str, Any] = {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": f"call_{idx + 1}",
+                            "type": "function",
+                            "function": {
+                                "name": name,
+                                "arguments": json.dumps(arguments),
+                            },
+                        }
+                    ],
+                }
+            else:
+                message = {
+                    "role": "assistant",
+                    "content": json.dumps(
+                        {
+                            "message": (
+                                "Hi, I'm Alex. My email is alex@example.com and "
+                                "order #W1001 arrived with the wrong color headphones; "
+                                "I want the black variant instead."
+                            )
+                        }
+                    ),
+                }
+            raw = json.dumps({"choices": [{"message": message}]}).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+            del format, args
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    return server, f"http://{host}:{port}/v1"
+
+
+def test_tau2_dialog_min_openai_http_native_tools(tmp_path: Path) -> None:
+    dataset = Path(
+        shutil.copytree(JOURNEYS, tmp_path / "journeys", ignore=shutil.ignore_patterns(".ageval"))
+    )
+    server, base = _serve_scripted()
+    profiles = dataset / "profiles.openai-http.yaml"
+    profiles.write_text(
+        "\n".join(
+            [
+                "format: ageval.profiles/1",
+                "environment: local",
+                "agent_profiles:",
+                "  user:",
+                "    executor: openai-http",
+                "    model: mock",
+                f"    base_url: {base}",
+                "    api_key: ${OPENAI_API_KEY}",
+                "    extensions:",
+                "      - plugin: openai-http",
+                "      - plugin: local",
+                "  service:",
+                "    executor: openai-http",
+                "    model: mock",
+                f"    base_url: {base}",
+                "    api_key: ${OPENAI_API_KEY}",
+                "    extensions:",
+                "      - plugin: openai-http",
+                "      - plugin: local",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.pop("AGEVAL_OFFLINE_AGENT", None)
+    env["OPENAI_API_KEY"] = "ci-loopback-placeholder"
+    try:
+        locked = _ageval(
+            env,
+            "lock",
+            str(dataset),
+            "--task",
+            TASK,
+            "--profiles",
+            str(profiles),
+            cwd=dataset,
+        )
+        assert locked.returncode == 0, locked.stderr
+        lock_doc = json.loads(locked.stdout)
+        dumped = json.dumps(lock_doc)
+        assert "ci-loopback-placeholder" not in dumped
+        assert "sk-" not in dumped.lower()
+        assert lock_doc["task_id"] == TASK
+
+        ran = _ageval(
+            env,
+            "run",
+            str(dataset),
+            "--task",
+            TASK,
+            "--profiles",
+            str(profiles),
+            cwd=dataset,
+        )
+        assert ran.returncode == 0, (ran.stdout, ran.stderr)
+        result = json.loads(ran.stdout)
+        assert result["status"] == "PASS"
+        assert "Tool " not in ran.stderr
+        assert "not found" not in ran.stderr.lower()
+        states = list(dataset.rglob("final-state.json"))
+        assert states, "published final-state missing"
+        final = json.loads(states[0].read_text(encoding="utf-8"))
+        assert int(final.get("tool_calls") or 0) > 0
+        used = final.get("tools_used") or []
+        assert "find_customer" in used
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_tau2_dialog_min_acp_lock_does_not_require_tools() -> None:
+    env = os.environ.copy()
+    env.setdefault("ZHIPU_API_KEY", "ci-offline-placeholder")
+    locked = _ageval(env, "lock", str(JOURNEYS), "--task", TASK, cwd=REPO)
+    assert locked.returncode == 0, locked.stderr
+    doc = json.loads(locked.stdout)
+    assert doc["task_id"] == TASK
+    overlay = doc.get("job_overlay") or {}
+    profiles = overlay.get("agent_profiles") or {}
+    for row in profiles.values():
+        if isinstance(row, dict):
+            assert row.get("executor") == "acp"

--- a/tests/adapters/test_executor_inventory.py
+++ b/tests/adapters/test_executor_inventory.py
@@ -36,10 +36,12 @@ def test_describe_acp_kind() -> None:
 
 
 def test_describe_api_client_no_binary() -> None:
-    row = describe_executor("openai-http", which=lambda _n: None, verbose=False)
+    row = describe_executor("openai-http", which=lambda _n: None, verbose=True)
     assert row["execution_mode"] == "api-client"
     assert row["binary_on_path"] is None
     assert row["host_ready"] is True
+    assert row["tools"] == "native"
+    assert row["session"] == "new-only"
 
 
 def test_describe_acp_entry_adapter_missing() -> None:

--- a/tests/helpers/agent_binding.py
+++ b/tests/helpers/agent_binding.py
@@ -22,12 +22,21 @@ class ScriptedExecutor:
 
     kind = "scripted"
 
-    def __init__(self, *, raises: BaseException | None = None, ok: bool = True) -> None:
+    def __init__(
+        self,
+        *,
+        raises: BaseException | None = None,
+        ok: bool = True,
+        tool_calls: tuple[dict[str, Any], ...] | None = None,
+    ) -> None:
         self.prompts: list[str] = []
         self.timeouts: list[float] = []
+        self.tools: list[Any] = []
+        self.messages: list[Any] = []
         self.closed = False
         self._raises = raises
         self._ok = ok
+        self._tool_calls = tool_calls or ()
 
     def invoke(
         self,
@@ -36,10 +45,14 @@ class ScriptedExecutor:
         timeout: float = 60.0,
         collect_dir: Any = None,
         redaction_sentinels: tuple[str, ...] | list[str] | None = None,
+        tools: Any = None,
+        messages: Any = None,
     ) -> AgentResult:
         del collect_dir, redaction_sentinels
         self.prompts.append(prompt)
         self.timeouts.append(timeout)
+        self.tools.append(tools)
+        self.messages.append(messages)
         if self._raises is not None:
             raise self._raises
         turn = len(self.prompts)
@@ -50,6 +63,7 @@ class ScriptedExecutor:
             ok=self._ok,
             error=None if self._ok else "scripted_failure",
             metadata={"executor_kind": self.kind},
+            tool_calls=self._tool_calls,
         )
 
     def close(self) -> None:

--- a/tests/plugins/test_acp_executor.py
+++ b/tests/plugins/test_acp_executor.py
@@ -49,7 +49,11 @@ def test_offline_forced() -> None:
     os.environ["AGEVAL_OFFLINE_AGENT"] = "1"
     try:
         ex = _executor(entry_id="opencode", model="entry-default")
-        r = ex.invoke("hi", timeout=5)
+        r = ex.invoke(
+            "hi",
+            timeout=5,
+            tools=[{"type": "function", "function": {"name": "unused"}}],
+        )
         assert r.ok is False
         assert r.error == "offline_forced"
         assert r.metadata is not None

--- a/tests/plugins/test_openai_http_executor.py
+++ b/tests/plugins/test_openai_http_executor.py
@@ -1,0 +1,144 @@
+"""openai-http: native tools= round-trip on a loopback mock; missing key fail-closed."""
+
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from typing import Any
+
+import pytest
+
+from ageval.plugins.contrib.openai_http.executor import OpenAIHTTPExecutor
+from ageval.plugins.executor_capabilities import get_capabilities
+
+
+def _serve(handler: type[BaseHTTPRequestHandler]) -> tuple[ThreadingHTTPServer, str]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    return server, f"http://{host}:{port}/v1"
+
+
+def test_capability_matrix_is_native_tools() -> None:
+    caps = get_capabilities("openai-http")
+    assert caps is not None
+    assert caps.tools == "native"
+    assert caps.session == "new-only"
+    assert caps.execution_mode == "api-client"
+
+
+def test_missing_credential_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    result = OpenAIHTTPExecutor(base_url="https://api.example.invalid/v1").invoke("hi")
+    assert result.ok is False
+    assert result.error == "missing_credential"
+    assert result.tool_calls == ()
+
+
+def test_tools_round_trip_on_loopback() -> None:
+    captured: dict[str, Any] = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length") or 0)
+            captured["path"] = self.path
+            captured["body"] = json.loads(self.rfile.read(length).decode("utf-8"))
+            payload = {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_1",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "find_customer",
+                                        "arguments": '{"email":"alex@example.com"}',
+                                    },
+                                }
+                            ],
+                        }
+                    }
+                ]
+            }
+            raw = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+            del format, args
+
+    server, base = _serve(Handler)
+    try:
+        result = OpenAIHTTPExecutor(model="mock", base_url=base).invoke(
+            "lookup the customer",
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "find_customer",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"email": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert result.ok is True
+    assert result.tool_calls == (
+        {
+            "id": "call_1",
+            "name": "find_customer",
+            "arguments": {"email": "alex@example.com"},
+        },
+    )
+    assert captured["path"].endswith("/chat/completions")
+    assert "tools" in captured["body"]
+    assert captured["body"]["tools"][0]["function"]["name"] == "find_customer"
+    dumped = json.dumps(captured["body"])
+    assert "sk-" not in dumped
+    assert "Bearer" not in dumped
+
+
+def test_omit_tools_keeps_content_path() -> None:
+    captured: dict[str, Any] = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length") or 0)
+            captured["body"] = json.loads(self.rfile.read(length).decode("utf-8"))
+            raw = json.dumps(
+                {"choices": [{"message": {"role": "assistant", "content": '{"ok":true}'}}]}
+            ).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+            del format, args
+
+    server, base = _serve(Handler)
+    try:
+        result = OpenAIHTTPExecutor(model="mock", base_url=base).invoke("hello")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert result.ok is True
+    assert result.tool_calls == ()
+    assert result.structured == {"ok": True}
+    assert "tools" not in captured["body"]

--- a/tests/runtime/test_parent_agent.py
+++ b/tests/runtime/test_parent_agent.py
@@ -57,6 +57,29 @@ def _open(service: ParentAgentService, profile_id: str = "solver") -> str:
     return str(opened["session_id"])
 
 
+def test_invoke_forwards_tools_and_returns_tool_calls(tmp_path: Path) -> None:
+    backend = ScriptedExecutor(
+        tool_calls=({"id": "call_1", "name": "lookup", "arguments": {"q": "a"}},)
+    )
+    service, _ = _service(tmp_path, executor=backend)
+    catalog = [{"type": "function", "function": {"name": "lookup"}}]
+    history = [{"role": "user", "content": "need lookup"}]
+
+    answer = service.invoke(
+        session_id=_open(service),
+        prompt="need lookup",
+        tools=catalog,
+        messages=history,
+    )
+
+    assert answer["ok"] is True
+    assert answer["tool_calls"] == [
+        {"id": "call_1", "name": "lookup", "arguments": {"q": "a"}},
+    ]
+    assert backend.tools == [catalog]
+    assert backend.messages == [history]
+
+
 def test_session_invokes_carry_turns_and_evidence(tmp_path: Path) -> None:
     service, backend = _service(tmp_path)
     session = _open(service)

--- a/tests/sdk/test_agent_session_api.py
+++ b/tests/sdk/test_agent_session_api.py
@@ -18,6 +18,40 @@ def test_session_rejects_profile_overrides() -> None:
     asyncio.run(_run())
 
 
+def test_session_forwards_tools_without_treating_them_as_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[dict[str, object]] = []
+
+    def _fake_call(payload: dict[str, object]) -> dict[str, object]:
+        captured.append(payload)
+        if payload.get("op") == "open":
+            return {"ok": True, "session_id": "sess_test"}
+        return {
+            "ok": True,
+            "text": "",
+            "tool_calls": [
+                {"id": "call_1", "name": "lookup", "arguments": {"q": "a"}},
+            ],
+        }
+
+    monkeypatch.delenv("AGEVAL_OFFLINE_AGENT", raising=False)
+    monkeypatch.setattr("ageval_sdk.agent._parent_call", _fake_call)
+    session = AgentSession(attempt_id="attempt_x", profile_id="p", max_turns=2)
+    catalog = [{"type": "function", "function": {"name": "lookup"}}]
+    history = [{"role": "user", "content": "hi"}]
+
+    answer = asyncio.run(session.invoke("hi", tools=catalog, messages=history))
+
+    assert answer["ok"] is True
+    assert answer["tool_calls"] == [
+        {"id": "call_1", "name": "lookup", "arguments": {"q": "a"}},
+    ]
+    invoke = next(item for item in captured if item.get("op") == "invoke")
+    assert invoke["tools"] == catalog
+    assert invoke["messages"] == history
+
+
 def test_unbound_session_reports_failure_instead_of_answering(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

`openai-http` now posts OpenAI-compatible `tools=` when a harness passes a catalog, and `AgentResult.tool_calls` round-trips to `run.py`. tau2-class harnesses (`tau2-dialog-min`, `tau3-airline`) execute domain tools via `ToolSet.call` / `Environment.get_response` instead of scraping assistant JSON as the primary channel. ACP still ignores the catalog (text invoke unchanged). Omit `tools`/`messages` = previous prompt-only behavior.

## Approach

- Design first: `docs/design/03-task-run-and-sdk.md` and `docs/design/05-runtime/agent-service.md`.
- SDK `session.invoke(..., tools=, messages=)` forwards over the parent socket; profile overrides stay rejected.
- Kind name stays `openai-http`. Capability matrix: `tools: native`, `session: new-only`.
- JSON scrape remains ACP fallback only. No new executor kind, no LiteLLM Core dependency, no ACP/MCP tool registration.

## Test plan

- [x] Local CI-equivalent: `ruff format --check`, `ruff check`, `pyright`, python-core pytest ignore list (643 passed, 3 skipped)
- [x] Public `ageval lock` / `ageval run` on `examples/journeys --task tau2-dialog-min` with loopback openai-http (native `tool_calls` > 0, PASS)
- [x] ACP lock of the same journey still binds `executor: acp` (no `tools=` required)
- [x] Missing credential fail-closed; lock JSON stores locator names only
- [x] Extra (this delivery): real `ageval run examples/tau3-airline --task airline-00` on `executor: openai-http`
  - LiteLLM gateway + `glm-5.2`: PASS, reward 1.0, harness `tool_calls` 2
  - GLM coding-plan key + `glm-5.2`: PASS, reward 1.0, harness `tool_calls` 2
  - Keys never written into lock/evidence (locator names only)

## Follow-ups

- Live ACP run of the converted harnesses is not claimed here (original coding-agent `Tool … not found` path is unchanged).
- `nooa` / `dsh` / `miniswe` invoke signatures do not take `tools=`; mixing those executors with tau2/tau3 harnesses would TypeError.

Closes #174
