### PR TITLE
feat: loopback HTTP empty keys and agent-install plugins

### DIFF
--- a/docs/design/05-runtime/agent-service.md
+++ b/docs/design/05-runtime/agent-service.md
@@ -93,7 +93,7 @@ kind 名仍是 `openai-http`（api-client）。没有第二套 dialect、没有 
 | 题包传入 `tools` | POST body 带 `tools`；读 `choices[0].message.tool_calls` → `AgentResult.tool_calls` |
 | `messages` | 若提供，作为 chat 历史（不再只包一轮 prompt） |
 | capability | `tools: native`，`session: new-only`（逻辑 session，无 provider resume） |
-| 凭证 | 一等字段 `model` / `base_url` / `api_key`（env locator）。缺钥 fail-closed（loopback 空钥仅用于本机 mock） |
+| 凭证 | 一等字段 `model` / `base_url` / `api_key`（env locator）。远程 URL 缺钥 fail-closed。loopback 空钥是 **HTTP executor 规则**（`openai-http` / `dsh` / `nooa` / `miniswe`），不是 openai-http 特例 |
 | `options.reasoning_effort` | 可选。有值则写入 Chat Completions 的 `reasoning_effort`；缺省不发该键。evidence：`locked_reasoning_effort` / `actual_reasoning_effort`（HTTP 200 时二者相同；4xx 时 actual 为 null） |
 
 tau2-class harness（journeys `tau2-dialog-min`、`examples/tau3-*`）把域 schema 传入 invoke；收到 `tool_calls` 后走 package `Environment.get_response` / `ToolSet.call`，再 `record_observation` 把回包挂到该 invoke。原生 `tool_calls` 是 **openai-http 的主动作通道**；「Return ONLY JSON」只留给没有 `tool_calls` 的文本 executor（ACP）。禁止在 Core 里 scrape vendor stdout 当工具通道。
@@ -113,7 +113,15 @@ tau2-class harness（journeys `tau2-dialog-min`、`examples/tau3-*`）把域 sch
 
 子进程环境只投影 allowlist（`PATH` / `HOME` / `LANG`、entry 声明的 credential 名、binding 的 `api_key` / `base_url`、`fixed_env`）。宿主里未声明的 token 进不了 entry。
 
-`--probe` / `ageval executors -v`：`credential_missing` 在需要密钥的 entry 上 fail-closed；keyless 只警告。
+`--probe` / `ageval executors -v`：`credential_missing` 在需要密钥的 entry 上 fail-closed；keyless 只警告。HTTP executor 在锁定 `base_url` 为 loopback 且钥省略 / locator 为空时 **不** 报 `credential_missing`。
+
+### HTTP loopback 空钥
+
+`openai-http` / `dsh` / `nooa` / `miniswe` 共用一条 host-only 判断（`src/ageval/plugins/http_loopback.py`）：host 仅为 `127.0.0.1` / `localhost` / `::1`。不含 RFC1918、不含名字里碰巧带这些子串的 URL。
+
+- loopback 且 `api_key` 省略或 locator env 为空 → invoke 继续（空 `Authorization` 或按该协议省略头）。
+- 非 loopback 缺钥 → 仍 fail-closed。
+- 不改 lock schema；locator **值**不进 lock / overlay / trajectory。ACP / `keyless_auth` 不动。
 
 ## Agent 运行时（挂 `after_environment_ready`）
 

--- a/docs/design/14-agent-hub.md
+++ b/docs/design/14-agent-hub.md
@@ -16,6 +16,8 @@ format `ageval.agent/1`。不要 `ageval.harness/1`，不要第二套 `package_k
 
 ## CLI
 
+`ageval agent install …` 写入 `~/.ageval/agents` 之后，按 `binding.extensions[].plugin` 安装尚未在本机的插件（复用 `ageval plugin install`；只写 `~/.ageval/plugins`）。contrib（如 `acp`）跳过。缺插件或 `host_requires` 不满足则整条 install fail-closed，不把「agent 已装、插件跳过」当成功。不新增 `ageval.agent/1` 字段，不改 profiles / task.yaml。
+
 `--agent pi` 解析仓内机制树（不必 `agent install`）。`--agent org/name@version` 仍是 upload 包。`--agent` 与 `--profiles` 互斥。`--model` 是 run 参数（`lock` / `run` / `campaign`）：先投影 `--agent`，再改已绑角色的 `binding.model`。省略则用包缺省（机制卡可以没有缺省）。不要 `--api-key` / `--base-url`。`ageval results --model` 仍是上传观测标签。不要把 Agent 包当成第二套 lock 权威。
 
 ## 溯源与可比性

--- a/examples/agents/dsh-default/agent.yaml
+++ b/examples/agents/dsh-default/agent.yaml
@@ -4,7 +4,8 @@ version: "0.1.0"
 label: "DeepSeek Harness (slim)"
 description: >-
   DeepSeek Harness JSON-RPC in the box (composition slim). Not ACP.
-  Install plugins/dsh first. Credentials stay locators until invoke.
+  ``ageval agent install`` also installs the ``dsh`` plugin. Credentials stay
+  locators until invoke.
 tags: [coding, dsh]
 binding:
   executor: dsh

--- a/plugins/dsh/README.md
+++ b/plugins/dsh/README.md
@@ -38,7 +38,7 @@ A kind that cannot `exec` / `upload` fails at `ageval lock`, not mid-invoke.
 | `options.max_tokens` | unset | Omit / blank / `null` → do not pass `max_tokens` (adapter default). A positive int is forwarded. `≤0`, bool, string, float fail closed. |
 | `options.provider` | `deepseek-official` | Provider id on `initialize`. |
 | `model` | `deepseek-v4-flash` | Passed on `initialize`. |
-| `api_key` | `DEEPSEEK_API_KEY` / `deepseek_api_key` / `litellm_api_key` | Env **locator name**. Projected as `DEEPSEEK_API_KEY`. |
+| `api_key` | `DEEPSEEK_API_KEY` / `deepseek_api_key` / `litellm_api_key` | Env **locator name**. Projected as `DEEPSEEK_API_KEY`. Omit on loopback `base_url` (`127.0.0.1` / `localhost` / `::1`). |
 | `base_url` | `DEEPSEEK_BASE_URL` / `deepseek_base_url` / `litellm_base_url` / `OPENAI_BASE_URL` | Projected as `DEEPSEEK_BASE_URL`. |
 
 ## Install

--- a/plugins/dsh/worker/ageval_executor_dsh.py
+++ b/plugins/dsh/worker/ageval_executor_dsh.py
@@ -33,6 +33,23 @@ if _PLUGIN_ROOT.is_dir() and str(_PLUGIN_ROOT) not in sys.path:
     sys.path.insert(0, str(_PLUGIN_ROOT))
 
 _OK_REASONS = frozenset({"completed", "max-tokens"})
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+def _is_http_loopback(url: str | None) -> bool:
+    try:
+        from ageval.plugins.http_loopback import is_http_loopback
+
+        return is_http_loopback(url)
+    except ImportError:
+        from urllib.parse import urlparse
+
+        text = str(url or "").strip()
+        if not text:
+            return False
+        parsed = urlparse(text if "://" in text else f"http://{text}")
+        host = (parsed.hostname or "").lower()
+        return host in _LOOPBACK_HOSTS
 
 
 def _load_trajectory() -> Any:
@@ -131,16 +148,22 @@ def main() -> int:
 
     alias = os.environ.get("deepseek_api_key")  # noqa: SIM112 — profile locator
     if not os.environ.get("DEEPSEEK_API_KEY") and not alias:
-        return _emit(
-            {
-                "ok": False,
-                "error": "dsh_missing_credential",
-                "model": model,
-                "text": "",
-                "metadata": {"plugin": "dsh"},
-            },
-            code=2,
+        base = (
+            os.environ.get("DEEPSEEK_BASE_URL")
+            or os.environ.get("OPENAI_BASE_URL")
+            or os.environ.get("litellm_base_url")  # noqa: SIM112 — profile locator
         )
+        if not _is_http_loopback(base):
+            return _emit(
+                {
+                    "ok": False,
+                    "error": "dsh_missing_credential",
+                    "model": model,
+                    "text": "",
+                    "metadata": {"plugin": "dsh"},
+                },
+                code=2,
+            )
 
     # Alias lowercase locator so the runtime sees the official name.
     if not os.environ.get("DEEPSEEK_API_KEY") and alias:

--- a/plugins/miniswe/README.md
+++ b/plugins/miniswe/README.md
@@ -38,7 +38,7 @@ client; they never enter the lock.
 | `options.cost_limit` | `0` | Cost cap. `0` = unlimited. Negative fail closed. |
 | `options.cmd_timeout` | `30` | Seconds per `host.exec` bash action. |
 | `model` | `openai/gpt-4o-mini` | LiteLLM model id on the parent. |
-| `api_key` | `OPENAI_API_KEY` / `litellm_api_key` / `LITELLM_API_KEY` | Env **locator name** for the parent HTTP client. |
+| `api_key` | `OPENAI_API_KEY` / `litellm_api_key` / `LITELLM_API_KEY` | Env **locator name** for the parent HTTP client. Omit on loopback `base_url` (`127.0.0.1` / `localhost` / `::1`). |
 | `base_url` | `OPENAI_BASE_URL` / `litellm_base_url` / `LITELLM_BASE_URL` | OpenAI-compatible base (`api_base`). |
 
 ## Install

--- a/plugins/miniswe/src/miniswe_plugin/factory.py
+++ b/plugins/miniswe/src/miniswe_plugin/factory.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from ageval.plugins.agent_result import AgentResult, parse_validated_text_structured
 from ageval.plugins.errors import ExtensionMaterializeError
+from ageval.plugins.http_loopback import is_http_loopback
 from miniswe_plugin import PLUGIN_ID
 from miniswe_plugin.env import ProtocolEnv
 from miniswe_plugin.trajectory import to_ageval_trajectory_events
@@ -287,6 +288,13 @@ class MinisweExecutorSPI:
         return ProtocolEnv(host=self.host, placement=self.placement, timeout=self.cmd_timeout)
 
     def _run_agent(self, prompt: str, *, timeout: float) -> dict[str, Any]:
+        key = resolve_api_key_value(self.api_key_env)
+        base = resolve_base_url(self.base_url)
+        if not key and not is_http_loopback(base):
+            raise ExtensionMaterializeError(
+                f"miniswe_missing_credential: env {self.api_key_env or 'OPENAI_API_KEY'!r} unset",
+                kind="extension_materialize_failed",
+            )
         try:
             from minisweagent.agents.default import DefaultAgent
             from minisweagent.models.litellm_model import LitellmModel
@@ -295,13 +303,6 @@ class MinisweExecutorSPI:
                 "miniswe_package_missing: install mini-swe-agent (uv sync --extra miniswe)",
                 kind="extension_materialize_failed",
             ) from exc
-        key = resolve_api_key_value(self.api_key_env)
-        base = resolve_base_url(self.base_url)
-        if not key and not (base and ("127.0.0.1" in base or "localhost" in base)):
-            raise ExtensionMaterializeError(
-                f"miniswe_missing_credential: env {self.api_key_env or 'OPENAI_API_KEY'!r} unset",
-                kind="extension_materialize_failed",
-            )
         model_kwargs: dict[str, Any] = {"drop_params": True}
         if key:
             model_kwargs["api_key"] = key

--- a/plugins/nooa/README.md
+++ b/plugins/nooa/README.md
@@ -34,7 +34,7 @@ A kind that cannot `exec` / `upload` fails at `ageval lock`, not mid-invoke.
 | `options.agent` | *(required)* | Package-local `module:Class` (subclass `nooa.Agent`, or a deterministic class). Missing → lock `nooa_options_agent_required`. |
 | `options.method` | `run` | Method invoked on that class. |
 | `model` | `openai/gpt-4.1-mini` | Model id projected into the worker. |
-| `api_key` | `OPENAI_API_KEY` / `litellm_api_key` | Env **locator name**. Value never enters the lock. |
+| `api_key` | `OPENAI_API_KEY` / `litellm_api_key` | Env **locator name**. Value never enters the lock. Omit on loopback `base_url` (`127.0.0.1` / `localhost` / `::1`). |
 | `base_url` | `OPENAI_BASE_URL` / `litellm_base_url` / `AGEVAL_OPENAI_BASE_URL` | OpenAI-compatible base projected as `OPENAI_BASE_URL`. |
 
 ## Install

--- a/plugins/nooa/worker/ageval_executor_nooa.py
+++ b/plugins/nooa/worker/ageval_executor_nooa.py
@@ -31,6 +31,24 @@ _PLUGIN_ROOT = Path("/opt/nooa")
 if _PLUGIN_ROOT.is_dir() and str(_PLUGIN_ROOT) not in sys.path:
     sys.path.insert(0, str(_PLUGIN_ROOT))
 
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+def _is_http_loopback(url: str | None) -> bool:
+    try:
+        from ageval.plugins.http_loopback import is_http_loopback
+
+        return is_http_loopback(url)
+    except ImportError:
+        from urllib.parse import urlparse
+
+        text = str(url or "").strip()
+        if not text:
+            return False
+        parsed = urlparse(text if "://" in text else f"http://{text}")
+        host = (parsed.hostname or "").lower()
+        return host in _LOOPBACK_HOSTS
+
 
 def _load_agent_class(agent_ref: str, package_root: Path) -> Any:
     import importlib.util
@@ -80,8 +98,6 @@ def _is_nooa_agent_type(cls: Any) -> bool:
 
 
 def _build_llm(*, model: str, api_base: str | None, api_key: str | None) -> Any:
-    from nooa.unifiedllm import get_llm_client
-
     overrides: dict[str, Any] = {"temperature": 0}
     base = (
         api_base or os.environ.get("OPENAI_BASE_URL") or os.environ.get("litellm_base_url")  # noqa: SIM112
@@ -91,8 +107,10 @@ def _build_llm(*, model: str, api_base: str | None, api_key: str | None) -> Any:
         overrides["api_base"] = base
     if key:
         overrides["api_key"] = key
-    if not key and not (base and ("127.0.0.1" in base or "localhost" in base)):
+    if not key and not _is_http_loopback(base if isinstance(base, str) else None):
         raise RuntimeError("nooa_missing_credential")
+    from nooa.unifiedllm import get_llm_client
+
     return get_llm_client(model or "openai/gpt-4.1-mini", **overrides)
 
 

--- a/skills/ageval-cli/references/commands.md
+++ b/skills/ageval-cli/references/commands.md
@@ -31,7 +31,7 @@ Stdout JSON (high level):
 - No secret values.
 - Does not create Run/Attempt or start Agent.
 - Rejects unknown format (`invalid_format` at `/format`), unknown `executor` kinds, and ACP profiles missing `- plugin: acp` / `options.entry`.
-- `--probe` on **run** (not a second lock mode that starts a box): lock plus observational readiness. Exit non-zero when the selected `environment` path is unsatisfied. Checks declared `host_requires`, Docker daemon when kind is docker, locator **names** (never values). ACP entries add `credential_missing` (fail-closed when the entry requires a key; warning-only when `keyless_auth`). `AGEVAL_OFFLINE_AGENT=1` is reported; probe still does not spawn.
+- `--probe` on **run** (not a second lock mode that starts a box): lock plus observational readiness. Exit non-zero when the selected `environment` path is unsatisfied. Checks declared `host_requires`, Docker daemon when kind is docker, locator **names** (never values). ACP entries add `credential_missing` (fail-closed when the entry requires a key; warning-only when `keyless_auth`). HTTP executors report `credential_missing` only when the locked `base_url` is not loopback. `AGEVAL_OFFLINE_AGENT=1` is reported; probe still does not spawn.
 
 ## `ageval run`
 

--- a/skills/ageval-cli/references/failures.md
+++ b/skills/ageval-cli/references/failures.md
@@ -10,7 +10,7 @@
 | `image_contribute_unsatisfied` / missing bake | Bound external executor but `config.image_layers` / `Dockerfile.bake` empty — `$ageval-plugin` |
 | `nooa_package_missing` / `No module named 'nooa'` | Host needs `uv sync --extra nooa`; docker image bake installs it in-image |
 | ACP entry not ready | `ageval executors -v` → that `entry_id` `host_ready` / install pin; no invoke-time `npm i` |
-| `credential_missing` | Declared credential env names unset and no `api_key` locator. Required entries fail at `--probe` / session-open; keyless (OAuth) entries warn only |
+| `credential_missing` | Declared credential env names unset and no `api_key` locator. Required ACP entries fail at `--probe` / session-open; keyless (OAuth) warn only. HTTP executors (`openai-http` / `dsh` / `nooa` / `miniswe`) skip this when locked `base_url` host is `127.0.0.1` / `localhost` / `::1` |
 | e2b / ssh probe not ready | Missing `E2B_API_KEY` or SSH locator — fail-closed, `started: false`. Skip ≠ pass |
 | PASS without real model | Forbidden — do not use fixtures as public proof |
 | Trajectory empty | Non-empty `agent_profiles` + `run.py` `Agent.session`/`invoke` |

--- a/src/ageval/application/agent_ops/install_plugins.py
+++ b/src/ageval/application/agent_ops/install_plugins.py
@@ -1,0 +1,181 @@
+"""Install plugins declared on an Agent binding (design/14).
+
+Called after the agent cache write. Reuses ``ageval plugin install``
+(``install_from_local`` / Hub fetch). Never rewrites profiles.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from ageval.config.errors import ConfigError
+from ageval.plugins.host_requires import host_requires_satisfied, installed_plugin
+from ageval.plugins.install import InstalledItem, install_extracted_hub, install_from_local
+from ageval.plugins.manifest import MANIFEST_NAMES, PluginManifestError, split_plugin_id
+from ageval.plugins.plugin_requires import PluginRequiresError
+from ageval.plugins.reserved import reserved_short_id
+from ageval.plugins.store import load_index
+
+HubFetch = Callable[[str], Path]
+
+
+def plugin_ids_from_binding(binding: Mapping[str, Any]) -> list[str]:
+    """Unique ``extensions[].plugin`` ids, declaration order."""
+    rows = binding.get("extensions")
+    if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes)):
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        plugin_id = str(row.get("plugin") or "").strip()
+        if not plugin_id or plugin_id in seen:
+            continue
+        seen.add(plugin_id)
+        out.append(plugin_id)
+    return out
+
+
+def install_declared_plugins(
+    binding: Mapping[str, Any],
+    *,
+    agent_root: Path | None = None,
+    hub_fetch: HubFetch | None = None,
+) -> list[InstalledItem]:
+    """Install each declared plugin or fail closed.
+
+    Contrib ids (``acp``, ``docker``, …) are skipped. Cached plugins are
+    ``already_present``. Missing source or unsatisfied ``host_requires``
+    raises ``ConfigError``.
+    """
+    items: list[InstalledItem] = []
+    for plugin_id in plugin_ids_from_binding(binding):
+        item = _install_one(plugin_id, agent_root=agent_root, hub_fetch=hub_fetch)
+        if item is not None:
+            items.append(item)
+    return items
+
+
+def _install_one(
+    plugin_id: str,
+    *,
+    agent_root: Path | None,
+    hub_fetch: HubFetch | None,
+) -> InstalledItem | None:
+    if reserved_short_id(plugin_id) is not None:
+        return None
+    cached = load_index().find(plugin_id)
+    if cached is not None:
+        _assert_host_requires(plugin_id)
+        return InstalledItem(
+            plugin_id=cached.plugin_id,
+            version=cached.version,
+            digest=cached.digest,
+            path=cached.path,
+            status="already_present",
+        )
+    try:
+        result = _fetch_and_install(plugin_id, agent_root=agent_root, hub_fetch=hub_fetch)
+    except PluginRequiresError as exc:
+        raise ConfigError(exc.kind, exc.message, location=plugin_id) from exc
+    except PluginManifestError as exc:
+        raise ConfigError(exc.kind, exc.message, location=plugin_id) from exc
+    _assert_host_requires(plugin_id)
+    for item in result.items:
+        if item.plugin_id == plugin_id:
+            return item
+    entry = result.entry
+    return InstalledItem(
+        plugin_id=entry.plugin_id,
+        version=entry.version,
+        digest=entry.digest,
+        path=entry.path,
+        status="installed",
+    )
+
+
+def _fetch_and_install(
+    plugin_id: str,
+    *,
+    agent_root: Path | None,
+    hub_fetch: HubFetch | None,
+) -> Any:
+    org, _name = split_plugin_id(plugin_id)
+    if org is not None:
+        if hub_fetch is None:
+            raise ConfigError(
+                "plugin_requires_unsatisfied",
+                f"plugin {plugin_id!r} needs a registry fetch",
+                location=plugin_id,
+            )
+        extracted = hub_fetch(plugin_id)
+        return install_extracted_hub(extracted, plugin_id=plugin_id, hub_fetch=hub_fetch)
+    local = _local_plugin_dir(plugin_id, agent_root=agent_root)
+    if local is None:
+        raise ConfigError(
+            "plugin_requires_unsatisfied",
+            f"plugin {plugin_id!r} is not installed and has no local plugin directory",
+            location=plugin_id,
+        )
+    return install_from_local(local, hub_fetch=hub_fetch)
+
+
+def _assert_host_requires(plugin_id: str) -> None:
+    found = installed_plugin(plugin_id)
+    if found is None:
+        raise ConfigError(
+            "plugin_requires_unsatisfied",
+            f"plugin {plugin_id!r} is not in the plugin index after install",
+            location=plugin_id,
+        )
+    manifest, root = found
+    if not host_requires_satisfied(manifest.host_requires, root=root):
+        raise ConfigError(
+            "host_requires_unsatisfied",
+            f"plugin {plugin_id!r} host_requires unsatisfied",
+            location=plugin_id,
+        )
+
+
+def _local_plugin_dir(plugin_id: str, *, agent_root: Path | None) -> Path | None:
+    """Find a local ``ageval.plugin/1`` tree for a short plugin id."""
+    _org, name = split_plugin_id(plugin_id)
+    candidates: list[Path] = []
+    cwd = Path.cwd()
+    candidates.append(cwd / plugin_id)
+    candidates.append(cwd / "plugins" / plugin_id)
+    candidates.append(cwd / "plugins" / name)
+    if agent_root is not None:
+        root = agent_root.expanduser().resolve(strict=False)
+        candidates.append(root.parent / name)
+        for parent in [root, *root.parents]:
+            candidates.append(parent / "plugins" / name)
+            if (parent / "pyproject.toml").is_file() and (parent / "src" / "ageval").is_dir():
+                break
+    seen: set[Path] = set()
+    for path in candidates:
+        try:
+            resolved = path.resolve(strict=False)
+        except OSError:
+            continue
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if not _is_plugin_dir(resolved):
+            continue
+        try:
+            from ageval.plugins.manifest import load_manifest
+
+            manifest = load_manifest(resolved)
+        except PluginManifestError:
+            continue
+        if manifest.plugin_id in {plugin_id, name}:
+            return resolved
+    return None
+
+
+def _is_plugin_dir(path: Path) -> bool:
+    return path.is_dir() and any((path / name).is_file() for name in MANIFEST_NAMES)

--- a/src/ageval/application/agent_ops/install_plugins.py
+++ b/src/ageval/application/agent_ops/install_plugins.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from ageval.config.errors import ConfigError
-from ageval.plugins.host_requires import host_requires_satisfied, installed_plugin
+from ageval.plugins.host_requires import evaluate_host_requires, installed_plugin
 from ageval.plugins.install import InstalledItem, install_extracted_hub, install_from_local
 from ageval.plugins.manifest import MANIFEST_NAMES, PluginManifestError, split_plugin_id
 from ageval.plugins.plugin_requires import PluginRequiresError
@@ -132,12 +132,38 @@ def _assert_host_requires(plugin_id: str) -> None:
             location=plugin_id,
         )
     manifest, root = found
-    if not host_requires_satisfied(manifest.host_requires, root=root):
-        raise ConfigError(
-            "host_requires_unsatisfied",
-            f"plugin {plugin_id!r} host_requires unsatisfied",
-            location=plugin_id,
-        )
+    missing = [
+        row
+        for row in evaluate_host_requires(manifest.host_requires, root=root, plugin_id=plugin_id)
+        if not row.get("ok")
+    ]
+    if not missing:
+        return
+    raise ConfigError(
+        "host_requires_unsatisfied",
+        _host_requires_message(plugin_id, missing),
+        location=plugin_id,
+    )
+
+
+def _host_requires_message(plugin_id: str, missing: list[dict[str, Any]]) -> str:
+    """Plugin cache is not the host extra. Spell the missing import/file and hint."""
+    parts: list[str] = []
+    for row in missing:
+        if row.get("import"):
+            bit = f"import {row['import']!r} missing"
+        elif row.get("file"):
+            bit = f"file {row['file']!r} missing"
+        else:
+            bit = "requirement missing"
+        hint = row.get("hint")
+        if isinstance(hint, str) and hint.strip():
+            bit = f"{bit} ({hint.strip()})"
+        parts.append(bit)
+    detail = "; ".join(parts) if parts else "host_requires unsatisfied"
+    return (
+        f"plugin {plugin_id!r} is in the plugin cache; this host cannot import/run it yet: {detail}"
+    )
 
 
 def _local_plugin_dir(plugin_id: str, *, agent_root: Path | None) -> Path | None:

--- a/src/ageval/application/agent_ops/install_remote.py
+++ b/src/ageval/application/agent_ops/install_remote.py
@@ -1,23 +1,47 @@
-"""Install an agent from the Registry into the local agents cache (design/14)."""
+"""Install an agent from a local path or the Registry into the agents cache."""
 
 from __future__ import annotations
 
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from ageval.agents.manifest import load_agent_manifest
+from ageval.agents.paths import package_dir
 from ageval.agents.reserved import reject_reserved_harness_id
 from ageval.agents.store import AgentIndexEntry, install_from_path
+from ageval.application.agent_ops.install_plugins import install_declared_plugins
 from ageval.config.errors import ConfigError
+from ageval.plugins.install import InstalledItem
 from ageval.registry.archive import extract_archive
 from ageval.registry.client import RegistryError
 from ageval.registry.media_types import AGENT_MEDIA_TYPE
 
+HubFetch = Callable[[str], Path]
+
 
 class AgentInstallCommand:
-    def __init__(self, client_factory: Any) -> None:
+    def __init__(
+        self,
+        client_factory: Any,
+        *,
+        hub_fetch: HubFetch | None = None,
+        cleanup_plugin_tmp: Callable[[], None] | None = None,
+    ) -> None:
         self._client_factory = client_factory
+        self._hub_fetch = hub_fetch
+        self._cleanup_plugin_tmp = cleanup_plugin_tmp
         self._tmp_dirs: list[tempfile.TemporaryDirectory[str]] = []
+
+    def install_agent_from_path(self, source: Path) -> dict[str, Any]:
+        """Copy a local agent package, then install declared plugins."""
+        entry = install_from_path(source)
+        try:
+            plugins = self._install_plugins(entry)
+        finally:
+            self.cleanup_tmp()
+        return _summary(entry, plugins=plugins)
 
     def install_agent_from_registry(
         self,
@@ -53,14 +77,13 @@ class AgentInstallCommand:
                 package_digest=ver_or_digest if ver_or_digest.startswith("sha256:") else None,
                 location=locator,
             )
-            entry: AgentIndexEntry = install_from_path(extract_dir, agent_id=package_id)
+            entry = install_from_path(extract_dir, agent_id=package_id)
+            plugins = self._install_plugins(entry)
         except RegistryError as exc:
             raise ConfigError(exc.code, exc.message, location="registry") from exc
         finally:
             self.cleanup_tmp()
-        summary = entry.as_dict()
-        summary["ok"] = True
-        summary["ref"] = f"{entry.agent_id}@{entry.version}"
+        summary = _summary(entry, plugins=plugins)
         summary["from"] = locator
         return summary
 
@@ -100,7 +123,34 @@ class AgentInstallCommand:
         archive_path.unlink(missing_ok=True)
         return extract_dir
 
+    def _install_plugins(self, entry: AgentIndexEntry) -> list[InstalledItem]:
+        root = package_dir(entry.agent_id, entry.version)
+        manifest = load_agent_manifest(root)
+        return install_declared_plugins(
+            manifest.binding,
+            agent_root=root,
+            hub_fetch=self._hub_fetch,
+        )
+
     def cleanup_tmp(self) -> None:
         while self._tmp_dirs:
             tmp = self._tmp_dirs.pop()
             tmp.cleanup()
+        if self._cleanup_plugin_tmp is not None:
+            self._cleanup_plugin_tmp()
+
+
+def _summary(entry: AgentIndexEntry, *, plugins: list[InstalledItem]) -> dict[str, Any]:
+    summary = entry.as_dict()
+    summary["ok"] = True
+    summary["ref"] = f"{entry.agent_id}@{entry.version}"
+    summary["plugins"] = [
+        {
+            "plugin_id": item.plugin_id,
+            "version": item.version,
+            "digest": item.digest,
+            "status": item.status,
+        }
+        for item in plugins
+    ]
+    return summary

--- a/src/ageval/application/composition.py
+++ b/src/ageval/application/composition.py
@@ -155,13 +155,20 @@ def build_agent_projection() -> Callable[..., Any]:
 def build_agent_commands() -> Any:
     from ageval.application.agent_ops.install_remote import AgentInstallCommand
     from ageval.application.agent_ops.publish import AgentPublishCommand
+    from ageval.application.plugin_ops.plugin_install_remote import PluginInstallCommand
 
-    install = AgentInstallCommand(client_factory=build_registry_client)
+    plugin_install = PluginInstallCommand(client_factory=build_registry_client)
+    install = AgentInstallCommand(
+        client_factory=build_registry_client,
+        hub_fetch=plugin_install.fetch_latest_plugin,
+        cleanup_plugin_tmp=plugin_install._cleanup_tmp,
+    )
     publish = AgentPublishCommand(client_factory=build_registry_client)
     return type(
         "AgentCommands",
         (),
         {
+            "install_agent_from_path": install.install_agent_from_path,
             "install_agent_from_registry": install.install_agent_from_registry,
             "cleanup_agent_tmp": install.cleanup_tmp,
             "publish_agent": publish.publish_agent,

--- a/src/ageval/application/run.py
+++ b/src/ageval/application/run.py
@@ -98,6 +98,10 @@ async def probe_attempt(
         probe["ready"] = False
         probe["error"] = f"{type(exc).__name__}: {exc}"
         return probe
+    if _http_credentials_missing(lock):
+        probe["ready"] = False
+        probe["error"] = "credential_missing"
+        return probe
     probe["ready"] = True
     return probe
 
@@ -247,6 +251,38 @@ def _open_evidence(
         run_id=run_id,
         dataset_root=dataset_root,
     )
+
+
+def _http_credentials_missing(lock: LockedTaskConfig) -> bool:
+    """True when an HTTP executor needs a key and the locked base_url is not loopback."""
+    from ageval.config.env_refs import resolve_locked_base_url
+    from ageval.config.errors import ConfigError
+    from ageval.plugins.executor_capabilities import get_capabilities
+    from ageval.plugins.http_loopback import HTTP_EXECUTORS, http_key_present, is_http_loopback
+
+    for row in lock.agent_profiles:
+        executor = str(row.get("executor") or "").strip()
+        if executor not in HTTP_EXECUTORS:
+            continue
+        raw = row.get("base_url")
+        try:
+            base = resolve_locked_base_url(raw if isinstance(raw, str) else None)
+        except ConfigError:
+            base = None
+        if is_http_loopback(base):
+            continue
+        names: list[str] = []
+        locator = row.get("api_key")
+        if isinstance(locator, str) and locator.strip():
+            names.append(locator.strip())
+        caps = get_capabilities(executor)
+        if caps is not None:
+            for name in caps.credential_env_names:
+                if name not in names:
+                    names.append(name)
+        if names and not http_key_present(names):
+            return True
+    return False
 
 
 def _selected_profile_id(lock: LockedTaskConfig) -> str:

--- a/src/ageval/cli/cmd_agent.py
+++ b/src/ageval/cli/cmd_agent.py
@@ -99,7 +99,7 @@ def agent_install(
         else:
             summary = cmds.install_agent_from_path(src_path)
     except ConfigError as exc:
-        emit({"ok": False, "error": exc.error_code, "message": str(exc)}, err=True)
+        emit({"ok": False, "error": exc.error_code, "message": exc.message}, err=True)
         raise typer.Exit(code=2) from exc
     except OSError as exc:
         emit({"ok": False, "error": "io_error", "message": str(exc)}, err=True)

--- a/src/ageval/cli/cmd_agent.py
+++ b/src/ageval/cli/cmd_agent.py
@@ -86,36 +86,26 @@ def agent_install(
         ),
     ],
 ) -> None:
-    """Install an agent into the local cache (never edits profiles)."""
+    """Install an agent (and its declared plugins) into the local cache."""
+    from ageval.application.composition import build_agent_commands
     from ageval.config.errors import ConfigError
 
+    cmds = build_agent_commands()
     src_path = Path(source)
-    if "@" in source and not src_path.exists():
-        from ageval.application.composition import build_agent_commands
-
-        cmds = build_agent_commands()
-        try:
-            summary = cmds.install_agent_from_registry(source)
-        except ConfigError as exc:
-            emit({"ok": False, "error": exc.error_code, "message": str(exc)}, err=True)
-            raise typer.Exit(code=2) from exc
-        emit(summary)
-        return
-
-    from ageval.agents.store import install_from_path
-
     try:
-        entry = install_from_path(src_path)
+        if "@" in source and not src_path.exists():
+            summary = cmds.install_agent_from_registry(source)
+        else:
+            summary = cmds.install_agent_from_path(src_path)
     except ConfigError as exc:
         emit({"ok": False, "error": exc.error_code, "message": str(exc)}, err=True)
         raise typer.Exit(code=2) from exc
     except OSError as exc:
         emit({"ok": False, "error": "io_error", "message": str(exc)}, err=True)
         raise typer.Exit(code=2) from exc
-    payload = entry.as_dict()
-    payload["ok"] = True
-    payload["ref"] = f"{entry.agent_id}@{entry.version}"
-    emit(payload)
+    finally:
+        cmds.cleanup_agent_tmp()
+    emit(summary)
 
 
 @agent_app.command("publish")

--- a/src/ageval/cli/cmd_agent.py
+++ b/src/ageval/cli/cmd_agent.py
@@ -1,6 +1,6 @@
 """CLI: ``ageval agent install|list|show|uninstall`` (design/14).
 
-Install writes only the local cache ($AGEVAL_HOME/agents) — never profiles /
+Install writes the agent cache and declared plugins — never profiles /
 task.yaml. Run with ``ageval run <dataset> --agent pi`` or ``--agent <id>@<version>``.
 """
 
@@ -17,8 +17,9 @@ agent_app = typer.Typer(
     name="agent",
     help=(
         "Manage local Agent definitions (ageval.agent/1).\n\n"
-        "install writes only ~/.ageval/agents (or $AGEVAL_HOME/agents) — it does "
-        "NOT modify profiles.yaml / task.yaml. Bind at run time with "
+        "install writes ~/.ageval/agents (or $AGEVAL_HOME/agents) and installs "
+        "plugins declared on binding.extensions[].plugin into ~/.ageval/plugins. "
+        "It does NOT modify profiles.yaml / task.yaml. Bind at run time with "
         "`ageval run <dataset> --agent pi` (builtin) or `--agent <id>@<version>`."
     ),
     no_args_is_help=True,

--- a/src/ageval/plugins/contrib/openai_http/README.md
+++ b/src/ageval/plugins/contrib/openai_http/README.md
@@ -23,7 +23,7 @@ No plugin `options` are consumed. Role profile fields only.
 | --- | --- | --- |
 | `model` | `gpt-4.1-mini` | Chat Completions model id the endpoint accepts. |
 | `base_url` | unset (executor default `https://api.openai.com/v1`) | `${ENV_NAME}` (lock stores the locator) or a literal `http(s)` URL. Host `AGEVAL_OPENAI_BASE_URL` is the fallback when the field is omitted. |
-| `api_key` | `OPENAI_API_KEY` | Env **locator name**, not the secret. Empty key is allowed only when `base_url` is loopback. |
+| `api_key` | `OPENAI_API_KEY` | Env **locator name**, not the secret. Empty key is allowed only when `base_url` host is `127.0.0.1` / `localhost` / `::1`. |
 
 ## Bind
 

--- a/src/ageval/plugins/contrib/openai_http/executor.py
+++ b/src/ageval/plugins/contrib/openai_http/executor.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from ageval.plugins.agent_result import AgentExecutor, AgentResult
 from ageval.plugins.contrib.openai_http.usage import normalize_openai_http_usage
+from ageval.plugins.http_loopback import is_http_loopback
 
 _DEFAULT_BASE = "https://api.openai.com/v1"
 _DEFAULT_KEY_ENV = "OPENAI_API_KEY"
@@ -118,8 +119,8 @@ class OpenAIHTTPExecutor(AgentExecutor):
         key_env = self.api_key_env or _DEFAULT_KEY_ENV
         key = os.environ.get(key_env, "")
         base = self.base_url or os.environ.get("AGEVAL_OPENAI_BASE_URL") or _DEFAULT_BASE
-        # Allow explicit empty-key local mock servers only when base_url is loopback.
-        if not key and "127.0.0.1" not in base and "localhost" not in base:
+        loopback = is_http_loopback(base)
+        if not key and not loopback:
             return AgentResult(
                 model=self.model,
                 text="",
@@ -129,7 +130,7 @@ class OpenAIHTTPExecutor(AgentExecutor):
             )
         from ageval.runtime.offline import is_offline_agent
 
-        if is_offline_agent() and "127.0.0.1" not in base and "localhost" not in base:
+        if is_offline_agent() and not loopback:
             return AgentResult(
                 model=self.model,
                 text="",
@@ -150,13 +151,13 @@ class OpenAIHTTPExecutor(AgentExecutor):
         if effort:
             payload["reasoning_effort"] = effort
         body = json.dumps(payload).encode("utf-8")
+        headers = {"Content-Type": "application/json"}
+        if key:
+            headers["Authorization"] = f"Bearer {key}"
         req = urllib.request.Request(
             url,
             data=body,
-            headers={
-                "Authorization": f"Bearer {key}",
-                "Content-Type": "application/json",
-            },
+            headers=headers,
             method="POST",
         )
         try:

--- a/src/ageval/plugins/http_loopback.py
+++ b/src/ageval/plugins/http_loopback.py
@@ -1,0 +1,37 @@
+"""Host-only loopback check for OpenAI-compatible HTTP executors.
+
+stdlib only so in-box workers can import it when ageval is on PYTHONPATH.
+RFC1918 and lookalike hostnames are not loopback.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from urllib.parse import urlparse
+
+HTTP_EXECUTORS = frozenset({"openai-http", "dsh", "nooa", "miniswe"})
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+def is_http_loopback(url: str | None) -> bool:
+    """True when *url*'s host is loopback. Empty / non-HTTP / LAN is false."""
+    if url is None:
+        return False
+    text = str(url).strip()
+    if not text:
+        return False
+    parsed = urlparse(text if "://" in text else f"http://{text}")
+    host = (parsed.hostname or "").lower()
+    return host in _LOOPBACK_HOSTS
+
+
+def http_key_present(
+    names: tuple[str, ...] | list[str],
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    """True when any locator name has a non-empty value. Values are not returned."""
+    import os
+
+    host = os.environ if environ is None else environ
+    return any(str(host.get(name) or "").strip() for name in names if name)

--- a/tests/agents/test_agent_install_plugins.py
+++ b/tests/agents/test_agent_install_plugins.py
@@ -1,0 +1,113 @@
+"""Agent install pulls declared plugins through one composition helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ageval.application.agent_ops.install_plugins import (
+    install_declared_plugins,
+    plugin_ids_from_binding,
+)
+from ageval.config.errors import ConfigError
+
+
+@pytest.fixture()
+def ageval_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "ageval-home"
+    home.mkdir()
+    monkeypatch.setenv("AGEVAL_HOME", str(home))
+    from ageval.plugins import bootstrap as boot
+    from ageval.plugins.registry import reset_global_registry
+
+    boot._BOOTSTRAPPED = False  # type: ignore[attr-defined]
+    reset_global_registry()
+    return home
+
+
+def _write_plugin(root: Path, plugin_id: str) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "plugin.yaml").write_text(
+        (
+            "format: ageval.plugin/1\n"
+            f"plugin_id: {plugin_id.split('/')[-1]}\n"
+            "version: 0.1.0\n"
+            "slots:\n"
+            "  chain:\n"
+            "    - id: after_environment_ready\n"
+            "      priority: 120\n"
+            "      entry: demo.hooks:build\n"
+        ),
+        encoding="utf-8",
+    )
+    src = root / "src" / "demo"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text("", encoding="utf-8")
+    (src / "hooks.py").write_text(
+        "def build(**_k):\n"
+        "    async def h(ctx, value, nxt):\n"
+        "        return await nxt(value)\n"
+        "    return h\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def test_plugin_ids_from_binding_unique_order() -> None:
+    assert plugin_ids_from_binding(
+        {
+            "extensions": [
+                {"plugin": "dsh"},
+                {"plugin": "acp"},
+                {"plugin": "dsh"},
+                {"options": {"entry": "pi"}},
+            ]
+        }
+    ) == ["dsh", "acp"]
+
+
+def test_contrib_plugin_is_skipped(ageval_home: Path) -> None:
+    del ageval_home
+    items = install_declared_plugins({"extensions": [{"plugin": "acp"}]})
+    assert items == []
+
+
+def test_hub_locator_uses_the_same_helper(ageval_home: Path, tmp_path: Path) -> None:
+    del ageval_home
+    extracted = _write_plugin(tmp_path / "extracted", "need-me")
+    fetched: list[str] = []
+
+    def hub_fetch(plugin_id: str) -> Path:
+        fetched.append(plugin_id)
+        return extracted
+
+    items = install_declared_plugins(
+        {"extensions": [{"plugin": "acme/need-me"}]},
+        hub_fetch=hub_fetch,
+    )
+    assert fetched == ["acme/need-me"]
+    assert items[0].plugin_id == "acme/need-me"
+    assert items[0].status == "installed"
+
+    again = install_declared_plugins(
+        {"extensions": [{"plugin": "acme/need-me"}]},
+        hub_fetch=hub_fetch,
+    )
+    assert again[0].status == "already_present"
+    assert fetched == ["acme/need-me"]
+
+
+def test_missing_plugin_fail_closes(ageval_home: Path) -> None:
+    del ageval_home
+    with pytest.raises(ConfigError) as ei:
+        install_declared_plugins({"extensions": [{"plugin": "no-such-plugin"}]})
+    assert ei.value.error_code == "plugin_requires_unsatisfied"
+
+
+def test_path_and_registry_commands_share_helper() -> None:
+    from ageval.application.agent_ops import install_remote as mod
+
+    source = Path(mod.__file__).read_text(encoding="utf-8")
+    assert source.count("self._install_plugins(") >= 2
+    assert "install_declared_plugins" in source

--- a/tests/agents/test_agent_install_plugins.py
+++ b/tests/agents/test_agent_install_plugins.py
@@ -98,6 +98,47 @@ def test_hub_locator_uses_the_same_helper(ageval_home: Path, tmp_path: Path) -> 
     assert fetched == ["acme/need-me"]
 
 
+def test_host_requires_message_names_import_and_hint(
+    ageval_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    del ageval_home
+    plugin = tmp_path / "plugins" / "needs-host"
+    plugin.mkdir(parents=True)
+    (plugin / "plugin.yaml").write_text(
+        (
+            "format: ageval.plugin/1\n"
+            "plugin_id: needs-host\n"
+            "version: 0.1.0\n"
+            "host_requires:\n"
+            "  - import: definitely_not_a_real_module\n"
+            "    hint: uv sync --extra nooa\n"
+            "slots:\n"
+            "  chain:\n"
+            "    - id: after_environment_ready\n"
+            "      priority: 120\n"
+            "      entry: demo.hooks:build\n"
+        ),
+        encoding="utf-8",
+    )
+    src = plugin / "src" / "demo"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text("", encoding="utf-8")
+    (src / "hooks.py").write_text(
+        "def build(**_k):\n"
+        "    async def h(ctx, value, nxt):\n"
+        "        return await nxt(value)\n"
+        "    return h\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ConfigError) as ei:
+        install_declared_plugins({"extensions": [{"plugin": "needs-host"}]})
+    assert ei.value.error_code == "host_requires_unsatisfied"
+    assert "plugin cache" in ei.value.message
+    assert "definitely_not_a_real_module" in ei.value.message
+    assert "uv sync --extra nooa" in ei.value.message
+
+
 def test_missing_plugin_fail_closes(ageval_home: Path) -> None:
     del ageval_home
     with pytest.raises(ConfigError) as ei:

--- a/tests/agents/test_cli_agent_lifecycle.py
+++ b/tests/agents/test_cli_agent_lifecycle.py
@@ -28,10 +28,12 @@ def env(tmp_path: Path) -> dict[str, str]:
     }
 
 
-def _cli(env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
+def _cli(
+    env: dict[str, str], *args: str, cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, "-m", "ageval.cli.main", *args],
-        cwd=ROOT,
+        cwd=str(cwd or ROOT),
         capture_output=True,
         text=True,
         env=env,
@@ -176,3 +178,133 @@ def test_lock_model_override_requires_agent_and_writes_overlay(
     missing = _cli(env, "lock", str(DATABASE), "--task", "terminal-jsonl-agg", "--model", "glm-4.7")
     assert missing.returncode == 2
     assert "invalid_override: --model requires --agent" in missing.stderr
+
+
+def _write_plugin(root: Path, plugin_id: str, *, host_import: str | None = None) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    requires = ""
+    if host_import:
+        requires = f"host_requires:\n  - import: {host_import}\n    hint: missing on purpose\n"
+    (root / "plugin.yaml").write_text(
+        (
+            "format: ageval.plugin/1\n"
+            f"plugin_id: {plugin_id}\n"
+            "version: 0.1.0\n"
+            f"{requires}"
+            "slots:\n"
+            "  chain:\n"
+            "    - id: after_environment_ready\n"
+            "      priority: 120\n"
+            "      entry: demo.hooks:build\n"
+        ),
+        encoding="utf-8",
+    )
+    src = root / "src" / "demo"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text("", encoding="utf-8")
+    (src / "hooks.py").write_text(
+        "def build(**_k):\n"
+        "    async def h(ctx, value, nxt):\n"
+        "        return await nxt(value)\n"
+        "    return h\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def _write_agent(root: Path, *, plugin: str) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "agent.yaml").write_text(
+        (
+            "format: ageval.agent/1\n"
+            "agent_id: uses-plugin\n"
+            "version: '0.1.0'\n"
+            "binding:\n"
+            "  executor: openai-http\n"
+            "  model: none\n"
+            "  extensions:\n"
+            f"    - plugin: {plugin}\n"
+        ),
+        encoding="utf-8",
+    )
+    return root
+
+
+def test_agent_install_installs_declared_plugin(env: dict[str, str], tmp_path: Path) -> None:
+    _write_plugin(tmp_path / "plugins" / "need-me", "need-me")
+    agent = _write_agent(tmp_path / "agents" / "uses-need-me", plugin="need-me")
+    profiles = tmp_path / "profiles.yaml"
+    original = "format: ageval.profiles/1\nenvironment: local\nagent_profiles: {}\n"
+    profiles.write_text(original, encoding="utf-8")
+
+    proc = _cli(env, "agent", "install", str(agent), cwd=tmp_path)
+    assert proc.returncode == 0, proc.stderr
+    data = json.loads(proc.stdout)
+    assert data["ok"] is True
+    assert data["plugins"][0]["plugin_id"] == "need-me"
+    assert data["plugins"][0]["status"] == "installed"
+
+    home = Path(env["AGEVAL_HOME"])
+    plugin_index = json.loads((home / "plugins" / "index.json").read_text(encoding="utf-8"))
+    assert any(p["plugin_id"] == "need-me" for p in plugin_index["plugins"])
+    assert profiles.read_text(encoding="utf-8") == original
+
+    again = _cli(env, "agent", "install", str(agent), cwd=tmp_path)
+    assert again.returncode == 0, again.stderr
+    repeated = json.loads(again.stdout)
+    assert repeated["ok"] is True
+    assert repeated["plugins"][0]["status"] == "already_present"
+
+
+def test_pi_default_does_not_install_acp(env: dict[str, str]) -> None:
+    proc = _cli(env, "agent", "install", str(EXAMPLE_AGENT))
+    assert proc.returncode == 0, proc.stderr
+    data = json.loads(proc.stdout)
+    assert data["ok"] is True
+    assert data.get("plugins") == []
+    home = Path(env["AGEVAL_HOME"])
+    index = home / "plugins" / "index.json"
+    assert not index.is_file() or "acp" not in index.read_text(encoding="utf-8")
+
+
+def test_agent_install_missing_plugin_fail_closes(env: dict[str, str], tmp_path: Path) -> None:
+    agent = _write_agent(tmp_path / "agents" / "uses-missing", plugin="definitely-missing-plugin")
+    proc = _cli(env, "agent", "install", str(agent), cwd=tmp_path)
+    assert proc.returncode == 2
+    payload = json.loads(proc.stderr or proc.stdout)
+    assert payload.get("ok") is False
+    assert payload.get("error") == "plugin_requires_unsatisfied"
+
+
+def test_agent_install_host_requires_fail_closes(env: dict[str, str], tmp_path: Path) -> None:
+    _write_plugin(
+        tmp_path / "plugins" / "needs-host",
+        "needs-host",
+        host_import="definitely_not_a_real_module",
+    )
+    agent = _write_agent(tmp_path / "agents" / "uses-needs-host", plugin="needs-host")
+    proc = _cli(env, "agent", "install", str(agent), cwd=tmp_path)
+    assert proc.returncode == 2
+    payload = json.loads(proc.stderr or proc.stdout)
+    assert payload.get("ok") is False
+    assert payload.get("error") == "host_requires_unsatisfied"
+
+
+def test_dsh_default_installs_plugin_or_fail_closes(env: dict[str, str]) -> None:
+    import importlib.util
+
+    proc = _cli(env, "agent", "install", str(ROOT / "examples/agents/dsh-default"))
+    has_sdk = importlib.util.find_spec("deepseek_harness") is not None
+    if has_sdk:
+        assert proc.returncode == 0, proc.stderr
+        data = json.loads(proc.stdout)
+        assert data["ok"] is True
+        assert any(p["plugin_id"] == "dsh" for p in data["plugins"])
+        home = Path(env["AGEVAL_HOME"])
+        plugin_index = json.loads((home / "plugins" / "index.json").read_text(encoding="utf-8"))
+        assert any(p["plugin_id"] == "dsh" for p in plugin_index["plugins"])
+        return
+    assert proc.returncode == 2
+    payload = json.loads(proc.stderr or proc.stdout)
+    assert payload.get("ok") is False
+    assert payload.get("error") in {"host_requires_unsatisfied", "plugin_requires_unsatisfied"}

--- a/tests/agents/test_cli_agent_lifecycle.py
+++ b/tests/agents/test_cli_agent_lifecycle.py
@@ -288,6 +288,11 @@ def test_agent_install_host_requires_fail_closes(env: dict[str, str], tmp_path: 
     payload = json.loads(proc.stderr or proc.stdout)
     assert payload.get("ok") is False
     assert payload.get("error") == "host_requires_unsatisfied"
+    message = str(payload.get("message") or "")
+    assert "plugin cache" in message
+    assert "definitely_not_a_real_module" in message
+    assert "missing on purpose" in message
+    assert not message.startswith("host_requires_unsatisfied:")
 
 
 def test_dsh_default_installs_plugin_or_fail_closes(env: dict[str, str]) -> None:

--- a/tests/architecture/test_composition_root.py
+++ b/tests/architecture/test_composition_root.py
@@ -38,6 +38,12 @@ def test_cli_campaign_uses_composition() -> None:
     assert "from ageval.application.campaign import run_campaign" not in sources
 
 
+def test_build_agent_commands_installs_from_path_and_registry() -> None:
+    cmds = composition.build_agent_commands()
+    assert callable(cmds.install_agent_from_path)
+    assert callable(cmds.install_agent_from_registry)
+
+
 def test_cli_imports_composition_only() -> None:
     cli_dir = Path(cli_main.__file__).resolve().parent
     offenders: list[str] = []

--- a/tests/plugins/test_http_loopback.py
+++ b/tests/plugins/test_http_loopback.py
@@ -1,0 +1,289 @@
+"""Shared HTTP loopback check: invoke, workers, and --probe."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from ageval.plugins.errors import ExtensionMaterializeError
+from ageval.plugins.http_loopback import HTTP_EXECUTORS, is_http_loopback
+
+ROOT = Path(__file__).resolve().parents[2]
+JOURNEYS = ROOT / "examples" / "journeys"
+_MINISWE_SRC = ROOT / "plugins" / "miniswe" / "src"
+if str(_MINISWE_SRC) not in sys.path:
+    sys.path.insert(0, str(_MINISWE_SRC))
+
+from miniswe_plugin.factory import MinisweExecutorSPI  # noqa: E402
+
+
+def _placement() -> SimpleNamespace:
+    return SimpleNamespace(user="10001:10001", cwd="/attempt/workspace", env={})
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("http://127.0.0.1:4000/v1", True),
+        ("http://localhost:8000", True),
+        ("http://[::1]:8000/v1", True),
+        ("https://127.0.0.1/v1", True),
+        ("http://LocalHost/v1", True),
+        (None, False),
+        ("", False),
+        ("https://api.openai.com/v1", False),
+        ("http://192.168.1.10:8000/v1", False),
+        ("http://10.0.0.8/v1", False),
+        ("http://example.com/127.0.0.1", False),
+        ("http://evil.test/?x=localhost", False),
+        ("http://localhost.example.com/v1", False),
+        ("http://127.0.0.1.attacker.test/v1", False),
+    ],
+)
+def test_is_http_loopback_host_only(url: str | None, expected: bool) -> None:
+    assert is_http_loopback(url) is expected
+
+
+def test_http_executors_are_the_four_openai_compatible_kinds() -> None:
+    assert frozenset({"openai-http", "dsh", "nooa", "miniswe"}) == HTTP_EXECUTORS
+
+
+def _load_worker(path: Path, name: str) -> object:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_dsh_worker_loopback_does_not_emit_missing_credential(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.delenv("deepseek_api_key", raising=False)
+    monkeypatch.delenv("AGEVAL_OFFLINE_AGENT", raising=False)
+    monkeypatch.setenv("DEEPSEEK_BASE_URL", "http://127.0.0.1:9/v1")
+    worker = ROOT / "plugins" / "dsh" / "worker" / "ageval_executor_dsh.py"
+    request = {
+        "prompt": "hi",
+        "model": "x",
+        "workdir": str(tmp_path / "ws"),
+        "session_root": str(tmp_path / "sessions"),
+        "cordis": str(tmp_path / "missing.cordis.yml"),
+    }
+    proc = subprocess.run(
+        [sys.executable, str(worker), json.dumps(request)],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(ROOT),
+        env=os.environ.copy(),
+        timeout=30,
+    )
+    assert proc.stdout.strip(), proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload.get("error") != "dsh_missing_credential"
+
+
+def test_dsh_worker_remote_missing_credential(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.delenv("deepseek_api_key", raising=False)
+    monkeypatch.delenv("AGEVAL_OFFLINE_AGENT", raising=False)
+    monkeypatch.setenv("DEEPSEEK_BASE_URL", "https://api.example.invalid/v1")
+    worker = ROOT / "plugins" / "dsh" / "worker" / "ageval_executor_dsh.py"
+    proc = subprocess.run(
+        [sys.executable, str(worker), json.dumps({"prompt": "hi", "model": "x"})],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(ROOT),
+        env=os.environ.copy(),
+        timeout=30,
+    )
+    payload = json.loads(proc.stdout)
+    assert payload["ok"] is False
+    assert payload["error"] == "dsh_missing_credential"
+
+
+def test_nooa_worker_loopback_does_not_raise_missing_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("litellm_api_key", raising=False)
+    mod = _load_worker(
+        ROOT / "plugins" / "nooa" / "worker" / "ageval_executor_nooa.py",
+        "ageval_executor_nooa_loopback",
+    )
+    try:
+        mod._build_llm(model="x", api_base="http://127.0.0.1:9/v1", api_key=None)
+    except RuntimeError as exc:
+        assert "nooa_missing_credential" not in str(exc)
+    except ImportError:
+        pass
+
+
+def test_nooa_worker_remote_missing_credential(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("litellm_api_key", raising=False)
+    mod = _load_worker(
+        ROOT / "plugins" / "nooa" / "worker" / "ageval_executor_nooa.py",
+        "ageval_executor_nooa_remote",
+    )
+    with pytest.raises(RuntimeError, match="nooa_missing_credential"):
+        mod._build_llm(model="x", api_base="https://api.example.invalid/v1", api_key=None)
+
+
+def test_miniswe_loopback_does_not_emit_missing_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("litellm_api_key", raising=False)
+    monkeypatch.delenv("LITELLM_API_KEY", raising=False)
+    monkeypatch.delenv("AGEVAL_OFFLINE_AGENT", raising=False)
+    spi = MinisweExecutorSPI(
+        host=SimpleNamespace(kind="local"),
+        placement=_placement(),
+        model="openai/x",
+        api_key=None,
+        base_url="http://127.0.0.1:9/v1",
+    )
+    try:
+        spi._run_agent("ping", timeout=1)
+    except ExtensionMaterializeError as exc:
+        assert "miniswe_missing_credential" not in str(exc)
+
+
+def test_miniswe_remote_missing_credential(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("litellm_api_key", raising=False)
+    monkeypatch.delenv("LITELLM_API_KEY", raising=False)
+    monkeypatch.delenv("AGEVAL_OFFLINE_AGENT", raising=False)
+    spi = MinisweExecutorSPI(
+        host=SimpleNamespace(kind="local"),
+        placement=_placement(),
+        model="openai/x",
+        api_key=None,
+        base_url="https://api.example.invalid/v1",
+    )
+    with pytest.raises(ExtensionMaterializeError, match="miniswe_missing_credential"):
+        spi._run_agent("ping", timeout=1)
+
+
+def _ageval_probe(
+    dataset: Path, profiles: Path, *, env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ageval.cli.main",
+            "run",
+            str(dataset),
+            "--task",
+            "terminal-jsonl-agg",
+            "--profiles",
+            str(profiles),
+            "--probe",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(dataset),
+        env=env,
+        timeout=60,
+    )
+
+
+def _http_profiles(path: Path, *, base_url: str, api_key: str | None) -> None:
+    lines = [
+        "format: ageval.profiles/1",
+        "environment: local",
+        "agent_profiles:",
+        "  solver:",
+        "    executor: openai-http",
+        "    model: mock",
+        f"    base_url: {base_url}",
+    ]
+    if api_key is not None:
+        lines.append(f"    api_key: {api_key}")
+    lines.extend(
+        [
+            "    extensions:",
+            "      - plugin: openai-http",
+            "      - plugin: local",
+            "",
+        ]
+    )
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def test_probe_loopback_http_without_key_is_not_credential_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    dataset = Path(
+        shutil.copytree(JOURNEYS, tmp_path / "journeys", ignore=shutil.ignore_patterns(".ageval"))
+    )
+    profiles = dataset / "profiles.loopback.yaml"
+    _http_profiles(profiles, base_url="http://127.0.0.1:9/v1", api_key=None)
+    env = os.environ.copy()
+    env.pop("OPENAI_API_KEY", None)
+    env.pop("AGEVAL_OFFLINE_AGENT", None)
+    proc = _ageval_probe(dataset, profiles, env=env)
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    data = json.loads(proc.stdout)
+    assert data.get("ready") is True
+    assert data.get("error") != "credential_missing"
+    locked = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ageval.cli.main",
+            "lock",
+            str(dataset),
+            "--task",
+            "terminal-jsonl-agg",
+            "--profiles",
+            str(profiles),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(dataset),
+        env=env,
+        timeout=60,
+    )
+    assert locked.returncode == 0, locked.stderr
+    overlay = json.loads(locked.stdout)["job_overlay"]
+    dumped = json.dumps(overlay)
+    assert "sk-" not in dumped.lower()
+    solver = overlay["agent_profiles"]["solver"]
+    assert solver["base_url"] == "http://127.0.0.1:9/v1"
+    assert "api_key" not in solver
+
+
+def test_probe_remote_http_without_key_is_credential_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    dataset = Path(
+        shutil.copytree(JOURNEYS, tmp_path / "journeys", ignore=shutil.ignore_patterns(".ageval"))
+    )
+    profiles = dataset / "profiles.remote.yaml"
+    _http_profiles(profiles, base_url="https://api.example.invalid/v1", api_key=None)
+    env = os.environ.copy()
+    env.pop("OPENAI_API_KEY", None)
+    env.pop("AGEVAL_OFFLINE_AGENT", None)
+    proc = _ageval_probe(dataset, profiles, env=env)
+    assert proc.returncode == 2, proc.stdout
+    data = json.loads(proc.stdout)
+    assert data.get("ready") is False
+    assert data.get("error") == "credential_missing"

--- a/tests/plugins/test_http_loopback.py
+++ b/tests/plugins/test_http_loopback.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -56,7 +57,7 @@ def test_http_executors_are_the_four_openai_compatible_kinds() -> None:
     assert frozenset({"openai-http", "dsh", "nooa", "miniswe"}) == HTTP_EXECUTORS
 
 
-def _load_worker(path: Path, name: str) -> object:
+def _load_worker(path: Path, name: str) -> Any:
     spec = importlib.util.spec_from_file_location(name, path)
     assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)

--- a/tests/plugins/test_openai_http_executor.py
+++ b/tests/plugins/test_openai_http_executor.py
@@ -38,6 +38,57 @@ def test_missing_credential_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None
     assert result.tool_calls == ()
 
 
+@pytest.mark.parametrize(
+    "base",
+    [
+        "http://192.168.1.10:8000/v1",
+        "http://10.0.0.1/v1",
+        "http://example.com/127.0.0.1",
+        "http://localhost.example.com/v1",
+    ],
+)
+def test_non_loopback_missing_credential_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, base: str
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    result = OpenAIHTTPExecutor(base_url=base).invoke("hi")
+    assert result.ok is False
+    assert result.error == "missing_credential"
+
+
+def test_loopback_invokes_without_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    captured: dict[str, Any] = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length") or 0)
+            captured["authorization"] = self.headers.get("Authorization")
+            captured["body"] = json.loads(self.rfile.read(length).decode("utf-8"))
+            payload = {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+            raw = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+            del format, args
+
+    server, base = _serve(Handler)
+    try:
+        result = OpenAIHTTPExecutor(model="mock", base_url=base).invoke("hi")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert result.ok is True
+    assert result.error is None
+    assert result.text == "ok"
+    assert captured.get("authorization") is None
+
+
 def test_tools_round_trip_on_loopback() -> None:
     captured: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary
HTTP executors (`openai-http`, `dsh`, `nooa`, `miniswe`) may omit `api_key` when the locked `base_url` host is loopback. `ageval agent install` then installs plugins declared on `binding.extensions[].plugin` (contrib like `acp` is skipped).

## Approach
- One host-only loopback helper in `src/ageval/plugins/http_loopback.py`. Remote URLs, including RFC1918, stay fail-closed. `--probe` skips `credential_missing` on loopback HTTP. Lock schema unchanged.
- After the agent cache write, one composition-root helper reuses `ageval plugin install`. Missing plugin or unsatisfied `host_requires` fail-closes the whole agent install. Profiles / task.yaml are not rewritten.

## Test plan
- [x] Local python-core equivalent: `ruff format --check src tests`, `ruff check src tests`, `pyright`, `scripts/check_builtin_plugins.py`, `pytest --ignore=tests/registry` (813 passed, 3 skipped)
- [x] Local python-registry equivalent: `pytest tests/registry` (222 passed, 1 skipped; `test_build_state_from_env_fail_closed` fails locally when Registry env is already set — unrelated, no registry diff)
- [x] Loopback HTTP with no key invokes; remote / RFC1918 / lookalike hosts fail closed
- [x] `--probe` on loopback HTTP without a key is not `credential_missing`
- [x] Agent install pulls a declared plugin; repeat is `already_present`; `pi-default` does not install `acp`
- [x] Missing plugin / unsatisfied `host_requires` exits 2 with `ok: false`
- [x] Design 05 and design 14 updated; public reader docs have no GitHub issue numbers

Closes #198
Closes #199