### PR TITLE
feat(runtime): first-class trajectory usage, Hub chips, slim evidence

### DIFF
--- a/apps/hub/src/components/trial/trajectory-panel.tsx
+++ b/apps/hub/src/components/trial/trajectory-panel.tsx
@@ -49,30 +49,15 @@ function firstClassUsage(usage: Record<string, unknown> | null | undefined): {
   completion: number | null;
   cached: number | null;
   costUsd: number | null;
-  extra: Record<string, unknown> | null;
 } {
   if (!usage) {
-    return { prompt: null, completion: null, cached: null, costUsd: null, extra: null };
+    return { prompt: null, completion: null, cached: null, costUsd: null };
   }
-  const extraRaw = usage.extra;
-  const extra =
-    extraRaw && typeof extraRaw === "object" && !Array.isArray(extraRaw)
-      ? (extraRaw as Record<string, unknown>)
-      : null;
-  const costObj =
-    extra?.cost && typeof extra.cost === "object" && !Array.isArray(extra.cost)
-      ? (extra.cost as Record<string, unknown>)
-      : usage.cost && typeof usage.cost === "object" && !Array.isArray(usage.cost)
-        ? (usage.cost as Record<string, unknown>)
-        : null;
   return {
-    prompt: asInt(usage.prompt_tokens) ?? asInt(usage.input_tokens),
-    completion: asInt(usage.completion_tokens) ?? asInt(usage.output_tokens),
-    cached: asInt(usage.cached_tokens) ?? asInt(usage.cached_read_tokens),
-    costUsd:
-      asFiniteNumber(usage.cost_usd) ??
-      (costObj ? asFiniteNumber(costObj.amount) : null),
-    extra,
+    prompt: asInt(usage.prompt_tokens),
+    completion: asInt(usage.completion_tokens),
+    cached: asInt(usage.cached_tokens),
+    costUsd: asFiniteNumber(usage.cost_usd),
   };
 }
 
@@ -85,11 +70,7 @@ function UsageChips({
 }) {
   const parsed = firstClassUsage(usage);
   const extra =
-    parsed.extra && Object.keys(parsed.extra).length > 0
-      ? parsed.extra
-      : siblingExtra && Object.keys(siblingExtra).length > 0
-        ? siblingExtra
-        : null;
+    siblingExtra && Object.keys(siblingExtra).length > 0 ? siblingExtra : null;
   const chips: Array<{ key: string; text: string }> = [];
   if (parsed.prompt != null) chips.push({ key: "prompt", text: `prompt ${parsed.prompt}` });
   if (parsed.completion != null) {

--- a/apps/hub/src/components/trial/trajectory-panel.tsx
+++ b/apps/hub/src/components/trial/trajectory-panel.tsx
@@ -33,6 +33,112 @@ type IconComp = ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
 const LONG_BODY_CHARS = 240;
 const LONG_BODY_LINES = 4;
 
+function asFiniteNumber(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return value;
+}
+
+function asInt(value: unknown): number | null {
+  const n = asFiniteNumber(value);
+  if (n == null || !Number.isInteger(n)) return null;
+  return n;
+}
+
+function firstClassUsage(usage: Record<string, unknown> | null | undefined): {
+  prompt: number | null;
+  completion: number | null;
+  cached: number | null;
+  costUsd: number | null;
+  extra: Record<string, unknown> | null;
+} {
+  if (!usage) {
+    return { prompt: null, completion: null, cached: null, costUsd: null, extra: null };
+  }
+  const extraRaw = usage.extra;
+  const extra =
+    extraRaw && typeof extraRaw === "object" && !Array.isArray(extraRaw)
+      ? (extraRaw as Record<string, unknown>)
+      : null;
+  const costObj =
+    extra?.cost && typeof extra.cost === "object" && !Array.isArray(extra.cost)
+      ? (extra.cost as Record<string, unknown>)
+      : usage.cost && typeof usage.cost === "object" && !Array.isArray(usage.cost)
+        ? (usage.cost as Record<string, unknown>)
+        : null;
+  return {
+    prompt: asInt(usage.prompt_tokens) ?? asInt(usage.input_tokens),
+    completion: asInt(usage.completion_tokens) ?? asInt(usage.output_tokens),
+    cached: asInt(usage.cached_tokens) ?? asInt(usage.cached_read_tokens),
+    costUsd:
+      asFiniteNumber(usage.cost_usd) ??
+      (costObj ? asFiniteNumber(costObj.amount) : null),
+    extra,
+  };
+}
+
+function UsageChips({
+  usage,
+  siblingExtra,
+}: {
+  usage: Record<string, unknown> | null | undefined;
+  siblingExtra?: Record<string, unknown> | null;
+}) {
+  const parsed = firstClassUsage(usage);
+  const extra =
+    parsed.extra && Object.keys(parsed.extra).length > 0
+      ? parsed.extra
+      : siblingExtra && Object.keys(siblingExtra).length > 0
+        ? siblingExtra
+        : null;
+  const chips: Array<{ key: string; text: string }> = [];
+  if (parsed.prompt != null) chips.push({ key: "prompt", text: `prompt ${parsed.prompt}` });
+  if (parsed.completion != null) {
+    chips.push({ key: "completion", text: `completion ${parsed.completion}` });
+  }
+  if (parsed.cached != null) chips.push({ key: "cached", text: `cached ${parsed.cached}` });
+  if (parsed.costUsd != null) {
+    const text =
+      parsed.costUsd === 0 ? "cost $0" : `cost $${Number(parsed.costUsd).toPrecision(4)}`;
+    chips.push({ key: "cost", text });
+  }
+  if (chips.length === 0 && !extra) return null;
+  return (
+    <div className="px-3 pb-2.5 space-y-1.5">
+      {chips.length ? (
+        <div className="flex flex-wrap gap-1">
+          {chips.map((c) => (
+            <span
+              key={c.key}
+              className="rounded-[6px] border border-hairline bg-canvas-soft px-1.5 py-0 font-mono text-[11px] text-body tabular"
+            >
+              {c.text}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      {extra ? (
+        <details className="text-[11px] text-mute">
+          <summary className="cursor-pointer select-none">extra</summary>
+          <pre className="mt-1 m-0 whitespace-pre-wrap break-words font-mono text-[11px] leading-4 text-body">
+            {JSON.stringify(extra, null, 2)}
+          </pre>
+        </details>
+      ) : null}
+    </div>
+  );
+}
+
+function stepElapsedMs(s: {
+  elapsed_ms?: number | null;
+  metadata?: Record<string, unknown> | null;
+}): number | null {
+  const direct = asFiniteNumber(s.elapsed_ms);
+  if (direct != null && direct >= 0) return direct;
+  const lat = asFiniteNumber(s.metadata?.latency_ms);
+  if (lat != null && lat >= 0) return lat;
+  return null;
+}
+
 function formatElapsedMs(ms: number): string {
   if (!Number.isFinite(ms) || ms < 0) return "";
   if (ms < 1000) return `${Math.round(ms)}ms`;
@@ -289,9 +395,6 @@ export function TrajectoryPanel({
             else if (s.ok === false) bits.push("not ok");
             if (s.stop_reason) bits.push(`stop=${s.stop_reason}`);
             if (s.error) bits.push(`error=${String(s.error)}`);
-            if (s.usage && typeof s.usage === "object") {
-              bits.push(`usage=${JSON.stringify(s.usage)}`);
-            }
             if (s.metadata && typeof s.metadata === "object") {
               const meta = s.metadata;
               const metaBits = (
@@ -371,13 +474,14 @@ export function TrajectoryPanel({
                   {s.ok === false ? (
                     <span className="text-error">not ok</span>
                   ) : null}
-                  {typeof s.elapsed_ms === "number" &&
-                  Number.isFinite(s.elapsed_ms) &&
-                  s.elapsed_ms >= 0 ? (
-                    <HoverTip content="tool duration (observational)">
-                      <span>{formatElapsedMs(s.elapsed_ms)}</span>
+                  {(() => {
+                    const elapsed = stepElapsedMs(s);
+                    return elapsed != null ? (
+                    <HoverTip content="duration (observational)">
+                      <span>{formatElapsedMs(elapsed)}</span>
                     </HoverTip>
-                  ) : null}
+                    ) : null;
+                  })()}
                 </div>
                 {body ? <CopyBodyButton text={body} /> : null}
               </div>
@@ -391,16 +495,23 @@ export function TrajectoryPanel({
                   expandAll={allExpanded}
                   expandGen={expandGen}
                 />
-              ) : s.error ? (
-                <p className="px-3 pb-2.5 text-sm text-error">{String(s.error)}</p>
-              ) : isTerminal ? (
-                <p className="px-3 pb-2.5 text-sm text-mute">terminal (no summary)</p>
-              ) : isPermission ? (
-                <p className="px-3 pb-2.5 text-sm text-mute">permission (no decision fields)</p>
-              ) : isToolCall || isObservation ? (
-                <p className="px-3 pb-2.5 text-sm text-mute">
-                  {isToolCall ? "tool call (no args)" : "observation (empty)"}
-                </p>
+              ) : null}
+              {isTerminal ? (
+                <UsageChips
+                  usage={s.usage}
+                  siblingExtra={s.extra}
+                />
+              ) : null}
+              {!body && !isTerminal ? (
+                s.error ? (
+                  <p className="px-3 pb-2.5 text-sm text-error">{String(s.error)}</p>
+                ) : isPermission ? (
+                  <p className="px-3 pb-2.5 text-sm text-mute">permission (no decision fields)</p>
+                ) : isToolCall || isObservation ? (
+                  <p className="px-3 pb-2.5 text-sm text-mute">
+                    {isToolCall ? "tool call (no args)" : "observation (empty)"}
+                  </p>
+                ) : null
               ) : null}
             </li>
           );

--- a/apps/hub/src/hooks/use-attempt-evidence.ts
+++ b/apps/hub/src/hooks/use-attempt-evidence.ts
@@ -160,6 +160,21 @@ export function useAttemptEvidence(
         if (cancelled) return;
         setInvProfileByDir(profileMap);
 
+        let trajectorySteps: TrajectoryStep[] = [];
+        if (pathSet.has("trajectory.jsonl")) {
+          try {
+            const f = await getAttemptFile(
+              runId,
+              toArchivePath("trajectory.jsonl", runId),
+              token,
+            );
+            if (cancelled) return;
+            trajectorySteps = parseTrajectoryJsonl(decodeFileContent(f) || "");
+          } catch {
+            trajectorySteps = [];
+          }
+        }
+
         const t = buildTrialMeta({
           runId,
           taskId: taskId || m.task_id || "",
@@ -168,6 +183,7 @@ export function useAttemptEvidence(
           summary: summaryJ,
           lock: lockJ,
           invMetas,
+          trajectorySteps,
         });
         setTrial(t);
         const tabs = availableTabsFromPaths(rel.map((f) => f.path));
@@ -222,7 +238,7 @@ export function useAttemptEvidence(
                 ...s,
                 invocation: dirname || undefined,
                 invocation_id: dirname || undefined,
-                profile_id,
+                profile_id: profile_id || s.profile_id,
               });
             }
           }

--- a/apps/hub/src/lib/attempt-evidence.ts
+++ b/apps/hub/src/lib/attempt-evidence.ts
@@ -278,13 +278,6 @@ function asInt(value: unknown): number | null {
   return n;
 }
 
-function extraBag(usage: Record<string, unknown> | null | undefined): Record<string, unknown> {
-  const extra = usage?.extra;
-  return extra && typeof extra === "object" && !Array.isArray(extra)
-    ? (extra as Record<string, unknown>)
-    : {};
-}
-
 function fmtTokenCount(n: number): string {
   if (n >= 1_000_000) {
     const v = n / 1_000_000;
@@ -304,36 +297,41 @@ function fmtCost(amount: number): string {
 
 export function summarizeUsage(
   usage: Record<string, unknown> | null | undefined,
+  extraRaw?: Record<string, unknown> | null,
 ): NonNullable<TrialActor["usage"]> | null {
-  if (!usage) return null;
-  const extra = extraBag(usage);
+  if (!usage && !extraRaw) return null;
+  const extra =
+    extraRaw && typeof extraRaw === "object" && !Array.isArray(extraRaw)
+      ? extraRaw
+      : {};
+  const fields = usage ?? {};
   const inp =
-    asInt(usage.prompt_tokens) ??
-    asInt(usage.input_tokens) ??
-    asInt(usage.inputTokens);
+    asInt(fields.prompt_tokens) ??
+    asInt(fields.input_tokens) ??
+    asInt(fields.inputTokens);
   const outp =
-    asInt(usage.completion_tokens) ??
-    asInt(usage.output_tokens) ??
-    asInt(usage.outputTokens);
+    asInt(fields.completion_tokens) ??
+    asInt(fields.output_tokens) ??
+    asInt(fields.outputTokens);
   const cachedRead =
-    asInt(usage.cached_tokens) ??
-    asInt(usage.cached_read_tokens) ??
-    asInt(usage.cachedReadTokens) ??
+    asInt(fields.cached_tokens) ??
+    asInt(fields.cached_read_tokens) ??
+    asInt(fields.cachedReadTokens) ??
     asInt(extra.cached_read_tokens);
   const cachedWrite =
     asInt(extra.cached_write_tokens) ??
-    asInt(usage.cached_write_tokens) ??
-    asInt(usage.cachedWriteTokens);
+    asInt(fields.cached_write_tokens) ??
+    asInt(fields.cachedWriteTokens);
   const total =
-    asInt(extra.total_tokens) ?? asInt(usage.total_tokens) ?? asInt(usage.totalTokens);
+    asInt(extra.total_tokens) ?? asInt(fields.total_tokens) ?? asInt(fields.totalTokens);
 
-  let costAmount = asFiniteNumber(usage.cost_usd);
+  let costAmount = asFiniteNumber(fields.cost_usd);
   let costCurrency: string | null = costAmount != null ? "USD" : null;
   const costRaw =
     extra.cost && typeof extra.cost === "object" && !Array.isArray(extra.cost)
       ? (extra.cost as Record<string, unknown>)
-      : usage.cost && typeof usage.cost === "object" && !Array.isArray(usage.cost)
-        ? (usage.cost as Record<string, unknown>)
+      : fields.cost && typeof fields.cost === "object" && !Array.isArray(fields.cost)
+        ? (fields.cost as Record<string, unknown>)
         : null;
   if (costAmount == null && costRaw) {
     costAmount = asFiniteNumber(costRaw.amount);
@@ -345,11 +343,11 @@ export function summarizeUsage(
   const contextRaw =
     extra.context && typeof extra.context === "object" && !Array.isArray(extra.context)
       ? (extra.context as Record<string, unknown>)
-      : usage.context && typeof usage.context === "object" && !Array.isArray(usage.context)
-        ? (usage.context as Record<string, unknown>)
+      : fields.context && typeof fields.context === "object" && !Array.isArray(fields.context)
+        ? (fields.context as Record<string, unknown>)
         : null;
-  const contextUsed = asInt(contextRaw?.used) ?? asInt(usage.used);
-  const contextSize = asInt(contextRaw?.size) ?? asInt(usage.size);
+  const contextUsed = asInt(contextRaw?.used) ?? asInt(fields.used);
+  const contextSize = asInt(contextRaw?.size) ?? asInt(fields.size);
 
   let cacheHitRate: number | null = null;
   if (inp != null && cachedRead != null && inp > 0) {
@@ -523,6 +521,7 @@ export function buildTrialMeta(opts: {
   }
 
   const jsonlUsage = new Map<string, Record<string, unknown>>();
+  const jsonlExtra = new Map<string, Record<string, unknown>>();
   const jsonlLatency = new Map<string, number>();
   const jsonlCount = new Map<string, number>();
   for (const step of trajectorySteps || []) {
@@ -532,6 +531,9 @@ export function buildTrialMeta(opts: {
     if (!orderedIds.includes(pid)) orderedIds.push(pid);
     if (step.usage && typeof step.usage === "object") {
       jsonlUsage.set(pid, step.usage);
+    }
+    if (step.extra && typeof step.extra === "object") {
+      jsonlExtra.set(pid, step.extra);
     }
     const elapsed = terminalElapsedMs(step);
     if (elapsed != null) {
@@ -568,7 +570,10 @@ export function buildTrialMeta(opts: {
     const roleCol = pid;
     const nInv = jsonlCount.get(pid) || invokeCount.get(pid) || 0;
     const latTotal = jsonlLatency.has(pid) ? jsonlLatency.get(pid) : latencySum.get(pid);
-    const usageSummary = summarizeUsage(jsonlUsage.get(pid) ?? null);
+    const usageSummary = summarizeUsage(
+      jsonlUsage.get(pid) ?? null,
+      jsonlExtra.get(pid) ?? null,
+    );
     actors.push({
       role: roleCol,
       agent: agentCol,

--- a/apps/hub/src/lib/attempt-evidence.ts
+++ b/apps/hub/src/lib/attempt-evidence.ts
@@ -267,6 +267,153 @@ function durationFromPhaseTiming(phaseTiming: Trial["phase_timing"]): string | n
   return seconds ? `${minutes}m ${String(seconds).padStart(2, "0")}s` : `${minutes}m`;
 }
 
+function asFiniteNumber(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return value;
+}
+
+function asInt(value: unknown): number | null {
+  const n = asFiniteNumber(value);
+  if (n == null || !Number.isInteger(n)) return null;
+  return n;
+}
+
+function extraBag(usage: Record<string, unknown> | null | undefined): Record<string, unknown> {
+  const extra = usage?.extra;
+  return extra && typeof extra === "object" && !Array.isArray(extra)
+    ? (extra as Record<string, unknown>)
+    : {};
+}
+
+function fmtTokenCount(n: number): string {
+  if (n >= 1_000_000) {
+    const v = n / 1_000_000;
+    return v === Math.trunc(v) ? `${v}M` : `${v.toFixed(1)}M`;
+  }
+  if (n >= 1000) {
+    const v = n / 1000;
+    return v === Math.trunc(v) ? `${v}K` : `${v.toFixed(1)}K`;
+  }
+  return String(n);
+}
+
+function fmtCost(amount: number): string {
+  if (amount === 0) return "0";
+  return Number(amount).toPrecision(4).replace(/\.?0+$/, "");
+}
+
+export function summarizeUsage(
+  usage: Record<string, unknown> | null | undefined,
+): NonNullable<TrialActor["usage"]> | null {
+  if (!usage) return null;
+  const extra = extraBag(usage);
+  const inp =
+    asInt(usage.prompt_tokens) ??
+    asInt(usage.input_tokens) ??
+    asInt(usage.inputTokens);
+  const outp =
+    asInt(usage.completion_tokens) ??
+    asInt(usage.output_tokens) ??
+    asInt(usage.outputTokens);
+  const cachedRead =
+    asInt(usage.cached_tokens) ??
+    asInt(usage.cached_read_tokens) ??
+    asInt(usage.cachedReadTokens) ??
+    asInt(extra.cached_read_tokens);
+  const cachedWrite =
+    asInt(extra.cached_write_tokens) ??
+    asInt(usage.cached_write_tokens) ??
+    asInt(usage.cachedWriteTokens);
+  const total =
+    asInt(extra.total_tokens) ?? asInt(usage.total_tokens) ?? asInt(usage.totalTokens);
+
+  let costAmount = asFiniteNumber(usage.cost_usd);
+  let costCurrency: string | null = costAmount != null ? "USD" : null;
+  const costRaw =
+    extra.cost && typeof extra.cost === "object" && !Array.isArray(extra.cost)
+      ? (extra.cost as Record<string, unknown>)
+      : usage.cost && typeof usage.cost === "object" && !Array.isArray(usage.cost)
+        ? (usage.cost as Record<string, unknown>)
+        : null;
+  if (costAmount == null && costRaw) {
+    costAmount = asFiniteNumber(costRaw.amount);
+    if (typeof costRaw.currency === "string" && costRaw.currency.trim()) {
+      costCurrency = costRaw.currency.trim();
+    }
+  }
+
+  const contextRaw =
+    extra.context && typeof extra.context === "object" && !Array.isArray(extra.context)
+      ? (extra.context as Record<string, unknown>)
+      : usage.context && typeof usage.context === "object" && !Array.isArray(usage.context)
+        ? (usage.context as Record<string, unknown>)
+        : null;
+  const contextUsed = asInt(contextRaw?.used) ?? asInt(usage.used);
+  const contextSize = asInt(contextRaw?.size) ?? asInt(usage.size);
+
+  let cacheHitRate: number | null = null;
+  if (inp != null && cachedRead != null && inp > 0) {
+    if (cachedRead <= inp) {
+      cacheHitRate = cachedRead / inp;
+    } else {
+      const denom = inp + cachedRead + (cachedWrite && cachedWrite > 0 ? cachedWrite : 0);
+      cacheHitRate = denom > 0 ? cachedRead / denom : null;
+    }
+  }
+
+  if (
+    inp == null &&
+    outp == null &&
+    costAmount == null &&
+    contextUsed == null &&
+    contextSize == null
+  ) {
+    return null;
+  }
+
+  const parts: string[] = [];
+  if (inp != null || outp != null) {
+    parts.push(
+      `in ${inp != null ? fmtTokenCount(inp) : "-"} / out ${outp != null ? fmtTokenCount(outp) : "-"}`,
+    );
+  }
+  if (cacheHitRate != null) {
+    parts.push(`cache ${Math.round(Math.max(0, Math.min(1, cacheHitRate)) * 100)}%`);
+  }
+  if (costAmount != null) {
+    const cur = (costCurrency || "").toUpperCase();
+    parts.push(cur === "" || cur === "USD" ? `$${fmtCost(costAmount)}` : `${fmtCost(costAmount)} ${cur}`);
+  }
+
+  return {
+    input_tokens: inp,
+    output_tokens: outp,
+    total_tokens: total,
+    cached_read_tokens: cachedRead,
+    cache_hit_rate: cacheHitRate,
+    cost_amount: costAmount,
+    cost_currency: costCurrency,
+    context_used: contextUsed,
+    context_size: contextSize,
+    label: parts.length ? parts.join(" · ") : null,
+  };
+}
+
+function terminalProfileId(step: TrajectoryStep): string | null {
+  if (typeof step.profile_id === "string" && step.profile_id) return step.profile_id;
+  const meta = step.metadata;
+  if (meta && typeof meta.profile_id === "string" && meta.profile_id) return meta.profile_id;
+  return null;
+}
+
+function terminalElapsedMs(step: TrajectoryStep): number | null {
+  const direct = asFiniteNumber(step.elapsed_ms);
+  if (direct != null && direct >= 0) return direct;
+  const lat = asFiniteNumber(step.metadata?.latency_ms);
+  if (lat != null && lat >= 0) return lat;
+  return null;
+}
+
 function formatLatencyMs(
   total: number | undefined,
   nInv: number,
@@ -286,8 +433,9 @@ export function buildTrialMeta(opts: {
   summary: Record<string, unknown>;
   lock: Record<string, unknown>;
   invMetas: Array<{ dirname: string; meta: Record<string, unknown> }>;
+  trajectorySteps?: TrajectoryStep[];
 }): Trial {
-  const { runId, taskId, relFiles, result, summary, lock, invMetas } = opts;
+  const { runId, taskId, relFiles, result, summary, lock, invMetas, trajectorySteps } = opts;
   const tabs = availableTabsFromPaths(relFiles);
 
   let status =
@@ -373,6 +521,28 @@ export function buildTrialMeta(opts: {
     }
     void dirname;
   }
+
+  const jsonlUsage = new Map<string, Record<string, unknown>>();
+  const jsonlLatency = new Map<string, number>();
+  const jsonlCount = new Map<string, number>();
+  for (const step of trajectorySteps || []) {
+    if (step.type !== "terminal") continue;
+    const pid = terminalProfileId(step);
+    if (!pid) continue;
+    if (!orderedIds.includes(pid)) orderedIds.push(pid);
+    if (step.usage && typeof step.usage === "object") {
+      jsonlUsage.set(pid, step.usage);
+    }
+    const elapsed = terminalElapsedMs(step);
+    if (elapsed != null) {
+      jsonlLatency.set(pid, (jsonlLatency.get(pid) || 0) + elapsed);
+      jsonlCount.set(pid, (jsonlCount.get(pid) || 0) + 1);
+    }
+    const mid = step.model ?? step.metadata?.model ?? step.metadata?.locked_model;
+    if (typeof mid === "string" && mid) invModel.set(pid, mid);
+    const ek = step.metadata?.executor_kind;
+    if (typeof ek === "string" && ek) invExecutor.set(pid, ek);
+  }
   if (orderedIds.length === 0) {
     for (const pid of byId.keys()) orderedIds.push(pid);
   }
@@ -396,8 +566,9 @@ export function buildTrialMeta(opts: {
     const agentCol =
       actorAgentName(p, overlay, invEntry.get(pid)) || pid;
     const roleCol = pid;
-    const nInv = invokeCount.get(pid) || 0;
-    const latTotal = latencySum.get(pid);
+    const nInv = jsonlCount.get(pid) || invokeCount.get(pid) || 0;
+    const latTotal = jsonlLatency.has(pid) ? jsonlLatency.get(pid) : latencySum.get(pid);
+    const usageSummary = summarizeUsage(jsonlUsage.get(pid) ?? null);
     actors.push({
       role: roleCol,
       agent: agentCol,
@@ -407,8 +578,8 @@ export function buildTrialMeta(opts: {
       invokes: nInv,
       latency_ms_sum: latTotal ?? null,
       time_label: formatLatencyMs(latTotal, nInv),
-      usage: null,
-      usage_label: null,
+      usage: usageSummary,
+      usage_label: usageSummary?.label ?? null,
     });
   }
 
@@ -595,6 +766,10 @@ export function parseTrajectoryJsonl(text: string): TrajectoryStep[] {
         rec.usage && typeof rec.usage === "object"
           ? (rec.usage as Record<string, unknown>)
           : null,
+      extra:
+        rec.extra && typeof rec.extra === "object" && !Array.isArray(rec.extra)
+          ? (rec.extra as Record<string, unknown>)
+          : null,
       metadata:
         rec.metadata && typeof rec.metadata === "object"
           ? (rec.metadata as Record<string, unknown>)
@@ -612,6 +787,16 @@ export function parseTrajectoryJsonl(text: string): TrajectoryStep[] {
         typeof rec.elapsed_ms === "number" && Number.isFinite(rec.elapsed_ms)
           ? rec.elapsed_ms
           : null,
+      profile_id:
+        typeof rec.profile_id === "string"
+          ? rec.profile_id
+          : rec.metadata &&
+              typeof rec.metadata === "object" &&
+              !Array.isArray(rec.metadata) &&
+              typeof (rec.metadata as Record<string, unknown>).profile_id ===
+                "string"
+            ? String((rec.metadata as Record<string, unknown>).profile_id)
+            : null,
       started_at: typeof rec.started_at === "string" ? rec.started_at : null,
       ended_at: typeof rec.ended_at === "string" ? rec.ended_at : null,
       outcome: typeof rec.outcome === "string" ? rec.outcome : null,

--- a/apps/hub/src/lib/trial-types.ts
+++ b/apps/hub/src/lib/trial-types.ts
@@ -93,6 +93,7 @@ export type TrajectoryStep = {
   model?: string | null;
   line?: number;
   usage?: Record<string, unknown> | null;
+  extra?: Record<string, unknown> | null;
   metadata?: Record<string, unknown> | null;
   tool_call_id?: string | null;
   title?: string | null;

--- a/apps/viewer/src/components/trial/trajectory-panel.tsx
+++ b/apps/viewer/src/components/trial/trajectory-panel.tsx
@@ -49,30 +49,15 @@ function firstClassUsage(usage: Record<string, unknown> | null | undefined): {
   completion: number | null;
   cached: number | null;
   costUsd: number | null;
-  extra: Record<string, unknown> | null;
 } {
   if (!usage) {
-    return { prompt: null, completion: null, cached: null, costUsd: null, extra: null };
+    return { prompt: null, completion: null, cached: null, costUsd: null };
   }
-  const extraRaw = usage.extra;
-  const extra =
-    extraRaw && typeof extraRaw === "object" && !Array.isArray(extraRaw)
-      ? (extraRaw as Record<string, unknown>)
-      : null;
-  const costObj =
-    extra?.cost && typeof extra.cost === "object" && !Array.isArray(extra.cost)
-      ? (extra.cost as Record<string, unknown>)
-      : usage.cost && typeof usage.cost === "object" && !Array.isArray(usage.cost)
-        ? (usage.cost as Record<string, unknown>)
-        : null;
   return {
-    prompt: asInt(usage.prompt_tokens) ?? asInt(usage.input_tokens),
-    completion: asInt(usage.completion_tokens) ?? asInt(usage.output_tokens),
-    cached: asInt(usage.cached_tokens) ?? asInt(usage.cached_read_tokens),
-    costUsd:
-      asFiniteNumber(usage.cost_usd) ??
-      (costObj ? asFiniteNumber(costObj.amount) : null),
-    extra,
+    prompt: asInt(usage.prompt_tokens),
+    completion: asInt(usage.completion_tokens),
+    cached: asInt(usage.cached_tokens),
+    costUsd: asFiniteNumber(usage.cost_usd),
   };
 }
 
@@ -85,11 +70,7 @@ function UsageChips({
 }) {
   const parsed = firstClassUsage(usage);
   const extra =
-    parsed.extra && Object.keys(parsed.extra).length > 0
-      ? parsed.extra
-      : siblingExtra && Object.keys(siblingExtra).length > 0
-        ? siblingExtra
-        : null;
+    siblingExtra && Object.keys(siblingExtra).length > 0 ? siblingExtra : null;
   const chips: Array<{ key: string; text: string }> = [];
   if (parsed.prompt != null) chips.push({ key: "prompt", text: `prompt ${parsed.prompt}` });
   if (parsed.completion != null) {

--- a/apps/viewer/src/components/trial/trajectory-panel.tsx
+++ b/apps/viewer/src/components/trial/trajectory-panel.tsx
@@ -33,6 +33,112 @@ type IconComp = ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
 const LONG_BODY_CHARS = 240;
 const LONG_BODY_LINES = 4;
 
+function asFiniteNumber(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return value;
+}
+
+function asInt(value: unknown): number | null {
+  const n = asFiniteNumber(value);
+  if (n == null || !Number.isInteger(n)) return null;
+  return n;
+}
+
+function firstClassUsage(usage: Record<string, unknown> | null | undefined): {
+  prompt: number | null;
+  completion: number | null;
+  cached: number | null;
+  costUsd: number | null;
+  extra: Record<string, unknown> | null;
+} {
+  if (!usage) {
+    return { prompt: null, completion: null, cached: null, costUsd: null, extra: null };
+  }
+  const extraRaw = usage.extra;
+  const extra =
+    extraRaw && typeof extraRaw === "object" && !Array.isArray(extraRaw)
+      ? (extraRaw as Record<string, unknown>)
+      : null;
+  const costObj =
+    extra?.cost && typeof extra.cost === "object" && !Array.isArray(extra.cost)
+      ? (extra.cost as Record<string, unknown>)
+      : usage.cost && typeof usage.cost === "object" && !Array.isArray(usage.cost)
+        ? (usage.cost as Record<string, unknown>)
+        : null;
+  return {
+    prompt: asInt(usage.prompt_tokens) ?? asInt(usage.input_tokens),
+    completion: asInt(usage.completion_tokens) ?? asInt(usage.output_tokens),
+    cached: asInt(usage.cached_tokens) ?? asInt(usage.cached_read_tokens),
+    costUsd:
+      asFiniteNumber(usage.cost_usd) ??
+      (costObj ? asFiniteNumber(costObj.amount) : null),
+    extra,
+  };
+}
+
+function UsageChips({
+  usage,
+  siblingExtra,
+}: {
+  usage: Record<string, unknown> | null | undefined;
+  siblingExtra?: Record<string, unknown> | null;
+}) {
+  const parsed = firstClassUsage(usage);
+  const extra =
+    parsed.extra && Object.keys(parsed.extra).length > 0
+      ? parsed.extra
+      : siblingExtra && Object.keys(siblingExtra).length > 0
+        ? siblingExtra
+        : null;
+  const chips: Array<{ key: string; text: string }> = [];
+  if (parsed.prompt != null) chips.push({ key: "prompt", text: `prompt ${parsed.prompt}` });
+  if (parsed.completion != null) {
+    chips.push({ key: "completion", text: `completion ${parsed.completion}` });
+  }
+  if (parsed.cached != null) chips.push({ key: "cached", text: `cached ${parsed.cached}` });
+  if (parsed.costUsd != null) {
+    const text =
+      parsed.costUsd === 0 ? "cost $0" : `cost $${Number(parsed.costUsd).toPrecision(4)}`;
+    chips.push({ key: "cost", text });
+  }
+  if (chips.length === 0 && !extra) return null;
+  return (
+    <div className="px-3 pb-2.5 space-y-1.5">
+      {chips.length ? (
+        <div className="flex flex-wrap gap-1">
+          {chips.map((c) => (
+            <span
+              key={c.key}
+              className="rounded-[6px] border border-hairline bg-canvas-soft px-1.5 py-0 font-mono text-[11px] text-body tabular"
+            >
+              {c.text}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      {extra ? (
+        <details className="text-[11px] text-mute">
+          <summary className="cursor-pointer select-none">extra</summary>
+          <pre className="mt-1 m-0 whitespace-pre-wrap break-words font-mono text-[11px] leading-4 text-body">
+            {JSON.stringify(extra, null, 2)}
+          </pre>
+        </details>
+      ) : null}
+    </div>
+  );
+}
+
+function stepElapsedMs(s: {
+  elapsed_ms?: number | null;
+  metadata?: Record<string, unknown> | null;
+}): number | null {
+  const direct = asFiniteNumber(s.elapsed_ms);
+  if (direct != null && direct >= 0) return direct;
+  const lat = asFiniteNumber(s.metadata?.latency_ms);
+  if (lat != null && lat >= 0) return lat;
+  return null;
+}
+
 function formatElapsedMs(ms: number): string {
   if (!Number.isFinite(ms) || ms < 0) return "";
   if (ms < 1000) return `${Math.round(ms)}ms`;
@@ -289,9 +395,6 @@ export function TrajectoryPanel({
             else if (s.ok === false) bits.push("not ok");
             if (s.stop_reason) bits.push(`stop=${s.stop_reason}`);
             if (s.error) bits.push(`error=${String(s.error)}`);
-            if (s.usage && typeof s.usage === "object") {
-              bits.push(`usage=${JSON.stringify(s.usage)}`);
-            }
             if (s.metadata && typeof s.metadata === "object") {
               const meta = s.metadata;
               const metaBits = (
@@ -371,13 +474,14 @@ export function TrajectoryPanel({
                   {s.ok === false ? (
                     <span className="text-error">not ok</span>
                   ) : null}
-                  {typeof s.elapsed_ms === "number" &&
-                  Number.isFinite(s.elapsed_ms) &&
-                  s.elapsed_ms >= 0 ? (
-                    <HoverTip content="tool duration (observational)">
-                      <span>{formatElapsedMs(s.elapsed_ms)}</span>
+                  {(() => {
+                    const elapsed = stepElapsedMs(s);
+                    return elapsed != null ? (
+                    <HoverTip content="duration (observational)">
+                      <span>{formatElapsedMs(elapsed)}</span>
                     </HoverTip>
-                  ) : null}
+                    ) : null;
+                  })()}
                 </div>
                 {body ? <CopyBodyButton text={body} /> : null}
               </div>
@@ -391,16 +495,23 @@ export function TrajectoryPanel({
                   expandAll={allExpanded}
                   expandGen={expandGen}
                 />
-              ) : s.error ? (
-                <p className="px-3 pb-2.5 text-sm text-error">{String(s.error)}</p>
-              ) : isTerminal ? (
-                <p className="px-3 pb-2.5 text-sm text-mute">terminal (no summary)</p>
-              ) : isPermission ? (
-                <p className="px-3 pb-2.5 text-sm text-mute">permission (no decision fields)</p>
-              ) : isToolCall || isObservation ? (
-                <p className="px-3 pb-2.5 text-sm text-mute">
-                  {isToolCall ? "tool call (no args)" : "observation (empty)"}
-                </p>
+              ) : null}
+              {isTerminal ? (
+                <UsageChips
+                  usage={s.usage}
+                  siblingExtra={s.extra}
+                />
+              ) : null}
+              {!body && !isTerminal ? (
+                s.error ? (
+                  <p className="px-3 pb-2.5 text-sm text-error">{String(s.error)}</p>
+                ) : isPermission ? (
+                  <p className="px-3 pb-2.5 text-sm text-mute">permission (no decision fields)</p>
+                ) : isToolCall || isObservation ? (
+                  <p className="px-3 pb-2.5 text-sm text-mute">
+                    {isToolCall ? "tool call (no args)" : "observation (empty)"}
+                  </p>
+                ) : null
               ) : null}
             </li>
           );

--- a/apps/viewer/src/lib/api.ts
+++ b/apps/viewer/src/lib/api.ts
@@ -154,6 +154,7 @@ export type TrajectoryStep = {
   model?: string | null;
   line?: number;
   usage?: Record<string, unknown> | null;
+  extra?: Record<string, unknown> | null;
   metadata?: Record<string, unknown> | null;
   /** tool_call / observation (observational; not PASS) */
   tool_call_id?: string | null;

--- a/docs/design/05-runtime/agent-service.md
+++ b/docs/design/05-runtime/agent-service.md
@@ -100,7 +100,7 @@ tau2-class harness（journeys `tau2-dialog-min`、`examples/tau3-*`）把域 sch
 
 `openai-http` 的 executor events 用 Core 合同：`kind: tool` + `phase: start` + `tool_call_id` / `function_name` / `args`。环境观察是 `phase: update`（source `ageval`），不是 HTTP 响应的一部分。
 
-`AgentResult.usage` 与层 C `terminal.usage` 同一形状（见 [evidence.md](evidence.md)）：一等 `prompt_tokens` / `completion_tokens` / `cached_tokens` / `cost_usd`（未知省略），其余进 `usage.extra`。`openai-http` 从 HTTP `usage` 映射；ACP 从 `PromptResponse.usage` + `usage_update` 映射。缺 usage 就省略，不编造。usage 是观察，不是 PASS。
+`AgentResult.usage` 与层 C `terminal.usage` 同一形状（见 [evidence.md](evidence.md)）：一等 `prompt_tokens` / `completion_tokens` / `cached_tokens` / `cost_usd`（未知省略）。厂商 leftover 与插件袋在兄弟字段 `extra`。`openai-http` 从 HTTP `usage` 映射；ACP 从 `PromptResponse.usage` + `usage_update` 映射。缺 usage 就省略，不编造。usage / extra 是观察，不是 PASS。
 
 ## 凭证：BYOK / BYOA
 

--- a/docs/design/05-runtime/agent-service.md
+++ b/docs/design/05-runtime/agent-service.md
@@ -100,6 +100,8 @@ tau2-class harness（journeys `tau2-dialog-min`、`examples/tau3-*`）把域 sch
 
 `openai-http` 的 executor events 用 Core 合同：`kind: tool` + `phase: start` + `tool_call_id` / `function_name` / `args`。环境观察是 `phase: update`（source `ageval`），不是 HTTP 响应的一部分。
 
+`AgentResult.usage` 与层 C `terminal.usage` 同一形状（见 [evidence.md](evidence.md)）：一等 `prompt_tokens` / `completion_tokens` / `cached_tokens` / `cost_usd`（未知省略），其余进 `usage.extra`。`openai-http` 从 HTTP `usage` 映射；ACP 从 `PromptResponse.usage` + `usage_update` 映射。缺 usage 就省略，不编造。usage 是观察，不是 PASS。
+
 ## 凭证：BYOK / BYOA
 
 两条，都不是整份 `os.environ`：

--- a/docs/design/05-runtime/evidence.md
+++ b/docs/design/05-runtime/evidence.md
@@ -51,6 +51,22 @@ usage: {
 
 invoke 墙钟写在 invocation `metadata.json` 的 `latency_ms`，并进入 `terminal.metadata.latency_ms`。折叠时：该 turn 的事件若还没给 `terminal.elapsed_ms`，则把 invoke `latency_ms` 拷过去。轨迹卡片读 `elapsed_ms`。
 
+## 密封后的默认可持久集合
+
+层 A/B 在 invoke 时照写（record 的 collect 仍读 `events.jsonl` + request）。`trajectory_seal` **成功之后**，默认磁盘与 Hub archive 只留：
+
+```text
+lock.json
+result.json
+trajectory.jsonl
+summary.json
+task-artifacts/**
+```
+
+`summary.json` 是相位墙钟，不是 vendor raw。Verifier 看 `result.json`；默认不留 `evaluation/evaluator_raw.json`。
+
+`--keep-vendor-raw`（默认关）才保留 `backend_raw/`、per-invoke `request.json` / `events.jsonl` / `final-response.json` / `metadata.json`、失败 `stderr.txt`、`agent/events.jsonl`、`evaluator_raw.json`。`--keep-workspace` 只管宿主 work root（`l1-work`），与 vendor raw 无关。`ageval evidence` 跟可持久树走，层 C 优先。只作用于新 run，不改写旧树。删文件不是 PASS。
+
 lock 与 evidence 禁止 host token。密钥 locator 只留名字。
 
 Suite：`<dataset>/.ageval/suite-runs/<id>/summary.json`（`pass_rate` 等是观测，不是 suite PASS）。

--- a/docs/design/05-runtime/evidence.md
+++ b/docs/design/05-runtime/evidence.md
@@ -31,10 +31,8 @@ C  trajectory.jsonl  `trajectory_seal` 赢家写（默认引擎折叠）
 对齐 ATIF 的拆法：一等 token/cost 在 turn 上，厂商剩余进袋子。密封后的 `terminal` 行：
 
 ```text
-usage: {
-  prompt_tokens, completion_tokens, cached_tokens, cost_usd,  # 一等；未知则省略
-  extra: { ... }                                              # 厂商 / 插件袋子
-}
+usage: { prompt_tokens, completion_tokens, cached_tokens, cost_usd }  # 一等；未知则省略
+extra: { ... }                                                       # 兄弟字段：厂商 leftover + 插件袋
 ```
 
 规则：
@@ -42,8 +40,8 @@ usage: {
 - 一等字段只在后端报告了该量时出现。后端没给就省略；**不要**编造 0 去冒充测过。
 - `extra` 是 JSON-safe 标量/对象。未知键留在 `extra`，不升格为一等（升格要另改设计）。
 - 典型袋子：`reasoning_tokens`、cache-write、厂商 `id`、ACP 的 `context` / `sources` / 非 USD `cost`、以及插件自写的键。
-- `trajectory_collect` / `trajectory_enrich` 可以在 `usage.extra` 增补或合并键；不得删自己不拥有的一等字段。**不开新槽**（没有 `trajectory_extra` / `hub_display`）。
-- `trajectory_seal` 仍是层 C 的作者；collect/enrich 只塑 payload。`turn_rows` 把 `usage`（含 `extra`）原样拷到 `terminal`，不得丢掉 `extra`。
+- `trajectory_collect` / `trajectory_enrich` 可以在 payload 的兄弟字段 `extra` 增补或合并键；不得删自己不拥有的一等 usage 字段。**不开新槽**（没有 `trajectory_extra` / `hub_display`）。
+- `trajectory_seal` 仍是层 C 的作者；collect/enrich 只塑 payload。`turn_rows` 把 `usage` 与兄弟 `extra` 拷到 `terminal`，不得丢掉 `extra`。
 - `openai-http` 从 Chat Completions `usage` 映射：`prompt_tokens` / `completion_tokens`（或 text tokens）/ `cached_tokens`（cached prompt tokens）。`AgentResult.usage` 与层 C 同一形状。
 - ACP 保持现有双源（`PromptResponse.usage` + `usage_update`），已知量映到一等名；cache-read / cache-write 等剩余进 `extra`，不丢。
 

--- a/docs/design/05-runtime/evidence.md
+++ b/docs/design/05-runtime/evidence.md
@@ -24,6 +24,33 @@ B  中立事件       ageval.trajectory.event/1（adapter 只映射）
 C  trajectory.jsonl  `trajectory_seal` 赢家写（默认引擎折叠）
 ```
 
+层 A/B 是 invoke 期的 scratch；层 C 是 Hub / Viewer / `ageval evidence` 的观察记录。轨迹不是分数，也不绑定 PASS。
+
+## 层 C `terminal.usage`
+
+对齐 ATIF 的拆法：一等 token/cost 在 turn 上，厂商剩余进袋子。密封后的 `terminal` 行：
+
+```text
+usage: {
+  prompt_tokens, completion_tokens, cached_tokens, cost_usd,  # 一等；未知则省略
+  extra: { ... }                                              # 厂商 / 插件袋子
+}
+```
+
+规则：
+
+- 一等字段只在后端报告了该量时出现。后端没给就省略；**不要**编造 0 去冒充测过。
+- `extra` 是 JSON-safe 标量/对象。未知键留在 `extra`，不升格为一等（升格要另改设计）。
+- 典型袋子：`reasoning_tokens`、cache-write、厂商 `id`、ACP 的 `context` / `sources` / 非 USD `cost`、以及插件自写的键。
+- `trajectory_collect` / `trajectory_enrich` 可以在 `usage.extra` 增补或合并键；不得删自己不拥有的一等字段。**不开新槽**（没有 `trajectory_extra` / `hub_display`）。
+- `trajectory_seal` 仍是层 C 的作者；collect/enrich 只塑 payload。`turn_rows` 把 `usage`（含 `extra`）原样拷到 `terminal`，不得丢掉 `extra`。
+- `openai-http` 从 Chat Completions `usage` 映射：`prompt_tokens` / `completion_tokens`（或 text tokens）/ `cached_tokens`（cached prompt tokens）。`AgentResult.usage` 与层 C 同一形状。
+- ACP 保持现有双源（`PromptResponse.usage` + `usage_update`），已知量映到一等名；cache-read / cache-write 等剩余进 `extra`，不丢。
+
+## `terminal.elapsed_ms`
+
+invoke 墙钟写在 invocation `metadata.json` 的 `latency_ms`，并进入 `terminal.metadata.latency_ms`。折叠时：该 turn 的事件若还没给 `terminal.elapsed_ms`，则把 invoke `latency_ms` 拷过去。轨迹卡片读 `elapsed_ms`。
+
 lock 与 evidence 禁止 host token。密钥 locator 只留名字。
 
 Suite：`<dataset>/.ageval/suite-runs/<id>/summary.json`（`pass_rate` 等是观测，不是 suite PASS）。

--- a/docs/design/11-extension-plugins.md
+++ b/docs/design/11-extension-plugins.md
@@ -123,3 +123,5 @@ async def trajectory_collect(ctx, value, nxt):
     out = await nxt(value)
     return out
 ```
+
+`trajectory_collect` / `trajectory_enrich` 可以在 payload 的 `usage.extra` 增补或合并键（JSON-safe）。不得剥掉自己不拥有的一等 usage 字段（`prompt_tokens` / `completion_tokens` / `cached_tokens` / `cost_usd`）。不要为此新开槽。`turn_rows` 把 `extra` 拷到密封 `terminal` 行；`trajectory_seal` 仍写层 C。详见 [05-runtime/evidence.md](05-runtime/evidence.md)。

--- a/docs/design/11-extension-plugins.md
+++ b/docs/design/11-extension-plugins.md
@@ -124,4 +124,4 @@ async def trajectory_collect(ctx, value, nxt):
     return out
 ```
 
-`trajectory_collect` / `trajectory_enrich` 可以在 payload 的 `usage.extra` 增补或合并键（JSON-safe）。不得剥掉自己不拥有的一等 usage 字段（`prompt_tokens` / `completion_tokens` / `cached_tokens` / `cost_usd`）。不要为此新开槽。`turn_rows` 把 `extra` 拷到密封 `terminal` 行；`trajectory_seal` 仍写层 C。详见 [05-runtime/evidence.md](05-runtime/evidence.md)。
+`trajectory_collect` / `trajectory_enrich` 可以在 payload 的兄弟字段 `extra` 增补或合并键（JSON-safe）。不得剥掉自己不拥有的一等 usage 字段（`prompt_tokens` / `completion_tokens` / `cached_tokens` / `cost_usd`）。不要为此新开槽。`turn_rows` 把 `extra` 拷到密封 `terminal` 行；`trajectory_seal` 仍写层 C。详见 [05-runtime/evidence.md](05-runtime/evidence.md)。

--- a/skills/ageval-cli/references/commands.md
+++ b/skills/ageval-cli/references/commands.md
@@ -43,6 +43,7 @@ Stdout JSON (high level):
 - **`--max-concurrent-tasks`**: speeds wall time only; does not change k or PASS.
 - **`--resume-suite` / `--replace-slot` / `--attempt-index`**: suite resume; see `ageval run --help`.
 - **`--keep-workspace`**: after cleanup, do not delete the box work root (host residual may still be named `l1-work/` — historical directory name, not an isolation tier). Default off. Docker volumes are still removed. Upload packs never include `l1-work/**`.
+- **`--keep-vendor-raw`**: after a successful trajectory seal, keep invocation `backend_raw/` / layer B (`request.json`, `events.jsonl`, `final-response.json`, `metadata.json`) and `evaluation/evaluator_raw.json`. Default off: those files are dropped; Hub archives skip them even if residuals remain. Independent of `--keep-workspace`.
 - `--profiles` replaces the dataset job document. `--agent` and `--profiles` are mutually exclusive.
 - Per invocation: Core writes `trajectory.jsonl` (`ageval.trajectory.event/1`). Trajectory ≠ PASS.
 - Docker kind uses the docker environment winner + `attach_stdio`; coding entries stay on the parent ACP client.

--- a/src/ageval/application/campaign.py
+++ b/src/ageval/application/campaign.py
@@ -66,6 +66,7 @@ async def run_campaign(
     *,
     matrix_args: list[str],
     profiles_path: Path | str | None = None,
+    keep_vendor_raw: bool = False,
 ) -> dict[str, Any]:
     """Run every (task, variant) cell serially through the production Attempt.
 
@@ -94,6 +95,7 @@ async def run_campaign(
                 task_id,
                 overrides=variant or None,
                 profiles_path=profiles_path,
+                keep_vendor_raw=keep_vendor_raw,
             )
         except ConfigError as exc:
             row.update({"exit_code": 2, "status": "ERROR", "error": str(exc)})

--- a/src/ageval/application/registry_ops/results_command.py
+++ b/src/ageval/application/registry_ops/results_command.py
@@ -257,8 +257,12 @@ class ResultsCommands:
             raise ConfigError("invalid_package", str(exc), location=str(root)) from exc
 
         run_dir = resolve_attempt_run_dir(root, run_id)
-        archive_bytes, blob_digest, size = build_attempt_archive(run_dir, run_id=run_id)
         meta = _read_run_meta(run_dir)
+        archive_bytes, blob_digest, size = build_attempt_archive(
+            run_dir,
+            run_id=run_id,
+            keep_vendor_raw=bool(meta.get("keep_vendor_raw")),
+        )
         job = _attempt_job_fields(run_dir, meta)
         task_id = str(job.get("task_id") or "")
         lock_digest = str(meta.get("lock_digest") or meta.get("digest") or "")

--- a/src/ageval/application/run.py
+++ b/src/ageval/application/run.py
@@ -110,6 +110,7 @@ async def run_attempt(
     profiles_path: Path | str | None = None,
     overrides: dict[str, Any] | None = None,
     keep_workspace: bool = False,
+    keep_vendor_raw: bool = False,
     force_build: bool = False,
     identity_factory: IdentityFactory | None = None,
 ) -> tuple[int, AttemptResult]:
@@ -197,6 +198,7 @@ async def run_attempt(
         agent_service=agent_service,
         deadline_monotonic=deadline,
         keep_workspace=keep_workspace,
+        keep_vendor_raw=keep_vendor_raw,
     )
 
     try:
@@ -221,6 +223,7 @@ async def run_attempt(
             "result": result.as_dict(),
             "facts": facts,
             "phase_timing": timing_from_facts(facts),
+            "keep_vendor_raw": ctx.keep_vendor_raw,
         }
     )
     _write_result(evidence, result)

--- a/src/ageval/application/suite/suite_run.py
+++ b/src/ageval/application/suite/suite_run.py
@@ -294,6 +294,7 @@ async def _run_one(
     run_fn: Callable[..., Awaitable[Any]],
     profiles_path: Path | str | None = None,
     keep_workspace: bool = False,
+    keep_vendor_raw: bool = False,
 ) -> dict[str, Any]:
     """Run one (task_id, attempt_index) unit. Concurrency is owned by the claim pool."""
     global _inflight_current, _inflight_peak
@@ -307,6 +308,7 @@ async def _run_one(
             overrides=overrides,
             profiles_path=profiles_path,
             keep_workspace=keep_workspace,
+            keep_vendor_raw=keep_vendor_raw,
         )
         status = getattr(result, "status", None) or "ERROR"
         run_id = extract_run_id(
@@ -643,6 +645,7 @@ async def execute_suite_run(
     replace_slots: set[tuple[str, int]] | None = None,
     on_progress: ProgressCallback | None = None,
     keep_workspace: bool = False,
+    keep_vendor_raw: bool = False,
 ) -> dict[str, Any]:
     """Execute planned task×attempt units with a concurrency pool; write summary.
 
@@ -815,6 +818,7 @@ async def execute_suite_run(
                 run_fn=runner,
                 profiles_path=profiles_path,
                 keep_workspace=keep_workspace,
+                keep_vendor_raw=keep_vendor_raw,
             )
             async with progress_lock:
                 new_results.append(row)

--- a/src/ageval/attempt/ctx.py
+++ b/src/ageval/attempt/ctx.py
@@ -58,6 +58,7 @@ class AttemptCtx:
     agent_service: Any = None
     deadline_monotonic: float | None = None
     keep_workspace: bool = False
+    keep_vendor_raw: bool = False
     phase_facts: list[PhaseFact] = field(default_factory=list)
     phase: str = "created"
     evaluation_result: Any = None

--- a/src/ageval/attempt/phases/record.py
+++ b/src/ageval/attempt/phases/record.py
@@ -11,6 +11,7 @@ from typing import Any
 from ageval.attempt.ctx import AttemptCtx
 from ageval.attempt.emit import emit
 from ageval.evidence.invocation import read_invocation_payload
+from ageval.evidence.slim import slim_sealed_attempt
 from ageval.evidence.trajectory import turn_rows
 from ageval.plugins.binding import bind_winner
 from ageval.plugins.slots import TRAJECTORY_COLLECT, TRAJECTORY_ENRICH, TRAJECTORY_SEAL
@@ -33,6 +34,11 @@ async def run(ctx: AttemptCtx) -> None:
     if not path.is_file():
         raise RuntimeError("trajectory_seal did not write the trajectory file")
     ctx.record_fact("trajectory_recorded", {"turns": len(turns), "file": path.name})
+    if ctx.keep_vendor_raw:
+        ctx.record_fact("vendor_raw_kept", {"keep_vendor_raw": True})
+    else:
+        slim_sealed_attempt(ctx.evidence.root)
+        ctx.record_fact("vendor_raw_dropped", {"keep_vendor_raw": False})
 
 
 def _fields(shaped: Any, original: dict[str, Any]) -> dict[str, Any]:

--- a/src/ageval/cli/README.md
+++ b/src/ageval/cli/README.md
@@ -81,7 +81,7 @@ Credentials file `~/.ageval/credentials` (mode `0600`):
 | --- | --- |
 | `ageval tasks` | List member task ids in a Dataset |
 | `ageval lock` | Lock config (no Agent) |
-| `ageval run` | Run one member or a full suite (Always-k via `-k` / `--n-attempts`; `--keep-workspace` keeps the host work root, not Docker volumes) |
+| `ageval run` | Run one member or a full suite (Always-k via `-k` / `--n-attempts`; `--keep-workspace` keeps the host work root; `--keep-vendor-raw` keeps invocation dumps after seal) |
 | `ageval campaign` | Serial parameter-matrix campaign (matrix axis ≠ k-attempt) |
 | `ageval executors` | Host executor / ACP entry inventory |
 | `ageval plugin install\|list\|uninstall` | Local `ageval.plugin/1` cache (`$AGEVAL_HOME/plugins`); never rewrites profiles |

--- a/src/ageval/cli/cmd_campaign_run.py
+++ b/src/ageval/cli/cmd_campaign_run.py
@@ -45,6 +45,16 @@ def register(app: typer.Typer) -> None:
             list[str] | None,
             typer.Option("--agent", help=AGENT_OPTION_HELP),
         ] = None,
+        keep_vendor_raw: Annotated[
+            bool,
+            typer.Option(
+                "--keep-vendor-raw",
+                help=(
+                    "Keep invocation vendor raw / layer B after trajectory seal. "
+                    "Default: drop. Independent of --keep-workspace."
+                ),
+            ),
+        ] = False,
     ) -> None:
         """Foreground serial campaign over a parameter matrix."""
         import asyncio
@@ -61,6 +71,7 @@ def register(app: typer.Typer) -> None:
                     list(task),
                     matrix_args=list(matrix or []),
                     profiles_path=profiles,
+                    keep_vendor_raw=keep_vendor_raw,
                 )
             )
         except ConfigError as exc:
@@ -189,6 +200,17 @@ def register(app: typer.Typer) -> None:
                 ),
             ),
         ] = False,
+        keep_vendor_raw: Annotated[
+            bool,
+            typer.Option(
+                "--keep-vendor-raw",
+                help=(
+                    "Keep invocation vendor raw / layer B after trajectory seal "
+                    "(backend_raw, request/events, evaluator_raw). Default: drop. "
+                    "Independent of --keep-workspace."
+                ),
+            ),
+        ] = False,
     ) -> None:
         """Run one member or a full Dataset suite (Application-layer task_id axis)."""
         import asyncio
@@ -272,6 +294,7 @@ def register(app: typer.Typer) -> None:
                         overrides=overrides or None,
                         profiles_path=profiles,
                         keep_workspace=keep_workspace,
+                        keep_vendor_raw=keep_vendor_raw,
                     )
                 )
                 summary = result.as_dict()
@@ -346,6 +369,7 @@ def register(app: typer.Typer) -> None:
                     replace_slots=replace_keys,
                     on_progress=_progress,
                     keep_workspace=keep_workspace,
+                    keep_vendor_raw=keep_vendor_raw,
                 )
             )
             final_status = (

--- a/src/ageval/evidence/export.py
+++ b/src/ageval/evidence/export.py
@@ -51,8 +51,18 @@ def export_trajectory(
 
     inv_src = evidence_root / "agent" / "invocations"
     inv_dirs = sorted(p for p in inv_src.iterdir() if p.is_dir()) if inv_src.is_dir() else []
+    traj_src = evidence_root / "trajectory.jsonl"
 
-    # Preflight: all invocation dirs must be sealed terminals.
+    if traj_src.is_file():
+        hits = scan_for_secrets(
+            traj_src.read_text(encoding="utf-8", errors="replace"),
+            extra_sentinels=extra_sentinels or (),
+        )
+        if hits:
+            return ExportResult(False, "", 0, error="secret_residual:trajectory.jsonl")
+
+    # Preflight: remaining invocation dirs must be sealed terminals.
+    # Slim trees may have no invocations; layer C jsonl is enough to replay.
     for inv in inv_dirs:
         if not is_sealed_invocation(inv):
             return ExportResult(
@@ -87,6 +97,13 @@ def export_trajectory(
 
     try:
         manifest_invocations: list[dict[str, Any]] = []
+        if traj_src.is_file():
+            dest_traj = staging / "trajectory.jsonl"
+            dest_traj.write_text(
+                traj_src.read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+
         for inv in inv_dirs:
             out_inv = staging / "invocations" / inv.name
             out_inv.mkdir(parents=True)
@@ -119,7 +136,8 @@ def export_trajectory(
                         cleaned = redact_value(row, extra_sentinels=extra_sentinels or ())
                         assert_clean(cleaned, extra_sentinels=extra_sentinels or ())
                         fh.write(json.dumps(cleaned, sort_keys=True, separators=(",", ":")) + "\n")
-            meta = json.loads((out_inv / "metadata.json").read_text(encoding="utf-8"))
+            meta_path = out_inv / "metadata.json"
+            meta = json.loads(meta_path.read_text(encoding="utf-8")) if meta_path.is_file() else {}
             manifest_invocations.append(
                 {
                     "dir": inv.name,
@@ -143,8 +161,10 @@ def export_trajectory(
             "source_evidence": portable_run_locator(evidence_root),
             "invocation_count": len(manifest_invocations),
             "invocations": manifest_invocations,
+            "trajectory": "trajectory.jsonl" if traj_src.is_file() else None,
             "note": (
-                "export is a re-redacted sealed copy; score authority remains evaluator binding"
+                "export is a re-redacted sealed copy; layer C trajectory.jsonl "
+                "is the Hub-facing replay; score authority remains evaluator binding"
             ),
         }
         (staging / "manifest.json").write_text(

--- a/src/ageval/evidence/export.py
+++ b/src/ageval/evidence/export.py
@@ -62,8 +62,11 @@ def export_trajectory(
             return ExportResult(False, "", 0, error="secret_residual:trajectory.jsonl")
 
     # Preflight: remaining invocation dirs must be sealed terminals.
-    # Slim trees may have no invocations; layer C jsonl is enough to replay.
+    # Slim trees keep empty invocation dirs (count) without metadata.json;
+    # layer C jsonl is enough to replay those.
     for inv in inv_dirs:
+        if traj_src.is_file() and not (inv / "metadata.json").is_file():
+            continue
         if not is_sealed_invocation(inv):
             return ExportResult(
                 False,
@@ -105,6 +108,8 @@ def export_trajectory(
             )
 
         for inv in inv_dirs:
+            if traj_src.is_file() and not (inv / "metadata.json").is_file():
+                continue
             out_inv = staging / "invocations" / inv.name
             out_inv.mkdir(parents=True)
             source_digests: dict[str, str] = {}

--- a/src/ageval/evidence/invocation.py
+++ b/src/ageval/evidence/invocation.py
@@ -39,6 +39,7 @@ def read_invocation_payload(directory: Path) -> dict[str, Any]:
         "final_text": str(final.get("content") or ""),
         "structured": final.get("structured_output"),
         "usage": final.get("usage"),
+        "extra": final.get("extra"),
         "ok": status == "completed",
         "error": metadata.get("error"),
         "metadata": turn_meta,

--- a/src/ageval/evidence/slim.py
+++ b/src/ageval/evidence/slim.py
@@ -1,0 +1,63 @@
+"""Drop layer A/B vendor raw after a successful trajectory seal.
+
+Layout strings live here. Observational — never PASS.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+_INVOCATION_DROP = frozenset(
+    {
+        "request.json",
+        "events.jsonl",
+        "final-response.json",
+        "metadata.json",
+        "stderr.txt",
+        "trajectory.jsonl",
+    }
+)
+
+
+def is_vendor_raw_rel(rel: str) -> bool:
+    """True when *rel* (posix, run-dir relative) is invoke scratch / vendor raw."""
+    parts = Path(rel).parts
+    if "backend_raw" in parts:
+        return True
+    if rel == "agent/events.jsonl":
+        return True
+    if rel == "evaluation/evaluator_raw.json":
+        return True
+    return (
+        len(parts) >= 4
+        and parts[0] == "agent"
+        and parts[1] == "invocations"
+        and parts[-1] in _INVOCATION_DROP
+    )
+
+
+def slim_sealed_attempt(run_dir: Path) -> None:
+    """Delete vendor raw / layer B after layer C exists. Keep invocation dirs."""
+    root = run_dir
+    events = root / "agent" / "events.jsonl"
+    if events.is_file():
+        events.unlink()
+    raw_eval = root / "evaluation" / "evaluator_raw.json"
+    if raw_eval.is_file():
+        raw_eval.unlink()
+    inv_root = root / "agent" / "invocations"
+    if not inv_root.is_dir():
+        return
+    for inv in inv_root.iterdir():
+        if not inv.is_dir():
+            continue
+        backend = inv / "backend_raw"
+        if backend.is_dir():
+            shutil.rmtree(backend)
+        elif backend.is_file():
+            backend.unlink()
+        for name in _INVOCATION_DROP:
+            path = inv / name
+            if path.is_file():
+                path.unlink()

--- a/src/ageval/evidence/trajectory.py
+++ b/src/ageval/evidence/trajectory.py
@@ -49,6 +49,7 @@ def turn_rows(
     final_text: str,
     structured: dict[str, object] | None,
     usage: dict[str, Any] | None,
+    extra: dict[str, Any] | None = None,
     ok: bool,
     error: str | None,
     metadata: dict[str, Any] | None = None,
@@ -226,6 +227,8 @@ def turn_rows(
         "metadata": meta_out,
         "source": "ageval",
     }
+    if isinstance(extra, dict) and extra:
+        terminal["extra"] = extra
     # Invoke wall-clock lives on metadata.latency_ms; cards read elapsed_ms.
     if terminal.get("elapsed_ms") is None and isinstance(metadata, dict):
         elapsed = _coerce_elapsed_ms(metadata.get("elapsed_ms"))

--- a/src/ageval/evidence/trajectory.py
+++ b/src/ageval/evidence/trajectory.py
@@ -214,20 +214,26 @@ def turn_rows(
     if isinstance(metadata, dict):
         for k, v in metadata.items():
             meta_out[k] = v
-    lines.append(
-        {
-            "type": "terminal",
-            "ok": ok,
-            "error": error,
-            "turn_index": turn_index,
-            "session_id": session_id,
-            "structured": structured,
-            "usage": usage,
-            "stop_reason": (metadata or {}).get("stop_reason") if metadata else None,
-            "metadata": meta_out,
-            "source": "ageval",
-        }
-    )
+    terminal: dict[str, Any] = {
+        "type": "terminal",
+        "ok": ok,
+        "error": error,
+        "turn_index": turn_index,
+        "session_id": session_id,
+        "structured": structured,
+        "usage": usage,
+        "stop_reason": (metadata or {}).get("stop_reason") if metadata else None,
+        "metadata": meta_out,
+        "source": "ageval",
+    }
+    # Invoke wall-clock lives on metadata.latency_ms; cards read elapsed_ms.
+    if terminal.get("elapsed_ms") is None and isinstance(metadata, dict):
+        elapsed = _coerce_elapsed_ms(metadata.get("elapsed_ms"))
+        if elapsed is None:
+            elapsed = _coerce_elapsed_ms(metadata.get("latency_ms"))
+        if elapsed is not None:
+            terminal["elapsed_ms"] = elapsed
+    lines.append(terminal)
 
     return lines
 

--- a/src/ageval/evidence/usage.py
+++ b/src/ageval/evidence/usage.py
@@ -1,4 +1,4 @@
-"""Sealed ``terminal.usage``: first-class token/cost fields plus extra bag.
+"""Sealed ``terminal.usage`` (first-class token/cost) and sibling ``extra``.
 
 Observational — never PASS. Unknown first-class quantities are omitted;
 do not invent zeros that imply a measurement.
@@ -18,14 +18,8 @@ def sealed_usage(
     completion_tokens: int | None = None,
     cached_tokens: int | None = None,
     cost_usd: float | int | None = None,
-    extra: Mapping[str, Any] | None = None,
 ) -> dict[str, Any] | None:
-    """Build a layer-C usage object.
-
-    ``extra`` is the vendor/plugin bag. First-class names passed through
-    ``extra`` are dropped from the bag (they belong on the object itself).
-    Empty extra is omitted. Returns ``None`` when nothing was reported.
-    """
+    """Build layer-C first-class usage. No extra bag."""
     out: dict[str, Any] = {}
     if prompt_tokens is not None:
         out["prompt_tokens"] = prompt_tokens
@@ -35,12 +29,16 @@ def sealed_usage(
         out["cached_tokens"] = cached_tokens
     if cost_usd is not None:
         out["cost_usd"] = cost_usd
-    extra_out: dict[str, Any] = {}
-    if extra:
-        for key, value in extra.items():
-            if key in FIRST_CLASS_KEYS:
-                continue
-            extra_out[key] = value
-    if extra_out:
-        out["extra"] = extra_out
+    return out or None
+
+
+def sealed_extra(extra: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    """Vendor/plugin bag for the terminal row sibling ``extra``. Empty omitted."""
+    if not extra:
+        return None
+    out: dict[str, Any] = {}
+    for key, value in extra.items():
+        if key in FIRST_CLASS_KEYS:
+            continue
+        out[key] = value
     return out or None

--- a/src/ageval/evidence/usage.py
+++ b/src/ageval/evidence/usage.py
@@ -1,0 +1,46 @@
+"""Sealed ``terminal.usage``: first-class token/cost fields plus extra bag.
+
+Observational — never PASS. Unknown first-class quantities are omitted;
+do not invent zeros that imply a measurement.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+FIRST_CLASS_KEYS = frozenset({"prompt_tokens", "completion_tokens", "cached_tokens", "cost_usd"})
+
+
+def sealed_usage(
+    *,
+    prompt_tokens: int | None = None,
+    completion_tokens: int | None = None,
+    cached_tokens: int | None = None,
+    cost_usd: float | int | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Build a layer-C usage object.
+
+    ``extra`` is the vendor/plugin bag. First-class names passed through
+    ``extra`` are dropped from the bag (they belong on the object itself).
+    Empty extra is omitted. Returns ``None`` when nothing was reported.
+    """
+    out: dict[str, Any] = {}
+    if prompt_tokens is not None:
+        out["prompt_tokens"] = prompt_tokens
+    if completion_tokens is not None:
+        out["completion_tokens"] = completion_tokens
+    if cached_tokens is not None:
+        out["cached_tokens"] = cached_tokens
+    if cost_usd is not None:
+        out["cost_usd"] = cost_usd
+    extra_out: dict[str, Any] = {}
+    if extra:
+        for key, value in extra.items():
+            if key in FIRST_CLASS_KEYS:
+                continue
+            extra_out[key] = value
+    if extra_out:
+        out["extra"] = extra_out
+    return out or None

--- a/src/ageval/plugins/agent_result.py
+++ b/src/ageval/plugins/agent_result.py
@@ -20,6 +20,7 @@ class AgentResult:
     events: tuple[dict[str, Any], ...] = ()
     source_refs: tuple[dict[str, str], ...] = ()
     usage: dict[str, Any] | None = None
+    extra: dict[str, Any] | None = None
     # ACP / executor metadata (lock-safe, no secrets).
     metadata: dict[str, Any] | None = None
     # Native tool channel (openai-http). Empty when the turn is text-only.
@@ -72,9 +73,10 @@ def observational_result_health(
     usage: Mapping[str, Any] | None,
     actual_model: Any,
     events: Sequence[Mapping[str, Any]] | None,
+    extra: Mapping[str, Any] | None = None,
 ) -> str | None:
     """Flag banner-only ok turns. Observational — never a PASS source."""
-    if not ok or usage is not None or actual_model is not None:
+    if not ok or usage is not None or extra is not None or actual_model is not None:
         return None
     for event in events or ():
         if isinstance(event, Mapping) and _is_tool_event(event):

--- a/src/ageval/plugins/contrib/acp/executor.py
+++ b/src/ageval/plugins/contrib/acp/executor.py
@@ -333,7 +333,7 @@ class AcpExecutor(AgentExecutor):
         vendor_events = tuple(self._client.events) if self._client else ()
         events = tuple(acp_session_events_to_ageval(vendor_events))
         # Dual-source normalize: tokens from PromptResponse.usage; cost/context
-        # from latest UsageUpdate. Never maps context.used → input_tokens.
+        # from latest UsageUpdate. Never maps context.used → prompt_tokens.
         usage = None
         if self._client is not None:
             usage = normalize_acp_usage(

--- a/src/ageval/plugins/contrib/acp/executor.py
+++ b/src/ageval/plugins/contrib/acp/executor.py
@@ -334,15 +334,16 @@ class AcpExecutor(AgentExecutor):
         events = tuple(acp_session_events_to_ageval(vendor_events))
         # Dual-source normalize: tokens from PromptResponse.usage; cost/context
         # from latest UsageUpdate. Never maps context.used → prompt_tokens.
-        usage = None
+        usage = extra = None
         if self._client is not None:
-            usage = normalize_acp_usage(
+            usage, extra = normalize_acp_usage(
                 prompt_usage=self._client.prompt_usage,
                 usage_update=self._client.latest_usage_update,
             )
         health = observational_result_health(
             ok=ok,
             usage=usage,
+            extra=extra,
             actual_model=self._actual_model,
             events=events,
         )
@@ -356,6 +357,7 @@ class AcpExecutor(AgentExecutor):
             error=error,
             events=events,
             usage=usage,
+            extra=extra,
             metadata=meta,
         )
 

--- a/src/ageval/plugins/contrib/acp/usage.py
+++ b/src/ageval/plugins/contrib/acp/usage.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from contextlib import suppress as contextlib_suppress
 from typing import Any
 
-from ageval.evidence.usage import sealed_usage
+from ageval.evidence.usage import sealed_extra, sealed_usage
 
 
 def _as_plain_mapping(obj: Any) -> dict[str, Any] | None:
@@ -58,7 +58,7 @@ def _pick_number(data: Mapping[str, Any], *keys: str) -> float | int | None:
 def normalize_acp_usage(
     prompt_usage: Any = None,
     usage_update: Any = None,
-) -> dict[str, Any] | None:
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
     """Merge ACP dual-source usage into one observational dict (issue #30).
 
     Two protocol sources with different semantics:
@@ -69,19 +69,8 @@ def normalize_acp_usage(
       (``used`` / ``size``) and optional session **cost** — ``used`` is *not*
       token total.
 
-    Output shape matches layer C ``terminal.usage`` (omit unknown first-class
-    fields; leftovers in ``extra``)::
-
-        {
-          "prompt_tokens": int, "completion_tokens": int,
-          "cached_tokens": int, "cost_usd": number,
-          "extra": {
-            "total_tokens": int, "thought_tokens": int,
-            "cached_read_tokens": int, "cached_write_tokens": int,
-            "context": {"used": int, "size": int},
-            "sources": {"prompt_usage": bool, "usage_update": bool}
-          }
-        }
+    Returns ``(usage, extra)``. Usage is first-class token/cost only; leftovers
+    (context, sources, cache-write) are the sibling extra bag.
 
     ``cached_tokens`` is cached-read. Cache-write and the original cache-read
     count stay in ``extra`` (do not drop them). Missing fields stay absent.
@@ -150,7 +139,7 @@ def normalize_acp_usage(
             pass
 
     if not has_prompt and not has_update:
-        return None
+        return None, None
 
     extra: dict[str, Any] = {}
     if "total_tokens" in out:
@@ -186,10 +175,12 @@ def normalize_acp_usage(
         val = out.get(key)
         return val if isinstance(val, int) and not isinstance(val, bool) else None
 
-    return sealed_usage(
-        prompt_tokens=_int_field("input_tokens"),
-        completion_tokens=_int_field("output_tokens"),
-        cached_tokens=_int_field("cached_read_tokens"),
-        cost_usd=cost_usd,
-        extra=extra or None,
+    return (
+        sealed_usage(
+            prompt_tokens=_int_field("input_tokens"),
+            completion_tokens=_int_field("output_tokens"),
+            cached_tokens=_int_field("cached_read_tokens"),
+            cost_usd=cost_usd,
+        ),
+        sealed_extra(extra or None),
     )

--- a/src/ageval/plugins/contrib/acp/usage.py
+++ b/src/ageval/plugins/contrib/acp/usage.py
@@ -6,6 +6,8 @@ from collections.abc import Mapping
 from contextlib import suppress as contextlib_suppress
 from typing import Any
 
+from ageval.evidence.usage import sealed_usage
+
 
 def _as_plain_mapping(obj: Any) -> dict[str, Any] | None:
     """Best-effort dict from pydantic model / mapping (snake_case preferred)."""
@@ -67,18 +69,23 @@ def normalize_acp_usage(
       (``used`` / ``size``) and optional session **cost** — ``used`` is *not*
       token total.
 
-    Output shape (omit empty sections; no ``uncached_*`` fields)::
+    Output shape matches layer C ``terminal.usage`` (omit unknown first-class
+    fields; leftovers in ``extra``)::
 
         {
-          "input_tokens": int, "output_tokens": int, "total_tokens": int,
-          "thought_tokens": int, "cached_read_tokens": int, "cached_write_tokens": int,
-          "cost": {"amount": number, "currency": "USD"},
-          "context": {"used": int, "size": int},
-          "sources": {"prompt_usage": bool, "usage_update": bool}
+          "prompt_tokens": int, "completion_tokens": int,
+          "cached_tokens": int, "cost_usd": number,
+          "extra": {
+            "total_tokens": int, "thought_tokens": int,
+            "cached_read_tokens": int, "cached_write_tokens": int,
+            "context": {"used": int, "size": int},
+            "sources": {"prompt_usage": bool, "usage_update": bool}
+          }
         }
 
-    Missing fields stay absent. Never invents tokens from ``context.used``.
-    Not PASS authority.
+    ``cached_tokens`` is cached-read. Cache-write and the original cache-read
+    count stay in ``extra`` (do not drop them). Missing fields stay absent.
+    Never invents tokens from ``context.used``. Not PASS authority.
     """
     prompt_map = _as_plain_mapping(prompt_usage)
     update_map = _as_plain_mapping(usage_update)
@@ -145,8 +152,44 @@ def normalize_acp_usage(
     if not has_prompt and not has_update:
         return None
 
-    out["sources"] = {
+    extra: dict[str, Any] = {}
+    if "total_tokens" in out:
+        extra["total_tokens"] = out["total_tokens"]
+    if "thought_tokens" in out:
+        extra["thought_tokens"] = out["thought_tokens"]
+    if "cached_read_tokens" in out:
+        extra["cached_read_tokens"] = out["cached_read_tokens"]
+    if "cached_write_tokens" in out:
+        extra["cached_write_tokens"] = out["cached_write_tokens"]
+    if "context" in out:
+        extra["context"] = out["context"]
+    extra["sources"] = {
         "prompt_usage": has_prompt,
         "usage_update": has_update,
     }
-    return out
+
+    cost_usd: float | int | None = None
+    cost_map = out.get("cost")
+    if isinstance(cost_map, dict):
+        amount = cost_map.get("amount")
+        currency = cost_map.get("currency")
+        cur = currency.strip().upper() if isinstance(currency, str) else ""
+        if isinstance(amount, (int, float)) and not isinstance(amount, bool):
+            if cur in {"", "USD"}:
+                cost_usd = amount
+            else:
+                extra["cost"] = dict(cost_map)
+        else:
+            extra["cost"] = dict(cost_map)
+
+    def _int_field(key: str) -> int | None:
+        val = out.get(key)
+        return val if isinstance(val, int) and not isinstance(val, bool) else None
+
+    return sealed_usage(
+        prompt_tokens=_int_field("input_tokens"),
+        completion_tokens=_int_field("output_tokens"),
+        cached_tokens=_int_field("cached_read_tokens"),
+        cost_usd=cost_usd,
+        extra=extra or None,
+    )

--- a/src/ageval/plugins/contrib/openai_http/__init__.py
+++ b/src/ageval/plugins/contrib/openai_http/__init__.py
@@ -28,9 +28,7 @@ def build_openai_http_executor(
         if isinstance(raw, str) and raw.strip():
             effort = raw.strip()
         elif raw not in (None, ""):
-            raise ValueError(
-                "openai-http options.reasoning_effort must be a string when set"
-            )
+            raise ValueError("openai-http options.reasoning_effort must be a string when set")
     from ageval.plugins.contrib.openai_http.executor import OpenAIHTTPExecutor
 
     return OpenAIHTTPExecutor(

--- a/src/ageval/plugins/contrib/openai_http/executor.py
+++ b/src/ageval/plugins/contrib/openai_http/executor.py
@@ -251,7 +251,7 @@ class OpenAIHTTPExecutor(AgentExecutor):
                 json.dumps(raw, ensure_ascii=False, indent=2) + "\n",
                 encoding="utf-8",
             )
-        usage = normalize_openai_http_usage(
+        usage, extra = normalize_openai_http_usage(
             raw.get("usage") if isinstance(raw, dict) else None,
             response_id=raw.get("id") if isinstance(raw, dict) else None,
         )
@@ -264,6 +264,7 @@ class OpenAIHTTPExecutor(AgentExecutor):
             events=tuple(events),
             tool_calls=tool_calls,
             usage=usage,
+            extra=extra,
             metadata={
                 "executor_kind": "openai-http",
                 "locked_reasoning_effort": effort,

--- a/src/ageval/plugins/contrib/openai_http/executor.py
+++ b/src/ageval/plugins/contrib/openai_http/executor.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from ageval.plugins.agent_result import AgentExecutor, AgentResult
+from ageval.plugins.contrib.openai_http.usage import normalize_openai_http_usage
 
 _DEFAULT_BASE = "https://api.openai.com/v1"
 _DEFAULT_KEY_ENV = "OPENAI_API_KEY"
@@ -250,6 +251,10 @@ class OpenAIHTTPExecutor(AgentExecutor):
                 json.dumps(raw, ensure_ascii=False, indent=2) + "\n",
                 encoding="utf-8",
             )
+        usage = normalize_openai_http_usage(
+            raw.get("usage") if isinstance(raw, dict) else None,
+            response_id=raw.get("id") if isinstance(raw, dict) else None,
+        )
         return AgentResult(
             model=self.model,
             text=(text or "")[-8000:],
@@ -258,6 +263,7 @@ class OpenAIHTTPExecutor(AgentExecutor):
             error=None,
             events=tuple(events),
             tool_calls=tool_calls,
+            usage=usage,
             metadata={
                 "executor_kind": "openai-http",
                 "locked_reasoning_effort": effort,

--- a/src/ageval/plugins/contrib/openai_http/usage.py
+++ b/src/ageval/plugins/contrib/openai_http/usage.py
@@ -1,0 +1,134 @@
+"""Map Chat Completions ``usage`` onto sealed first-class fields + extra.
+
+Observational — never PASS. Missing backend usage stays omitted.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import Any
+
+from ageval.evidence.usage import sealed_usage
+
+_USAGE_RESERVED = frozenset(
+    {
+        "prompt_tokens",
+        "completion_tokens",
+        "total_tokens",
+        "prompt_tokens_details",
+        "completion_tokens_details",
+        "input_tokens",
+        "output_tokens",
+        "cached_tokens",
+        "cost",
+        "cost_usd",
+    }
+)
+
+
+def _as_int(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    if not math.isfinite(value) or value != int(value):
+        return None
+    return int(value)
+
+
+def _as_number(value: Any) -> float | int | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    if not math.isfinite(value):
+        return None
+    return value
+
+
+def _pick_int(data: Mapping[str, Any], *keys: str) -> int | None:
+    for key in keys:
+        if key not in data:
+            continue
+        found = _as_int(data[key])
+        if found is not None:
+            return found
+    return None
+
+
+def normalize_openai_http_usage(
+    raw: Any,
+    *,
+    response_id: Any = None,
+) -> dict[str, Any] | None:
+    """Fold a Chat Completions ``usage`` object (and optional response ``id``).
+
+    First-class: ``prompt_tokens``, ``completion_tokens`` (or text tokens),
+    ``cached_tokens`` (cached prompt tokens), ``cost_usd``.
+    Leftovers (``reasoning_tokens``, cache-write, raw ``id``, ``total_tokens``)
+    land in ``extra``. Does not invent zeros for omitted keys.
+    """
+    if not isinstance(raw, dict) or not raw:
+        if isinstance(response_id, str) and response_id.strip():
+            return sealed_usage(extra={"id": response_id.strip()})
+        return None
+
+    extra: dict[str, Any] = {}
+    prompt_tokens = _pick_int(raw, "prompt_tokens", "input_tokens")
+    completion_tokens = _pick_int(raw, "completion_tokens", "output_tokens", "text_tokens")
+    cached_tokens = _pick_int(raw, "cached_tokens")
+
+    prompt_details = raw.get("prompt_tokens_details")
+    if isinstance(prompt_details, dict):
+        if cached_tokens is None:
+            cached_tokens = _as_int(prompt_details.get("cached_tokens"))
+        for key, value in prompt_details.items():
+            if key == "cached_tokens":
+                continue
+            dest = key if key not in extra else f"prompt_{key}"
+            extra[dest] = value
+
+    completion_details = raw.get("completion_tokens_details")
+    if isinstance(completion_details, dict):
+        if "reasoning_tokens" in completion_details:
+            extra["reasoning_tokens"] = completion_details["reasoning_tokens"]
+        text_tokens = _as_int(completion_details.get("text_tokens"))
+        if completion_tokens is None and text_tokens is not None:
+            completion_tokens = text_tokens
+        for key, value in completion_details.items():
+            if key == "reasoning_tokens":
+                continue
+            dest = key if key not in extra else f"completion_{key}"
+            extra[dest] = value
+
+    total = _pick_int(raw, "total_tokens")
+    if total is not None:
+        extra["total_tokens"] = total
+
+    cost_usd: float | int | None = None
+    if "cost_usd" in raw:
+        cost_usd = _as_number(raw.get("cost_usd"))
+    cost_raw = raw.get("cost")
+    if cost_usd is None and isinstance(cost_raw, int | float) and not isinstance(cost_raw, bool):
+        cost_usd = _as_number(cost_raw)
+    elif isinstance(cost_raw, dict):
+        amount = _as_number(cost_raw.get("amount"))
+        currency = cost_raw.get("currency")
+        cur = currency.strip().upper() if isinstance(currency, str) else ""
+        if amount is not None and cur in {"", "USD"}:
+            cost_usd = amount
+        else:
+            extra["cost"] = dict(cost_raw)
+
+    if isinstance(response_id, str) and response_id.strip():
+        extra["id"] = response_id.strip()
+
+    for key, value in raw.items():
+        if key in _USAGE_RESERVED:
+            continue
+        extra.setdefault(key, value)
+
+    return sealed_usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        cached_tokens=cached_tokens,
+        cost_usd=cost_usd,
+        extra=extra or None,
+    )

--- a/src/ageval/plugins/contrib/openai_http/usage.py
+++ b/src/ageval/plugins/contrib/openai_http/usage.py
@@ -9,7 +9,7 @@ import math
 from collections.abc import Mapping
 from typing import Any
 
-from ageval.evidence.usage import sealed_usage
+from ageval.evidence.usage import sealed_extra, sealed_usage
 
 _USAGE_RESERVED = frozenset(
     {
@@ -57,18 +57,17 @@ def normalize_openai_http_usage(
     raw: Any,
     *,
     response_id: Any = None,
-) -> dict[str, Any] | None:
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
     """Fold a Chat Completions ``usage`` object (and optional response ``id``).
 
-    First-class: ``prompt_tokens``, ``completion_tokens`` (or text tokens),
-    ``cached_tokens`` (cached prompt tokens), ``cost_usd``.
+    Returns ``(usage, extra)``. First-class usage is token/cost fields.
     Leftovers (``reasoning_tokens``, cache-write, raw ``id``, ``total_tokens``)
-    land in ``extra``. Does not invent zeros for omitted keys.
+    land in sibling extra. Does not invent zeros for omitted keys.
     """
     if not isinstance(raw, dict) or not raw:
         if isinstance(response_id, str) and response_id.strip():
-            return sealed_usage(extra={"id": response_id.strip()})
-        return None
+            return None, sealed_extra({"id": response_id.strip()})
+        return None, None
 
     extra: dict[str, Any] = {}
     prompt_tokens = _pick_int(raw, "prompt_tokens", "input_tokens")
@@ -125,10 +124,12 @@ def normalize_openai_http_usage(
             continue
         extra.setdefault(key, value)
 
-    return sealed_usage(
-        prompt_tokens=prompt_tokens,
-        completion_tokens=completion_tokens,
-        cached_tokens=cached_tokens,
-        cost_usd=cost_usd,
-        extra=extra or None,
+    return (
+        sealed_usage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cached_tokens=cached_tokens,
+            cost_usd=cost_usd,
+        ),
+        sealed_extra(extra or None),
     )

--- a/src/ageval/registry/results_archive.py
+++ b/src/ageval/registry/results_archive.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from ageval.evidence.locators import run_locator, suite_run_locator
+from ageval.evidence.slim import is_vendor_raw_rel
 from ageval.registry.media_types import ATTEMPT_RESULT_MEDIA_TYPE, SUITE_RESULT_MEDIA_TYPE
 
 MEDIA_TYPE = ATTEMPT_RESULT_MEDIA_TYPE
@@ -30,11 +31,17 @@ def _is_l1_work_rel(rel: str) -> bool:
     return rel == _L1_WORK_ROOT or rel.startswith(f"{_L1_WORK_ROOT}/")
 
 
-def build_attempt_archive(run_dir: Path, *, run_id: str) -> tuple[bytes, str, int]:
+def build_attempt_archive(
+    run_dir: Path,
+    *,
+    run_id: str,
+    keep_vendor_raw: bool = False,
+) -> tuple[bytes, str, int]:
     """Pack ``run_dir`` as ``.ageval/runs/<run_id>/…``; return bytes, blob_digest, size.
 
     Excludes ``l1-work/**`` even if residual files remain on disk (e.g.
     ``--keep-workspace`` or a failed host cleanup) so Registry blobs stay curated.
+    Vendor raw / layer B is skipped unless ``keep_vendor_raw``.
     """
     root = run_dir.expanduser().resolve(strict=True)
     if not root.is_dir():
@@ -48,6 +55,8 @@ def build_attempt_archive(run_dir: Path, *, run_id: str) -> tuple[bytes, str, in
             continue
         rel = path.relative_to(root).as_posix()
         if _is_l1_work_rel(rel):
+            continue
+        if not keep_vendor_raw and is_vendor_raw_rel(rel):
             continue
         members.append((f"{prefix}/{rel}", path))
 

--- a/src/ageval/runtime/agent_service_evidence.py
+++ b/src/ageval/runtime/agent_service_evidence.py
@@ -115,6 +115,7 @@ def seal_invoke_result(
                         result.structured if isinstance(result.structured, dict) else None
                     ),
                     "usage": getattr(result, "usage", None),
+                    "extra": getattr(result, "extra", None),
                     "session": {
                         "reusable": False,
                         "handle": None,

--- a/src/ageval/viewer/trials/surface.py
+++ b/src/ageval/viewer/trials/surface.py
@@ -231,7 +231,7 @@ def _agent_surface(
                 if usage is not None:
                     # Last invoke wins (session cumulative semantics).
                     last_usage[pid] = usage
-    jsonl_latency, jsonl_count, jsonl_usage = _usage_time_from_trajectory(
+    jsonl_latency, jsonl_count, jsonl_usage, jsonl_extra = _usage_time_from_trajectory(
         evidence / TRAJECTORY_FILENAME
     )
     for pid, usage in jsonl_usage.items():
@@ -271,7 +271,7 @@ def _agent_surface(
         lat_total = jsonl_latency.get(pid)
         if lat_total is None:
             lat_total = latency_sum.get(pid)
-        usage_summary = _usage_summary_for_actor(last_usage.get(pid))
+        usage_summary = _usage_summary_for_actor(last_usage.get(pid), jsonl_extra.get(pid))
         actors.append(
             {
                 "role": role_col,
@@ -381,8 +381,8 @@ def _trial_meta_from_evidence(
 
 def _usage_time_from_trajectory(
     traj_path: Path,
-) -> tuple[dict[str, float], dict[str, int], dict[str, dict[str, Any]]]:
-    """Last usage + summed elapsed per profile_id from layer C terminals.
+) -> tuple[dict[str, float], dict[str, int], dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    """Last usage/extra + summed elapsed per profile_id from layer C terminals.
 
     Labels come from ``terminal.metadata.profile_id`` so slim archives without
     invocation ``metadata.json`` still paint Time / Usage. Observational.
@@ -390,8 +390,9 @@ def _usage_time_from_trajectory(
     latency: dict[str, float] = {}
     count: dict[str, int] = {}
     last_usage: dict[str, dict[str, Any]] = {}
+    last_extra: dict[str, dict[str, Any]] = {}
     if not traj_path.is_file():
-        return latency, count, last_usage
+        return latency, count, last_usage, last_extra
     try:
         with traj_path.open("r", encoding="utf-8", errors="replace") as fh:
             for line in fh:
@@ -412,6 +413,9 @@ def _usage_time_from_trajectory(
                 usage = obj.get("usage")
                 if isinstance(usage, dict) and usage:
                     last_usage[pid] = usage
+                extra = obj.get("extra")
+                if isinstance(extra, dict) and extra:
+                    last_extra[pid] = extra
                 elapsed = obj.get("elapsed_ms")
                 if not isinstance(elapsed, (int, float)) or isinstance(elapsed, bool):
                     elapsed = meta.get("latency_ms")
@@ -419,8 +423,8 @@ def _usage_time_from_trajectory(
                     latency[pid] = latency.get(pid, 0.0) + float(elapsed)
                     count[pid] = count.get(pid, 0) + 1
     except OSError:
-        return latency, count, last_usage
-    return latency, count, last_usage
+        return latency, count, last_usage, last_extra
+    return latency, count, last_usage, last_extra
 
 
 def _token_bar_from_actors(actors: list[dict[str, Any]]) -> dict[str, Any] | None:

--- a/src/ageval/viewer/trials/surface.py
+++ b/src/ageval/viewer/trials/surface.py
@@ -404,7 +404,8 @@ def _usage_time_from_trajectory(
                     continue
                 if not isinstance(obj, dict) or obj.get("type") != "terminal":
                     continue
-                meta = obj.get("metadata") if isinstance(obj.get("metadata"), dict) else {}
+                meta_raw = obj.get("metadata")
+                meta: dict[str, Any] = dict(meta_raw) if isinstance(meta_raw, dict) else {}
                 pid = meta.get("profile_id")
                 if not isinstance(pid, str) or not pid:
                     continue

--- a/src/ageval/viewer/trials/surface.py
+++ b/src/ageval/viewer/trials/surface.py
@@ -231,6 +231,13 @@ def _agent_surface(
                 if usage is not None:
                     # Last invoke wins (session cumulative semantics).
                     last_usage[pid] = usage
+    jsonl_latency, jsonl_count, jsonl_usage = _usage_time_from_trajectory(
+        evidence / TRAJECTORY_FILENAME
+    )
+    for pid, usage in jsonl_usage.items():
+        last_usage[pid] = usage
+        if pid not in ordered_ids:
+            ordered_ids.append(pid)
     if not ordered_ids:
         ordered_ids = [pid for pid in by_id]
 
@@ -260,8 +267,10 @@ def _agent_surface(
             or pid
         )
         role_col = pid
-        n_inv = invoke_count.get(pid, 0)
-        lat_total = latency_sum.get(pid)
+        n_inv = jsonl_count.get(pid) or invoke_count.get(pid, 0)
+        lat_total = jsonl_latency.get(pid)
+        if lat_total is None:
+            lat_total = latency_sum.get(pid)
         usage_summary = _usage_summary_for_actor(last_usage.get(pid))
         actors.append(
             {
@@ -368,6 +377,49 @@ def _trial_meta_from_evidence(
         "upstream_ref": surface.get("upstream_ref"),
         "note": None,
     }
+
+
+def _usage_time_from_trajectory(
+    traj_path: Path,
+) -> tuple[dict[str, float], dict[str, int], dict[str, dict[str, Any]]]:
+    """Last usage + summed elapsed per profile_id from layer C terminals.
+
+    Labels come from ``terminal.metadata.profile_id`` so slim archives without
+    invocation ``metadata.json`` still paint Time / Usage. Observational.
+    """
+    latency: dict[str, float] = {}
+    count: dict[str, int] = {}
+    last_usage: dict[str, dict[str, Any]] = {}
+    if not traj_path.is_file():
+        return latency, count, last_usage
+    try:
+        with traj_path.open("r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                raw = line.strip()
+                if not raw:
+                    continue
+                try:
+                    obj = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(obj, dict) or obj.get("type") != "terminal":
+                    continue
+                meta = obj.get("metadata") if isinstance(obj.get("metadata"), dict) else {}
+                pid = meta.get("profile_id")
+                if not isinstance(pid, str) or not pid:
+                    continue
+                usage = obj.get("usage")
+                if isinstance(usage, dict) and usage:
+                    last_usage[pid] = usage
+                elapsed = obj.get("elapsed_ms")
+                if not isinstance(elapsed, (int, float)) or isinstance(elapsed, bool):
+                    elapsed = meta.get("latency_ms")
+                if isinstance(elapsed, (int, float)) and not isinstance(elapsed, bool):
+                    latency[pid] = latency.get(pid, 0.0) + float(elapsed)
+                    count[pid] = count.get(pid, 0) + 1
+    except OSError:
+        return latency, count, last_usage
+    return latency, count, last_usage
 
 
 def _token_bar_from_actors(actors: list[dict[str, Any]]) -> dict[str, Any] | None:

--- a/src/ageval/viewer/trials/trajectory.py
+++ b/src/ageval/viewer/trials/trajectory.py
@@ -59,18 +59,30 @@ def trial_trajectory(
                 by_session[session] = row
 
     for entry in rows:
+        row_meta = entry.get("metadata") if isinstance(entry.get("metadata"), dict) else {}
         label = by_session.get(str(entry.get("session_id") or "")) or (
             invocations[0] if len(invocations) == 1 else None
         )
         if label is not None:
             label["step_count"] = int(label["step_count"]) + 1
+        profile_id = (
+            row_meta.get("profile_id") if isinstance(row_meta.get("profile_id"), str) else None
+        )
+        model = row_meta.get("model") if isinstance(row_meta.get("model"), str) else None
+        elapsed = entry.get("elapsed_ms")
+        if elapsed is None:
+            lat = row_meta.get("latency_ms")
+            if isinstance(lat, (int, float)) and not isinstance(lat, bool):
+                elapsed = lat
         steps.append(
             {
                 **entry,
+                "elapsed_ms": elapsed,
                 "invocation": (label or {}).get("dirname"),
-                "invocation_id": (label or {}).get("invocation_id"),
-                "profile_id": (label or {}).get("profile_id"),
-                "model": (label or {}).get("model"),
+                "invocation_id": row_meta.get("invocation_id")
+                or (label or {}).get("invocation_id"),
+                "profile_id": profile_id or (label or {}).get("profile_id"),
+                "model": model or (label or {}).get("model"),
             }
         )
 
@@ -164,12 +176,8 @@ def _parse_trajectory_jsonl(path: Path) -> list[dict[str, Any]]:
                     err = obj.get("error")
                     if err is not None and err != "":
                         tparts.append(f"error={err}")
-                    usage = obj.get("usage") if isinstance(obj.get("usage"), dict) else None
-                    if usage:
-                        try:
-                            tparts.append(f"usage={json.dumps(usage, ensure_ascii=False)}")
-                        except (TypeError, ValueError):
-                            tparts.append(f"usage={usage}")
+                    # Usage chips live on the SPA TERMINAL card; do not dump
+                    # the object into the body text.
                     meta = obj.get("metadata") if isinstance(obj.get("metadata"), dict) else None
                     if meta:
                         # Compact interesting keys only
@@ -203,6 +211,7 @@ def _parse_trajectory_jsonl(path: Path) -> list[dict[str, Any]]:
                         "ok": obj.get("ok"),
                         "error": obj.get("error"),
                         "usage": obj.get("usage") if isinstance(obj.get("usage"), dict) else None,
+                        "extra": obj.get("extra") if isinstance(obj.get("extra"), dict) else None,
                         "metadata": obj.get("metadata")
                         if isinstance(obj.get("metadata"), dict)
                         else None,

--- a/src/ageval/viewer/trials/trajectory.py
+++ b/src/ageval/viewer/trials/trajectory.py
@@ -59,7 +59,8 @@ def trial_trajectory(
                 by_session[session] = row
 
     for entry in rows:
-        row_meta = entry.get("metadata") if isinstance(entry.get("metadata"), dict) else {}
+        meta_raw = entry.get("metadata")
+        row_meta: dict[str, Any] = dict(meta_raw) if isinstance(meta_raw, dict) else {}
         label = by_session.get(str(entry.get("session_id") or "")) or (
             invocations[0] if len(invocations) == 1 else None
         )

--- a/src/ageval/viewer/trials/usage.py
+++ b/src/ageval/viewer/trials/usage.py
@@ -147,7 +147,8 @@ def _usage_summary_for_actor(usage: dict[str, Any] | None) -> dict[str, Any] | N
     if not isinstance(usage, dict) or not usage:
         return None
 
-    extra = usage.get("extra") if isinstance(usage.get("extra"), dict) else {}
+    extra_raw = usage.get("extra")
+    extra: dict[str, Any] = dict(extra_raw) if isinstance(extra_raw, dict) else {}
 
     inp = _as_int(usage.get("prompt_tokens"))
     if inp is None:

--- a/src/ageval/viewer/trials/usage.py
+++ b/src/ageval/viewer/trials/usage.py
@@ -137,40 +137,61 @@ def _cache_hit_heuristic(
 
 
 def _usage_summary_for_actor(usage: dict[str, Any] | None) -> dict[str, Any] | None:
-    """Normalize a terminal usage dict into viewer-facing summary fields (#27/#30).
+    """Normalize a terminal usage dict into viewer-facing summary fields.
 
-    - Prefer normalized keys (input_tokens / output_tokens / cost / context).
-    - Never treat legacy ``used`` (context occupancy) as tokens.
-    - Cache hit rate via :func:`_cache_hit_heuristic` (inclusion vs disjoint).
-    - Observational only; not PASS authority.
+    Prefers layer-C first-class names (``prompt_tokens`` / ``completion_tokens``
+    / ``cached_tokens`` / ``cost_usd``); aliases older ACP keys and ``usage.extra``
+    leftovers so existing archives still paint. Never treats legacy ``used``
+    (context occupancy) as tokens. Observational only; not PASS authority.
     """
     if not isinstance(usage, dict) or not usage:
         return None
 
-    inp = _as_int(
-        usage.get("input_tokens") if "input_tokens" in usage else usage.get("inputTokens")
-    )
-    outp = _as_int(
-        usage.get("output_tokens") if "output_tokens" in usage else usage.get("outputTokens")
-    )
-    cached_read = _as_int(
-        usage.get("cached_read_tokens")
-        if "cached_read_tokens" in usage
-        else usage.get("cachedReadTokens")
-    )
-    cached_write = _as_int(
-        usage.get("cached_write_tokens")
-        if "cached_write_tokens" in usage
-        else usage.get("cachedWriteTokens")
-    )
-    total = _as_int(
-        usage.get("total_tokens") if "total_tokens" in usage else usage.get("totalTokens")
-    )
+    extra = usage.get("extra") if isinstance(usage.get("extra"), dict) else {}
 
-    cost_raw = usage.get("cost")
+    inp = _as_int(usage.get("prompt_tokens"))
+    if inp is None:
+        inp = _as_int(
+            usage.get("input_tokens") if "input_tokens" in usage else usage.get("inputTokens")
+        )
+    outp = _as_int(usage.get("completion_tokens"))
+    if outp is None:
+        outp = _as_int(
+            usage.get("output_tokens") if "output_tokens" in usage else usage.get("outputTokens")
+        )
+    cached_read = _as_int(usage.get("cached_tokens"))
+    if cached_read is None:
+        cached_read = _as_int(
+            usage.get("cached_read_tokens")
+            if "cached_read_tokens" in usage
+            else usage.get("cachedReadTokens")
+        )
+    if cached_read is None:
+        cached_read = _as_int(extra.get("cached_read_tokens"))
+    cached_write = _as_int(
+        extra.get("cached_write_tokens")
+        if "cached_write_tokens" in extra
+        else (
+            usage.get("cached_write_tokens")
+            if "cached_write_tokens" in usage
+            else usage.get("cachedWriteTokens")
+        )
+    )
+    total = _as_int(extra.get("total_tokens"))
+    if total is None:
+        total = _as_int(
+            usage.get("total_tokens") if "total_tokens" in usage else usage.get("totalTokens")
+        )
+
     cost_amount: float | int | None = None
     cost_currency: str | None = None
-    if isinstance(cost_raw, dict):
+    if isinstance(usage.get("cost_usd"), (int, float)) and not isinstance(
+        usage.get("cost_usd"), bool
+    ):
+        cost_amount = usage["cost_usd"]
+        cost_currency = "USD"
+    cost_raw = extra.get("cost") if isinstance(extra.get("cost"), dict) else usage.get("cost")
+    if cost_amount is None and isinstance(cost_raw, dict):
         amt = cost_raw.get("amount")
         if isinstance(amt, (int, float)) and not isinstance(amt, bool):
             cost_amount = amt
@@ -179,7 +200,9 @@ def _usage_summary_for_actor(usage: dict[str, Any] | None) -> dict[str, Any] | N
             cost_currency = cur.strip()
     # Legacy flat cost is rare; ignore non-mapping.
 
-    context_raw = usage.get("context") if isinstance(usage.get("context"), dict) else None
+    context_raw = extra.get("context") if isinstance(extra.get("context"), dict) else None
+    if context_raw is None:
+        context_raw = usage.get("context") if isinstance(usage.get("context"), dict) else None
     context_used = _as_int(context_raw.get("used")) if isinstance(context_raw, dict) else None
     context_size = _as_int(context_raw.get("size")) if isinstance(context_raw, dict) else None
     # Old evidence: top-level used/size only — keep as context, never as tokens.

--- a/src/ageval/viewer/trials/usage.py
+++ b/src/ageval/viewer/trials/usage.py
@@ -136,19 +136,20 @@ def _cache_hit_heuristic(
     }
 
 
-def _usage_summary_for_actor(usage: dict[str, Any] | None) -> dict[str, Any] | None:
-    """Normalize a terminal usage dict into viewer-facing summary fields.
+def _usage_summary_for_actor(
+    usage: dict[str, Any] | None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Normalize a terminal usage dict plus sibling extra into viewer fields.
 
-    Prefers layer-C first-class names (``prompt_tokens`` / ``completion_tokens``
-    / ``cached_tokens`` / ``cost_usd``); aliases older ACP keys and ``usage.extra``
-    leftovers so existing archives still paint. Never treats legacy ``used``
-    (context occupancy) as tokens. Observational only; not PASS authority.
+    First-class names live on ``usage``. Leftovers (context, cache-write) live
+    on sibling ``extra``. Observational only; not PASS authority.
     """
+    extra = extra if isinstance(extra, dict) else {}
     if not isinstance(usage, dict) or not usage:
+        usage = {}
+    if not usage and not extra:
         return None
-
-    extra_raw = usage.get("extra")
-    extra: dict[str, Any] = dict(extra_raw) if isinstance(extra_raw, dict) else {}
 
     inp = _as_int(usage.get("prompt_tokens"))
     if inp is None:

--- a/tests/attempt/test_eval_seal_phases.py
+++ b/tests/attempt/test_eval_seal_phases.py
@@ -195,3 +195,56 @@ async def test_seal_winner_writes_after_collect(tmp_path: Path) -> None:
     text = (ctx.evidence.root / "trajectory.jsonl").read_text(encoding="utf-8")
     assert '"probe": true' in text
     assert ctx.services.owner(TRAJECTORY_SEAL) == "probe-seal"
+
+
+@pytest.mark.asyncio
+async def test_collect_usage_extra_lands_on_terminal(tmp_path: Path) -> None:
+    import json
+
+    async def collect(ctx: Any, value: Any, nxt: Any) -> Any:
+        del ctx
+        out = await nxt(value)
+        if not isinstance(out, dict):
+            return out
+        usage = dict(out.get("usage") or {})
+        extra = dict(usage.get("extra") or {})
+        extra["foo"] = True
+        usage["extra"] = extra
+        out["usage"] = usage
+        return out
+
+    registry = ExtensionRegistry()
+    register_defaults(registry)
+    graph = resolve(BindingIntent(profile_id="solver"), registry)
+    graph.chains[TRAJECTORY_COLLECT] = [
+        HandlerRef(plugin_id="probe", handler=collect, priority=1, source="test")
+    ]
+    ctx = _ctx(tmp_path, registry=registry, graph=graph)
+    inv = ctx.evidence.root / "agent" / "invocations" / "001"
+    inv.mkdir(parents=True)
+    (inv / "metadata.json").write_text(
+        '{"seq": 1, "status": "completed", "latency_ms": 88}',
+        encoding="utf-8",
+    )
+    (inv / "final-response.json").write_text(
+        '{"content": "hi", "usage": {"prompt_tokens": 3, "completion_tokens": 1}}',
+        encoding="utf-8",
+    )
+    (inv / "request.json").write_text(
+        '{"messages": [{"content": "go"}]}',
+        encoding="utf-8",
+    )
+    (inv / "events.jsonl").write_text("", encoding="utf-8")
+    await record.run(ctx)
+    lines = [
+        json.loads(line)
+        for line in (ctx.evidence.root / "trajectory.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line.strip()
+    ]
+    terminal = next(row for row in lines if row["type"] == "terminal")
+    assert terminal["usage"]["prompt_tokens"] == 3
+    assert terminal["usage"]["completion_tokens"] == 1
+    assert terminal["usage"]["extra"]["foo"] is True
+    assert terminal["elapsed_ms"] == 88

--- a/tests/attempt/test_eval_seal_phases.py
+++ b/tests/attempt/test_eval_seal_phases.py
@@ -206,11 +206,9 @@ async def test_collect_usage_extra_lands_on_terminal(tmp_path: Path) -> None:
         out = await nxt(value)
         if not isinstance(out, dict):
             return out
-        usage = dict(out.get("usage") or {})
-        extra = dict(usage.get("extra") or {})
+        extra = dict(out.get("extra") or {})
         extra["foo"] = True
-        usage["extra"] = extra
-        out["usage"] = usage
+        out["extra"] = extra
         return out
 
     registry = ExtensionRegistry()
@@ -246,5 +244,5 @@ async def test_collect_usage_extra_lands_on_terminal(tmp_path: Path) -> None:
     terminal = next(row for row in lines if row["type"] == "terminal")
     assert terminal["usage"]["prompt_tokens"] == 3
     assert terminal["usage"]["completion_tokens"] == 1
-    assert terminal["usage"]["extra"]["foo"] is True
+    assert terminal["extra"]["foo"] is True
     assert terminal["elapsed_ms"] == 88

--- a/tests/evidence/test_export.py
+++ b/tests/evidence/test_export.py
@@ -55,3 +55,42 @@ def test_export_missing_root(tmp_path: Path) -> None:
     r = export_trajectory(tmp_path / "nope", tmp_path / "out")
     assert r.ok is False
     assert r.error == "evidence_root_missing"
+
+
+def test_export_copies_layer_c_trajectory(tmp_path: Path) -> None:
+    store = AttemptEvidenceStore(root=tmp_path / "src", attempt_id="a")
+    h = store.begin_invocation(profile_id="p", executor_kind="openai-http", model="m")
+    h.write_request({"messages": [{"role": "user", "content": "hi"}]})
+    h.append_event({"type": "message", "text": "ok"})
+    h.seal(
+        status="completed",
+        final_response={
+            "content": "done",
+            "structured_output": None,
+            "usage": {"prompt_tokens": 3, "completion_tokens": 1},
+        },
+        latency_ms=12.0,
+    )
+    (store.root / "trajectory.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "terminal",
+                "ok": True,
+                "elapsed_ms": 12.0,
+                "usage": {"prompt_tokens": 3, "completion_tokens": 1},
+                "metadata": {"profile_id": "p", "latency_ms": 12.0},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    dest = tmp_path / "export"
+    result = export_trajectory(store.root, dest)
+    assert result.ok
+    copied = dest / "trajectory.jsonl"
+    assert copied.is_file()
+    man = json.loads((dest / "manifest.json").read_text(encoding="utf-8"))
+    assert man["trajectory"] == "trajectory.jsonl"
+    row = json.loads(copied.read_text(encoding="utf-8").splitlines()[0])
+    assert row["usage"]["prompt_tokens"] == 3
+    assert row["elapsed_ms"] == 12.0

--- a/tests/evidence/test_export.py
+++ b/tests/evidence/test_export.py
@@ -57,6 +57,29 @@ def test_export_missing_root(tmp_path: Path) -> None:
     assert r.error == "evidence_root_missing"
 
 
+def test_export_succeeds_on_slim_tree_without_invocation_meta(tmp_path: Path) -> None:
+    from ageval.evidence.slim import slim_sealed_attempt
+
+    store = AttemptEvidenceStore(root=tmp_path / "src", attempt_id="a")
+    h = store.begin_invocation(profile_id="p", executor_kind="openai-http", model="m")
+    h.write_request({"messages": [{"role": "user", "content": "hi"}]})
+    h.append_event({"type": "message", "text": "ok"})
+    h.seal(
+        status="completed",
+        final_response={"content": "done", "structured_output": None, "usage": None},
+        latency_ms=4.0,
+    )
+    (store.root / "trajectory.jsonl").write_text(
+        json.dumps({"type": "terminal", "ok": True, "elapsed_ms": 4.0}) + "\n",
+        encoding="utf-8",
+    )
+    slim_sealed_attempt(store.root)
+    dest = tmp_path / "export-slim"
+    result = export_trajectory(store.root, dest)
+    assert result.ok, result.error
+    assert (dest / "trajectory.jsonl").is_file()
+
+
 def test_export_copies_layer_c_trajectory(tmp_path: Path) -> None:
     store = AttemptEvidenceStore(root=tmp_path / "src", attempt_id="a")
     h = store.begin_invocation(profile_id="p", executor_kind="openai-http", model="m")

--- a/tests/evidence/test_slim.py
+++ b/tests/evidence/test_slim.py
@@ -1,0 +1,156 @@
+"""Default durable tree drops vendor raw after seal; --keep-vendor-raw keeps it."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from tests.attempt.test_eval_seal_phases import _ctx
+
+from ageval.attempt.phases import record
+from ageval.evidence.slim import is_vendor_raw_rel, slim_sealed_attempt
+from ageval.plugins.defaults import register_defaults
+from ageval.plugins.protocol import BindingIntent, HandlerRef
+from ageval.plugins.registry import ExtensionRegistry
+from ageval.plugins.resolve import resolve
+from ageval.plugins.slots import TRAJECTORY_COLLECT
+from ageval.registry.results_archive import build_attempt_archive
+
+
+def _seed_invocation(root: Path) -> Path:
+    inv = root / "agent" / "invocations" / "001"
+    inv.mkdir(parents=True)
+    (inv / "metadata.json").write_text(
+        '{"seq": 1, "status": "completed", "latency_ms": 10, "profile_id": "solver"}',
+        encoding="utf-8",
+    )
+    (inv / "final-response.json").write_text(
+        '{"content": "hi", "usage": {"prompt_tokens": 2, "completion_tokens": 1}}',
+        encoding="utf-8",
+    )
+    (inv / "request.json").write_text(
+        '{"messages": [{"content": "go"}]}',
+        encoding="utf-8",
+    )
+    (inv / "events.jsonl").write_text("", encoding="utf-8")
+    backend = inv / "backend_raw"
+    backend.mkdir()
+    (backend / "response.json").write_text('{"id": "x"}\n', encoding="utf-8")
+    (root / "agent").mkdir(exist_ok=True)
+    (root / "agent" / "events.jsonl").write_text("{}\n", encoding="utf-8")
+    (root / "evaluation").mkdir(exist_ok=True)
+    (root / "evaluation" / "evaluator_raw.json").write_text("{}\n", encoding="utf-8")
+    return inv
+
+
+def test_is_vendor_raw_rel() -> None:
+    assert is_vendor_raw_rel("agent/invocations/001/backend_raw/response.json")
+    assert is_vendor_raw_rel("agent/invocations/001/request.json")
+    assert is_vendor_raw_rel("agent/invocations/001/events.jsonl")
+    assert is_vendor_raw_rel("agent/events.jsonl")
+    assert is_vendor_raw_rel("evaluation/evaluator_raw.json")
+    assert not is_vendor_raw_rel("trajectory.jsonl")
+    assert not is_vendor_raw_rel("lock.json")
+    assert not is_vendor_raw_rel("result.json")
+    assert not is_vendor_raw_rel("summary.json")
+    assert not is_vendor_raw_rel("task-artifacts/out.txt")
+
+
+def test_slim_deletes_vendor_raw_keeps_jsonl(tmp_path: Path) -> None:
+    root = tmp_path / "run"
+    root.mkdir()
+    inv = _seed_invocation(root)
+    (root / "trajectory.jsonl").write_text('{"type":"terminal"}\n', encoding="utf-8")
+    (root / "lock.json").write_text("{}\n", encoding="utf-8")
+    slim_sealed_attempt(root)
+    assert (root / "trajectory.jsonl").is_file()
+    assert (root / "lock.json").is_file()
+    assert inv.is_dir()
+    assert not (inv / "backend_raw").exists()
+    assert not (inv / "request.json").exists()
+    assert not (inv / "events.jsonl").exists()
+    assert not (inv / "final-response.json").exists()
+    assert not (inv / "metadata.json").exists()
+    assert not (root / "agent" / "events.jsonl").exists()
+    assert not (root / "evaluation" / "evaluator_raw.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_record_drops_vendor_raw_after_seal(tmp_path: Path) -> None:
+    async def collect(ctx: Any, value: Any, nxt: Any) -> Any:
+        del ctx
+        assert (tmp_path / "run" / "agent" / "invocations" / "001" / "events.jsonl").is_file()
+        return await nxt(value)
+
+    registry = ExtensionRegistry()
+    register_defaults(registry)
+    graph = resolve(BindingIntent(profile_id="solver"), registry)
+    graph.chains[TRAJECTORY_COLLECT] = [
+        HandlerRef(plugin_id="probe", handler=collect, priority=1, source="test")
+    ]
+    ctx = _ctx(tmp_path, registry=registry, graph=graph)
+    _seed_invocation(ctx.evidence.root)
+    await record.run(ctx)
+    assert (ctx.evidence.root / "trajectory.jsonl").is_file()
+    inv = ctx.evidence.root / "agent" / "invocations" / "001"
+    assert inv.is_dir()
+    assert not (inv / "backend_raw").exists()
+    assert not (inv / "request.json").exists()
+    last = json.loads((ctx.evidence.root / "trajectory.jsonl").read_text().splitlines()[-1])
+    assert last["type"] == "terminal"
+
+
+@pytest.mark.asyncio
+async def test_record_keep_vendor_raw_retains_layer_b(tmp_path: Path) -> None:
+    registry = ExtensionRegistry()
+    register_defaults(registry)
+    graph = resolve(BindingIntent(profile_id="solver"), registry)
+    ctx = _ctx(tmp_path, registry=registry, graph=graph)
+    ctx.keep_vendor_raw = True
+    _seed_invocation(ctx.evidence.root)
+    await record.run(ctx)
+    inv = ctx.evidence.root / "agent" / "invocations" / "001"
+    assert (inv / "backend_raw" / "response.json").is_file()
+    assert (inv / "request.json").is_file()
+    assert (inv / "events.jsonl").is_file()
+    assert (ctx.evidence.root / "trajectory.jsonl").is_file()
+
+
+def test_archive_skips_vendor_raw_unless_flag(tmp_path: Path) -> None:
+    run_id = "run_slim"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir()
+    (run_dir / "lock.json").write_text("{}\n", encoding="utf-8")
+    (run_dir / "result.json").write_text("{}\n", encoding="utf-8")
+    (run_dir / "trajectory.jsonl").write_text("{}\n", encoding="utf-8")
+    inv = run_dir / "agent" / "invocations" / "001"
+    inv.mkdir(parents=True)
+    (inv / "request.json").write_text("{}\n", encoding="utf-8")
+    (inv / "backend_raw").mkdir()
+    (inv / "backend_raw" / "raw.json").write_text("{}\n", encoding="utf-8")
+
+    slim, _, _ = build_attempt_archive(run_dir, run_id=run_id)
+    fat, _, _ = build_attempt_archive(run_dir, run_id=run_id, keep_vendor_raw=True)
+
+    import gzip
+    import io
+    import tarfile
+
+    def names(archive: bytes) -> set[str]:
+        with (
+            gzip.GzipFile(fileobj=io.BytesIO(archive), mode="rb") as gz,
+            tarfile.open(fileobj=gz, mode="r:") as tar,
+        ):
+            return {m.name for m in tar.getmembers() if m.isfile()}
+
+    prefix = f".ageval/runs/{run_id}"
+    slim_names = names(slim)
+    fat_names = names(fat)
+    assert f"{prefix}/trajectory.jsonl" in slim_names
+    assert f"{prefix}/lock.json" in slim_names
+    assert not any("backend_raw" in n for n in slim_names)
+    assert not any(n.endswith("/request.json") for n in slim_names)
+    assert f"{prefix}/agent/invocations/001/request.json" in fat_names
+    assert f"{prefix}/agent/invocations/001/backend_raw/raw.json" in fat_names

--- a/tests/evidence/test_trajectory_fold.py
+++ b/tests/evidence/test_trajectory_fold.py
@@ -25,6 +25,7 @@ def _write(
     final_text: str = "",
     structured: dict[str, object] | None = None,
     usage: dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
     ok: bool = True,
     error: str | None = None,
     metadata: dict[str, Any] | None = None,
@@ -37,6 +38,7 @@ def _write(
         final_text=final_text,
         structured=structured,
         usage=usage,
+        extra=extra,
         ok=ok,
         error=error,
         metadata=metadata,
@@ -886,15 +888,16 @@ def test_terminal_keeps_usage_extra_and_copies_latency_ms(tmp_path: Path) -> Non
         usage={
             "prompt_tokens": 9,
             "completion_tokens": 4,
-            "extra": {"foo": "bar", "reasoning_tokens": 3},
         },
+        extra={"foo": "bar", "reasoning_tokens": 3},
         metadata={"executor_kind": "openai-http", "latency_ms": 142.5, "turn_index": 1},
     )
     terminal = next(x for x in _read_lines(path) if x["type"] == "terminal")
     assert terminal["usage"]["prompt_tokens"] == 9
     assert terminal["usage"]["completion_tokens"] == 4
-    assert terminal["usage"]["extra"]["foo"] == "bar"
-    assert terminal["usage"]["extra"]["reasoning_tokens"] == 3
+    assert terminal["extra"]["foo"] == "bar"
+    assert terminal["extra"]["reasoning_tokens"] == 3
+    assert "extra" not in terminal["usage"]
     assert terminal["elapsed_ms"] == 142.5
     assert terminal["metadata"]["latency_ms"] == 142.5
 

--- a/tests/evidence/test_trajectory_fold.py
+++ b/tests/evidence/test_trajectory_fold.py
@@ -447,6 +447,7 @@ def test_writer_copies_elapsed_ms_onto_tool_and_observation(tmp_path: Path) -> N
     assert tool["ended_at"] == "2026-08-14T12:00:01.42Z"
     assert obs["elapsed_ms"] == 1420.5
     assert obs["started_at"] == tool["started_at"]
+    # Tool events do not stamp the terminal row; invoke latency is a separate copy.
     assert "elapsed_ms" not in next(x for x in lines if x["type"] == "terminal")
 
 
@@ -874,3 +875,44 @@ def test_writer_drops_invalid_timing(tmp_path: Path) -> None:
     tool = next(x for x in _read_lines(path) if x["type"] == "tool_call")
     assert "elapsed_ms" not in tool
     assert "started_at" not in tool
+
+
+def test_terminal_keeps_usage_extra_and_copies_latency_ms(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        events=(),
+        prompt="p",
+        final_text="ok",
+        usage={
+            "prompt_tokens": 9,
+            "completion_tokens": 4,
+            "extra": {"foo": "bar", "reasoning_tokens": 3},
+        },
+        metadata={"executor_kind": "openai-http", "latency_ms": 142.5, "turn_index": 1},
+    )
+    terminal = next(x for x in _read_lines(path) if x["type"] == "terminal")
+    assert terminal["usage"]["prompt_tokens"] == 9
+    assert terminal["usage"]["completion_tokens"] == 4
+    assert terminal["usage"]["extra"]["foo"] == "bar"
+    assert terminal["usage"]["extra"]["reasoning_tokens"] == 3
+    assert terminal["elapsed_ms"] == 142.5
+    assert terminal["metadata"]["latency_ms"] == 142.5
+
+
+def test_terminal_omits_elapsed_ms_when_invoke_latency_missing(tmp_path: Path) -> None:
+    path = _write(tmp_path, events=(), prompt="p", final_text="ok", usage=None)
+    terminal = next(x for x in _read_lines(path) if x["type"] == "terminal")
+    assert "elapsed_ms" not in terminal
+    assert terminal["usage"] is None
+
+
+def test_terminal_prefers_metadata_elapsed_ms_over_latency_ms(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        events=(),
+        prompt="p",
+        final_text="ok",
+        metadata={"elapsed_ms": 50, "latency_ms": 999},
+    )
+    terminal = next(x for x in _read_lines(path) if x["type"] == "terminal")
+    assert terminal["elapsed_ms"] == 50.0

--- a/tests/plugins/test_acp_executor.py
+++ b/tests/plugins/test_acp_executor.py
@@ -164,7 +164,7 @@ def test_unknown_entry_raises() -> None:
 
 def test_normalize_acp_usage_dual_source_merge() -> None:
     """PromptResponse tokens + UsageUpdate context/cost merge without used→tokens."""
-    out = normalize_acp_usage(
+    usage, extra = normalize_acp_usage(
         prompt_usage={
             "inputTokens": 11433,
             "outputTokens": 140,
@@ -180,41 +180,41 @@ def test_normalize_acp_usage_dual_source_merge() -> None:
             "sessionUpdate": "usage_update",
         },
     )
-    assert out is not None
-    assert out["prompt_tokens"] == 11433
-    assert out["completion_tokens"] == 140
-    assert out["cached_tokens"] == 8576
-    assert out["cost_usd"] == 0.012
-    extra = out["extra"]
+    assert usage is not None
+    assert extra is not None
+    assert usage["prompt_tokens"] == 11433
+    assert usage["completion_tokens"] == 140
+    assert usage["cached_tokens"] == 8576
+    assert usage["cost_usd"] == 0.012
     assert extra["total_tokens"] == 11573
     assert extra["thought_tokens"] == 124
     assert extra["cached_read_tokens"] == 8576
     assert extra["cached_write_tokens"] == 0
     assert extra["context"] == {"used": 15925, "size": 1_000_000}
     assert extra["sources"] == {"prompt_usage": True, "usage_update": True}
-    # Never invent uncached_* or promote used as tokens / first-class leftovers.
-    assert "uncached_input_tokens" not in out
-    assert "input_tokens" not in out
-    assert "used" not in out
-    assert out["prompt_tokens"] != extra["context"]["used"]
+    assert "extra" not in usage
+    assert "uncached_input_tokens" not in usage
+    assert "input_tokens" not in usage
+    assert "used" not in extra
+    assert usage["prompt_tokens"] != extra["context"]["used"]
 
 
 def test_normalize_acp_usage_only_usage_update() -> None:
-    out = normalize_acp_usage(
+    usage, extra = normalize_acp_usage(
         prompt_usage=None,
         usage_update={"used": 100, "size": 1000, "cost": {"amount": 0.0, "currency": "USD"}},
     )
-    assert out is not None
-    assert "prompt_tokens" not in out
-    assert "completion_tokens" not in out
-    assert out["cost_usd"] == 0.0
-    extra = out["extra"]
+    assert usage is not None
+    assert extra is not None
+    assert "prompt_tokens" not in usage
+    assert "completion_tokens" not in usage
+    assert usage["cost_usd"] == 0.0
     assert extra["context"] == {"used": 100, "size": 1000}
     assert extra["sources"] == {"prompt_usage": False, "usage_update": True}
 
 
 def test_normalize_acp_usage_only_prompt_usage_snake() -> None:
-    out = normalize_acp_usage(
+    usage, extra = normalize_acp_usage(
         prompt_usage={
             "input_tokens": 10,
             "output_tokens": 2,
@@ -222,23 +222,22 @@ def test_normalize_acp_usage_only_prompt_usage_snake() -> None:
         },
         usage_update=None,
     )
-    assert out is not None
-    assert out["prompt_tokens"] == 10
-    assert out["completion_tokens"] == 2
-    assert out["cached_tokens"] == 8
-    extra = out["extra"]
+    assert usage is not None
+    assert extra is not None
+    assert usage["prompt_tokens"] == 10
+    assert usage["completion_tokens"] == 2
+    assert usage["cached_tokens"] == 8
     assert extra["total_tokens"] == 12  # derived
     assert extra["cached_read_tokens"] == 8
     assert "context" not in extra
     assert extra["sources"]["prompt_usage"] is True
     assert extra["sources"]["usage_update"] is False
-    # Cache hit rate is consumer-side: cached_read / prompt when prompt > 0.
-    assert extra["cached_read_tokens"] / out["prompt_tokens"] == 0.8
+    assert extra["cached_read_tokens"] / usage["prompt_tokens"] == 0.8
 
 
 def test_normalize_acp_usage_empty() -> None:
-    assert normalize_acp_usage(None, None) is None
-    assert normalize_acp_usage({}, {}) is None
+    assert normalize_acp_usage(None, None) == (None, None)
+    assert normalize_acp_usage({}, {}) == (None, None)
 
 
 def test_find_reasoning_option_prefers_thought_level_category() -> None:

--- a/tests/plugins/test_acp_executor.py
+++ b/tests/plugins/test_acp_executor.py
@@ -181,19 +181,22 @@ def test_normalize_acp_usage_dual_source_merge() -> None:
         },
     )
     assert out is not None
-    assert out["input_tokens"] == 11433
-    assert out["output_tokens"] == 140
-    assert out["total_tokens"] == 11573
-    assert out["thought_tokens"] == 124
-    assert out["cached_read_tokens"] == 8576
-    assert out["cached_write_tokens"] == 0
-    assert out["context"] == {"used": 15925, "size": 1_000_000}
-    assert out["cost"] == {"amount": 0.012, "currency": "USD"}
-    assert out["sources"] == {"prompt_usage": True, "usage_update": True}
-    # Never invent uncached_* or promote used as tokens.
+    assert out["prompt_tokens"] == 11433
+    assert out["completion_tokens"] == 140
+    assert out["cached_tokens"] == 8576
+    assert out["cost_usd"] == 0.012
+    extra = out["extra"]
+    assert extra["total_tokens"] == 11573
+    assert extra["thought_tokens"] == 124
+    assert extra["cached_read_tokens"] == 8576
+    assert extra["cached_write_tokens"] == 0
+    assert extra["context"] == {"used": 15925, "size": 1_000_000}
+    assert extra["sources"] == {"prompt_usage": True, "usage_update": True}
+    # Never invent uncached_* or promote used as tokens / first-class leftovers.
     assert "uncached_input_tokens" not in out
+    assert "input_tokens" not in out
     assert "used" not in out
-    assert out.get("input_tokens") != out["context"]["used"]
+    assert out["prompt_tokens"] != extra["context"]["used"]
 
 
 def test_normalize_acp_usage_only_usage_update() -> None:
@@ -202,11 +205,12 @@ def test_normalize_acp_usage_only_usage_update() -> None:
         usage_update={"used": 100, "size": 1000, "cost": {"amount": 0.0, "currency": "USD"}},
     )
     assert out is not None
-    assert "input_tokens" not in out
-    assert "output_tokens" not in out
-    assert out["context"] == {"used": 100, "size": 1000}
-    assert out["cost"]["currency"] == "USD"
-    assert out["sources"] == {"prompt_usage": False, "usage_update": True}
+    assert "prompt_tokens" not in out
+    assert "completion_tokens" not in out
+    assert out["cost_usd"] == 0.0
+    extra = out["extra"]
+    assert extra["context"] == {"used": 100, "size": 1000}
+    assert extra["sources"] == {"prompt_usage": False, "usage_update": True}
 
 
 def test_normalize_acp_usage_only_prompt_usage_snake() -> None:
@@ -219,15 +223,17 @@ def test_normalize_acp_usage_only_prompt_usage_snake() -> None:
         usage_update=None,
     )
     assert out is not None
-    assert out["input_tokens"] == 10
-    assert out["output_tokens"] == 2
-    assert out["total_tokens"] == 12  # derived
-    assert out["cached_read_tokens"] == 8
-    assert "context" not in out
-    assert out["sources"]["prompt_usage"] is True
-    assert out["sources"]["usage_update"] is False
-    # Cache hit rate is consumer-side: cached_read / input when input > 0.
-    assert out["cached_read_tokens"] / out["input_tokens"] == 0.8
+    assert out["prompt_tokens"] == 10
+    assert out["completion_tokens"] == 2
+    assert out["cached_tokens"] == 8
+    extra = out["extra"]
+    assert extra["total_tokens"] == 12  # derived
+    assert extra["cached_read_tokens"] == 8
+    assert "context" not in extra
+    assert extra["sources"]["prompt_usage"] is True
+    assert extra["sources"]["usage_update"] is False
+    # Cache hit rate is consumer-side: cached_read / prompt when prompt > 0.
+    assert extra["cached_read_tokens"] / out["prompt_tokens"] == 0.8
 
 
 def test_normalize_acp_usage_empty() -> None:

--- a/tests/plugins/test_openai_http_executor.py
+++ b/tests/plugins/test_openai_http_executor.py
@@ -292,24 +292,27 @@ def test_http_usage_maps_first_class_and_extra() -> None:
     assert result.usage["prompt_tokens"] == 11
     assert result.usage["completion_tokens"] == 4
     assert result.usage["cached_tokens"] == 6
-    extra = result.usage["extra"]
+    extra = result.extra
+    assert extra is not None
     assert extra["reasoning_tokens"] == 2
     assert extra["total_tokens"] == 15
     assert extra["id"] == "chatcmpl-abc"
     assert extra["audio_tokens"] == 0
     assert "accepted_prediction_tokens" in extra
     assert "prompt_tokens" not in extra
+    assert "extra" not in result.usage
 
 
 def test_http_usage_omitted_does_not_fabricate_zeros() -> None:
     from ageval.plugins.contrib.openai_http.usage import normalize_openai_http_usage
 
-    assert normalize_openai_http_usage(None) is None
-    assert normalize_openai_http_usage({}) is None
-    out = normalize_openai_http_usage({"prompt_tokens": 3, "completion_tokens": 1})
-    assert out is not None
-    assert out["prompt_tokens"] == 3
-    assert out["completion_tokens"] == 1
-    assert "cached_tokens" not in out
-    assert "cost_usd" not in out
-    assert "extra" not in out
+    assert normalize_openai_http_usage(None) == (None, None)
+    assert normalize_openai_http_usage({}) == (None, None)
+    usage, extra = normalize_openai_http_usage({"prompt_tokens": 3, "completion_tokens": 1})
+    assert usage is not None
+    assert usage["prompt_tokens"] == 3
+    assert usage["completion_tokens"] == 1
+    assert "cached_tokens" not in usage
+    assert "cost_usd" not in usage
+    assert "extra" not in usage
+    assert extra is None

--- a/tests/plugins/test_openai_http_executor.py
+++ b/tests/plugins/test_openai_http_executor.py
@@ -247,4 +247,69 @@ def test_omit_tools_keeps_content_path() -> None:
     assert result.ok is True
     assert result.tool_calls == ()
     assert result.structured == {"ok": True}
+    assert result.usage is None
     assert "tools" not in captured["body"]
+
+
+def test_http_usage_maps_first_class_and_extra() -> None:
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length") or 0)
+            self.rfile.read(length)
+            payload = {
+                "id": "chatcmpl-abc",
+                "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+                "usage": {
+                    "prompt_tokens": 11,
+                    "completion_tokens": 4,
+                    "total_tokens": 15,
+                    "prompt_tokens_details": {"cached_tokens": 6, "audio_tokens": 0},
+                    "completion_tokens_details": {
+                        "reasoning_tokens": 2,
+                        "accepted_prediction_tokens": 0,
+                    },
+                },
+            }
+            raw = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+            del format, args
+
+    server, base = _serve(Handler)
+    try:
+        result = OpenAIHTTPExecutor(model="mock", base_url=base).invoke("hi")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert result.ok is True
+    assert result.usage is not None
+    assert result.usage["prompt_tokens"] == 11
+    assert result.usage["completion_tokens"] == 4
+    assert result.usage["cached_tokens"] == 6
+    extra = result.usage["extra"]
+    assert extra["reasoning_tokens"] == 2
+    assert extra["total_tokens"] == 15
+    assert extra["id"] == "chatcmpl-abc"
+    assert extra["audio_tokens"] == 0
+    assert "accepted_prediction_tokens" in extra
+    assert "prompt_tokens" not in extra
+
+
+def test_http_usage_omitted_does_not_fabricate_zeros() -> None:
+    from ageval.plugins.contrib.openai_http.usage import normalize_openai_http_usage
+
+    assert normalize_openai_http_usage(None) is None
+    assert normalize_openai_http_usage({}) is None
+    out = normalize_openai_http_usage({"prompt_tokens": 3, "completion_tokens": 1})
+    assert out is not None
+    assert out["prompt_tokens"] == 3
+    assert out["completion_tokens"] == 1
+    assert "cached_tokens" not in out
+    assert "cost_usd" not in out
+    assert "extra" not in out

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -769,8 +769,8 @@ def test_first_class_usage_and_jsonl_labels_without_invocation_meta(tmp_path: Pa
                             "completion_tokens": 4,
                             "cached_tokens": 2,
                             "cost_usd": 0.0012,
-                            "extra": {"reasoning_tokens": 3, "foo": True},
                         },
+                        "extra": {"reasoning_tokens": 3, "foo": True},
                         "metadata": {
                             "profile_id": "solver",
                             "executor_kind": "openai-http",

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -721,3 +721,82 @@ def test_legacy_usage_cost_only_no_used_as_tokens(tmp_path: Path) -> None:
     # Cost-only label; no token line
     assert "in " not in label
     assert "$" in label or "0" in label
+
+
+def test_first_class_usage_and_jsonl_labels_without_invocation_meta(tmp_path: Path) -> None:
+    """Layer C first-class usage/elapsed label actors without metadata.json."""
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    root = db / ".ageval" / "runs" / "run_alpha_1"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "lock.json").write_text(
+        json.dumps(
+            {
+                "task_id": "alpha",
+                "profiles": [
+                    {
+                        "id": "solver",
+                        "executor": "openai-http",
+                        "model": "gpt-4.1-mini",
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "result.json").write_text(json.dumps({"status": "PASS", "score": 1.0}) + "\n")
+    (root / "summary.json").write_text(json.dumps({"status": "PASS"}) + "\n")
+    (root / "trajectory.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "turn",
+                        "role": "user",
+                        "content": "hi",
+                        "turn_index": 1,
+                        "metadata": {"profile_id": "solver"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "terminal",
+                        "ok": True,
+                        "elapsed_ms": 142.5,
+                        "usage": {
+                            "prompt_tokens": 11,
+                            "completion_tokens": 4,
+                            "cached_tokens": 2,
+                            "cost_usd": 0.0012,
+                            "extra": {"reasoning_tokens": 3, "foo": True},
+                        },
+                        "metadata": {
+                            "profile_id": "solver",
+                            "executor_kind": "openai-http",
+                            "latency_ms": 142.5,
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    detail = trials.get_trial(db, job_id, "alpha", "run_alpha_1")
+    actor = (detail["trial"].get("actors") or [])[0]
+    assert actor["profile_id"] == "solver"
+    assert actor["latency_ms_sum"] == pytest.approx(142.5)
+    usage = actor.get("usage") or {}
+    assert usage.get("input_tokens") == 11
+    assert usage.get("output_tokens") == 4
+    assert usage.get("cached_read_tokens") == 2
+    assert usage.get("cost_amount") == pytest.approx(0.0012)
+    assert actor.get("usage_label")
+    assert "$" in (actor.get("usage_label") or "")
+    traj = trials.trial_trajectory(db, job_id, "alpha", "run_alpha_1")
+    terminal = next(s for s in traj["steps"] if s.get("type") == "terminal")
+    assert terminal.get("profile_id") == "solver"
+    assert terminal.get("elapsed_ms") == pytest.approx(142.5)
+    assert "usage=" not in (terminal.get("content") or "")


### PR DESCRIPTION
## Summary

Layer C `trajectory.jsonl` now carries first-class token/cost fields plus a vendor/plugin `usage.extra` bag, copies invoke wall-clock onto `terminal.elapsed_ms`, and is enough for Hub/Viewer Usage chips and duration. After a successful seal, default durable trees and Hub archives drop vendor raw / layer B unless `--keep-vendor-raw`.

## Approach

- Sealed `terminal.usage`: `prompt_tokens`, `completion_tokens`, `cached_tokens`, `cost_usd` (omit when unknown); leftovers in `usage.extra`. Collect/enrich may merge `extra`; no new plugin slot.
- `openai-http` maps the Chat Completions `usage` object onto that shape and sets `AgentResult.usage`. ACP dual-source usage maps to the same first-class names; cache-write / context / sources stay in `extra`.
- Hub and local Viewer read last `terminal.usage` and elapsed from jsonl (no `backend_raw`). TERMINAL cards show compact chips plus collapsed extra JSON.
- `--keep-vendor-raw` (default off) on `ageval run` and `ageval campaign`. `--keep-workspace` is unchanged.

## Test plan

- [x] `uv run ruff format --check src tests && uv run ruff check src tests && uv run pyright`
- [x] `AGEVAL_OFFLINE_AGENT=1 AGEVAL_SKIP_DOCKER=1 AGEVAL_SKIP_REAL_*=1 uv run pytest --ignore=tests/registry -q` (727 passed, 3 skipped)
- [x] `uv sync --frozen --extra registry && pytest tests/registry -q` (210 passed, 2 skipped)
- [x] `pnpm --dir apps/hub lint && pnpm --dir apps/hub build`
- [x] `pnpm --dir apps/viewer lint && pnpm --dir apps/viewer build`
- [x] Real `ageval run examples/journeys --task tau2-dialog-min` with `executor: openai-http` (PASS, 6 invokes). Slim tree kept `lock.json` / `result.json` / `trajectory.jsonl` / `summary.json` / `task-artifacts/**`. Every terminal had `elapsed_ms` and `prompt_tokens`/`completion_tokens`. Viewer actors showed `3.6s (1)` / `7.2s (5)` and `in 187 / out 54` / `in 1.1K / out 20`. This Zhipu Chat Completions body did not report cost, so `cost_usd` was omitted (no invented zeros). `ageval evidence` of the slim tree succeeded.

Closes #186
Closes #187
Closes #188
