### PR TITLE
feat(runtime): summary.extra, summary_enrich, and dataset_id@version labels

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,7 +58,7 @@ dataset root (ageval.yaml / ageval.dataset/1)
        environment  host.start → upload data/ → after_environment_ready → environment_setup
        run          subprocess run.py ← Agent Service socket ← attach_stdio
        evaluate     stop writers → upload evaluation/ → evaluation_runtime → bind
-       record       trajectory_collect → trajectory_seal
+       record       trajectory_collect → trajectory_seal → summary_enrich
        finally      cleanup → host.stop
   → .ageval/runs/<attempt_id>/
 ```
@@ -319,13 +319,14 @@ evaluate phase
 record phase
   trajectory_collect → enrich  # fail-open chain
   trajectory_seal              # exclusive-slot winner writes trajectory.jsonl (layer C)
+  summary_enrich               # fail-open; Attempt summary.extra (omit when empty)
 
 cleanup (finally)
   cleanup_report
   host.stop
 ```
 
-`FAIL_OPEN_SLOTS`: `before_run` / `after_run` / `trajectory_collect` / `trajectory_enrich` / `cleanup_report`. Any other slot failure fails that phase.
+`FAIL_OPEN_SLOTS`: `before_run` / `after_run` / `trajectory_collect` / `trajectory_enrich` / `summary_enrich` / `cleanup_report`. Any other slot failure fails that phase.
 
 ## Lifecycle (Current)
 

--- a/apps/hub/src/components/trial/outcome-strip.tsx
+++ b/apps/hub/src/components/trial/outcome-strip.tsx
@@ -28,6 +28,14 @@ export function OutcomeStrip({ trial }: { trial: Trial }) {
         </Outcome>
       </div>
       {trial.note ? <p className="text-xs text-mute">{trial.note}</p> : null}
+      {trial.extra && Object.keys(trial.extra).length > 0 ? (
+        <details className="text-[11px] text-mute">
+          <summary className="cursor-pointer select-none">extra</summary>
+          <pre className="mt-1 m-0 whitespace-pre-wrap break-words font-mono text-[11px] leading-4 text-body">
+            {JSON.stringify(trial.extra, null, 2)}
+          </pre>
+        </details>
+      ) : null}
       {trial.error ? (
         <p className="text-sm text-error rounded-[8px] bg-error-soft/40 px-3 py-2">
           {String(trial.error)}

--- a/apps/hub/src/components/trial/trial-header.tsx
+++ b/apps/hub/src/components/trial/trial-header.tsx
@@ -37,6 +37,16 @@ export function TrialHeader({
           <span>
             task <span className="text-body font-medium">{taskId}</span>
           </span>
+          {trial?.dataset_ref ? (
+            <>
+              <span className="text-mute select-none" aria-hidden>
+                ·
+              </span>
+              <span className="text-body font-medium font-mono text-[13px]">
+                {trial.dataset_ref}
+              </span>
+            </>
+          ) : null}
           {trial?.framework ? (
             <>
               <span className="text-mute select-none" aria-hidden>

--- a/apps/hub/src/lib/api.ts
+++ b/apps/hub/src/lib/api.ts
@@ -393,6 +393,7 @@ export async function resolveAgentPackageDigest(
 export type AttemptMeta = {
   run_id: string;
   dataset_id?: string;
+  dataset_version?: string;
   task_id?: string;
   status?: string;
   visibility?: string;

--- a/apps/hub/src/lib/attempt-evidence.ts
+++ b/apps/hub/src/lib/attempt-evidence.ts
@@ -23,6 +23,29 @@ import { environmentFromOverlay, type JobOverlay } from "@/lib/api";
 const MAX_TRAJECTORY_STEPS = 2_000;
 const MAX_JSONL_LINE = 64_000;
 
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** Sibling extra, else already-sealed usage.extra on old jsonl. Empty omitted. */
+export function terminalExtra(
+  rec: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const sibling = asObject(rec.extra);
+  if (sibling && Object.keys(sibling).length) return sibling;
+  const usage = asObject(rec.usage);
+  const nested = usage ? asObject(usage.extra) : null;
+  if (nested && Object.keys(nested).length) return nested;
+  return null;
+}
+
+function observationalBag(value: unknown): Record<string, unknown> | null {
+  const bag = asObject(value);
+  return bag && Object.keys(bag).length ? bag : null;
+}
+
 export function runRootPrefix(runId: string): string {
   return `.ageval/runs/${runId}`;
 }
@@ -694,6 +717,7 @@ export function buildTrialMeta(opts: {
         ? upstream.ref
         : null,
     note: null,
+    extra: observationalBag(summary.extra),
   };
 }
 
@@ -771,10 +795,7 @@ export function parseTrajectoryJsonl(text: string): TrajectoryStep[] {
         rec.usage && typeof rec.usage === "object"
           ? (rec.usage as Record<string, unknown>)
           : null,
-      extra:
-        rec.extra && typeof rec.extra === "object" && !Array.isArray(rec.extra)
-          ? (rec.extra as Record<string, unknown>)
-          : null,
+      extra: terminalExtra(rec),
       metadata:
         rec.metadata && typeof rec.metadata === "object"
           ? (rec.metadata as Record<string, unknown>)

--- a/apps/hub/src/lib/attempt-evidence.ts
+++ b/apps/hub/src/lib/attempt-evidence.ts
@@ -9,7 +9,7 @@ import type {
   TrajectoryStep,
   TreeEntry,
 } from "@/lib/trial-types";
-import { displayAgentName, reasoningEffortFromBinding } from "@/lib/utils";
+import { datasetRef, displayAgentName, reasoningEffortFromBinding } from "@/lib/utils";
 
 import {
   FIRST_TAB_ORDER,
@@ -718,6 +718,13 @@ export function buildTrialMeta(opts: {
         : null,
     note: null,
     extra: observationalBag(summary.extra),
+    dataset_id: typeof lock.dataset_id === "string" ? lock.dataset_id : null,
+    dataset_version:
+      typeof lock.dataset_version === "string" ? lock.dataset_version : null,
+    dataset_ref: datasetRef(
+      typeof lock.dataset_id === "string" ? lock.dataset_id : null,
+      typeof lock.dataset_version === "string" ? lock.dataset_version : null,
+    ),
   };
 }
 

--- a/apps/hub/src/lib/trial-types.ts
+++ b/apps/hub/src/lib/trial-types.ts
@@ -52,6 +52,8 @@ export type Trial = {
   upstream_name?: string | null;
   upstream_ref?: string | null;
   note?: string | null;
+  /** Attempt-grain observational bag from summary.extra; omit when empty. */
+  extra?: Record<string, unknown> | null;
   /** Wall-time phases (environment/run/evaluate/record/cleanup) */
   phase_timing?: {
     schema?: string;

--- a/apps/hub/src/lib/trial-types.ts
+++ b/apps/hub/src/lib/trial-types.ts
@@ -52,6 +52,9 @@ export type Trial = {
   upstream_name?: string | null;
   upstream_ref?: string | null;
   note?: string | null;
+  dataset_id?: string | null;
+  dataset_version?: string | null;
+  dataset_ref?: string | null;
   /** Attempt-grain observational bag from summary.extra; omit when empty. */
   extra?: Record<string, unknown> | null;
   /** Wall-time phases (environment/run/evaluate/record/cleanup) */

--- a/apps/hub/src/lib/utils.ts
+++ b/apps/hub/src/lib/utils.ts
@@ -5,6 +5,17 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/** Locked package identity. Empty when either side is missing. */
+export function datasetRef(
+  id?: string | null,
+  version?: string | null,
+): string | null {
+  const a = (id || "").trim();
+  const b = (version || "").trim();
+  if (!a || !b) return null;
+  return `${a}@${b}`;
+}
+
 export function formatScore(value: number | null | undefined): string {
   if (value == null || Number.isNaN(value)) return "-";
   return Number(value).toFixed(2);

--- a/apps/hub/src/pages/HomePage.tsx
+++ b/apps/hub/src/pages/HomePage.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/lib/api";
 import { getGithubUser, getToken } from "@/lib/auth";
 import { rememberReturnPath } from "@/lib/return-path";
-import { formatDate } from "@/lib/utils";
+import { datasetRef, formatDate } from "@/lib/utils";
 
 type TaskRow = { datasetId: string; taskId: string };
 
@@ -314,7 +314,9 @@ export function HomePage() {
                     <span key="id" className="font-mono text-xs">
                       {s.suite_run_id}
                     </span>,
-                    s.dataset_id || "—",
+                    datasetRef(s.dataset_id, s.dataset_version) ||
+                      s.dataset_id ||
+                      "—",
                     <span key="env" className="font-mono text-xs">
                       {environmentFromOverlay(s.job_overlay) || "—"}
                     </span>,

--- a/apps/hub/src/pages/HomePage.tsx
+++ b/apps/hub/src/pages/HomePage.tsx
@@ -314,9 +314,7 @@ export function HomePage() {
                     <span key="id" className="font-mono text-xs">
                       {s.suite_run_id}
                     </span>,
-                    datasetRef(s.dataset_id, s.dataset_version) ||
-                      s.dataset_id ||
-                      "—",
+                    datasetRef(s.dataset_id, s.dataset_version) || "—",
                     <span key="env" className="font-mono text-xs">
                       {environmentFromOverlay(s.job_overlay) || "—"}
                     </span>,

--- a/apps/hub/src/pages/OrganizationDetailPage.tsx
+++ b/apps/hub/src/pages/OrganizationDetailPage.tsx
@@ -56,7 +56,7 @@ import {
   RegistryHttpError,
 } from "@/lib/api";
 import { getGithubUser, getToken } from "@/lib/auth";
-import { formatDate } from "@/lib/utils";
+import { datasetRef, formatDate } from "@/lib/utils";
 
 type Tab = "overview" | "settings";
 
@@ -662,7 +662,8 @@ export function OrganizationDetailPage() {
                                   to={`/datasets/${encodeDatasetId(s.dataset_id)}`}
                                   className="text-link hover:text-link-deep hover:underline"
                                 >
-                                  {s.dataset_id}
+                                  {datasetRef(s.dataset_id, s.dataset_version) ||
+                                    s.dataset_id}
                                 </Link>
                               ) : (
                                 "—"

--- a/apps/hub/src/pages/OrganizationDetailPage.tsx
+++ b/apps/hub/src/pages/OrganizationDetailPage.tsx
@@ -663,7 +663,7 @@ export function OrganizationDetailPage() {
                                   className="text-link hover:text-link-deep hover:underline"
                                 >
                                   {datasetRef(s.dataset_id, s.dataset_version) ||
-                                    s.dataset_id}
+                                    "—"}
                                 </Link>
                               ) : (
                                 "—"

--- a/apps/hub/src/pages/TaskDetailPage.tsx
+++ b/apps/hub/src/pages/TaskDetailPage.tsx
@@ -47,6 +47,7 @@ import { ModelLabel } from "@/components/model-label";
 import {
   cn,
   displayLabelsFromOverlay,
+  datasetRef,
   formatDate,
   formatScore,
   reasoningEffortFromOverlay,
@@ -125,6 +126,7 @@ export function TaskDetailPage() {
       created_at?: number | string;
       run_id?: string | null;
       has_attempt_content?: boolean;
+      dataset_ref?: string | null;
     }>
   >([]);
   const [error, setError] = useState<string | null>(null);
@@ -279,6 +281,7 @@ export function TaskDetailPage() {
             created_at: s.created_at,
             run_id: hit.run_id ?? null,
             has_attempt_content: Boolean(hit.has_attempt_content),
+            dataset_ref: datasetRef(s.dataset_id, s.dataset_version),
           });
         }
         for (const a of attempts) {
@@ -293,6 +296,7 @@ export function TaskDetailPage() {
             created_at: a.created_at,
             run_id: a.run_id,
             has_attempt_content: true,
+            dataset_ref: datasetRef(a.dataset_id, a.dataset_version),
           });
         }
         rows.sort((left, right) => {
@@ -569,6 +573,7 @@ export function TaskDetailPage() {
                 <TableHeader>
                   <TableRow className="hover:bg-transparent">
                     <TableHead>Job</TableHead>
+                    <TableHead>Dataset</TableHead>
                     <TableHead>Status</TableHead>
                     <TableHead className="text-right">Score</TableHead>
                     <TableHead>Harness</TableHead>
@@ -620,6 +625,9 @@ export function TaskDetailPage() {
                               summary only
                             </span>
                           ) : null}
+                        </TableCell>
+                        <TableCell className="font-mono text-xs text-body">
+                          {j.dataset_ref || "-"}
                         </TableCell>
                         <TableCell className="text-sm">
                           {j.status || "-"}

--- a/apps/viewer/src/components/trial/outcome-strip.tsx
+++ b/apps/viewer/src/components/trial/outcome-strip.tsx
@@ -28,6 +28,14 @@ export function OutcomeStrip({ trial }: { trial: Trial }) {
         </Outcome>
       </div>
       {trial.note ? <p className="text-xs text-mute">{trial.note}</p> : null}
+      {trial.extra && Object.keys(trial.extra).length > 0 ? (
+        <details className="text-[11px] text-mute">
+          <summary className="cursor-pointer select-none">extra</summary>
+          <pre className="mt-1 m-0 whitespace-pre-wrap break-words font-mono text-[11px] leading-4 text-body">
+            {JSON.stringify(trial.extra, null, 2)}
+          </pre>
+        </details>
+      ) : null}
       {trial.error ? (
         <p className="text-sm text-error rounded-[8px] bg-error-soft/40 px-3 py-2">
           {String(trial.error)}

--- a/apps/viewer/src/components/trial/trial-header.tsx
+++ b/apps/viewer/src/components/trial/trial-header.tsx
@@ -45,6 +45,16 @@ export function TrialHeader({
           <span>
             task <span className="text-body font-medium">{taskId}</span>
           </span>
+          {trial?.dataset_ref ? (
+            <>
+              <span className="text-mute select-none" aria-hidden>
+                ·
+              </span>
+              <span className="text-body font-medium font-mono text-[13px]">
+                {trial.dataset_ref}
+              </span>
+            </>
+          ) : null}
           {trial?.framework ? (
             <>
               <span className="text-mute select-none" aria-hidden>

--- a/apps/viewer/src/lib/api.ts
+++ b/apps/viewer/src/lib/api.ts
@@ -110,6 +110,8 @@ export type Trial = {
   upstream_name?: string | null;
   upstream_ref?: string | null;
   note?: string | null;
+  /** Attempt-grain observational bag from summary.extra; omit when empty. */
+  extra?: Record<string, unknown> | null;
   /** Wall-time phases (environment/run/evaluate/record/cleanup) */
   phase_timing?: {
     schema?: string;

--- a/apps/viewer/src/lib/api.ts
+++ b/apps/viewer/src/lib/api.ts
@@ -6,6 +6,8 @@ export type Job = {
   source_kind?: "suite" | "single" | string;
   dataset_id?: string | null;
   dataset_version?: string | null;
+  /** Locked package identity: dataset_id@version from summary or lock. */
+  dataset_ref?: string | null;
   agent_label?: string;
   model_label?: string;
   reasoning_effort?: string;
@@ -110,6 +112,9 @@ export type Trial = {
   upstream_name?: string | null;
   upstream_ref?: string | null;
   note?: string | null;
+  dataset_id?: string | null;
+  dataset_version?: string | null;
+  dataset_ref?: string | null;
   /** Attempt-grain observational bag from summary.extra; omit when empty. */
   extra?: Record<string, unknown> | null;
   /** Wall-time phases (environment/run/evaluate/record/cleanup) */

--- a/apps/viewer/src/pages/JobDetailPage.tsx
+++ b/apps/viewer/src/pages/JobDetailPage.tsx
@@ -184,12 +184,12 @@ export function JobDetailPage() {
                   />
                 </>
               ) : null}
-              {job.source ? (
+              {job.dataset_ref ? (
                 <>
                   {job.agent_label || job.model_label ? (
                     <span aria-hidden>/</span>
                   ) : null}
-                  <span>{job.source}</span>
+                  <span className="font-mono">{job.dataset_ref}</span>
                 </>
               ) : null}
             </p>
@@ -266,7 +266,7 @@ export function JobDetailPage() {
                         />
                       </TableCell>
                       <TableCell className="text-body">
-                        {t.dataset || job?.source || "-"}
+                        {t.dataset || job?.dataset_ref || "-"}
                       </TableCell>
                       <TableCell className="tabular">{formatScore(t.score)}</TableCell>
                       <TableCell className="tabular">{trialCount || 1}</TableCell>

--- a/apps/viewer/src/pages/JobsPage.tsx
+++ b/apps/viewer/src/pages/JobsPage.tsx
@@ -169,6 +169,7 @@ export function JobsPage() {
         j.job_name,
         j.source,
         j.source_kind,
+        j.dataset_ref,
         j.job_id,
         j.task_id,
         j.agent_label,
@@ -387,6 +388,7 @@ export function JobsPage() {
                   />
                 </TableHead>
                 <TableHead>{head("job_name", "Job Name")}</TableHead>
+                <TableHead>Dataset</TableHead>
                 <TableHead>{head("agent_label", "Harness")}</TableHead>
                 <TableHead>{head("model_label", "Models")}</TableHead>
                 <TableHead>{head("result", "Result")}</TableHead>
@@ -402,21 +404,21 @@ export function JobsPage() {
             <TableBody>
               {loading && (
                 <TableRow>
-                  <TableCell colSpan={10} className="text-mute py-10 text-center">
+                  <TableCell colSpan={11} className="text-mute py-10 text-center">
                     Loading jobs...
                   </TableCell>
                 </TableRow>
               )}
               {!loading && error && (
                 <TableRow>
-                  <TableCell colSpan={10} className="text-error py-10 text-center">
+                  <TableCell colSpan={11} className="text-error py-10 text-center">
                     {error}
                   </TableCell>
                 </TableRow>
               )}
               {!loading && !error && filtered.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={10} className="text-mute py-10 text-center">
+                  <TableCell colSpan={11} className="text-mute py-10 text-center">
                     No matching jobs.
                   </TableCell>
                 </TableRow>
@@ -454,6 +456,11 @@ export function JobsPage() {
                     <TableCell className="font-medium max-w-[16rem]">
                       <HoverTip content={jobDisplayName(job)}>
                         <span className="block truncate">{jobDisplayName(job)}</span>
+                      </HoverTip>
+                    </TableCell>
+                    <TableCell className="font-mono text-xs text-body max-w-[16rem]">
+                      <HoverTip content={job.dataset_ref || ""}>
+                        <span className="block truncate">{job.dataset_ref || "-"}</span>
                       </HoverTip>
                     </TableCell>
                     <TableCell className="max-w-[14rem]">

--- a/docs/design/01-ageval-core.md
+++ b/docs/design/01-ageval-core.md
@@ -130,12 +130,12 @@ async def run(ctx) -> None:
 | --- | --- |
 | run | `before_run` / `after_run`；`before/after_agent_open\|invoke\|close`；`normalize_agent_result` |
 | evaluate | `before_evaluate` / `after_evaluate`（可注 metrics，**不能改 PASS**）。**upload gold 是引擎代码**，不是 `evaluation_runtime` 的方法。独占槽 `evaluation_runtime` 默认跑盒内 `evaluator.py` |
-| record | `trajectory_collect` / `trajectory_enrich`（fail-open）；独占槽 `trajectory_seal` 写层 C（fail-closed：丢文件即相位失败） |
+| record | `trajectory_collect` / `trajectory_enrich`（fail-open）；独占槽 `trajectory_seal` 写层 C（fail-closed：丢文件即相位失败）；`summary_enrich`（fail-open，seal 成功后一次，写 Attempt `summary.extra`） |
 | cleanup | `cleanup_report`（链）；cleanup phase 本身由 finally 调用 |
 
 `executor` 是 **run 里的独占槽**，不是 attempt 上的独立 phase。ACP attach 发生在第一次 invoke，不是独立 phase。
 
-`FAIL_OPEN_SLOTS`：`before_run` / `after_run` / `trajectory_collect` / `trajectory_enrich` / `cleanup_report`。其余槽失败即该相位失败。
+`FAIL_OPEN_SLOTS`：`before_run` / `after_run` / `trajectory_collect` / `trajectory_enrich` / `summary_enrich` / `cleanup_report`。其余槽失败即该相位失败。
 
 完整 emit 图：[ARCHITECTURE.md](../../ARCHITECTURE.md) § Extension emit map、[05-runtime/README.md](05-runtime/README.md)。
 

--- a/docs/design/05-runtime/README.md
+++ b/docs/design/05-runtime/README.md
@@ -44,6 +44,7 @@ evaluate
 record
   trajectory_collect → enrich
   trajectory_seal             # 独占槽；默认引擎写 trajectory.jsonl
+  summary_enrich              # fail-open；Attempt summary.extra，空则省略
 
 cleanup (finally)
   cleanup_report

--- a/docs/design/05-runtime/evidence.md
+++ b/docs/design/05-runtime/evidence.md
@@ -9,7 +9,7 @@
 | `lock.json` | 无 secret 的 lock 摘要 |
 | `result.json` | 扁平 Result（status/score/kind/logs） |
 | `trajectory.jsonl` | 层 C；`trajectory_seal` 独占槽默认引擎写 |
-| `summary.json` | 相位事实 / timing |
+| `summary.json` | 相位事实 / timing；可选根字段 `extra`（Attempt 级观察袋，空则省略） |
 | `agent/` | invoke 级观察 |
 
 `Result.logs` / `evidence_path` 指向该树。
@@ -40,10 +40,26 @@ extra: { ... }                                                       # 兄弟字
 - 一等字段只在后端报告了该量时出现。后端没给就省略；**不要**编造 0 去冒充测过。
 - `extra` 是 JSON-safe 标量/对象。未知键留在 `extra`，不升格为一等（升格要另改设计）。
 - 典型袋子：`reasoning_tokens`、cache-write、厂商 `id`、ACP 的 `context` / `sources` / 非 USD `cost`、以及插件自写的键。
-- `trajectory_collect` / `trajectory_enrich` 可以在 payload 的兄弟字段 `extra` 增补或合并键；不得删自己不拥有的一等 usage 字段。**不开新槽**（没有 `trajectory_extra` / `hub_display`）。
+- `trajectory_collect` / `trajectory_enrich` 可以在 payload 的兄弟字段 `extra` 增补或合并键；不得删自己不拥有的一等 usage 字段。invoke 这袋 **不开新槽**（没有 `trajectory_extra` / `hub_display`）。
 - `trajectory_seal` 仍是层 C 的作者；collect/enrich 只塑 payload。`turn_rows` 把 `usage` 与兄弟 `extra` 拷到 `terminal`，不得丢掉 `extra`。
 - `openai-http` 从 Chat Completions `usage` 映射：`prompt_tokens` / `completion_tokens`（或 text tokens）/ `cached_tokens`（cached prompt tokens）。`AgentResult.usage` 与层 C 同一形状。
 - ACP 保持现有双源（`PromptResponse.usage` + `usage_update`），已知量映到一等名；cache-read / cache-write 等剩余进 `extra`，不丢。
+
+## Attempt `summary.extra`
+
+两只观察袋、两档粒度。invoke 袋是密封 `terminal` 的兄弟字段 `extra`。Attempt 袋是 `summary.json` 的根字段 `extra`：
+
+```text
+extra: { <plugin_id>: { ... }, ... }   # 空则省略整键；默认 = 旧 summary 形状
+```
+
+规则：
+
+- 观察袋，不是 PASS。Core **不**把 invoke 的 `terminal.extra` 聚合成 `summary.extra`（插件若要读 jsonl 自己读）。
+- 链槽 `summary_enrich`（fail-open，形状 `(ctx, value, nxt)`）在 `trajectory_seal` 成功之后 emit **一次**；`value` 是这只袋，引擎起点 `{}`。插件只写自己的 `extra[<plugin_id>]`，不得删自己不拥有的键。
+- 不复用 `trajectory_collect` / `trajectory_enrich`（每 invoke）、`trajectory_seal`（层 C 独占作者）、`after_run` / `after_evaluate`、`cleanup_report`。
+- Core 把合并后的袋写入 `summary.json`；空袋不写 `extra` 键。
+- Hub / Viewer 在 attempt / job summary 上投影折叠 JSON；没有袋就没有这块 chrome。不为此开 `hub_display`，不加 CLI 旗。`ageval plugin install` 仍不改 profiles。opt-in 走 `extensions`。
 
 ## `terminal.elapsed_ms`
 

--- a/docs/design/11-extension-plugins.md
+++ b/docs/design/11-extension-plugins.md
@@ -30,7 +30,7 @@
 | 槽 | 语义 | 例子 |
 | --- | --- | --- |
 | 独占 | 全 Attempt 一个赢家；登记为同名 service | `environment`、`executor`、`evaluation_runtime`、`trajectory_seal` |
-| 链 | `(ctx, value, nxt)` | `after_environment_ready`、`environment_setup`、`trajectory_collect` |
+| 链 | `(ctx, value, nxt)` | `after_environment_ready`、`environment_setup`、`trajectory_collect`、`summary_enrich` |
 
 `profiles.environment` / `profiles.executor` = 选独占槽赢家。`evaluation_runtime` / `trajectory_seal` **没有** job 字段糖；默认赢家即可，替换只能走显式 `extensions` 行（`slot` + `plugin`）。`extensions` 也是链槽 opt-in。未列入 `extensions` 的不进链、不进服务表（引擎默认除外）。
 
@@ -114,7 +114,7 @@ Hub `/plugins` 可以把 first-party contrib 画成 **catalog overlay**，不是
 
 四条不相等：**Hub 认得** ≠ **本机能跑** ≠ **镜像已 bake** ≠ **`ageval plugin install` 装过**。空店 Explore 仍应看到这七张卡；e2b / ssh / daytona 缺 extra 或缺钥时卡仍在，lock/run 维持既有 skip / fail-closed。七个短 id 保留：`ageval plugin publish` 与 `ageval plugin install` 撞到它们 fail-closed，避免 `/plugins/docker` 和店包抢同一条路由。运行时装载路径仍是 `bootstrap.py`。
 
-`FAIL_OPEN_SLOTS`：`before_run` / `after_run` / `trajectory_collect` / `trajectory_enrich` / `cleanup_report`。其余失败即该相位失败。
+`FAIL_OPEN_SLOTS`：`before_run` / `after_run` / `trajectory_collect` / `trajectory_enrich` / `summary_enrich` / `cleanup_report`。其余失败即该相位失败。
 
 钩子形状：
 
@@ -124,4 +124,6 @@ async def trajectory_collect(ctx, value, nxt):
     return out
 ```
 
-`trajectory_collect` / `trajectory_enrich` 可以在 payload 的兄弟字段 `extra` 增补或合并键（JSON-safe）。不得剥掉自己不拥有的一等 usage 字段（`prompt_tokens` / `completion_tokens` / `cached_tokens` / `cost_usd`）。不要为此新开槽。`turn_rows` 把 `extra` 拷到密封 `terminal` 行；`trajectory_seal` 仍写层 C。详见 [05-runtime/evidence.md](05-runtime/evidence.md)。
+`trajectory_collect` / `trajectory_enrich` 可以在 payload 的兄弟字段 `extra` 增补或合并键（JSON-safe）。不得剥掉自己不拥有的一等 usage 字段（`prompt_tokens` / `completion_tokens` / `cached_tokens` / `cost_usd`）。invoke 这袋不要新开槽。`turn_rows` 把 `extra` 拷到密封 `terminal` 行；`trajectory_seal` 仍写层 C。
+
+Attempt 级观察袋走另一条链：`summary_enrich`。`trajectory_seal` 成功之后 emit 一次，`value` 是 `summary.extra` 袋（引擎起点 `{}`）。插件只写 `extra[<plugin_id>]`，不得剥自己不拥有的键。空袋不进 `summary.json`。不是 PASS。详见 [05-runtime/evidence.md](05-runtime/evidence.md)。

--- a/services/registry/queries.py
+++ b/services/registry/queries.py
@@ -60,10 +60,10 @@ def list_versions_query(dataset_id: str, *, include_private: bool = False) -> tu
 
 INSERT_ATTEMPT = """
 INSERT INTO attempt_results(
-    run_id, dataset_id, task_id, lock_digest, status,
+    run_id, dataset_id, dataset_version, task_id, lock_digest, status,
     visibility, blob_digest, size, created_at, uploaded_by,
     suite_run_id, environment, agent_label, model_label, score
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
 
 SELECT_ATTEMPT = "SELECT * FROM attempt_results WHERE run_id=?"
@@ -429,6 +429,7 @@ SCHEMA_MIGRATIONS: tuple[tuple[str, str, str], ...] = (
     ("attempt_results", "agent_label", "TEXT NOT NULL DEFAULT ''"),
     ("attempt_results", "model_label", "TEXT NOT NULL DEFAULT ''"),
     ("attempt_results", "score", "REAL"),
+    ("attempt_results", "dataset_version", "TEXT NOT NULL DEFAULT ''"),
     ("suite_results", "uploaded_by", "TEXT NOT NULL DEFAULT ''"),
     ("suite_results", "complete", "INTEGER NOT NULL DEFAULT 0"),
     ("suite_results", "bound_kind", "TEXT NOT NULL DEFAULT 'unknown'"),

--- a/services/registry/result_service.py
+++ b/services/registry/result_service.py
@@ -315,10 +315,10 @@ class ResultService:
         visibility = str(meta.get("visibility") or "private")
         blob_digest = str(meta.get("blob_digest") or "")
         size = int(meta.get("size") or size_on_disk)
-        if not suite_run_id or not dataset_id:
+        if not suite_run_id or not dataset_id or not dataset_version.strip():
             raise RegistryAppError(
                 "invalid_request",
-                "suite_run_id and dataset_id required",
+                "suite_run_id, dataset_id, and dataset_version required",
                 http_status=400,
             )
         if visibility not in {"private", "public"}:

--- a/services/registry/result_service.py
+++ b/services/registry/result_service.py
@@ -21,8 +21,8 @@ from services.registry.dataset import (
     task_set_digest,
 )
 from services.registry.errors import RegistryAppError
-from services.registry.paging import page_slice
 from services.registry.official import official_dataset_ids
+from services.registry.paging import page_slice
 from services.registry.runtime_service import attach_agent_refs
 from services.registry.store import (
     AttemptResultRow,
@@ -118,6 +118,7 @@ class ResultService:
             )
         run_id = str(meta.get("run_id") or "")
         dataset_id = str(meta.get("dataset_id") or "")
+        dataset_version = str(meta.get("dataset_version") or "").strip()
         task_id = str(meta.get("task_id") or "")
         lock_digest = str(meta.get("lock_digest") or "")
         status = str(meta.get("status") or "")
@@ -134,10 +135,10 @@ class ResultService:
             raw_score = None
         if isinstance(raw_score, int | float):
             score = float(raw_score)
-        if not run_id or not dataset_id:
+        if not run_id or not dataset_id or not dataset_version:
             raise RegistryAppError(
                 "invalid_request",
-                "run_id and dataset_id required",
+                "run_id, dataset_id, and dataset_version required",
                 http_status=400,
             )
         if visibility not in {"private", "public"}:
@@ -178,6 +179,7 @@ class ResultService:
         row = AttemptResultRow(
             run_id=run_id,
             dataset_id=dataset_id,
+            dataset_version=dataset_version,
             task_id=task_id,
             lock_digest=lock_digest,
             status=status,

--- a/services/registry/store.py
+++ b/services/registry/store.py
@@ -57,6 +57,7 @@ class AttemptResultRow:
     blob_digest: str
     size: int
     created_at: float
+    dataset_version: str = ""
     uploaded_by: str = ""
     # Optional link to parent suite/job (#43); empty on standalone uploads.
     suite_run_id: str = ""
@@ -655,6 +656,7 @@ class MetadataStore(MetadataStoreProtocol):
                     (
                         row.run_id,
                         row.dataset_id,
+                        row.dataset_version,
                         row.task_id,
                         row.lock_digest,
                         row.status,
@@ -1119,9 +1121,7 @@ class MetadataStore(MetadataStoreProtocol):
 
     def count_package_digest_refs(self, package_digest: str) -> int:
         with self._connect() as conn:
-            cur = self._exec(
-                conn, Q.COUNT_PACKAGE_DIGEST_REFS, (package_digest, package_digest)
-            )
+            cur = self._exec(conn, Q.COUNT_PACKAGE_DIGEST_REFS, (package_digest, package_digest))
             return int(cur.fetchone()["n"])
 
     def list_suite_task_refs(self, dataset_id: str) -> list[dict[str, Any]]:
@@ -1296,6 +1296,9 @@ class MetadataStore(MetadataStoreProtocol):
         return AttemptResultRow(
             run_id=r["run_id"],
             dataset_id=r["dataset_id"],
+            dataset_version=str(r["dataset_version"])
+            if "dataset_version" in keys and r["dataset_version"]
+            else "",
             task_id=r["task_id"],
             lock_digest=r["lock_digest"],
             status=r["status"],
@@ -2183,6 +2186,7 @@ def attempt_to_dict(row: AttemptResultRow) -> dict[str, Any]:
     out: dict[str, Any] = {
         "run_id": row.run_id,
         "dataset_id": row.dataset_id,
+        "dataset_version": row.dataset_version,
         "task_id": row.task_id,
         "lock_digest": row.lock_digest,
         "status": row.status,

--- a/skills/ageval-plugin/references/mechanism.md
+++ b/skills/ageval-plugin/references/mechanism.md
@@ -18,7 +18,7 @@ Do not revive the deleted `ageval.agent_executors` entry-point bypass.
 
 ## Slots
 
-Ids live in `src/ageval/plugins/slots.py`. Exclusive: `environment`, `executor`, `evaluation_runtime`, `trajectory_seal`. Chain: environment ready/setup, run bookends, agent open/invoke/close, evaluate bookends, `trajectory_collect` / `trajectory_enrich`, `cleanup_report`.
+Ids live in `src/ageval/plugins/slots.py`. Exclusive: `environment`, `executor`, `evaluation_runtime`, `trajectory_seal`. Chain: environment ready/setup, run bookends, agent open/invoke/close, evaluate bookends, `trajectory_collect` / `trajectory_enrich`, `summary_enrich`, `cleanup_report`.
 
 `evaluation_runtime` / `trajectory_seal` have engine defaults (`plugin_id: default`). No job-field sugar; replace only with an explicit `extensions` row. PASS still enters only through `bind_evaluation`.
 
@@ -31,6 +31,7 @@ open_session → pin graph → before/after_agent_open
 invoke       → before_agent_invoke → executor.invoke → after_agent_invoke
              → normalize_agent_result
 record       → trajectory_collect → enrich → trajectory_seal writes trajectory.jsonl
+             → summary_enrich (fail-open; Attempt summary.extra)
 close        → before_agent_close → executor.close → after_agent_close
 ```
 

--- a/src/ageval/application/registry_ops/results_command.py
+++ b/src/ageval/application/registry_ops/results_command.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Any
 
 from ageval.application.suite import ensure_suite_metrics, ensure_suite_task_refs
-from ageval.config.dataset import load_dataset_manifest
 from ageval.config.errors import ConfigError
+from ageval.evidence.identity import dataset_identity
 from ageval.evidence.locators import default_runs_root, resolve_attempt_run_dir
 from ageval.registry.client import RegistryError
 from ageval.registry.resolve import resolve_dataset_root
@@ -51,8 +51,11 @@ def _attempt_job_fields(run_dir: Path, meta: dict[str, Any]) -> dict[str, Any]:
         if isinstance(raw_score, bool) or not isinstance(raw_score, int | float)
         else float(raw_score)
     )
+    dataset_id, dataset_version = dataset_identity(lock, location=str(lock_path))
     return {
         "task_id": task_id,
+        "dataset_id": dataset_id,
+        "dataset_version": dataset_version,
         "environment": environment,
         "agent_label": agent_label,
         "model_label": model_label,
@@ -248,14 +251,6 @@ class ResultsCommands:
                 location="registry",
             )
         root = dataset_root.expanduser().resolve(strict=False)
-        try:
-            manifest = load_dataset_manifest(root)
-            dataset_id = manifest.dataset_id
-        except ConfigError:
-            raise
-        except Exception as exc:  # noqa: BLE001
-            raise ConfigError("invalid_package", str(exc), location=str(root)) from exc
-
         run_dir = resolve_attempt_run_dir(root, run_id)
         meta = _read_run_meta(run_dir)
         archive_bytes, blob_digest, size = build_attempt_archive(
@@ -264,6 +259,8 @@ class ResultsCommands:
             keep_vendor_raw=bool(meta.get("keep_vendor_raw")),
         )
         job = _attempt_job_fields(run_dir, meta)
+        dataset_id = str(job["dataset_id"])
+        dataset_version = str(job["dataset_version"])
         task_id = str(job.get("task_id") or "")
         lock_digest = str(meta.get("lock_digest") or meta.get("digest") or "")
         status = str(meta.get("status") or meta.get("verdict") or meta.get("outcome") or "")
@@ -281,6 +278,7 @@ class ResultsCommands:
                 info = client.upload_attempt(
                     run_id=run_id,
                     dataset_id=dataset_id,
+                    dataset_version=dataset_version,
                     task_id=task_id,
                     lock_digest=lock_digest,
                     status=status,
@@ -304,6 +302,7 @@ class ResultsCommands:
                         "already_exists": True,
                         "run_id": run_id,
                         "dataset_id": dataset_id,
+                        "dataset_version": dataset_version,
                         "blob_digest": blob_digest,
                         "size": size,
                         "visibility": "public" if public else "private",
@@ -317,6 +316,7 @@ class ResultsCommands:
             "already_exists": False,
             "run_id": info.get("run_id", run_id),
             "dataset_id": info.get("dataset_id", dataset_id),
+            "dataset_version": info.get("dataset_version", dataset_version),
             "blob_digest": info.get("blob_digest", blob_digest),
             "size": info.get("size", size),
             "visibility": info.get("visibility", "private"),
@@ -411,17 +411,9 @@ class ResultsCommands:
         except (TypeError, ValueError):
             exit_code = 0
 
-        dataset_id = str(summary.get("dataset_id") or "")
-        dataset_version = str(summary.get("dataset_version") or "")
-        if not dataset_id:
-            try:
-                man = load_dataset_manifest(root)
-                dataset_id = man.dataset_id
-                dataset_version = dataset_version or man.version
-            except ConfigError:
-                raise
-            except Exception as exc:  # noqa: BLE001
-                raise ConfigError("invalid_package", str(exc), location=str(root)) from exc
+        dataset_id, dataset_version = dataset_identity(
+            summary, location=str(suite_dir / "summary.json")
+        )
 
         run_ids = _run_ids_from_task_refs(task_refs) if with_attempts else []
         if with_attempts:

--- a/src/ageval/application/run.py
+++ b/src/ageval/application/run.py
@@ -218,14 +218,16 @@ async def run_attempt(
         facts=tuple(ctx.facts_as_list()),
     )
     facts = ctx.facts_as_list()
-    evidence.write_summary(
-        {
-            "result": result.as_dict(),
-            "facts": facts,
-            "phase_timing": timing_from_facts(facts),
-            "keep_vendor_raw": ctx.keep_vendor_raw,
-        }
-    )
+    summary: dict[str, Any] = {
+        "result": result.as_dict(),
+        "facts": facts,
+        "phase_timing": timing_from_facts(facts),
+        "keep_vendor_raw": ctx.keep_vendor_raw,
+    }
+    extra = ctx.summary_extra
+    if extra:
+        summary["extra"] = extra
+    evidence.write_summary(summary)
     _write_result(evidence, result)
     return _exit_code(result), result
 

--- a/src/ageval/application/suite/suite_run.py
+++ b/src/ageval/application/suite/suite_run.py
@@ -423,6 +423,8 @@ def _write_suite_progress(
     doc = {
         "schema": "ageval.suite.progress/1",
         "suite_run_id": plan.suite_run_id,
+        "dataset_id": plan.dataset_id,
+        "dataset_version": plan.dataset_version,
         "status": status,
         "done": done,
         "total": total,

--- a/src/ageval/attempt/ctx.py
+++ b/src/ageval/attempt/ctx.py
@@ -59,6 +59,7 @@ class AttemptCtx:
     deadline_monotonic: float | None = None
     keep_workspace: bool = False
     keep_vendor_raw: bool = False
+    summary_extra: dict[str, Any] | None = None
     phase_facts: list[PhaseFact] = field(default_factory=list)
     phase: str = "created"
     evaluation_result: Any = None

--- a/src/ageval/attempt/phases/record.py
+++ b/src/ageval/attempt/phases/record.py
@@ -1,7 +1,8 @@
-"""record phase: collect, enrich, then the seal winner writes the trajectory.
+"""record phase: collect, enrich, seal, then summary_enrich.
 
 Plugins may shape each turn's payload; the ``trajectory_seal`` winner writes
-the file. Collect/enrich are fail-open; losing the sealed file fails the phase.
+the file. Collect/enrich/summary_enrich are fail-open; losing the sealed file
+fails the phase. ``summary_enrich`` runs once after a successful seal.
 """
 
 from __future__ import annotations
@@ -14,7 +15,12 @@ from ageval.evidence.invocation import read_invocation_payload
 from ageval.evidence.slim import slim_sealed_attempt
 from ageval.evidence.trajectory import turn_rows
 from ageval.plugins.binding import bind_winner
-from ageval.plugins.slots import TRAJECTORY_COLLECT, TRAJECTORY_ENRICH, TRAJECTORY_SEAL
+from ageval.plugins.slots import (
+    SUMMARY_ENRICH,
+    TRAJECTORY_COLLECT,
+    TRAJECTORY_ENRICH,
+    TRAJECTORY_SEAL,
+)
 
 PHASE = "record"
 
@@ -39,6 +45,8 @@ async def run(ctx: AttemptCtx) -> None:
     else:
         slim_sealed_attempt(ctx.evidence.root)
         ctx.record_fact("vendor_raw_dropped", {"keep_vendor_raw": False})
+    bag = await emit(ctx, SUMMARY_ENRICH, {})
+    ctx.summary_extra = bag if isinstance(bag, dict) and bag else None
 
 
 def _fields(shaped: Any, original: dict[str, Any]) -> dict[str, Any]:

--- a/src/ageval/evidence/identity.py
+++ b/src/ageval/evidence/identity.py
@@ -1,0 +1,35 @@
+"""Locked ``dataset_id@version`` from a finished record. No yaml fallback."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ageval.config.errors import ConfigError
+
+
+def dataset_identity(doc: Any, *, location: str) -> tuple[str, str]:
+    """``dataset_id`` + ``dataset_version`` from lock.json or suite summary.json."""
+    if not isinstance(doc, dict):
+        raise ConfigError(
+            "invalid_schema",
+            "missing dataset_id@version",
+            location=location,
+        )
+    dataset_id = doc.get("dataset_id")
+    dataset_version = doc.get("dataset_version")
+    if (
+        not isinstance(dataset_id, str)
+        or not dataset_id.strip()
+        or not isinstance(dataset_version, str)
+        or not dataset_version.strip()
+    ):
+        raise ConfigError(
+            "invalid_schema",
+            "missing dataset_id@version",
+            location=location,
+        )
+    return dataset_id.strip(), dataset_version.strip()
+
+
+def dataset_ref(dataset_id: str, dataset_version: str) -> str:
+    return f"{dataset_id}@{dataset_version}"

--- a/src/ageval/evidence/usage.py
+++ b/src/ageval/evidence/usage.py
@@ -42,3 +42,21 @@ def sealed_extra(extra: Mapping[str, Any] | None) -> dict[str, Any] | None:
             continue
         out[key] = value
     return out or None
+
+
+def observational_bag(value: Any) -> dict[str, Any] | None:
+    """Non-empty object bag, or None. Observational — never PASS."""
+    return value if isinstance(value, dict) and value else None
+
+
+def terminal_extra(row: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    """Sibling ``extra``, else already-sealed ``usage.extra`` on old jsonl."""
+    if not isinstance(row, Mapping):
+        return None
+    sibling = observational_bag(row.get("extra"))
+    if sibling is not None:
+        return sibling
+    usage = row.get("usage")
+    if isinstance(usage, Mapping):
+        return observational_bag(usage.get("extra"))
+    return None

--- a/src/ageval/plugins/slots.py
+++ b/src/ageval/plugins/slots.py
@@ -52,6 +52,7 @@ AFTER_EVALUATE: Final = "after_evaluate"
 # --- record phase chain ---
 TRAJECTORY_COLLECT: Final = "trajectory_collect"
 TRAJECTORY_ENRICH: Final = "trajectory_enrich"
+SUMMARY_ENRICH: Final = "summary_enrich"
 
 # --- cleanup phase chain ---
 CLEANUP_REPORT: Final = "cleanup_report"
@@ -81,6 +82,7 @@ _SLOT_KINDS: Final[dict[str, SlotKind]] = {
     AFTER_EVALUATE: SlotKind.CHAIN,
     TRAJECTORY_COLLECT: SlotKind.CHAIN,
     TRAJECTORY_ENRICH: SlotKind.CHAIN,
+    SUMMARY_ENRICH: SlotKind.CHAIN,
     CLEANUP_REPORT: SlotKind.CHAIN,
 }
 
@@ -101,6 +103,7 @@ FAIL_OPEN_SLOTS: Final[frozenset[str]] = frozenset(
         AFTER_RUN,
         TRAJECTORY_COLLECT,
         TRAJECTORY_ENRICH,
+        SUMMARY_ENRICH,
         CLEANUP_REPORT,
     }
 )

--- a/src/ageval/registry/client.py
+++ b/src/ageval/registry/client.py
@@ -375,6 +375,7 @@ class RegistryClient:
         *,
         run_id: str,
         dataset_id: str,
+        dataset_version: str,
         task_id: str,
         lock_digest: str,
         status: str,
@@ -392,6 +393,7 @@ class RegistryClient:
         meta: dict[str, Any] = {
             "run_id": run_id,
             "dataset_id": dataset_id,
+            "dataset_version": dataset_version,
             "task_id": task_id,
             "lock_digest": lock_digest,
             "status": status,

--- a/src/ageval/viewer/jobs.py
+++ b/src/ageval/viewer/jobs.py
@@ -21,6 +21,7 @@ from ageval.application.suite import (
 from ageval.application.suite.suite_metrics import attempt_started_at
 from ageval.config.dataset import load_dataset_manifest
 from ageval.config.errors import ConfigError
+from ageval.evidence.identity import dataset_identity, dataset_ref
 from ageval.evidence.locators import (
     default_runs_root,
     default_suite_runs_root,
@@ -32,34 +33,6 @@ from ageval.viewer.browse import commands_for
 
 def _suite_root(dataset_root: Path) -> Path:
     return default_suite_runs_root(dataset_root.expanduser().resolve(strict=False))
-
-
-def dataset_identity(doc: Any, *, location: str) -> tuple[str, str]:
-    """``dataset_id`` + ``dataset_version`` from a finished record. No yaml fallback."""
-    if not isinstance(doc, dict):
-        raise ConfigError(
-            "invalid_schema",
-            "missing dataset_id@version",
-            location=location,
-        )
-    dataset_id = doc.get("dataset_id")
-    dataset_version = doc.get("dataset_version")
-    if (
-        not isinstance(dataset_id, str)
-        or not dataset_id.strip()
-        or not isinstance(dataset_version, str)
-        or not dataset_version.strip()
-    ):
-        raise ConfigError(
-            "invalid_schema",
-            "missing dataset_id@version",
-            location=location,
-        )
-    return dataset_id.strip(), dataset_version.strip()
-
-
-def dataset_ref(dataset_id: str, dataset_version: str) -> str:
-    return f"{dataset_id}@{dataset_version}"
 
 
 def _load_summary(path: Path) -> dict[str, Any]:

--- a/src/ageval/viewer/jobs.py
+++ b/src/ageval/viewer/jobs.py
@@ -34,6 +34,34 @@ def _suite_root(dataset_root: Path) -> Path:
     return default_suite_runs_root(dataset_root.expanduser().resolve(strict=False))
 
 
+def dataset_identity(doc: Any, *, location: str) -> tuple[str, str]:
+    """``dataset_id`` + ``dataset_version`` from a finished record. No yaml fallback."""
+    if not isinstance(doc, dict):
+        raise ConfigError(
+            "invalid_schema",
+            "missing dataset_id@version",
+            location=location,
+        )
+    dataset_id = doc.get("dataset_id")
+    dataset_version = doc.get("dataset_version")
+    if (
+        not isinstance(dataset_id, str)
+        or not dataset_id.strip()
+        or not isinstance(dataset_version, str)
+        or not dataset_version.strip()
+    ):
+        raise ConfigError(
+            "invalid_schema",
+            "missing dataset_id@version",
+            location=location,
+        )
+    return dataset_id.strip(), dataset_version.strip()
+
+
+def dataset_ref(dataset_id: str, dataset_version: str) -> str:
+    return f"{dataset_id}@{dataset_version}"
+
+
 def _load_summary(path: Path) -> dict[str, Any]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -199,20 +227,20 @@ def _in_progress_suite_row(
     manifest: Any = None,
 ) -> dict[str, Any]:
     """Suite that has progress.json but no summary yet — still running."""
-    man = manifest
-    if man is None:
-        with contextlib.suppress(ConfigError):
-            man = load_dataset_manifest(dataset_root)
+    del dataset_root, manifest
     sid = str(progress.get("suite_run_id") or suite_dir.name)
     total = int(progress.get("total") or 0)
     done = int(progress.get("done") or 0)
+    did, ver = dataset_identity(progress, location=str(suite_dir / "progress.json"))
+    ref = dataset_ref(did, ver)
     return {
         "job_id": sid,
         "job_name": sid,
         "source_kind": "suite",
-        "source": man.dataset_id if man else dataset_root.name,
-        "dataset_id": man.dataset_id if man else None,
-        "dataset_version": man.version if man else None,
+        "source": did,
+        "dataset_id": did,
+        "dataset_version": ver,
+        "dataset_ref": ref,
         "agent_label": "",
         "model_label": "",
         "reasoning_effort": "",
@@ -260,11 +288,6 @@ def _job_row(
         # Prefer counting actual refs
         trials_done = len(refs) if refs else n_tasks
 
-    man = manifest
-    if man is None:
-        with contextlib.suppress(ConfigError):
-            man = load_dataset_manifest(dataset_root)
-
     overlay = _overlay_from_job_summary(summary, dataset_root=dataset_root)
     from ageval.config.overlay_files import overlay_paths_from_job_overlay
     from ageval.config.profiles import display_labels_from_overlay
@@ -275,15 +298,16 @@ def _job_row(
     if not model_label:
         model_label = str(summary.get("model_label") or "")
 
+    did, ver = dataset_identity(summary, location=str(suite_dir / "summary.json"))
+    ref = dataset_ref(did, ver)
     return {
         "job_id": str(summary.get("suite_run_id") or suite_dir.name),
         "job_name": str(summary.get("suite_run_id") or suite_dir.name),
         "source_kind": "suite",
-        "source": str(
-            summary.get("dataset_id") or (man.dataset_id if man else "") or dataset_root.name
-        ),
-        "dataset_id": summary.get("dataset_id") or (man.dataset_id if man else None),
-        "dataset_version": summary.get("dataset_version") or (man.version if man else None),
+        "source": did,
+        "dataset_id": did,
+        "dataset_version": ver,
+        "dataset_ref": ref,
         "agent_label": agent_label,
         "model_label": model_label,
         "reasoning_effort": _reasoning_effort_from_summary(summary),
@@ -567,17 +591,17 @@ def _single_job_row(
     from ageval.config.profiles import reasoning_effort_from_overlay
 
     overlay = lock.get("job_overlay") if isinstance(lock.get("job_overlay"), dict) else None
-    man = manifest
-    if man is None:
-        with contextlib.suppress(ConfigError):
-            man = load_dataset_manifest(dataset_root)
+    del manifest
+    did, ver = dataset_identity(lock, location=str(evidence / "lock.json"))
+    ref = dataset_ref(did, ver)
     return {
         "job_id": run_id,
         "job_name": run_id,
         "source_kind": "single",
         "source": task_id or "single",
-        "dataset_id": man.dataset_id if man else None,
-        "dataset_version": man.version if man else None,
+        "dataset_id": did,
+        "dataset_version": ver,
+        "dataset_ref": ref,
         "agent_label": agent_label,
         "model_label": model_label,
         "reasoning_effort": reasoning_effort_from_overlay(overlay),
@@ -761,7 +785,7 @@ def get_job(dataset_root: Path, job_id: str) -> dict[str, Any]:
                 "model_label": job.get("model_label") or "",
                 "reasoning_effort": job.get("reasoning_effort") or "",
                 "provider_label": job.get("provider_label") or "",
-                "dataset": job.get("source") or job.get("dataset_id"),
+                "dataset": job.get("dataset_ref") or job.get("dataset_id"),
                 "duration": full.get("duration"),
                 "phase_timing": full.get("phase_timing"),
                 "n": n_val,
@@ -854,7 +878,7 @@ def _get_single_job(root: Path, job_id: str) -> dict[str, Any]:
             "model_label": job.get("model_label") or "",
             "reasoning_effort": job.get("reasoning_effort") or "",
             "provider_label": job.get("provider_label") or "",
-            "dataset": job.get("source") or job.get("dataset_id"),
+            "dataset": job.get("dataset_ref") or job.get("dataset_id"),
             "duration": job.get("duration"),
             "n": 1,
         }

--- a/src/ageval/viewer/trials/surface.py
+++ b/src/ageval/viewer/trials/surface.py
@@ -10,7 +10,14 @@ from typing import Any
 from ageval.evidence.attempt_record import has_attempt_result, read_attempt_result
 from ageval.evidence.trajectory import TRAJECTORY_FILENAME
 from ageval.evidence.usage import observational_bag, terminal_extra
-from ageval.viewer.jobs import _duration_label, _environment_kind, _phase_timing, _started_at
+from ageval.viewer.jobs import (
+    _duration_label,
+    _environment_kind,
+    _phase_timing,
+    _started_at,
+    dataset_identity,
+    dataset_ref,
+)
 from ageval.viewer.trials.paths import _read_json_object
 from ageval.viewer.trials.usage import (
     _format_latency_ms,
@@ -339,6 +346,8 @@ def _trial_meta_from_evidence(
             error = str(error)
     locked_task = lock.get("task_id") if isinstance(lock.get("task_id"), str) else None
     surface = _agent_surface(evidence, lock=lock)
+    did, ver = dataset_identity(lock, location=str(evidence / "lock.json"))
+    ref = dataset_ref(did, ver)
 
     phase_timing = _phase_timing(summary) or _phase_timing(suite_row)
     duration = _duration_label(phase_timing)
@@ -378,6 +387,9 @@ def _trial_meta_from_evidence(
         "upstream_ref": surface.get("upstream_ref"),
         "note": None,
         "extra": observational_bag(summary.get("extra")),
+        "dataset_id": did,
+        "dataset_version": ver,
+        "dataset_ref": ref,
     }
 
 

--- a/src/ageval/viewer/trials/surface.py
+++ b/src/ageval/viewer/trials/surface.py
@@ -8,16 +8,10 @@ from pathlib import Path
 from typing import Any
 
 from ageval.evidence.attempt_record import has_attempt_result, read_attempt_result
+from ageval.evidence.identity import dataset_identity, dataset_ref
 from ageval.evidence.trajectory import TRAJECTORY_FILENAME
 from ageval.evidence.usage import observational_bag, terminal_extra
-from ageval.viewer.jobs import (
-    _duration_label,
-    _environment_kind,
-    _phase_timing,
-    _started_at,
-    dataset_identity,
-    dataset_ref,
-)
+from ageval.viewer.jobs import _duration_label, _environment_kind, _phase_timing, _started_at
 from ageval.viewer.trials.paths import _read_json_object
 from ageval.viewer.trials.usage import (
     _format_latency_ms,

--- a/src/ageval/viewer/trials/surface.py
+++ b/src/ageval/viewer/trials/surface.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from ageval.evidence.attempt_record import has_attempt_result, read_attempt_result
 from ageval.evidence.trajectory import TRAJECTORY_FILENAME
+from ageval.evidence.usage import observational_bag, terminal_extra
 from ageval.viewer.jobs import _duration_label, _environment_kind, _phase_timing, _started_at
 from ageval.viewer.trials.paths import _read_json_object
 from ageval.viewer.trials.usage import (
@@ -376,6 +377,7 @@ def _trial_meta_from_evidence(
         "upstream_name": surface.get("upstream_name"),
         "upstream_ref": surface.get("upstream_ref"),
         "note": None,
+        "extra": observational_bag(summary.get("extra")),
     }
 
 
@@ -413,8 +415,8 @@ def _usage_time_from_trajectory(
                 usage = obj.get("usage")
                 if isinstance(usage, dict) and usage:
                     last_usage[pid] = usage
-                extra = obj.get("extra")
-                if isinstance(extra, dict) and extra:
+                extra = terminal_extra(obj)
+                if extra:
                     last_extra[pid] = extra
                 elapsed = obj.get("elapsed_ms")
                 if not isinstance(elapsed, (int, float)) or isinstance(elapsed, bool):

--- a/src/ageval/viewer/trials/trajectory.py
+++ b/src/ageval/viewer/trials/trajectory.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from ageval.evidence.trajectory import TRAJECTORY_FILENAME
+from ageval.evidence.usage import terminal_extra
 from ageval.viewer.jobs import get_job, safe_id_segment
 from ageval.viewer.trials.constants import MAX_JSONL_LINE, MAX_TRAJECTORY_STEPS
 from ageval.viewer.trials.paths import (
@@ -212,7 +213,7 @@ def _parse_trajectory_jsonl(path: Path) -> list[dict[str, Any]]:
                         "ok": obj.get("ok"),
                         "error": obj.get("error"),
                         "usage": obj.get("usage") if isinstance(obj.get("usage"), dict) else None,
-                        "extra": obj.get("extra") if isinstance(obj.get("extra"), dict) else None,
+                        "extra": terminal_extra(obj),
                         "metadata": obj.get("metadata")
                         if isinstance(obj.get("metadata"), dict)
                         else None,

--- a/tests/application/test_attempt_job_fields.py
+++ b/tests/application/test_attempt_job_fields.py
@@ -15,6 +15,8 @@ def test_attempt_job_fields_reads_lock_environment(tmp_path: Path) -> None:
         json.dumps(
             {
                 "task_id": "terminal-jsonl-agg",
+                "dataset_id": "example/journeys",
+                "dataset_version": "0.1.0",
                 "environment": "e2b",
                 "job_overlay": {
                     "environment": "e2b",
@@ -28,6 +30,8 @@ def test_attempt_job_fields_reads_lock_environment(tmp_path: Path) -> None:
     )
     fields = _attempt_job_fields(run, {"kind": "e2b", "score": 1.0, "status": "PASS"})
     assert fields["environment"] == "e2b"
+    assert fields["dataset_id"] == "example/journeys"
+    assert fields["dataset_version"] == "0.1.0"
     assert fields["task_id"] == "terminal-jsonl-agg"
     assert fields["model_label"] == "glm-5.2"
     assert fields["score"] == 1.0

--- a/tests/application/test_upload_suite_slot.py
+++ b/tests/application/test_upload_suite_slot.py
@@ -68,6 +68,10 @@ def _seed(db: Path, *, suite_id: str = "suite1") -> None:
     for rid in ("newrun", "oldrun"):
         run_dir = db / ".ageval" / "runs" / rid
         run_dir.mkdir(parents=True)
+        run_dir.joinpath("lock.json").write_text(
+            '{"task_id": "hello", "dataset_id": "test/db", "dataset_version": "0.1.0"}\n',
+            encoding="utf-8",
+        )
         run_dir.joinpath("result.json").write_text(
             f'{{"status": "PASS", "task_id": "hello", "run_id": "{rid}"}}\n',
             encoding="utf-8",
@@ -143,6 +147,10 @@ def test_append_slot_resolves_always_k_index_from_attempts(tmp_path: Path) -> No
     for rid in ("idx0", "idx2", "idx1new", "idx1old"):
         run_dir = db / ".ageval" / "runs" / rid
         run_dir.mkdir(parents=True)
+        run_dir.joinpath("lock.json").write_text(
+            '{"task_id": "hello", "dataset_id": "test/db", "dataset_version": "0.1.0"}\n',
+            encoding="utf-8",
+        )
         run_dir.joinpath("result.json").write_text("{}\n", encoding="utf-8")
 
     captured: dict[str, Any] = {}

--- a/tests/attempt/test_eval_seal_phases.py
+++ b/tests/attempt/test_eval_seal_phases.py
@@ -19,6 +19,7 @@ from ageval.plugins.services import ServiceTable
 from ageval.plugins.slots import (
     AFTER_EVALUATE,
     EVALUATION_RUNTIME,
+    SUMMARY_ENRICH,
     TRAJECTORY_COLLECT,
     TRAJECTORY_SEAL,
 )
@@ -246,3 +247,70 @@ async def test_collect_usage_extra_lands_on_terminal(tmp_path: Path) -> None:
     assert terminal["usage"]["completion_tokens"] == 1
     assert terminal["extra"]["foo"] is True
     assert terminal["elapsed_ms"] == 88
+
+
+def _write_summary_like_run(ctx: AttemptCtx) -> dict[str, Any]:
+    """Same omit-when-empty rule as ``application/run.py``."""
+    import json
+
+    summary: dict[str, Any] = {"result": {"status": "PASS"}, "facts": ctx.facts_as_list()}
+    if ctx.summary_extra:
+        summary["extra"] = ctx.summary_extra
+    ctx.evidence.write_summary(summary)
+    return json.loads((ctx.evidence.root / "summary.json").read_text(encoding="utf-8"))
+
+
+@pytest.mark.asyncio
+async def test_summary_enrich_lands_on_summary_json(tmp_path: Path) -> None:
+    async def enrich(ctx: Any, value: Any, nxt: Any) -> Any:
+        del ctx
+        bag = dict(await nxt(value) or {})
+        bag["probe"] = {"foo": True}
+        return bag
+
+    registry = ExtensionRegistry()
+    register_defaults(registry)
+    graph = resolve(BindingIntent(profile_id="solver"), registry)
+    graph.chains[SUMMARY_ENRICH] = [
+        HandlerRef(plugin_id="probe", handler=enrich, priority=1, source="test")
+    ]
+    ctx = _ctx(tmp_path, registry=registry, graph=graph)
+    await record.run(ctx)
+    assert ctx.summary_extra == {"probe": {"foo": True}}
+    doc = _write_summary_like_run(ctx)
+    assert doc["extra"]["probe"]["foo"] is True
+
+
+@pytest.mark.asyncio
+async def test_summary_enrich_omits_empty_bag(tmp_path: Path) -> None:
+    registry = ExtensionRegistry()
+    register_defaults(registry)
+    graph = resolve(BindingIntent(profile_id="solver"), registry)
+    ctx = _ctx(tmp_path, registry=registry, graph=graph)
+    await record.run(ctx)
+    assert ctx.summary_extra is None
+    doc = _write_summary_like_run(ctx)
+    assert "extra" not in doc
+
+
+@pytest.mark.asyncio
+async def test_summary_enrich_fail_open_leaves_empty_bag(tmp_path: Path) -> None:
+    async def boom(ctx: Any, value: Any, nxt: Any) -> Any:
+        del ctx, value, nxt
+        raise RuntimeError("summary enrich exploded")
+
+    registry = ExtensionRegistry()
+    register_defaults(registry)
+    graph = resolve(BindingIntent(profile_id="solver"), registry)
+    graph.chains[SUMMARY_ENRICH] = [
+        HandlerRef(plugin_id="probe", handler=boom, priority=1, source="test")
+    ]
+    ctx = _ctx(tmp_path, registry=registry, graph=graph)
+    await record.run(ctx)
+    assert ctx.summary_extra is None
+    assert any(
+        f.name == "slot_failed_open" and f.detail.get("slot") == SUMMARY_ENRICH
+        for f in ctx.phase_facts
+    )
+    doc = _write_summary_like_run(ctx)
+    assert "extra" not in doc

--- a/tests/evidence/test_usage.py
+++ b/tests/evidence/test_usage.py
@@ -1,0 +1,27 @@
+"""First-class usage plus sibling extra bags (observational, not PASS)."""
+
+from __future__ import annotations
+
+from ageval.evidence.usage import observational_bag, sealed_extra, sealed_usage, terminal_extra
+
+
+def test_sealed_usage_omits_unknown_and_zeros_are_caller_owned() -> None:
+    assert sealed_usage(prompt_tokens=3, completion_tokens=1) == {
+        "prompt_tokens": 3,
+        "completion_tokens": 1,
+    }
+    assert sealed_usage() is None
+
+
+def test_sealed_extra_strips_first_class_keys() -> None:
+    assert sealed_extra({"reasoning_tokens": 2, "prompt_tokens": 9}) == {"reasoning_tokens": 2}
+    assert sealed_extra({}) is None
+
+
+def test_terminal_extra_prefers_sibling_then_usage_extra() -> None:
+    assert terminal_extra({"extra": {"foo": True}, "usage": {"extra": {"old": 1}}}) == {"foo": True}
+    assert terminal_extra({"usage": {"prompt_tokens": 1, "extra": {"old": 1}}}) == {"old": 1}
+    assert terminal_extra({"extra": {}, "usage": {"extra": {"old": 1}}}) == {"old": 1}
+    assert terminal_extra({"usage": {"prompt_tokens": 1}}) is None
+    assert observational_bag({}) is None
+    assert observational_bag({"probe": {"foo": True}}) == {"probe": {"foo": True}}

--- a/tests/plugins/test_eval_seal_defaults.py
+++ b/tests/plugins/test_eval_seal_defaults.py
@@ -13,6 +13,7 @@ from ageval.plugins.services import RESERVED_SERVICE_IDS
 from ageval.plugins.slots import (
     EVALUATION_RUNTIME,
     FAIL_OPEN_SLOTS,
+    SUMMARY_ENRICH,
     TRAJECTORY_SEAL,
 )
 
@@ -25,6 +26,7 @@ def test_sugar_slots_do_not_include_eval_or_seal() -> None:
 def test_eval_and_seal_are_fail_closed() -> None:
     assert EVALUATION_RUNTIME not in FAIL_OPEN_SLOTS
     assert TRAJECTORY_SEAL not in FAIL_OPEN_SLOTS
+    assert SUMMARY_ENRICH in FAIL_OPEN_SLOTS
 
 
 def test_reserved_services_still_block_pass_identity_cleanup_evidence() -> None:

--- a/tests/registry/test_metadata_repository.py
+++ b/tests/registry/test_metadata_repository.py
@@ -79,6 +79,7 @@ def test_attempt_row_stores_environment(tmp_path: Path) -> None:
     row = AttemptResultRow(
         run_id="attempt_env_1",
         dataset_id="example/journeys",
+        dataset_version="0.1.0",
         task_id="terminal-jsonl-agg",
         lock_digest="sha256:abc",
         status="PASS",

--- a/tests/registry/test_registry_operator.py
+++ b/tests/registry/test_registry_operator.py
@@ -139,6 +139,7 @@ def test_results_upload_get_roundtrip(
     run_id = "sha256_deadbeef_run_test1"
     run_dir = db / ".ageval" / "runs" / run_id
     run_dir.mkdir(parents=True)
+    _write_lock(run_dir)
     (run_dir / "result.json").write_text(
         json.dumps({"task_id": "hello", "status": "PASS", "ok": True}),
         encoding="utf-8",
@@ -148,9 +149,12 @@ def test_results_upload_get_roundtrip(
     up = upload_attempt_result(db, run_id=run_id)
     assert up["ok"] is True
     assert up["run_id"] == run_id
+    assert up["dataset_id"] == "test/publish-min"
+    assert up["dataset_version"] == "0.1.0"
 
     listed = list_attempt_results(dataset_id="test/publish-min")
     assert listed["count"] == 1
+    assert listed["items"][0]["dataset_version"] == "0.1.0"
 
     out = tmp_path / "restored"
     got = get_attempt_result(run_id, out_dir=out)
@@ -159,6 +163,25 @@ def test_results_upload_get_roundtrip(
     assert (restored / "result.json").is_file()
     data = json.loads((restored / "result.json").read_text(encoding="utf-8"))
     assert data["status"] == "PASS"
+
+
+def test_attempt_upload_fails_closed_without_lock_identity(
+    registry_server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from ageval.config.errors import ConfigError
+
+    _auth_env(monkeypatch, registry_server, tmp_path)
+    _ensure_org()
+    db = tmp_path / "db-no-lock"
+    import shutil
+
+    shutil.copytree(FIXTURE, db)
+    run_id = "sha256_missing_lock"
+    run_dir = db / ".ageval" / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "result.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(ConfigError, match="missing dataset_id@version"):
+        upload_attempt_result(db, run_id=run_id)
 
 
 def test_results_private_without_token_404(
@@ -173,6 +196,7 @@ def test_results_private_without_token_404(
     run_id = "sha256_cafe_run_priv"
     run_dir = db / ".ageval" / "runs" / run_id
     run_dir.mkdir(parents=True)
+    _write_lock(run_dir)
     (run_dir / "result.json").write_text("{}", encoding="utf-8")
     upload_attempt_result(db, run_id=run_id)
 
@@ -327,6 +351,7 @@ def test_results_upload_scope_cannot_read_private(
     run_id = "sha256_upload_only_run"
     run_dir = db / ".ageval" / "runs" / run_id
     run_dir.mkdir(parents=True)
+    _write_lock(run_dir)
     (run_dir / "result.json").write_text("{}", encoding="utf-8")
 
     upload_attempt_result(db, run_id=run_id)
@@ -699,9 +724,24 @@ def test_multipart_payload_trailing_lf_preserved() -> None:
     assert parts["archive"].endswith(b"\n")
 
 
+def _write_lock(run_dir: Path, *, task_id: str = "hello") -> None:
+    (run_dir / "lock.json").write_text(
+        json.dumps(
+            {
+                "task_id": task_id,
+                "dataset_id": "test/publish-min",
+                "dataset_version": "0.1.0",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 def _write_local_attempt(db: Path, run_id: str, *, task_id: str = "a") -> Path:
     run_dir = db / ".ageval" / "runs" / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
+    _write_lock(run_dir, task_id=task_id)
     (run_dir / "result.json").write_text(
         json.dumps({"task_id": task_id, "status": "PASS", "score": 1.0}, indent=2) + "\n",
         encoding="utf-8",

--- a/tests/registry/test_registry_org_share.py
+++ b/tests/registry/test_registry_org_share.py
@@ -178,6 +178,17 @@ def test_result_uploaded_by_and_share_org(
     run_id = "sha256_share_run1"
     run_dir = db / ".ageval" / "runs" / run_id
     run_dir.mkdir(parents=True)
+    (run_dir / "lock.json").write_text(
+        json.dumps(
+            {
+                "task_id": "hello",
+                "dataset_id": "test/publish-min",
+                "dataset_version": "0.1.0",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     (run_dir / "result.json").write_text(
         json.dumps({"task_id": "hello", "status": "PASS"}),
         encoding="utf-8",

--- a/tests/registry/test_registry_owner_ops.py
+++ b/tests/registry/test_registry_owner_ops.py
@@ -80,6 +80,17 @@ def _seed_attempt(
         shutil.copytree(FIXTURE, db)
     run_dir = db / ".ageval" / "runs" / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "lock.json").write_text(
+        json.dumps(
+            {
+                "task_id": "hello",
+                "dataset_id": "test/publish-min",
+                "dataset_version": "0.1.0",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     (run_dir / "result.json").write_text(
         json.dumps({"task_id": "hello", "status": "PASS"}),
         encoding="utf-8",

--- a/tests/registry/test_suite_append_slot.py
+++ b/tests/registry/test_suite_append_slot.py
@@ -98,6 +98,7 @@ def _upload_attempt(
         meta={
             "run_id": run_id,
             "dataset_id": dataset_id,
+            "dataset_version": "0.1.0",
             "task_id": "hello",
             "lock_digest": "sha256:x",
             "status": status,

--- a/tests/registry/test_suite_append_slot.py
+++ b/tests/registry/test_suite_append_slot.py
@@ -112,6 +112,15 @@ def _upload_attempt(
     )
 
 
+def test_upload_suite_requires_dataset_version(tmp_path: Path) -> None:
+    results = _services(tmp_path)
+    auth = TokenInfo(scopes=frozenset({"results:upload"}), user_id="alice")
+    meta, archive = _suite_archive(tmp_path, "suite_no_ver")
+    del meta["dataset_version"]
+    with pytest.raises(RegistryAppError, match="dataset_version"):
+        results.upload_suite(meta=meta, archive=archive, auth=auth)
+
+
 def test_append_slot_updates_metrics_and_keeps_old_attempt(tmp_path: Path) -> None:
     results = _services(tmp_path)
     auth = TokenInfo(scopes=frozenset({"results:upload"}), user_id="alice")

--- a/tests/viewer/test_local_job_delete.py
+++ b/tests/viewer/test_local_job_delete.py
@@ -39,6 +39,14 @@ def _seed_attempt(
         evidence / "result.json",
         {"task_id": task_id, "status": "PASS", "score": 1.0},
     )
+    _write_json(
+        evidence / "lock.json",
+        {
+            "task_id": task_id,
+            "dataset_id": "test/suite-min",
+            "dataset_version": "0.1.0",
+        },
+    )
     return evidence
 
 
@@ -74,6 +82,7 @@ def _seed_suite(
             "schema": "ageval.suite.summary/1",
             "suite_run_id": job_id,
             "dataset_id": "test/suite-min",
+            "dataset_version": "0.1.0",
             "tasks": tasks,
             "task_refs": refs,
             "attempts": [
@@ -156,6 +165,7 @@ def test_delete_suite_cascades_previous_attempts(tmp_path: Path) -> None:
             "schema": "ageval.suite.summary/1",
             "suite_run_id": job_id,
             "dataset_id": "test/suite-min",
+            "dataset_version": "0.1.0",
             "tasks": [{"task_id": "alpha", "status": "PASS", "run_id": "run_new"}],
             "task_refs": [
                 {
@@ -211,6 +221,8 @@ def test_list_jobs_includes_progress_only_suite(tmp_path: Path) -> None:
         {
             "schema": "ageval.suite.progress/1",
             "suite_run_id": "suite_live",
+            "dataset_id": "test/suite-min",
+            "dataset_version": "0.1.0",
             "status": "running",
             "done": 1,
             "total": 100,

--- a/tests/viewer/test_viewer_jobs.py
+++ b/tests/viewer/test_viewer_jobs.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from ageval.config.errors import ConfigError
 from ageval.viewer import jobs
 
 REPO = Path(__file__).resolve().parents[2]
@@ -53,6 +54,20 @@ def _seed_suite_run(db: Path, job_id: str = "suite_demo_job_001") -> str:
     return job_id
 
 
+def _write_lock(evidence: Path, *, task_id: str) -> None:
+    (evidence / "lock.json").write_text(
+        json.dumps(
+            {
+                "task_id": task_id,
+                "dataset_id": "test/suite-min",
+                "dataset_version": "0.1.0",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 def _clean_db(tmp_path: Path) -> Path:
     """Copy fixture without leftover .ageval suite-runs from local smokes."""
     db = tmp_path / "db"
@@ -70,6 +85,8 @@ def test_get_job_from_attempts_only_summary(tmp_path: Path) -> None:
             {
                 "schema": "ageval.suite.summary/1",
                 "suite_run_id": job_id,
+                "dataset_id": "test/suite-min",
+                "dataset_version": "0.1.0",
                 "attempts": [
                     {
                         "task_id": "alpha",
@@ -111,11 +128,65 @@ def test_list_and_get_job(tmp_path: Path) -> None:
     assert listed["items"][0]["agent_label"] == "codex"
     assert listed["items"][0]["environment"] == "docker"
     assert listed["items"][0]["started"] == "2026-07-14T19:46:20Z"
+    assert listed["items"][0]["dataset_ref"] == "test/suite-min@0.1.0"
 
     detail = jobs.get_job(db, job_id)
     assert detail["task_count"] == 3
     assert detail["tasks"][0]["task_id"] == "alpha"
     assert detail["tasks"][1]["status"] == "FAIL"
+    assert detail["job"]["dataset_ref"] == "test/suite-min@0.1.0"
+    assert detail["tasks"][0]["dataset"] == "test/suite-min@0.1.0"
+
+
+def test_suite_identity_is_summary_not_opened_yaml(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    summary_path = db / ".ageval" / "suite-runs" / job_id / "summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["dataset_id"] = "official/tau3-airline"
+    summary["dataset_version"] = "0.1.0"
+    summary_path.write_text(json.dumps(summary) + "\n", encoding="utf-8")
+    row = jobs.list_jobs(db)["items"][0]
+    assert row["dataset_ref"] == "official/tau3-airline@0.1.0"
+    assert row["dataset_id"] == "official/tau3-airline"
+    detail = jobs.get_job(db, job_id)
+    assert detail["job"]["dataset_ref"] == "official/tau3-airline@0.1.0"
+
+
+def test_missing_suite_identity_fails_closed(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    summary_path = db / ".ageval" / "suite-runs" / job_id / "summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    del summary["dataset_version"]
+    summary_path.write_text(json.dumps(summary) + "\n", encoding="utf-8")
+    with pytest.raises(ConfigError, match="missing dataset_id@version"):
+        jobs.list_jobs(db)
+
+
+def test_single_job_identity_is_lock_not_opened_yaml(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    evidence = _write_attempt_evidence(db, "run_locked", task_id="alpha", kind="docker")
+    lock_path = evidence / "lock.json"
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    lock["dataset_id"] = "official/tau3-airline"
+    lock["dataset_version"] = "0.1.0"
+    lock_path.write_text(json.dumps(lock) + "\n", encoding="utf-8")
+    row = next(item for item in jobs.list_jobs(db)["items"] if item["job_id"] == "run_locked")
+    assert row["dataset_ref"] == "official/tau3-airline@0.1.0"
+    detail = jobs.get_job(db, "run_locked")
+    assert detail["job"]["dataset_ref"] == "official/tau3-airline@0.1.0"
+    assert detail["tasks"][0]["dataset"] == "official/tau3-airline@0.1.0"
+
+
+def test_missing_lock_identity_fails_closed(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    evidence = _write_attempt_evidence(db, "run_nolock", task_id="alpha", kind="docker")
+    lock = json.loads((evidence / "lock.json").read_text(encoding="utf-8"))
+    del lock["dataset_id"]
+    (evidence / "lock.json").write_text(json.dumps(lock) + "\n", encoding="utf-8")
+    with pytest.raises(ConfigError, match="missing dataset_id@version"):
+        jobs.list_jobs(db)
 
 
 def test_suite_job_axes_come_from_attempt_lock_overlay(tmp_path: Path) -> None:
@@ -126,6 +197,8 @@ def test_suite_job_axes_come_from_attempt_lock_overlay(tmp_path: Path) -> None:
         json.dumps(
             {
                 "task_id": "alpha",
+                "dataset_id": "test/suite-min",
+                "dataset_version": "0.1.0",
                 "environment": "e2b",
                 "job_overlay": {
                     "environment": "e2b",
@@ -146,6 +219,8 @@ def test_suite_job_axes_come_from_attempt_lock_overlay(tmp_path: Path) -> None:
             {
                 "schema": "ageval.suite.summary/1",
                 "suite_run_id": job_id,
+                "dataset_id": "test/suite-min",
+                "dataset_version": "0.1.0",
                 "agent_label": "e2b/dsh",
                 "model_label": "glm-5.2",
                 "tasks": [
@@ -211,11 +286,13 @@ def test_list_includes_single_task_attempt(tmp_path: Path) -> None:
         + "\n",
         encoding="utf-8",
     )
+    _write_lock(evidence, task_id="alpha")
     listed = jobs.list_jobs(db)
     assert listed["count"] == 1
     row = listed["items"][0]
     assert row["job_id"] == run_id
     assert row["source_kind"] == "single"
+    assert row["dataset_ref"] == "test/suite-min@0.1.0"
     assert row["source"] == "alpha"
     assert row["environment"] is None
     assert row["started"] is None
@@ -241,6 +318,7 @@ def test_list_includes_task_local_single_attempt(tmp_path: Path) -> None:
         + "\n",
         encoding="utf-8",
     )
+    _write_lock(evidence, task_id="beta")
     listed = jobs.list_jobs(db)
     row = next(item for item in listed["items"] if item["job_id"] == run_id)
     assert row["source_kind"] == "single"
@@ -257,6 +335,7 @@ def test_job_task_exposes_attempt_run_ids_for_k(tmp_path: Path) -> None:
         "schema": "ageval.suite.summary/1",
         "suite_run_id": job_id,
         "dataset_id": "test/suite-min",
+        "dataset_version": "0.1.0",
         "n_attempts": 2,
         "tasks": [
             {
@@ -302,6 +381,7 @@ def test_job_task_exposes_attempt_run_ids_for_k(tmp_path: Path) -> None:
         json.dumps({"task_id": "alpha", "status": "PASS", "score": 1.0}) + "\n",
         encoding="utf-8",
     )
+    _write_lock(extra, task_id="alpha")
     listed = jobs.list_jobs(db)
     kinds = {item["job_id"]: item.get("source_kind") for item in listed["items"]}
     assert kinds.get(job_id) == "suite"
@@ -340,6 +420,8 @@ def _write_attempt_evidence(
         json.dumps(
             {
                 "task_id": task_id,
+                "dataset_id": "test/suite-min",
+                "dataset_version": "0.1.0",
                 "environment": kind,
                 "job_overlay": {"environment": kind, "agent_profiles": {}},
             }

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -63,6 +63,8 @@ def _write_evidence(db: Path, run_id: str, *, task_id: str = "alpha") -> Path:
         json.dumps(
             {
                 "task_id": task_id,
+                "dataset_id": "test/suite-min",
+                "dataset_version": "0.1.0",
                 "digest": "sha256:deadbeef",
                 "environment": "e2b",
                 "job_overlay": {"environment": "e2b", "agent_profiles": {}},
@@ -203,6 +205,9 @@ def test_resolve_and_trial_detail(tmp_path: Path) -> None:
 
     detail = trials.get_trial(db, job_id, "alpha", "run_alpha_1")
     assert detail["ok"] is True
+    assert detail["trial"]["dataset_ref"] == "test/suite-min@0.1.0"
+    assert detail["trial"]["dataset_id"] == "test/suite-min"
+    assert detail["trial"]["dataset_version"] == "0.1.0"
     assert detail["trial"]["run_id"] == "run_alpha_1"
     assert detail["trial"]["status"] == "PASS"
     tabs = detail["trial"]["available_tabs"]
@@ -234,6 +239,30 @@ def test_resolve_and_trial_detail(tmp_path: Path) -> None:
     assert actors[0].get("usage_label")
     assert "in " in actors[0]["usage_label"]
     assert detail["trial"].get("upstream_url") is None
+
+
+def test_trial_identity_is_lock_not_opened_yaml(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    evidence = _write_evidence(db, "run_alpha_1", task_id="alpha")
+    lock_path = evidence / "lock.json"
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    lock["dataset_id"] = "official/tau3-airline"
+    lock["dataset_version"] = "0.1.0"
+    lock_path.write_text(json.dumps(lock) + "\n", encoding="utf-8")
+    detail = trials.get_trial(db, job_id, "alpha", "run_alpha_1")
+    assert detail["trial"]["dataset_ref"] == "official/tau3-airline@0.1.0"
+
+
+def test_trial_missing_lock_identity_fails_closed(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    evidence = _write_evidence(db, "run_alpha_1", task_id="alpha")
+    lock = json.loads((evidence / "lock.json").read_text(encoding="utf-8"))
+    del lock["dataset_version"]
+    (evidence / "lock.json").write_text(json.dumps(lock) + "\n", encoding="utf-8")
+    with pytest.raises(ConfigError, match="missing dataset_id@version"):
+        trials.get_trial(db, job_id, "alpha", "run_alpha_1")
 
 
 def test_trajectory_steps(tmp_path: Path) -> None:
@@ -383,6 +412,7 @@ def test_get_trial_opens_previous_without_listing_it(tmp_path: Path) -> None:
         "schema": "ageval.suite.summary/1",
         "suite_run_id": job_id,
         "dataset_id": "test/suite-min",
+        "dataset_version": "0.1.0",
         "tasks": [{"task_id": "alpha", "status": "PASS", "score": 1.0, "run_id": "run_new"}],
         "attempts": [
             {
@@ -483,6 +513,8 @@ def _write_multi_role_evidence(db: Path, run_id: str, *, task_id: str = "alpha")
         json.dumps(
             {
                 "task_id": task_id,
+                "dataset_id": "test/suite-min",
+                "dataset_version": "0.1.0",
                 "digest": "sha256:multi",
                 "provenance": {
                     "kind": "reimplementation",
@@ -670,6 +702,8 @@ def test_legacy_usage_cost_only_no_used_as_tokens(tmp_path: Path) -> None:
         json.dumps(
             {
                 "task_id": "alpha",
+                "dataset_id": "test/suite-min",
+                "dataset_version": "0.1.0",
                 "profiles": [
                     {
                         "id": "main-pi",
@@ -733,6 +767,8 @@ def test_first_class_usage_and_jsonl_labels_without_invocation_meta(tmp_path: Pa
         json.dumps(
             {
                 "task_id": "alpha",
+                "dataset_id": "test/suite-min",
+                "dataset_version": "0.1.0",
                 "profiles": [
                     {
                         "id": "solver",
@@ -810,7 +846,14 @@ def test_old_usage_extra_alias_and_summary_extra(tmp_path: Path) -> None:
     root = db / ".ageval" / "runs" / "run_alpha_1"
     root.mkdir(parents=True, exist_ok=True)
     (root / "lock.json").write_text(
-        json.dumps({"task_id": "alpha", "profiles": [{"id": "solver", "executor": "openai-http"}]})
+        json.dumps(
+            {
+                "task_id": "alpha",
+                "dataset_id": "test/suite-min",
+                "dataset_version": "0.1.0",
+                "profiles": [{"id": "solver", "executor": "openai-http"}],
+            }
+        )
         + "\n",
         encoding="utf-8",
     )

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -800,3 +800,43 @@ def test_first_class_usage_and_jsonl_labels_without_invocation_meta(tmp_path: Pa
     assert terminal.get("profile_id") == "solver"
     assert terminal.get("elapsed_ms") == pytest.approx(142.5)
     assert "usage=" not in (terminal.get("content") or "")
+    assert terminal.get("extra") == {"reasoning_tokens": 3, "foo": True}
+    assert detail["trial"].get("extra") is None
+
+
+def test_old_usage_extra_alias_and_summary_extra(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    root = db / ".ageval" / "runs" / "run_alpha_1"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "lock.json").write_text(
+        json.dumps({"task_id": "alpha", "profiles": [{"id": "solver", "executor": "openai-http"}]})
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "result.json").write_text(json.dumps({"status": "PASS", "score": 1.0}) + "\n")
+    (root / "summary.json").write_text(
+        json.dumps({"status": "PASS", "extra": {"probe": {"foo": True}}}) + "\n"
+    )
+    (root / "trajectory.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "terminal",
+                "ok": True,
+                "usage": {
+                    "prompt_tokens": 2,
+                    "completion_tokens": 1,
+                    "extra": {"reasoning_tokens": 9},
+                },
+                "metadata": {"profile_id": "solver"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    detail = trials.get_trial(db, job_id, "alpha", "run_alpha_1")
+    assert detail["trial"]["extra"] == {"probe": {"foo": True}}
+    traj = trials.trial_trajectory(db, job_id, "alpha", "run_alpha_1")
+    terminal = next(s for s in traj["steps"] if s.get("type") == "terminal")
+    assert terminal.get("extra") == {"reasoning_tokens": 9}
+    assert "extra" in (terminal.get("usage") or {})


### PR DESCRIPTION
## Summary

Jobs and attempts are labeled with the `dataset_id@version` they were locked against, from that record's `summary.json` or `lock.json` (not the currently opened `ageval.yaml`). Attempt summaries can carry an observational `extra` bag via a new fail-open `summary_enrich` chain slot. Invoke leftovers stay on sibling `terminal.extra`; Hub/Viewer still paint old `usage.extra`.

## Approach

- Design first: invoke-grain `terminal.extra` vs Attempt-grain `summary.extra`; `usage` remains first-class token/cost only.
- `summary_enrich` emits once after a successful `trajectory_seal`. Plugins write `extra[<plugin_id>]`. Empty bags are omitted.
- Viewer and Hub headers/lists show `dataset_id@version` from stored lock/summary meta. Missing either field fails closed. No yaml substitute. No new CLI flag. Extra is not PASS.

## Test plan

- [x] `uv run ruff format --check src tests && uv run ruff check src tests && uv run pyright`
- [x] `AGEVAL_OFFLINE_AGENT=1 AGEVAL_SKIP_DOCKER=1 AGEVAL_SKIP_REAL_*=1 uv run pytest --ignore=tests/registry -q` (740 passed, 3 skipped)
- [x] `uv sync --frozen --extra registry && pytest tests/registry -q` (211 passed, 2 skipped)
- [x] `pnpm --dir apps/hub lint && pnpm --dir apps/hub build`
- [x] `pnpm --dir apps/viewer lint && pnpm --dir apps/viewer build`
- [x] Viewer suite/single/trial identity uses lock/summary, not opened yaml; missing pair raises `missing dataset_id@version`
- [x] `summary_enrich` collect-style handler lands `extra.<plugin_id>.foo` on `summary.json`; empty bag omitted
- [x] TERMINAL extra JSON reads sibling `extra`, then old `usage.extra`
- [ ] Click a suite job and a trial in local Viewer and confirm headers show `dataset_id@version`
- [ ] Hub Home / task Jobs / attempt header show the stored pair after upload

Closes #189
Closes #191
