### PR TITLE
feat(eval): optional evaluator SDK invoke records judge observation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,7 +57,7 @@ dataset root (ageval.yaml / ageval.dataset/1)
   → run_attempt
        environment  host.start → upload data/ → after_environment_ready → environment_setup
        run          subprocess run.py ← Agent Service socket ← attach_stdio
-       evaluate     stop writers → upload evaluation/ → evaluation_runtime → bind
+       evaluate     solver writers stopped → upload evaluation/ → evaluation_runtime → bind
        record       trajectory_collect → trajectory_seal → summary_enrich
        finally      cleanup → host.stop
   → .ageval/runs/<attempt_id>/
@@ -289,7 +289,7 @@ Third-party workflow SDKs: allowed only as a task or **explicit** external plugi
 
 The host **awaits** registered chain slots / exclusive winners. Plugins rewrite or short-circuit via `(ctx, value, nxt)`; they do **not** drop declaration rows for Core to interpret later.
 
-Slot-name authority: `src/ageval/plugins/slots.py`. Only **exclusive** and **chain**. Current exclusive slots: `environment`, `executor`, `evaluation_runtime`, `trajectory_seal`. The last two default to the engine (`plugin_id: default`). PASS still enters Result only through `bind_evaluation`; `evaluation_runtime` returns raw and must not write a verdict itself. `pass` / `identity` / `cleanup` / `evidence` are not services.
+Slot-name authority: `src/ageval/plugins/slots.py`. Only **exclusive** and **chain**. Current exclusive slots: `environment`, `executor`, `evaluation_runtime`, `trajectory_seal`. `environment` / `evaluation_runtime` / `trajectory_seal` are Attempt-wide; `executor` is one winner **per profile graph**. The last two default to the engine (`plugin_id: default`). PASS still enters Result only through `bind_evaluation`; `evaluation_runtime` returns raw and must not write a verdict itself. `pass` / `identity` / `cleanup` / `evidence` are not services.
 
 ```text
 environment phase
@@ -305,22 +305,24 @@ run phase
   subprocess python -m ageval.runtime.task_worker → run.py
     Agent.session → unix socket → ParentAgentService
       before/after_agent_open
-      before_agent_invoke → executor.invoke(attach_stdio) → after_agent_invoke
+      before_agent_invoke → this profile's executor.invoke → after_agent_invoke
       normalize_agent_result
       before/after_agent_close
-  stop Agent Service; mark_writers_stopped
+  seal_run (solver writers stopped; Agent Service stays up); mark_writers_stopped
   after_run
 
 evaluate phase
   before_evaluate
   upload evaluation/           # gold enters the box only now (engine code, not a slot)
   evaluation_runtime.evaluate  # exclusive-slot winner; default in-box evaluator.py
+                               # optional Agent.session(<judge>).invoke via parent socket
   bind_evaluation              # PASS enters Result only here
   after_evaluate               # must not change status
 
 record phase
   trajectory_collect → enrich  # fail-open chain
-  trajectory_seal              # exclusive-slot winner writes trajectory.jsonl (layer C)
+  trajectory_seal              # exclusive-slot winner writes run-phase trajectory.jsonl
+  evaluation/observation.jsonl # evaluate-phase layer C when SDK invoked (omit user)
   summary_enrich               # fail-open; Attempt summary.extra (omit when empty)
 
 cleanup (finally)

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ ageval treats **Harness** as a first-class evaluation axis.
 
 **Evaluation**
 
-- **Lock one experiment.** Dataset, Harness, and environment lock together into a reproducible digest. Scores are not comparable across different bindings.
+- **Lock one experiment.** Dataset, Harness, and environment lock together into a reproducible digest.
 - **One task, a suite, a matrix, or repeats.** Run a single task, a full dataset, a parameter matrix on one task, or multiple independent Attempts of the same job (pass@k).
-- **Scoring is separate from the Agent.** Gold does not enter the Agent view. PASS comes only from `evaluator.py`; trajectories are for inspection.
-- **Limits are enforced before invocation.** Wall time, memory, processes, and invocation ceilings are enforced by the runtime before invoke; `run.py` cannot raise them.
+- **Scoring is separate from the Agent.** Gold does not enter the Agent view. PASS comes only from `evaluator.py` (deterministic script by default; optional `Agent.session` as LLM-as-judge). Trajectories are for inspection.
+- **Limits are enforced before invocation.** Wall time, memory, processes, and invocation ceilings are set by the runtime before invoke.
 
 **Composition**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -70,10 +70,10 @@ ageval 把 **Harness** 作为一等评测维度。
 
 **评测**
 
-- **锁定一次实验。** dataset、Harness 与运行环境一并 lock，得到可复现 digest。绑定不同则分数不可比。
+- **锁定一次实验。** dataset、Harness 与运行环境一并 lock，得到可复现 digest。
 - **单题、整包、矩阵与重复。** 可运行单个 task、完整 dataset、同一 task 上的参数矩阵，或同一 job 的多次独立 Attempt（pass@k）。
-- **评分与 Agent 分离。** gold 不进入 Agent 可见范围。PASS 仅来自 `evaluator.py`；轨迹用于检查。
-- **上限在调用前强制。** 墙钟、内存、进程与调用次数由 runtime 在 invoke 之前强制；`run.py` 不得自行提升。
+- **评分与 Agent 分离。** gold 不进入 Agent 可见范围。PASS 仅来自 `evaluator.py`（缺省确定性脚本；可选 `Agent.session` 做 LLM-as-judge）。轨迹用于检查。
+- **上限在调用前强制。** 墙钟、内存、进程与调用次数由 runtime 在 invoke 之前确定。
 
 **组合**
 

--- a/apps/hub/src/components/trial/evidence-tabs.tsx
+++ b/apps/hub/src/components/trial/evidence-tabs.tsx
@@ -12,6 +12,9 @@ export function EvidenceTabs({
   trajLoading,
   steps,
   trajNote,
+  observationSteps,
+  obsLoading,
+  obsNote,
   result,
   actors,
   tree,
@@ -29,6 +32,9 @@ export function EvidenceTabs({
   trajLoading: boolean;
   steps: TrajectoryStep[];
   trajNote: string | null;
+  observationSteps?: TrajectoryStep[];
+  obsLoading?: boolean;
+  obsNote?: string | null;
   result: Record<string, unknown> | null;
   actors: NonNullable<Trial["actors"]>;
   tree: TreeEntry[];
@@ -44,6 +50,10 @@ export function EvidenceTabs({
     label?: string;
   }> | null;
 }) {
+  const verifierSteps = observationSteps || [];
+  const showVerifierTrajectory =
+    activeTab === "verifier" && (obsLoading || verifierSteps.length > 0);
+
   if (availableTabs.length === 0) {
     return (
       <p className="text-sm text-mute">
@@ -76,7 +86,17 @@ export function EvidenceTabs({
         />
       )}
 
-      {activeTab && activeTab !== "trajectory" && (
+      {showVerifierTrajectory && (
+        <TrajectoryPanel
+          loading={!!obsLoading}
+          steps={verifierSteps}
+          note={obsNote ?? null}
+          result={result}
+          actors={[]}
+        />
+      )}
+
+      {activeTab && activeTab !== "trajectory" && !showVerifierTrajectory && (
         <FileSplitPanel
           tree={tree}
           treeLoading={treeLoading}

--- a/apps/hub/src/hooks/use-attempt-evidence.ts
+++ b/apps/hub/src/hooks/use-attempt-evidence.ts
@@ -5,6 +5,7 @@ import {
   buildTrialMeta,
   firstTab,
   invDirFromTrajPath,
+  OBSERVATION_REL,
   parseTrajectoryJsonl,
   trajectoryRelPaths,
   scopeForTab,
@@ -68,6 +69,11 @@ export function useAttemptEvidence(
   const [steps, setSteps] = useState<TrajectoryStep[]>([]);
   const [trajNote, setTrajNote] = useState<string | null>(null);
   const [trajLoading, setTrajLoading] = useState(false);
+  const [observationSteps, setObservationSteps] = useState<TrajectoryStep[]>(
+    [],
+  );
+  const [obsNote, setObsNote] = useState<string | null>(null);
+  const [obsLoading, setObsLoading] = useState(false);
 
   const [tree, setTree] = useState<TreeEntry[]>([]);
   const [treeGroups, setTreeGroups] = useState<Array<{
@@ -210,6 +216,39 @@ export function useAttemptEvidence(
     if (!activeTab || !runId) return;
     let cancelled = false;
 
+    if (activeTab === "verifier") {
+      const hasObs = relFiles.some((f) => f.path === OBSERVATION_REL);
+      if (hasObs) {
+        setObsLoading(true);
+        setObsNote(null);
+        setObservationSteps([]);
+        (async () => {
+          try {
+            const f = await getAttemptFile(
+              runId,
+              toArchivePath(OBSERVATION_REL, runId),
+              token,
+            );
+            if (cancelled) return;
+            const parsed = parseTrajectoryJsonl(decodeFileContent(f) || "");
+            setObservationSteps(parsed);
+            setObsNote(null);
+          } catch (e) {
+            if (!cancelled) {
+              setObservationSteps([]);
+              setObsNote(e instanceof Error ? e.message : String(e));
+            }
+          } finally {
+            if (!cancelled) setObsLoading(false);
+          }
+        })();
+      } else {
+        setObservationSteps([]);
+        setObsNote(null);
+        setObsLoading(false);
+      }
+    }
+
     if (activeTab === "trajectory") {
       setTrajLoading(true);
       setTrajNote(null);
@@ -343,6 +382,9 @@ export function useAttemptEvidence(
     steps,
     trajNote,
     trajLoading,
+    observationSteps,
+    obsNote,
+    obsLoading,
     tree,
     treeGroups,
     treeLoading,

--- a/apps/hub/src/lib/attempt-evidence.ts
+++ b/apps/hub/src/lib/attempt-evidence.ts
@@ -74,6 +74,8 @@ export function hasAnyUnder(relPaths: string[], dir: string): boolean {
   return relPaths.some((p) => p === d || p.startsWith(d + "/"));
 }
 
+export const OBSERVATION_REL = "evaluation/observation.jsonl";
+
 /** Attempt-root record-phase file, then any per-invocation copies. */
 export function trajectoryRelPaths(relFiles: string[]): string[] {
   if (relFiles.includes("trajectory.jsonl")) return ["trajectory.jsonl"];

--- a/apps/hub/src/pages/AttemptEvidencePage.tsx
+++ b/apps/hub/src/pages/AttemptEvidencePage.tsx
@@ -85,6 +85,9 @@ export function AttemptEvidencePage() {
     steps,
     trajNote,
     trajLoading,
+    observationSteps,
+    obsNote,
+    obsLoading,
     tree,
     treeGroups,
     treeLoading,
@@ -259,6 +262,9 @@ export function AttemptEvidencePage() {
               trajLoading={trajLoading}
               steps={steps}
               trajNote={trajNote}
+              observationSteps={observationSteps}
+              obsLoading={obsLoading}
+              obsNote={obsNote}
               result={result}
               actors={trial.actors || []}
               tree={tree}

--- a/apps/viewer/src/components/trial/evidence-tabs.tsx
+++ b/apps/viewer/src/components/trial/evidence-tabs.tsx
@@ -12,6 +12,9 @@ export function EvidenceTabs({
   trajLoading,
   steps,
   trajNote,
+  observationSteps,
+  obsLoading,
+  obsNote,
   result,
   actors,
   tree,
@@ -29,6 +32,9 @@ export function EvidenceTabs({
   trajLoading: boolean;
   steps: TrajectoryStep[];
   trajNote: string | null;
+  observationSteps?: TrajectoryStep[];
+  obsLoading?: boolean;
+  obsNote?: string | null;
   result: Record<string, unknown> | null;
   actors: NonNullable<Trial["actors"]>;
   tree: TreeEntry[];
@@ -44,6 +50,10 @@ export function EvidenceTabs({
     label?: string;
   }> | null;
 }) {
+  const verifierSteps = observationSteps || [];
+  const showVerifierTrajectory =
+    activeTab === "verifier" && (obsLoading || verifierSteps.length > 0);
+
   if (availableTabs.length === 0) {
     return (
       <p className="text-sm text-mute">
@@ -76,7 +86,17 @@ export function EvidenceTabs({
         />
       )}
 
-      {activeTab && activeTab !== "trajectory" && (
+      {showVerifierTrajectory && (
+        <TrajectoryPanel
+          loading={!!obsLoading}
+          steps={verifierSteps}
+          note={obsNote ?? null}
+          result={result}
+          actors={[]}
+        />
+      )}
+
+      {activeTab && activeTab !== "trajectory" && !showVerifierTrajectory && (
         <FileSplitPanel
           tree={tree}
           treeLoading={treeLoading}

--- a/apps/viewer/src/hooks/use-trial-detail.ts
+++ b/apps/viewer/src/hooks/use-trial-detail.ts
@@ -10,6 +10,7 @@ import {
 import {
   fetchTrial,
   fetchTrialFile,
+  fetchTrialObservation,
   fetchTrialTrajectory,
   fetchTrialTree,
   type Job,
@@ -45,6 +46,9 @@ export function useTrialDetail(jobId: string, taskId: string, runId: string) {
   const [steps, setSteps] = useState<TrajectoryStep[]>([]);
   const [trajNote, setTrajNote] = useState<string | null>(null);
   const [trajLoading, setTrajLoading] = useState(false);
+  const [observationSteps, setObservationSteps] = useState<TrajectoryStep[]>([]);
+  const [obsNote, setObsNote] = useState<string | null>(null);
+  const [obsLoading, setObsLoading] = useState(false);
 
   const [tree, setTree] = useState<TreeEntry[]>([]);
   const [treeGroups, setTreeGroups] = useState<
@@ -120,6 +124,25 @@ export function useTrialDetail(jobId: string, taskId: string, runId: string) {
       return () => {
         cancelled = true;
       };
+    }
+
+    if (activeTab === "verifier") {
+      setObsLoading(true);
+      fetchTrialObservation(jobId, taskId, runId)
+        .then((data) => {
+          if (cancelled) return;
+          setObservationSteps(data.steps || []);
+          setObsNote(data.note || null);
+        })
+        .catch((e: Error) => {
+          if (!cancelled) {
+            setObservationSteps([]);
+            setObsNote(e.message);
+          }
+        })
+        .finally(() => {
+          if (!cancelled) setObsLoading(false);
+        });
     }
 
     const scope = TREE_SCOPES[activeTab];
@@ -199,6 +222,9 @@ export function useTrialDetail(jobId: string, taskId: string, runId: string) {
     steps,
     trajNote,
     trajLoading,
+    observationSteps,
+    obsNote,
+    obsLoading,
     tree,
     treeGroups,
     treeLoading,

--- a/apps/viewer/src/lib/api.ts
+++ b/apps/viewer/src/lib/api.ts
@@ -406,3 +406,15 @@ export function fetchTrialTrajectory(jobId: string, taskId: string, runId: strin
     note?: string;
   }>(`${trialBase(jobId, taskId, runId)}/trajectory`);
 }
+
+export function fetchTrialObservation(jobId: string, taskId: string, runId: string) {
+  return getJson<{
+    ok: boolean;
+    run_id: string;
+    task_id: string;
+    steps: TrajectoryStep[];
+    step_count: number;
+    truncated?: boolean;
+    note?: string;
+  }>(`${trialBase(jobId, taskId, runId)}/observation`);
+}

--- a/apps/viewer/src/pages/TrialDetailPage.tsx
+++ b/apps/viewer/src/pages/TrialDetailPage.tsx
@@ -41,6 +41,9 @@ export function TrialDetailPage() {
     steps,
     trajNote,
     trajLoading,
+    observationSteps,
+    obsNote,
+    obsLoading,
     tree,
     treeGroups,
     treeLoading,
@@ -112,6 +115,9 @@ export function TrialDetailPage() {
               trajLoading={trajLoading}
               steps={steps}
               trajNote={trajNote}
+              observationSteps={observationSteps}
+              obsLoading={obsLoading}
+              obsNote={obsNote}
               result={result}
               actors={trial.actors || []}
               tree={tree}

--- a/docs/design/01-ageval-core.md
+++ b/docs/design/01-ageval-core.md
@@ -62,14 +62,16 @@ Current 实现把前四相放进循环并在相位失败时记 `phase_failed`，
 
 | 槽种类 | 语义 | 例子 |
 | --- | --- | --- |
-| **独占** | 全 Attempt 一个赢家；自动登记为同名 **service** | `environment`、`executor`、`evaluation_runtime`、`trajectory_seal` |
+| **独占** | 每个 resolved graph 一个赢家；登记为同名 **service** | `environment`、`executor`、`evaluation_runtime`、`trajectory_seal` |
 | **链** | `(ctx, value, nxt)` | `after_environment_ready`、`environment_setup` |
 
-`profiles.executor: acp` = 选独占槽 `executor` 的赢家，不是另一套插件系统。
+`environment` / `evaluation_runtime` / `trajectory_seal` 是 **Attempt 级** 一份赢家。`executor` 按 `agent_profiles` **每行一份**：solver 与 judge 可以选不同机制。两个插件仍不得抢同一 graph 上的同一独占槽。
+
+`agent_profiles.<id>.executor: acp` = 选该 profile 独占槽 `executor` 的赢家，不是另一套插件系统，也不是 Attempt 上只许一个 executor 插件。
 
 槽名权威：`src/ageval/plugins/slots.py`。新**时间线**槽仍要改 attempt 宿主；插件不可自造槽名。
 
-Current 独占槽：`environment`、`executor`、`evaluation_runtime`、`trajectory_seal`。后两者的默认赢家是引擎（`plugin_id: default`，`is_default=True`）：盒内 `evaluator.py`（via `host.exec`）与层 C `trajectory.jsonl` 写入。没有 job 字段糖；替换只能走显式 `extensions` 行（`slot` + `plugin`）。缺默认注册 → lock fail-closed。
+Current 独占槽：`environment`、`executor`、`evaluation_runtime`、`trajectory_seal`。后两者的默认赢家是引擎（`plugin_id: default`，`is_default=True`）：盒内 `evaluator.py`（via `host.exec`）与层 C 写入（run 相位 `trajectory.jsonl`；evaluate 相位若有 SDK invoke 则另写 `evaluation/observation.jsonl`）。没有 job 字段糖；替换只能走显式 `extensions` 行（`slot` + `plugin`）。缺默认注册 → lock fail-closed。
 
 PASS 仍只经 `AttemptCtx.bind_evaluation` 进入 Result。`evaluation_runtime` 赢家返回 raw，不得自己写 verdict。`pass` / `identity` / `cleanup` / `evidence` 仍不是服务。
 
@@ -78,9 +80,9 @@ PASS 仍只经 `AttemptCtx.bind_evaluation` 进入 Result。`evaluation_runtime`
 | phase | 默认做什么 |
 | --- | --- |
 | `environment` | `host.start` + upload seed + 槽（见下） |
-| `run` | 调 task `run.py`；内含 agent open/invoke/close **子槽** |
-| `evaluate` | 停 writer、materialize gold、调 `evaluation_runtime` 赢家、`bind_evaluation` |
-| `record` | collect/enrich → `trajectory_seal` 赢家写 `trajectory.jsonl` |
+| `run` | 调 task `run.py`；内含 agent open/invoke/close **子槽**。结束时停 solver writer，**保持** Agent Service |
+| `evaluate` | materialize gold、调 `evaluation_runtime` 赢家（可选 SDK `Agent.session`）、`bind_evaluation` |
+| `record` | collect/enrich → `trajectory_seal` 写 run 相位 `trajectory.jsonl`；evaluate 相位 invoke 另封 `evaluation/observation.jsonl`（省略 user） |
 | `cleanup` | `host.stop`；实现可加报告，不能选择跳过 |
 
 **没有 `provision` phase。**
@@ -111,7 +113,7 @@ async def run(ctx) -> None:
 
 ```python
 async def run(ctx) -> None:
-    await emit(ctx, "before_evaluate")          # 停 writer 已在 run 结束完成
+    await emit(ctx, "before_evaluate")          # solver writer 已在 run 结束停掉；Agent Service 仍在
     # 引擎 upload gold —— 不挂在 before_evaluate 链上
     if ctx.evaluation_src.exists():
         await ctx.host.upload(ctx.evaluation_src, "/attempt/evaluation")
@@ -122,7 +124,9 @@ async def run(ctx) -> None:
 
 - Agent / `run.py` / `environment_setup` **禁止**看到 `evaluation/`（不 upload、不 mount、不 COPY 进 Agent 用镜像层）。
 - 这是 **时间切开**，不是 `path_views`。evidence 记 `gold_materialized_at: evaluate`（Current 事实名 `gold_materialized`）。
+- gold 进盒之后 solver 不得再 invoke。evaluate 相位可以按 **另一** profile（例 `judge`）走同一 Parent Agent Service。
 - 另开 Host 打分 **不是默认**；若以后要，用 job 开关，缺省仍同盒晚上传。
+- judge 观察不是 PASS。`observation.jsonl` 缺席 = 今日脚本评测路径。
 
 ### 其他 slot
 
@@ -130,10 +134,10 @@ async def run(ctx) -> None:
 | --- | --- |
 | run | `before_run` / `after_run`；`before/after_agent_open\|invoke\|close`；`normalize_agent_result` |
 | evaluate | `before_evaluate` / `after_evaluate`（可注 metrics，**不能改 PASS**）。**upload gold 是引擎代码**，不是 `evaluation_runtime` 的方法。独占槽 `evaluation_runtime` 默认跑盒内 `evaluator.py` |
-| record | `trajectory_collect` / `trajectory_enrich`（fail-open）；独占槽 `trajectory_seal` 写层 C（fail-closed：丢文件即相位失败）；`summary_enrich`（fail-open，seal 成功后一次，写 Attempt `summary.extra`） |
+| record | `trajectory_collect` / `trajectory_enrich`（fail-open）；独占槽 `trajectory_seal` 写 run 相位层 C（fail-closed：丢文件即相位失败）；evaluate 相位 invoke 封到 `evaluation/observation.jsonl`（有才写；省略 user）；`summary_enrich`（fail-open，seal 成功后一次，写 Attempt `summary.extra`） |
 | cleanup | `cleanup_report`（链）；cleanup phase 本身由 finally 调用 |
 
-`executor` 是 **run 里的独占槽**，不是 attempt 上的独立 phase。ACP attach 发生在第一次 invoke，不是独立 phase。
+`executor` 是 **profile graph 里的独占槽**（run 与 evaluate 的 `Agent.session` 都走它），不是 attempt 上的独立 phase。ACP attach 发生在该 profile 第一次 invoke，不是独立 phase。
 
 `FAIL_OPEN_SLOTS`：`before_run` / `after_run` / `trajectory_collect` / `trajectory_enrich` / `summary_enrich` / `cleanup_report`。其余槽失败即该相位失败。
 
@@ -175,7 +179,7 @@ job 选盒子：`profiles.yaml` 的 `environment:`，不是 `provider.kind`。
 cli → application.composition.build_*
         → config.load_and_lock
         → identity.new_run / new_trial / new_attempt
-        → bind environment winner + executor winner
+        → bind environment winner（Attempt 级）+ 各 profile 的 executor 赢家
         → ParentAgentService
         → run_attempt
 ```

--- a/docs/design/03-task-run-and-sdk.md
+++ b/docs/design/03-task-run-and-sdk.md
@@ -60,6 +60,8 @@ from ageval_sdk import (
 
 `run.py` 通过 `ctx.agent.session(...).invoke` 调 Agent。ACP attach 发生在第一次 invoke。SDK 不拥有 `host.start`、凭据文件内容、final PASS。
 
+evaluate 相位同样可以用 SDK：gold 已 upload 之后，`evaluator.py` 可以 `Agent.session(<role>).invoke`（role 须在同一份 `profiles.yaml` 里，且不得复用 solver 的 key locator）。这些 invoke 走同一 Parent Agent Service 与该 profile 的 executor。密封进 `evaluation/observation.jsonl`，省略 `user` 行。`evaluator.py` **不得** bind PASS；仍返回 `{status, score, metrics}`。不调 `Agent.session` = 今日路径，无 observation 文件。invoke kwargs 仍不得改 `profile_id` / executor。
+
 ## invoke 工具通道
 
 `Agent.session(profile_id).invoke` 默认仍是今天的 **prompt-only** 文本调用。可选关键字（省略 = 旧行为）：

--- a/docs/design/05-runtime/README.md
+++ b/docs/design/05-runtime/README.md
@@ -6,9 +6,9 @@ Runtime 在这里指：**盒子、ACP、evaluate、evidence、campaign**。结�
 | --- | --- |
 | [lifecycle.md](lifecycle.md) | Run / Trial / Attempt 身份与五相位状态机 |
 | [environment.md](environment.md) | Protocol 与四 kind |
-| [agent-service.md](agent-service.md) | parent ACP client + `attach_stdio`；openai-http 原生 `tools=` |
-| [evaluation.md](evaluation.md) | 停写、upload gold、绑定 PASS |
-| [evidence.md](evidence.md) | `.ageval/runs/` |
+| [agent-service.md](agent-service.md) | parent ACP client + `attach_stdio`；executor 按 profile 绑；openai-http 原生 `tools=` |
+| [evaluation.md](evaluation.md) | 停 solver writer、upload gold、可选 judge SDK invoke、绑定 PASS |
+| [evidence.md](evidence.md) | `.ageval/runs/`；`evaluation/observation.jsonl` |
 | [campaign-suite.md](campaign-suite.md) | campaign 与 suite |
 
 Core 保留：身份、deadline、硬顶、cleanup、PASS 入口。题包保留 loop。插件填槽。
@@ -28,22 +28,24 @@ run
   before_run
   task_worker → run.py
     before/after_agent_open
-    before_agent_invoke → executor.invoke → after_agent_invoke
+    before_agent_invoke → 该 profile 的 executor.invoke → after_agent_invoke
     normalize_agent_result
     before/after_agent_close
-  stop Agent Service；writers stopped
+  停 solver writer；Agent Service 保持到 evaluate 结束
   after_run
 
 evaluate
   before_evaluate
   upload evaluation/          # 引擎代码；不是 before_evaluate 链槽
   evaluation_runtime          # 独占槽；默认盒内 evaluator.py
+                              # 可选 Agent.session(<judge>).invoke（同一 Parent Agent Service）
   bind_evaluation             # PASS 只从这里进
   after_evaluate              # 不得改 status
 
 record
   trajectory_collect → enrich
-  trajectory_seal             # 独占槽；默认引擎写 trajectory.jsonl
+  trajectory_seal             # 独占槽；run 相位 → trajectory.jsonl
+                              # evaluate 相位 → evaluation/observation.jsonl（有才写；省略 user）
   summary_enrich              # fail-open；Attempt summary.extra，空则省略
 
 cleanup (finally)
@@ -51,4 +53,4 @@ cleanup (finally)
   host.stop
 ```
 
-槽种类只有 exclusive（`environment`、`executor`、`evaluation_runtime`、`trajectory_seal`）与 chain。PASS 仍只经 `bind_evaluation`。
+槽种类只有 exclusive（`environment`、`executor`、`evaluation_runtime`、`trajectory_seal`）与 chain。`executor` 按 profile 各绑一份；`environment` 仍 Attempt 级一份。PASS 仍只经 `bind_evaluation`。

--- a/docs/design/05-runtime/agent-service.md
+++ b/docs/design/05-runtime/agent-service.md
@@ -2,6 +2,8 @@
 
 两条 **独立** 的 coding-agent inlet，都占独占槽 `executor`。不要把第二条折进 ACP 插件，也不要写成 `executor: pi` / `executor: claude`。
 
+`executor` 的独占赢家是 **每个 `agent_profiles` 一行一份**，不是 Attempt 上只许一个机制。同一 Attempt：solver 可以 `executor: acp`，judge 可以 `executor: openai-http`。`environment` 仍是 Attempt 级一份。两个插件仍不得抢**同一 profile graph** 上的 `executor`。lock 的 `extension_bindings` 按 profile id 各记一份。
+
 | 赢家 | JSON-RPC client 在哪 | 盒子 cap | 完成信号 |
 | --- | --- | --- | --- |
 | `executor: acp` | **parent 唯一** ACP client（`attach_stdio` 管子） | `attach_stdio` | ACP 帧（`stopReason`） |
@@ -66,20 +68,24 @@ agent_profiles:
 ## 调用链
 
 ```text
-run.py  Agent.session(profile).invoke
+run.py / evaluator.py  Agent.session(profile).invoke
   → unix socket AGEVAL_AGENT_SERVICE_SOCK
   → ParentAgentService
+       按该 profile 的 executor 赢家 invoke
        before_agent_invoke
        executor.invoke → host.attach_stdio(entry argv) 或 host.exec（盒内 worker）
                         或 openai-http POST /chat/completions
        after_agent_invoke
        normalize_agent_result
-  → 层 C：evidence 写 trajectory.jsonl
+  → 层 C：run 相位 → trajectory.jsonl
+           evaluate 相位 → evaluation/observation.jsonl（省略 user）
 ```
 
-`ParentAgentService.invoke` 只回 `AgentResult`（含可选 `tool_calls`）。**不**在每次 invoke 后 `download` 盒内 workspace。轨迹来自 executor events。缺的 publishable 文件在 **writer 停后** 由 run 相位 harvest（Protocol `download`），evaluate 再把 `task-artifacts` upload 进盒。
+`ParentAgentService.invoke` 只回 `AgentResult`（含可选 `tool_calls`）。**不**在每次 invoke 后 `download` 盒内 workspace。轨迹来自 executor events。缺的 publishable 文件在 **solver writer 停后** 由 run 相位 harvest（Protocol `download`），evaluate 再把 `task-artifacts` upload 进盒。
 
-ACP attach 发生在第一次 invoke，不是独立 phase。`acp-oneshot` 每次 invoke 都 exec 一次 wrapper，完成 = 该进程退出码 + 解析出的 `AgentResult`。Harness completed / 轨迹 **不是** PASS。
+Agent Service **跨 evaluate 保持**（或 reopen）：`evaluator.py` 才能 `Agent.session`。run 结束停的是 **solver writer**（该相位已打开的 profile 不得再 invoke），不是把整段服务拆掉再打分。gold 已经在盒内；solver 不得在 gold 之后 invoke。Attempt 结束（cleanup / `run_attempt` finally）才停服务。
+
+ACP attach 发生在第一次 invoke，不是独立 phase。`acp-oneshot` 每次 invoke 都 exec 一次 wrapper，完成 = 该进程退出码 + 解析出的 `AgentResult`。Harness completed / 轨迹 / judge 输出 **不是** PASS。
 
 Socket 帧可带 `tools` / `messages`（省略 = prompt-only）。parent 原样转给 executor；ACP 忽略这两项。`tool_calls` 回 worker。request.json / trajectory **只记 locator 与目录名，不记密钥**。
 

--- a/docs/design/05-runtime/evaluation.md
+++ b/docs/design/05-runtime/evaluation.md
@@ -5,7 +5,8 @@ writer 必须先停。然后 upload `evaluation/`，再在**同一盒子**里 `h
 实现：`src/ageval/evaluation/package_evaluator.py` + `box_runner.py` + `bind.py`。相位代码：`src/ageval/attempt/phases/evaluate.py`。
 
 ```text
-run 结束 → mark_writers_stopped
+run 结束 → 停 solver writer（run 相位已打开的 session 不得再 invoke）
+         → Agent Service 保持（或 reopen）到 evaluate 结束
          → harvest 缺的 publishable：从盒内 /attempt/workspace/<basename>
            download 到 evidence/task-artifacts（已有则跳过）
 evaluate
@@ -13,11 +14,27 @@ evaluate
   upload artifacts（题包 publish 的 + harvest 补上的）
   upload evaluation/          # gold 此刻才在盒内（引擎代码，不挂链槽，也不是 evaluation SPI）
   evaluation_runtime.evaluate # 独占槽赢家；默认盒内 evaluator.py via host.exec
+                              # 可选：evaluator.py 调 Agent.session(<role>).invoke
   bind_evaluation             # Result.status 只在这里写入；赢家返回 raw，不得 bind
   after_evaluate              # 可注 metrics，改 status → RuntimeError
 ```
 
-PASS 只经 `bind_evaluation` 进入 Result。`RunTerminal.completed`、轨迹完整、ACP 正常结束，都不是 PASS。缺轨迹不得发明 PASS。
+PASS 只经 `bind_evaluation` 进入 Result。`RunTerminal.completed`、轨迹完整、ACP 正常结束、judge 输出、`evaluation/observation.jsonl` 是否写全，都不是 PASS。缺轨迹不得发明 PASS。
+
+`evaluation_runtime` 默认仍是盒内 `evaluator.py`。缺省路径：evaluator **不**调 `Agent.session` → 无 `evaluation/observation.jsonl`，Verifier 仍是 `result.json` + `evaluation/` 文件树。这是 opt-in，不是新槽、不是新 profile 文件。
+
+## 可选：evaluate 相位 SDK invoke（LLM-as-judge）
+
+同一份 job `profiles.yaml` 多一行 `agent_profiles.<id>`（例：`judge`），task 角色表列入同一 id。gold **已经** upload 之后，`evaluator.py` 可以 `Agent.session("judge").invoke(...)`（可多次）。提示词归题包。`invoke` kwargs 仍不得改 `profile_id` / executor。
+
+这些 invoke 走 **同一** Parent Agent Service 与该 profile 自己的 executor 赢家（ACP、openai-http、…）。同一 Attempt 上 solver 与 judge **可以** 选不同机制（solver `acp`、judge `openai-http`）。`environment` 仍是 Attempt 级一份。
+
+约束：
+
+- gold 进盒之后，**solver（run 相位已用过的 profile）不得再 invoke**。
+- evaluate 相位的 invoke scratch 不得进 `agent/invocations/`，以免 Agent 页 / 根 `trajectory.jsonl` 吞掉。布局字符串只在 `src/ageval/evidence/`。
+- 密封行写入 `evaluation/observation.jsonl`（层 C，与 Agent 轨迹同一行形）。**省略 `user` 行**（judge 提示常含 hidden reference）。不是 bind 的输入，不拷进 `result.json` / `metrics` / `summary.extra` / `evaluation/evaluator_raw.json`。
+- `evaluator.py` 仍返回 `{status, score, metrics}`；`bind_evaluation` 只读这份。
 
 低分是有效 FAIL。cleanup 失败只 warning。evaluator 缺产物应 FAIL，不要把 KeyError 变成引擎崩溃。
 

--- a/docs/design/05-runtime/evidence.md
+++ b/docs/design/05-runtime/evidence.md
@@ -8,9 +8,11 @@
 | --- | --- |
 | `lock.json` | 无 secret 的 lock 摘要 |
 | `result.json` | 扁平 Result（status/score/kind/logs） |
-| `trajectory.jsonl` | 层 C；`trajectory_seal` 独占槽默认引擎写 |
+| `trajectory.jsonl` | 层 C（**run 相位** Agent invoke）；`trajectory_seal` 独占槽默认引擎写 |
+| `evaluation/observation.jsonl` | 层 C（**evaluate 相位** SDK invoke，opt-in）；无则 Verifier 仍是文件树 |
 | `summary.json` | 相位事实 / timing；可选根字段 `extra`（Attempt 级观察袋，空则省略） |
-| `agent/` | invoke 级观察 |
+| `agent/` | run 相位 invoke 级观察 |
+| `evaluation/` | gold 不在此树的 Attempt 侧；盒内 gold 是时间切开。`evaluator_raw.json` 默认不留 |
 
 `Result.logs` / `evidence_path` 指向该树。
 
@@ -26,7 +28,22 @@ C  trajectory.jsonl  `trajectory_seal` 赢家写（默认引擎折叠）
 
 层 A/B 是 invoke 期的 scratch；层 C 是 Hub / Viewer / `ageval evidence` 的观察记录。轨迹不是分数，也不绑定 PASS。
 
-层 C 按 invoke 序（Attempt 内 `seq` / `turn_index`）写成一个文件。每一行带一等 `profile_id`：这是 package role（`Agent.session(profile_id)`），不是 chat `role`（user/assistant）。同一 invoke 的 user / tool / assistant / terminal 共用该值。Hub / Viewer 按文件序展示，用 `profile_id` 区分是谁在说话，**不**按 role 重分组。旧 jsonl 若只有 `terminal.metadata.profile_id`，读侧按 `turn_index` 回填到该轮其它行。
+两份观察记录、两个页签，**同一**层 C 行形（`ageval.trajectory.event/1` → thought / assistant / tool_call / observation / permission / terminal）。没有第二套 schema。HTTP judge 通常只有 assistant + terminal；ACP judge 以后可以有 tool。
+
+| 表面 | 文件 | 谁写 | SPA |
+| --- | --- | --- | --- |
+| Agent | Attempt 根 `trajectory.jsonl` | run 相位 invoke | Trajectory 页（不变） |
+| Evaluation | `evaluation/observation.jsonl` | evaluate 相位 SDK invoke | Verifier 页 |
+
+层 C 按 invoke 序（Attempt 内 `seq` / `turn_index`）写成**各自**的文件。每一行带一等 `profile_id`：这是 package role（`Agent.session(profile_id)`），不是 chat `role`（user/assistant）。同一 invoke 的 tool / assistant / terminal 共用该值。Hub / Viewer 按文件序展示，用 `profile_id` 区分是谁在说话，**不**按 role 重分组。旧 jsonl 若只有 `terminal.metadata.profile_id`，读侧按 `turn_index` 回填到该轮其它行。
+
+`evaluation/observation.jsonl` 密封时 **省略 `user` 行**。judge 提示经常嵌 hidden reference / gold 正文；那份正文不得进 evidence。assistant / thought / tool / terminal / usage 保留。未知 usage 字段省略，不编造 0。准则拆分等 leftover 进 `terminal.extra`，不升格一等列。record 相位密封 Agent 轨迹时 **忽略** evaluate 相位的 invoke。
+
+evaluate 相位的 invoke scratch 写在 `evaluation/` 下（布局字符串只在 `src/ageval/evidence/`），**不**进 `agent/invocations/`。Agent 页与根 `trajectory.jsonl` 看不到这些目录。`--keep-vendor-raw` 才保留该 scratch（与 run 相位 vendor raw 同一旗）。
+
+缺省（evaluator 不调 `Agent.session`）不写 `observation.jsonl`。Verifier 仍是 `result.json` + `evaluation/` 文件树。有 `observation.jsonl` 且含层 C 步时，Viewer / Hub 的 Verifier **复用 TrajectoryPanel**（同一卡片 / thought 折 / usage）；**不要**把该文件喂给 Agent 的 Trajectory 页。Trajectory 页的 actors 表仍是 run 相位 profile，不把 judge invoke 并进去。
+
+观察不是分数。`result.json` 的 `status` 只来自 `evaluator.py` 返回值经 `bind_evaluation`。
 
 ## 层 C `terminal.usage`
 
@@ -77,9 +94,10 @@ result.json
 trajectory.jsonl
 summary.json
 task-artifacts/**
+evaluation/observation.jsonl   # 仅当 evaluate 相位有 SDK invoke
 ```
 
-`summary.json` 是相位墙钟，不是 vendor raw。Verifier 看 `result.json`；默认不留 `evaluation/evaluator_raw.json`。
+`summary.json` 是相位墙钟，不是 vendor raw。Verifier 看 `result.json`；有 `observation.jsonl` 时再叠层 C 步。默认不留 `evaluation/evaluator_raw.json`。`slim_sealed_attempt` 与 Hub Attempt archive 同一套 keep/drop：留下 `observation.jsonl`，丢掉 `evaluator_raw.json`。
 
 `--keep-vendor-raw`（默认关）才保留 `backend_raw/`、per-invoke `request.json` / `events.jsonl` / `final-response.json` / `metadata.json`、失败 `stderr.txt`、`agent/events.jsonl`、`evaluator_raw.json`。`--keep-workspace` 只管宿主 work root（`l1-work`），与 vendor raw 无关。`ageval evidence` 跟可持久树走，层 C 优先。只作用于新 run，不改写旧树。删文件不是 PASS。
 

--- a/docs/design/11-extension-plugins.md
+++ b/docs/design/11-extension-plugins.md
@@ -29,10 +29,12 @@
 
 | 槽 | 语义 | 例子 |
 | --- | --- | --- |
-| 独占 | 全 Attempt 一个赢家；登记为同名 service | `environment`、`executor`、`evaluation_runtime`、`trajectory_seal` |
+| 独占 | 每个 resolved graph 一个赢家；登记为同名 service | `environment`、`executor`、`evaluation_runtime`、`trajectory_seal` |
 | 链 | `(ctx, value, nxt)` | `after_environment_ready`、`environment_setup`、`trajectory_collect`、`summary_enrich` |
 
-`profiles.environment` / `profiles.executor` = 选独占槽赢家。`evaluation_runtime` / `trajectory_seal` **没有** job 字段糖；默认赢家即可，替换只能走显式 `extensions` 行（`slot` + `plugin`）。`extensions` 也是链槽 opt-in。未列入 `extensions` 的不进链、不进服务表（引擎默认除外）。
+`environment` / `evaluation_runtime` / `trajectory_seal` 是 Attempt 级一份赢家。`executor` 按 `agent_profiles` 每行一份：同一 Attempt 上 solver 与 judge 可以选不同 executor 插件（仍各是该 graph 上的独占赢家）。两个插件抢**同一 graph** 的同一独占槽或同一 export id → fail closed。
+
+`profiles.environment` / `agent_profiles.<id>.executor` = 选独占槽赢家。`evaluation_runtime` / `trajectory_seal` **没有** job 字段糖；默认赢家即可，替换只能走显式 `extensions` 行（`slot` + `plugin`）。`extensions` 也是链槽 opt-in。未列入 `extensions` 的不进链、不进服务表（引擎默认除外）。不开 `evaluation_collect` 一类新槽；evaluate 相位 SDK invoke 复用现有 invoke → 层 B → fold。
 
 Current 独占槽：`environment`、`executor`、`evaluation_runtime`、`trajectory_seal`。后两者默认是引擎（`plugin_id: default`）。PASS 仍只经 `bind_evaluation` 进入；`pass` / `identity` / `cleanup` / `evidence` 不准 export。
 
@@ -86,18 +88,18 @@ agent_profiles:
 - `ageval plugin install` 只写 `~/.ageval/plugins`，永不改 profiles。
 - 按机制命名（`acp` / `acp-oneshot` / `docker` / `e2b` / `daytona` / `ssh` / `nooa`）。禁止按 bench 名。
 
-独占槽默认赢家（Current）：`environment` 由 job `environment:` 选出（缺省常见 local 或 docker，以 profiles 为准）；`executor` 由 `agent_profiles.*.executor` 选出（coding-agent 默认 acp）；`evaluation_runtime` / `trajectory_seal` 由引擎 `plugin_id: default` 赢（盒内 `evaluator.py` / 层 C writer）。缺默认注册 → lock fail-closed。
+独占槽默认赢家（Current）：`environment` 由 job `environment:` 选出（缺省常见 local 或 docker，以 profiles 为准）；`executor` 由 **各** `agent_profiles.*.executor` 选出（coding-agent 默认 acp；judge 行可以是 `openai-http`）；`evaluation_runtime` / `trajectory_seal` 由引擎 `plugin_id: default` 赢（盒内 `evaluator.py` / 层 C writer）。缺默认注册 → lock fail-closed。lock 记录 **per-profile** executor 绑定。
 
 链默认：`after_environment_ready`（ACP 探测安装 + HOME overlay）；`environment_setup`（`setup.sh`，引擎 defaults）。
 
 ## 解析
 
 ```text
-profiles.environment / executor / extensions
-  → registry resolve
-       exclusive  单赢家（priority，并列 fail closed）
+profiles.environment / agent_profiles.<id>.executor / extensions
+  → registry resolve（每个 profile 一份 graph；environment 赢家必须一致）
+       exclusive  该 graph 单赢家（priority，并列 fail closed）
        chain      已排序的 nxt 链
-  → lock.extension_bindings 进 digest
+  → lock.extension_bindings 按 profile id 进 digest
 ```
 
 inject 用 `service: environment`，不写死 `plugin_id: e2b`。`executor: acp` 要 `attach_stdio`；盒内 worker（dsh / nooa / `acp-oneshot`）要 `exec`（dsh / nooa 另要 `upload`）。缺则 lock 失败。盒子没有 `attach_stdio` 不是把 oneshot 折进 ACP 插件的理由。

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -13,13 +13,13 @@
 | **Campaign** | 矩阵展开的多 Trial（`ageval campaign`） |
 | **suite** | 一份 dataset 去掉 `--task` 的全成员跑。suite 指标是观测，不是 suite PASS |
 | **run.py** | 题包 run phase 入口（`async def run(ctx)`）。不可读 `evaluation/` |
-| **evaluator.py** | 题包打分；PASS 只从 evaluate 相位绑定进入 |
+| **evaluator.py** | 题包打分；PASS 只从 evaluate 相位绑定进入。可选 `Agent.session`（LLM-as-judge）；观察不是 PASS |
 | **RunTerminal** | 题包结束信号；`completed` ≠ PASS |
 | **phase** | attempt 上的一大步（environment / run / evaluate / record / cleanup） |
-| **独占槽** | 全 Attempt 一个赢家；登记为同名 service |
+| **独占槽** | 每个 resolved graph 一个赢家；登记为同名 service。`environment` 是 Attempt 级一份；`executor` 按 profile 各绑一份 |
 | **链槽** | phase 内钩子，handler `(ctx, value, nxt)` |
 | **environment**（槽） | 盒子赢家：`local` / `docker` / `e2b` / `ssh` / `daytona`，同一 Protocol |
-| **executor**（槽） | Agent 后端赢家。coding-agent 默认 `acp`（parent client + `attach_stdio`）；`acp-oneshot` 是盒内一次性 client + `exec` |
+| **executor**（槽） | 该 `agent_profiles` 行的 Agent 后端赢家。coding-agent 默认 `acp`（parent client + `attach_stdio`）；`acp-oneshot` 是盒内一次性 client + `exec`。同一 Attempt 上不同 profile 可选不同机制 |
 | **acp-oneshot** | 外置 executor 插件：parent 一次 `host.exec` 跑盒内 ACP server+client；不要求 `attach_stdio` |
 | **service / inject** | 按名取能力：独占赢家以槽名 export；调用方 inject 服务名 + capabilities；lock 期解析。`exec` 是 Protocol 方法，不是独立 service |
 | **attach_stdio** | host 在已开盒里起前台进程并交回 stdin/stdout |

--- a/skills/ageval-cli/SKILL.md
+++ b/skills/ageval-cli/SKILL.md
@@ -34,7 +34,7 @@ TTY prints a short recap (no digest / sha256). A pipe keeps JSON. `ageval run --
 
 Exit: 0 PASS / probe ready; 1 FAIL / probe not ready; 2 ERROR.
 
-Single Attempt evidence: `<dataset>/.ageval/runs/<id>/` (`lock.json`, `result.json`, `trajectory.jsonl`). Trajectory ≠ PASS.
+Single Attempt evidence: `<dataset>/.ageval/runs/<id>/` (`lock.json`, `result.json`, `trajectory.jsonl`; optional `evaluation/observation.jsonl` for evaluate-phase SDK invoke). Trajectory ≠ PASS.
 
 `--probe` missing `E2B_API_KEY` or ssh locator → ready false, started false.
 

--- a/skills/ageval-cli/references/commands.md
+++ b/skills/ageval-cli/references/commands.md
@@ -44,10 +44,10 @@ Stdout JSON (high level):
 - **`--max-concurrent-tasks`**: speeds wall time only; does not change k or PASS.
 - **`--resume-suite` / `--replace-slot` / `--attempt-index`**: suite resume; see `ageval run --help`.
 - **`--keep-workspace`**: after cleanup, do not delete the box work root (host residual may still be named `l1-work/` — historical directory name, not an isolation tier). Default off. Docker volumes are still removed. Upload packs never include `l1-work/**`.
-- **`--keep-vendor-raw`**: after a successful trajectory seal, keep invocation `backend_raw/` / layer B (`request.json`, `events.jsonl`, `final-response.json`, `metadata.json`) and `evaluation/evaluator_raw.json`. Default off: those files are dropped; Hub archives skip them even if residuals remain. Independent of `--keep-workspace`.
+- **`--keep-vendor-raw`**: after a successful trajectory seal, keep invocation `backend_raw/` / layer B (`request.json`, `events.jsonl`, `final-response.json`, `metadata.json`) and `evaluation/evaluator_raw.json`. Default off: those files are dropped; Hub archives skip them even if residuals remain. `evaluation/observation.jsonl` (evaluate-phase SDK invoke) is **kept** either way. Independent of `--keep-workspace`.
 - `--profiles` replaces the dataset job document. `--agent` and `--profiles` are mutually exclusive. `--agent pi` resolves the shipped catalog tree (no install). `--model` requires `--agent` and writes this run’s overlay model; omit it to keep the package default. Not `ageval results --model`.
 - `--dir <path>`: only with a registry ref. Looks at `<path>/<dataset_id>/` (example: `--dir tmp` + `official/demo@0.1.0` → `tmp/official/demo`). Reuse that child if it already matches; otherwise fetch into it and run. Relative paths are from cwd. Local path + `--dir` is `invalid_override`.
-- Per invocation: Core writes `trajectory.jsonl` (`ageval.trajectory.event/1`). Trajectory ≠ PASS.
+- Per invocation: Core writes `trajectory.jsonl` (`ageval.trajectory.event/1`) for **run-phase** Agent turns. Evaluate-phase SDK invoke (LLM-as-judge) writes `evaluation/observation.jsonl` instead. Neither file is PASS.
 - Docker kind uses the docker environment winner + `attach_stdio`; coding entries stay on the parent ACP client.
 
 ## `ageval evidence`

--- a/skills/ageval-config-package/SKILL.md
+++ b/skills/ageval-config-package/SKILL.md
@@ -2,9 +2,9 @@
 name: ageval-config-package
 description: >
   Author ageval datasets (ageval.yaml + tasks/*/task.yaml, run.py/evaluator.py,
-  profiles.yaml, environment kinds local|docker|e2b|ssh|daytona, limits, gold isolation).
-  Triggers: ageval.yaml, task.yaml, profiles.yaml, dataset, environment kind.
-  Never secrets in yaml. Never provider.kind.
+  profiles.yaml, environment kinds local|docker|e2b|ssh|daytona, limits, gold isolation,
+  script vs LLM-as-judge scoring). Triggers: ageval.yaml, task.yaml, profiles.yaml,
+  dataset, environment kind, evaluator.py. Never secrets in yaml. Never provider.kind.
 ---
 
 # Config / dataset + task
@@ -54,6 +54,15 @@ agent_profiles:
 ```
 
 Gold lives in `evaluation/` and is uploaded at evaluate, not before. `setup.sh` is the last environment slot.
+
+Two scoring styles in `evaluator.py` (same barrier; PASS still the return value):
+
+| Style | When | Evidence |
+| --- | --- | --- |
+| Deterministic script | Default. Compare artifacts to gold. No `Agent.session`. | `result.json`. No `evaluation/observation.jsonl`. |
+| LLM-as-judge | Extra role on the **same** `profiles.yaml` (e.g. `judge`). After gold lands, `Agent.session("judge").invoke`. | `evaluation/observation.jsonl` (no `user` rows). Not merged into Agent `trajectory.jsonl`. |
+
+Judge binding stays in `profiles.yaml` (not on the member task). Budget `limits.agent_invocations` for solver **and** judge. SDK session into the evaluator process is projected on `environment: local`. No `Agent.session` = script path.
 
 `--profiles` swaps the job. `--agent` is mutually exclusive with `--profiles`. `--model` requires `--agent`.
 

--- a/skills/ageval-config-package/references/isolation.md
+++ b/skills/ageval-config-package/references/isolation.md
@@ -7,6 +7,7 @@ Authority: `docs/design/06-capability-adapter-visibility.md`, `docs/design/05-ru
 - Put hidden labels under `evaluation/` (paths never mounted to Agent).
 - Gold is uploaded at the start of evaluate, not during run. This is a cut in **time**, not `path_views`.
 - Evaluator receives allowlisted staged inputs only after writer barrier.
+- Optional LLM-as-judge: `Agent.session` is allowed **after** that upload. Solver profiles that already ran must not invoke. Judge prompts stay out of `evaluation/observation.jsonl` user rows.
 
 ## Box kind
 

--- a/skills/ageval-platform/SKILL.md
+++ b/skills/ageval-platform/SKILL.md
@@ -27,11 +27,11 @@ Runtime owns lock, Attempt, the box, hard ceilings, trajectory, independent eval
 | --- | --- |
 | **Core:** lock, Attempt phases, box Protocol, Agent Service, hard ceilings, bind PASS | Task loop, scoring algorithm |
 | **`run.py`:** loop, tools, publish | PASS, credentials, opening the box |
-| **evaluator:** truth | Starting the Agent |
+| **evaluator:** truth (script, or optional `Agent.session` after gold) | Opening the box; binding PASS from trajectory |
 
 ## Red lines
 
-1. Trajectory ≠ PASS.
+1. Trajectory ≠ PASS (`trajectory.jsonl` and `evaluation/observation.jsonl`).
 2. No secrets in lock / yaml / evidence. Env vars are locators.
 3. Adapters named by mechanism (`acp`, `docker`, `e2b`, `ssh`). Never by benchmark.
 4. Kind is `environment: local|docker|e2b|ssh|daytona`.

--- a/skills/ageval-sdk-harness/SKILL.md
+++ b/skills/ageval-sdk-harness/SKILL.md
@@ -2,9 +2,10 @@
 name: ageval-sdk-harness
 description: >
   Write dataset run.py with ageval_sdk (RunContext, Agent/AgentSession, ToolSet,
-  RunTerminal, publish). Use for task run.py, sessions, tool guards. Triggers:
-  AgentSession, RunTerminal, ctx.publish_json, write run.py. SDK never decides
-  PASS or holds host credentials.
+  RunTerminal, publish). Use for task run.py, sessions, tool guards, optional
+  evaluator.py LLM-as-judge. Triggers: AgentSession, RunTerminal,
+  ctx.publish_json, write run.py, evaluator.py. SDK never decides PASS or holds
+  host credentials.
 ---
 
 # SDK / run.py
@@ -23,10 +24,13 @@ async def run(ctx: RunContext) -> RunTerminal:
 
 `RunTerminal.completed` is not PASS. Evaluator is a separate process.
 
+Default `evaluator.py` is a script: read artifacts + gold, return `{status, score, metrics}`. Optional LLM-as-judge: after gold is uploaded, `Agent.session(<role>).invoke` on a role declared in the same `profiles.yaml`. Parent injects `inputs["agent"]` when the socket is projected (`environment: local`). Still return `{status, score, metrics}` — judge text and `evaluation/observation.jsonl` are not PASS. `invoke` kwargs must not override `profile_id` / executor.
+
 | May | Must not |
 | --- | --- |
 | Open sessions, tools, publish | Decide PASS |
 | Use `ctx.params` | Re-read lock or secrets |
 | Return completed/failed | Raise Core ceilings |
+| Evaluator `Agent.session` after gold | Bind PASS from judge prose / observation.jsonl |
 
 API: [references/api.md](references/api.md). Antipatterns: [references/antipatterns.md](references/antipatterns.md).

--- a/skills/ageval-sdk-harness/references/antipatterns.md
+++ b/skills/ageval-sdk-harness/references/antipatterns.md
@@ -3,6 +3,7 @@
 | Antipattern | Do instead |
 | --- | --- |
 | Treat `completed` as PASS | Independent evaluator only |
+| Treat judge `invoke` text / `observation.jsonl` as PASS | Return `{status, score, metrics}`; engine binds |
 | `if executor == "codex":` / `if entry == "pi":` for Core policy | Switch `agent_profiles` / `active_profile` / `parameters.roles` |
 | Write `executor: codex` in package yaml | `executor: acp` + `- plugin: acp` / `options.entry: codex` (etc.) |
 | Read `~/.codex/auth.json` or print secrets | Rely on Runtime projection |

--- a/skills/ageval-sdk-harness/references/api.md
+++ b/skills/ageval-sdk-harness/references/api.md
@@ -25,4 +25,8 @@ Optional invoke kwargs: `tools` (OpenAI-style catalog) and `messages` (chat hist
 
 When `AGEVAL_OFFLINE_AGENT=1`, invoke fails closed (`offline_forced`) — never stub PASS on public paths.
 
+## Evaluator (optional)
+
+`evaluator.py` may construct `Agent(attempt_id=…)` or use injected `inputs["agent"]` when `AGEVAL_AGENT_SERVICE_SOCK` is set. Same `Agent.session(profile_id).invoke` as `run.py`. Evaluate-phase turns fold to `evaluation/observation.jsonl` (omit `user`). Not PASS.
+
 Design: `docs/design/03-task-run-and-sdk.md`.

--- a/src/ageval/attempt/ctx.py
+++ b/src/ageval/attempt/ctx.py
@@ -98,7 +98,7 @@ class AttemptCtx:
         self._writers_stopped = True
 
     def assert_writers_stopped(self) -> None:
-        """Evaluate must not start while the Agent side can still write."""
+        """Evaluate must not start while run-phase Agent writers can still write."""
         if not self._writers_stopped:
             raise RuntimeError("agent writers not confirmed stopped before evaluate")
 

--- a/src/ageval/attempt/phases/evaluate.py
+++ b/src/ageval/attempt/phases/evaluate.py
@@ -19,7 +19,7 @@ PHASE = "evaluate"
 
 async def run(ctx: AttemptCtx) -> None:
     ctx.phase = PHASE
-    ctx.assert_writers_stopped()
+    ctx.assert_writers_stopped()  # solver writers; Agent Service may still be up
     await emit(ctx, BEFORE_EVALUATE)
     await _upload_task_artifacts(ctx)
     if ctx.evaluation_src is not None and ctx.evaluation_src.is_dir():

--- a/src/ageval/attempt/phases/record.py
+++ b/src/ageval/attempt/phases/record.py
@@ -7,13 +7,14 @@ fails the phase. ``summary_enrich`` runs once after a successful seal.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from ageval.attempt.ctx import AttemptCtx
 from ageval.attempt.emit import emit
 from ageval.evidence.invocation import read_invocation_payload
 from ageval.evidence.slim import slim_sealed_attempt
-from ageval.evidence.trajectory import turn_rows
+from ageval.evidence.trajectory import turn_rows, write_evaluation_observation
 from ageval.plugins.binding import bind_winner
 from ageval.plugins.slots import (
     SUMMARY_ENRICH,
@@ -27,12 +28,7 @@ PHASE = "record"
 
 async def run(ctx: AttemptCtx) -> None:
     ctx.phase = PHASE
-    turns: list[list[dict[str, Any]]] = []
-    for directory in ctx.evidence.list_invocations():
-        payload = read_invocation_payload(directory)
-        shaped = await emit(ctx, TRAJECTORY_COLLECT, payload)
-        shaped = await emit(ctx, TRAJECTORY_ENRICH, shaped)
-        turns.append(turn_rows(**_fields(shaped, payload)))
+    turns = await _fold_invocations(ctx, ctx.evidence.list_invocations(), include_user=True)
     impl = bind_winner(ctx.registry, ctx.bindings, TRAJECTORY_SEAL)
     plugin_id = ctx.bindings.winners[TRAJECTORY_SEAL].plugin_id
     ctx.services.register(TRAJECTORY_SEAL, impl, plugin_id=plugin_id)
@@ -40,6 +36,19 @@ async def run(ctx: AttemptCtx) -> None:
     if not path.is_file():
         raise RuntimeError("trajectory_seal did not write the trajectory file")
     ctx.record_fact("trajectory_recorded", {"turns": len(turns), "file": path.name})
+    eval_turns = await _fold_invocations(
+        ctx, ctx.evidence.list_evaluation_invocations(), include_user=False
+    )
+    if eval_turns:
+        obs = write_evaluation_observation(
+            ctx.evidence.root,
+            eval_turns,
+            redaction_sentinels=ctx.evidence.sentinels,
+        )
+        ctx.record_fact(
+            "evaluation_observation_recorded",
+            {"turns": len(eval_turns), "file": obs.name},
+        )
     if ctx.keep_vendor_raw:
         ctx.record_fact("vendor_raw_kept", {"keep_vendor_raw": True})
     else:
@@ -47,6 +56,21 @@ async def run(ctx: AttemptCtx) -> None:
         ctx.record_fact("vendor_raw_dropped", {"keep_vendor_raw": False})
     bag = await emit(ctx, SUMMARY_ENRICH, {})
     ctx.summary_extra = bag if isinstance(bag, dict) and bag else None
+
+
+async def _fold_invocations(
+    ctx: AttemptCtx,
+    directories: list[Path],
+    *,
+    include_user: bool,
+) -> list[list[dict[str, Any]]]:
+    turns: list[list[dict[str, Any]]] = []
+    for directory in directories:
+        payload = read_invocation_payload(directory)
+        shaped = await emit(ctx, TRAJECTORY_COLLECT, payload)
+        shaped = await emit(ctx, TRAJECTORY_ENRICH, shaped)
+        turns.append(turn_rows(**_fields(shaped, payload), include_user=include_user))
+    return turns
 
 
 def _fields(shaped: Any, original: dict[str, Any]) -> dict[str, Any]:

--- a/src/ageval/attempt/phases/run.py
+++ b/src/ageval/attempt/phases/run.py
@@ -29,8 +29,9 @@ async def run(ctx: AttemptCtx) -> None:
             raise RuntimeError(error)
     finally:
         if ctx.agent_service is not None:
-            await _stop_agent_service(ctx)
-        # No Agent can write after this point; evaluate may now start.
+            await _seal_run_agent_service(ctx)
+        # Solver writers cannot write after this point; evaluate may now start.
+        # The Agent Service socket stays up so evaluator.py can still session().
         ctx.mark_writers_stopped()
     await harvest_workspace_artifacts(ctx)
     await emit(ctx, AFTER_RUN)
@@ -42,7 +43,13 @@ async def _run_task_entry(ctx: AttemptCtx) -> dict[str, object]:
     return await launch_task_worker(ctx)
 
 
-async def _stop_agent_service(ctx: AttemptCtx) -> None:
+async def _seal_run_agent_service(ctx: AttemptCtx) -> None:
+    seal = getattr(ctx.agent_service, "seal_run", None)
+    if callable(seal):
+        result = seal()
+        if hasattr(result, "__await__"):
+            await result
+        return
     stop = getattr(ctx.agent_service, "stop", None)
     if stop is None:
         return

--- a/src/ageval/attempt/phases/run.py
+++ b/src/ageval/attempt/phases/run.py
@@ -7,6 +7,9 @@ credential or the box handle.
 
 from __future__ import annotations
 
+import inspect
+from typing import Any
+
 from ageval.attempt.artifact_harvest import harvest_workspace_artifacts
 from ageval.attempt.ctx import AttemptCtx
 from ageval.attempt.emit import emit
@@ -46,13 +49,14 @@ async def _run_task_entry(ctx: AttemptCtx) -> dict[str, object]:
 async def _seal_run_agent_service(ctx: AttemptCtx) -> None:
     seal = getattr(ctx.agent_service, "seal_run", None)
     if callable(seal):
-        result = seal()
-        if hasattr(result, "__await__"):
-            await result
+        await _maybe_await(seal())
         return
     stop = getattr(ctx.agent_service, "stop", None)
     if stop is None:
         return
-    result = stop()
-    if hasattr(result, "__await__"):
+    await _maybe_await(stop())
+
+
+async def _maybe_await(result: Any) -> None:
+    if inspect.isawaitable(result):
         await result

--- a/src/ageval/evaluation/box_runner.py
+++ b/src/ageval/evaluation/box_runner.py
@@ -20,6 +20,19 @@ from typing import Any
 RESULT_NAME = "evaluation.json"
 
 
+def _maybe_agent() -> Any:
+    """Harness Agent when the parent socket is projected; omit otherwise."""
+    sock = os.environ.get("AGEVAL_AGENT_SERVICE_SOCK", "").strip()
+    attempt_id = os.environ.get("AGEVAL_ATTEMPT_ID", "").strip()
+    if not sock or not attempt_id:
+        return None
+    try:
+        from ageval_sdk import Agent
+    except ImportError:
+        return None
+    return Agent(attempt_id=attempt_id)
+
+
 def _load_callable(module_path: Path, entrypoint: str) -> Any:
     module_name, _, func_name = entrypoint.partition(":")
     if not module_name or not func_name:
@@ -60,16 +73,18 @@ def main(argv: list[str]) -> int:
     # "the thing the task produced".
     artifacts_dir.mkdir(parents=True, exist_ok=True)
     os.chdir(artifacts_dir)
-    verdict = func(
-        {
-            "artifacts": _published(artifacts_dir),
-            "artifacts_dir": str(artifacts_dir),
-            "workspace_dir": os.environ["AGEVAL_WORKSPACE"],
-            "evaluation_dir": os.environ["AGEVAL_EVALUATION"],
-            "inputs": request.get("inputs") or [],
-            "parameters": request.get("parameters") or {},
-        }
-    )
+    payload: dict[str, Any] = {
+        "artifacts": _published(artifacts_dir),
+        "artifacts_dir": str(artifacts_dir),
+        "workspace_dir": os.environ["AGEVAL_WORKSPACE"],
+        "evaluation_dir": os.environ["AGEVAL_EVALUATION"],
+        "inputs": request.get("inputs") or [],
+        "parameters": request.get("parameters") or {},
+    }
+    agent = _maybe_agent()
+    if agent is not None:
+        payload["agent"] = agent
+    verdict = func(payload)
     if not isinstance(verdict, dict):
         print(json.dumps({"status": "ERROR", "error": "verdict_not_object"}))
         return 1

--- a/src/ageval/evaluation/box_runner.py
+++ b/src/ageval/evaluation/box_runner.py
@@ -73,7 +73,7 @@ def main(argv: list[str]) -> int:
     # "the thing the task produced".
     artifacts_dir.mkdir(parents=True, exist_ok=True)
     os.chdir(artifacts_dir)
-    payload: dict[str, Any] = {
+    inputs: dict[str, Any] = {
         "artifacts": _published(artifacts_dir),
         "artifacts_dir": str(artifacts_dir),
         "workspace_dir": os.environ["AGEVAL_WORKSPACE"],
@@ -83,8 +83,8 @@ def main(argv: list[str]) -> int:
     }
     agent = _maybe_agent()
     if agent is not None:
-        payload["agent"] = agent
-    verdict = func(payload)
+        inputs["agent"] = agent
+    verdict = func(inputs)
     if not isinstance(verdict, dict):
         print(json.dumps({"status": "ERROR", "error": "verdict_not_object"}))
         return 1

--- a/src/ageval/evaluation/package_evaluator.py
+++ b/src/ageval/evaluation/package_evaluator.py
@@ -44,13 +44,20 @@ async def evaluate_in_box(ctx: AttemptCtx) -> dict[str, Any]:
     # Local boxes share this interpreter's filesystem, so the evaluator process
     # gets the same import contract as ``run.py``: dataset root then task dir
     # (``from shared.lib…``). Docker/e2b/ssh must bake or COPY ``shared/``.
-    exec_env = None
+    exec_env: dict[str, str] | None = None
     if getattr(ctx.host, "kind", None) == "local":
         exec_env = {
             "PYTHONPATH": os.pathsep.join(
                 [str(ctx.dataset_root.resolve()), str(ctx.task_root.resolve())]
             )
         }
+    sock = getattr(ctx.agent_service, "socket_path", None)
+    # The parent socket is a host Unix path. Local exec shares that filesystem;
+    # other kinds must not inherit a path they cannot open.
+    if sock is not None and getattr(ctx.host, "kind", None) == "local":
+        exec_env = dict(exec_env or {})
+        exec_env["AGEVAL_AGENT_SERVICE_SOCK"] = str(sock)
+        exec_env["AGEVAL_ATTEMPT_ID"] = ctx.attempt_id
     result = await ctx.host.exec(
         [*ctx.host.python_command, _RUNNER_NAME, json.dumps(request)],
         cwd=_BOX_EVALUATOR_DIR,

--- a/src/ageval/evidence/__init__.py
+++ b/src/ageval/evidence/__init__.py
@@ -8,7 +8,11 @@ from ageval.evidence.invocation import read_invocation_payload
 from ageval.evidence.locators import portable_run_locator, resolve_evidence_root, resolve_run_dir
 from ageval.evidence.redaction import RedactionError, redact_value, scan_for_secrets
 from ageval.evidence.store import AttemptEvidenceStore, InvocationHandle
-from ageval.evidence.trajectory import turn_rows, write_attempt_trajectory
+from ageval.evidence.trajectory import (
+    turn_rows,
+    write_attempt_trajectory,
+    write_evaluation_observation,
+)
 
 __all__ = [
     "AttemptEvidenceStore",
@@ -24,4 +28,5 @@ __all__ = [
     "turn_rows",
     "write_attempt_result",
     "write_attempt_trajectory",
+    "write_evaluation_observation",
 ]

--- a/src/ageval/evidence/slim.py
+++ b/src/ageval/evidence/slim.py
@@ -25,13 +25,13 @@ def is_vendor_raw_rel(rel: str) -> bool:
     parts = Path(rel).parts
     if "backend_raw" in parts:
         return True
-    if rel == "agent/events.jsonl":
+    if rel in {"agent/events.jsonl", "evaluation/events.jsonl"}:
         return True
     if rel == "evaluation/evaluator_raw.json":
         return True
     return (
         len(parts) >= 4
-        and parts[0] == "agent"
+        and parts[0] in {"agent", "evaluation"}
         and parts[1] == "invocations"
         and parts[-1] in _INVOCATION_DROP
     )
@@ -40,13 +40,18 @@ def is_vendor_raw_rel(rel: str) -> bool:
 def slim_sealed_attempt(run_dir: Path) -> None:
     """Delete vendor raw / layer B after layer C exists. Keep invocation dirs."""
     root = run_dir
-    events = root / "agent" / "events.jsonl"
-    if events.is_file():
-        events.unlink()
+    for rel in ("agent/events.jsonl", "evaluation/events.jsonl"):
+        events = root / rel
+        if events.is_file():
+            events.unlink()
     raw_eval = root / "evaluation" / "evaluator_raw.json"
     if raw_eval.is_file():
         raw_eval.unlink()
-    inv_root = root / "agent" / "invocations"
+    for rel in ("agent/invocations", "evaluation/invocations"):
+        _slim_invocation_tree(root / rel)
+
+
+def _slim_invocation_tree(inv_root: Path) -> None:
     if not inv_root.is_dir():
         return
     for inv in inv_root.iterdir():

--- a/src/ageval/evidence/store.py
+++ b/src/ageval/evidence/store.py
@@ -29,6 +29,12 @@ from ageval.evidence.schema import (
     normalize_event,
 )
 
+# Layout strings live here. Run-phase invoke scratch vs evaluate-phase scratch.
+AGENT_INVOCATIONS_REL = "agent/invocations"
+EVALUATION_INVOCATIONS_REL = "evaluation/invocations"
+AGENT_EVENTS_REL = "agent/events.jsonl"
+EVALUATION_EVENTS_REL = "evaluation/events.jsonl"
+
 
 def _utc_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
@@ -71,12 +77,13 @@ class InvocationHandle:
     started_at: str
     status: str = "running"
     sealed: bool = False
+    rel_prefix: str = AGENT_INVOCATIONS_REL
     _event_seq: int = 0
     _lock: threading.Lock = field(default_factory=threading.Lock)
 
     @property
     def relative_path(self) -> str:
-        return f"agent/invocations/{self.directory.name}"
+        return f"{self.rel_prefix}/{self.directory.name}"
 
     def write_request(self, request: dict[str, Any]) -> None:
         """Write redacted request; on residual secret seal redaction_failed and re-raise."""
@@ -288,6 +295,7 @@ class AttemptEvidenceStore:
     dataset_root: Path | None = None
     sentinels: list[str] = field(default_factory=list)
     _seq: int = 0
+    _eval_seq: int = 0
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _invocations: dict[str, InvocationHandle] = field(default_factory=dict)
     _sealed_summary: bool = False
@@ -317,7 +325,11 @@ class AttemptEvidenceStore:
 
     def append_agent_index(self, event: dict[str, Any]) -> None:
         cleaned = redact_and_assert(event, extra_sentinels=self.sentinels)
-        self._append_jsonl(self.root / "agent" / "events.jsonl", cleaned)
+        self._append_jsonl(self.root / AGENT_EVENTS_REL, cleaned)
+
+    def append_evaluation_index(self, event: dict[str, Any]) -> None:
+        cleaned = redact_and_assert(event, extra_sentinels=self.sentinels)
+        self._append_jsonl(self.root / EVALUATION_EVENTS_REL, cleaned)
 
     def write_evaluation(self, name: str, doc: dict[str, Any]) -> None:
         if ".." in name or "/" in name or "\\" in name:
@@ -344,13 +356,19 @@ class AttemptEvidenceStore:
         executor_kind: str,
         model: str,
         invocation_id: str | None = None,
+        surface: str = "agent",
     ) -> InvocationHandle:
+        rel_prefix = EVALUATION_INVOCATIONS_REL if surface == "evaluate" else AGENT_INVOCATIONS_REL
         with self._lock:
-            self._seq += 1
-            seq = self._seq
+            if surface == "evaluate":
+                self._eval_seq += 1
+                seq = self._eval_seq
+            else:
+                self._seq += 1
+                seq = self._seq
             inv_id = invocation_id or f"inv_{uuid.uuid4().hex[:16]}"
             dirname = invocation_dir_name(seq, inv_id)
-            directory = self.root / "agent" / "invocations" / dirname
+            directory = self.root / rel_prefix / dirname
             directory.mkdir(parents=True, exist_ok=False)
             started = _utc_now()
             handle = InvocationHandle(
@@ -363,6 +381,7 @@ class AttemptEvidenceStore:
                 model=model,
                 attempt_id=self.attempt_id,
                 started_at=started,
+                rel_prefix=rel_prefix,
             )
             meta = {
                 "schema": METADATA_SCHEMA_VERSION,
@@ -379,25 +398,35 @@ class AttemptEvidenceStore:
                 "error": None,
                 "event_schema": "ageval.trajectory.event/1",
                 "event_count": 0,
+                "surface": surface,
             }
             _atomic_write_json(directory / "metadata.json", meta)
             # Empty events file for append-only contract.
             (directory / "events.jsonl").write_text("", encoding="utf-8")
             self._invocations[inv_id] = handle
-            self.append_agent_index(
-                {
-                    "type": "invocation_begin",
-                    "invocation_id": inv_id,
-                    "seq": seq,
-                    "profile_id": profile_id,
-                    "executor_kind": executor_kind,
-                    "started_at": started,
-                }
-            )
+            begin = {
+                "type": "invocation_begin",
+                "invocation_id": inv_id,
+                "seq": seq,
+                "profile_id": profile_id,
+                "executor_kind": executor_kind,
+                "started_at": started,
+                "surface": surface,
+            }
+            if surface == "evaluate":
+                self.append_evaluation_index(begin)
+            else:
+                self.append_agent_index(begin)
             return handle
 
     def list_invocations(self) -> list[Path]:
-        base = self.root / "agent" / "invocations"
+        return self._list_invocation_dirs(AGENT_INVOCATIONS_REL)
+
+    def list_evaluation_invocations(self) -> list[Path]:
+        return self._list_invocation_dirs(EVALUATION_INVOCATIONS_REL)
+
+    def _list_invocation_dirs(self, rel: str) -> list[Path]:
+        base = self.root / rel
         if not base.is_dir():
             return []
         return sorted(p for p in base.iterdir() if p.is_dir())

--- a/src/ageval/evidence/trajectory.py
+++ b/src/ageval/evidence/trajectory.py
@@ -16,6 +16,8 @@ from typing import Any
 from ageval.evidence.schema import EVENT_SCHEMA_VERSION
 
 TRAJECTORY_FILENAME = "trajectory.jsonl"
+OBSERVATION_FILENAME = "observation.jsonl"
+OBSERVATION_REL = "evaluation/observation.jsonl"
 _TOOL_PHASES = frozenset({"start", "update"})
 
 
@@ -42,6 +44,28 @@ def write_attempt_trajectory(
     return path
 
 
+def write_evaluation_observation(
+    run_dir: Path,
+    turns: list[list[dict[str, Any]]],
+    *,
+    redaction_sentinels: tuple[str, ...] | list[str] | None = None,
+) -> Path:
+    """Write evaluate-phase layer C. Observational — never PASS.
+
+    Absent turns must not create the file (no-SDK evaluators stay on the
+    result.json + evaluation/ tree).
+    """
+    from ageval.evidence.redaction import redact_value
+
+    sentinels = tuple(s for s in (redaction_sentinels or ()) if s)
+    rows = [redact_value(row, extra_sentinels=sentinels) for turn in turns for row in turn]
+    path = run_dir / OBSERVATION_REL
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = "".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in rows)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
 def turn_rows(
     *,
     prompt: str,
@@ -53,6 +77,7 @@ def turn_rows(
     ok: bool,
     error: str | None,
     metadata: dict[str, Any] | None = None,
+    include_user: bool = True,
 ) -> list[dict[str, Any]]:
     """Fold one invocation's events into turn-level training rows.
 
@@ -61,6 +86,9 @@ def turn_rows(
 
     Row order: user → (thought? → tool_call → observation)* →
     assistant (final) → permission* → terminal.
+
+    ``include_user=False`` omits the user row (evaluate-phase observation:
+    judge prompts often embed hidden reference text).
 
     ``profile_id`` on every row is the package role
     (``Agent.session(profile_id)``), not chat ``role``.
@@ -102,16 +130,18 @@ def turn_rows(
     if producer is None:
         producer = "ageval"
 
-    lines: list[dict[str, Any]] = [
-        {
-            "type": "turn",
-            "role": "user",
-            "content": prompt,
-            "turn_index": turn_index,
-            "session_id": session_id,
-            "source": "ageval",
-        }
-    ]
+    lines: list[dict[str, Any]] = []
+    if include_user:
+        lines.append(
+            {
+                "type": "turn",
+                "role": "user",
+                "content": prompt,
+                "turn_index": turn_index,
+                "session_id": session_id,
+                "source": "ageval",
+            }
+        )
 
     def flush_thought() -> None:
         content = "".join(thought_parts)

--- a/src/ageval/runtime/agent_service_protocol.py
+++ b/src/ageval/runtime/agent_service_protocol.py
@@ -65,6 +65,10 @@ class AgentServiceServer:
         self._thread = threading.Thread(target=self._loop, name="ageval-agent-service", daemon=True)
         self._thread.start()
 
+    def seal_run(self) -> None:
+        """Close run-phase sessions; leave the socket up for evaluate."""
+        self.service.seal_run()
+
     def stop(self) -> None:
         """Close every session, then the socket. No Agent can write after this."""
         for session_id in self.service.open_session_ids():

--- a/src/ageval/runtime/parent_agent.py
+++ b/src/ageval/runtime/parent_agent.py
@@ -122,6 +122,8 @@ class ParentAgentService:
     invocations_completed: int = 0
     _sessions: dict[str, SessionBinding] = field(default_factory=dict, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    _run_sealed: bool = field(default=False, repr=False)
+    _run_profile_ids: set[str] = field(default_factory=set, repr=False)
 
     def __post_init__(self) -> None:
         if self.invoke_quota is None:
@@ -131,9 +133,29 @@ class ParentAgentService:
 
     # --- sessions ------------------------------------------------------------
 
+    def seal_run(self) -> None:
+        """Stop solver writers; keep the socket so evaluate can still invoke.
+
+        Profiles that already opened a session during run may not invoke after
+        gold lands. New profiles (e.g. ``judge``) still may.
+        """
+        with self._lock:
+            self._run_sealed = True
+            self._run_profile_ids = {binding.profile_id for binding in self._sessions.values()}
+            session_ids = [sid for sid, binding in self._sessions.items() if not binding.closed]
+        for session_id in session_ids:
+            self.close_session(session_id=session_id)
+
     def open_session(self, *, profile_id: str, actor_id: str | None = None) -> dict[str, Any]:
         if self._wall_expired():
             return {"ok": False, "error": "wall_time_exceeded", "profile_id": profile_id}
+        with self._lock:
+            if self._run_sealed and profile_id in self._run_profile_ids:
+                return {
+                    "ok": False,
+                    "error": "solver_writers_stopped",
+                    "profile_id": profile_id,
+                }
         actor = str(actor_id).strip() if actor_id and str(actor_id).strip() else None
         try:
             bound = self.binder.bind(profile_id)
@@ -417,6 +439,7 @@ class ParentAgentService:
             profile_id=binding.profile_id,
             executor_kind=binding.executor_kind,
             model=binding.model,
+            surface="evaluate" if self._run_sealed else "agent",
         )
         try:
             write_invoke_request(

--- a/src/ageval/viewer/server.py
+++ b/src/ageval/viewer/server.py
@@ -349,6 +349,13 @@ def make_handler(
                             trials.trial_trajectory(root, job_id, task_id, run_id),
                         )
                         return
+                    if len(parts) == 6 and parts[5] == "observation":
+                        _json(
+                            self,
+                            200,
+                            trials.trial_evaluation_observation(root, job_id, task_id, run_id),
+                        )
+                        return
             except ConfigError as exc:
                 status = 404 if "unknown" in exc.error_code else 400
                 _error(self, status, exc.error_code, str(exc))

--- a/src/ageval/viewer/trials/__init__.py
+++ b/src/ageval/viewer/trials/__init__.py
@@ -19,7 +19,7 @@ from ageval.viewer.trials.constants import (
 from ageval.viewer.trials.fs import trial_file, trial_tree
 from ageval.viewer.trials.meta import get_trial, list_task_trials
 from ageval.viewer.trials.paths import parse_query, resolve_evidence_root
-from ageval.viewer.trials.trajectory import trial_trajectory
+from ageval.viewer.trials.trajectory import trial_evaluation_observation, trial_trajectory
 from ageval.viewer.trials.usage import _usage_summary_for_actor
 
 __all__ = [
@@ -33,6 +33,7 @@ __all__ = [
     "parse_query",
     "resolve_evidence_root",
     "trial_file",
+    "trial_evaluation_observation",
     "trial_trajectory",
     "trial_tree",
     "_usage_summary_for_actor",

--- a/src/ageval/viewer/trials/trajectory.py
+++ b/src/ageval/viewer/trials/trajectory.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from ageval.evidence.trajectory import TRAJECTORY_FILENAME
+from ageval.evidence.trajectory import OBSERVATION_REL, TRAJECTORY_FILENAME
 from ageval.evidence.usage import terminal_extra
 from ageval.viewer.jobs import get_job, safe_id_segment
 from ageval.viewer.trials.constants import MAX_JSONL_LINE, MAX_TRAJECTORY_STEPS
@@ -98,6 +98,56 @@ def trial_trajectory(
         "steps": steps,
         "step_count": len(steps),
         "invocations": invocations,
+        "truncated": truncated,
+        "note": None,
+    }
+
+
+def trial_evaluation_observation(
+    dataset_root: Path,
+    job_id: str,
+    task_id: str,
+    run_id: str,
+) -> dict[str, Any]:
+    """Verifier steps from ``evaluation/observation.jsonl``. Missing file → no steps."""
+    root = dataset_root.expanduser().resolve(strict=False)
+    safe_id_segment(job_id, field="job_id")
+    task_id = safe_id_segment(task_id, field="task_id")
+    rid = _safe_run_id(run_id)
+    get_job(root, job_id)
+    evidence = resolve_evidence_root(root, rid, task_id=task_id, require_task_match=True)
+    path = evidence / OBSERVATION_REL
+    rows = _parse_trajectory_jsonl(path) if path.is_file() else []
+    truncated = len(rows) >= MAX_TRAJECTORY_STEPS
+    steps: list[dict[str, Any]] = []
+    for entry in rows:
+        meta_raw = entry.get("metadata")
+        row_meta: dict[str, Any] = dict(meta_raw) if isinstance(meta_raw, dict) else {}
+        parsed_pid = entry.get("profile_id") if isinstance(entry.get("profile_id"), str) else None
+        meta_pid = (
+            row_meta.get("profile_id") if isinstance(row_meta.get("profile_id"), str) else None
+        )
+        elapsed = entry.get("elapsed_ms")
+        if elapsed is None:
+            lat = row_meta.get("latency_ms")
+            if isinstance(lat, (int, float)) and not isinstance(lat, bool):
+                elapsed = lat
+        steps.append(
+            {
+                **entry,
+                "elapsed_ms": elapsed,
+                "profile_id": parsed_pid or meta_pid,
+                "model": row_meta.get("model") if isinstance(row_meta.get("model"), str) else None,
+            }
+        )
+    _backfill_profile_ids(steps)
+    return {
+        "ok": True,
+        "run_id": rid,
+        "task_id": task_id,
+        "steps": steps,
+        "step_count": len(steps),
+        "invocations": [],
         "truncated": truncated,
         "note": None,
     }

--- a/tests/acceptance/test_eval_judge_observation.py
+++ b/tests/acceptance/test_eval_judge_observation.py
@@ -146,6 +146,9 @@ def test_opt_in_judge_writes_observation_not_trajectory(tmp_path: Path) -> None:
         assert any(row.get("profile_id") == "judge" for row in rows)
         assert any(row.get("type") == "terminal" for row in rows)
         assert "ignored-verdict" in dumped_obs
+        traj_rows = [json.loads(line) for line in dumped_traj.splitlines() if line.strip()]
+        assert all(row.get("profile_id") != "judge" for row in traj_rows)
+        assert "ignored-verdict" not in dumped_traj
         assert not (run_dir / "evaluation" / "evaluator_raw.json").exists()
         result_doc = json.loads((run_dir / "result.json").read_text(encoding="utf-8"))
         assert result_doc["status"] == "PASS"

--- a/tests/acceptance/test_eval_judge_observation.py
+++ b/tests/acceptance/test_eval_judge_observation.py
@@ -1,0 +1,154 @@
+"""Opt-in evaluator SDK invoke writes evaluation/observation.jsonl."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+
+REPO = Path(__file__).resolve().parents[2]
+FIXTURE = REPO / "tests" / "fixtures" / "datasets" / "eval-judge-min"
+GOLD = "secret-gold-token-eval-judge"
+
+
+def _ageval(env: dict[str, str], *args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "ageval.cli.main", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        env=env,
+        timeout=180,
+    )
+
+
+def _serve_judge() -> tuple[ThreadingHTTPServer, str]:
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length") or 0)
+            self.rfile.read(length)
+            raw = json.dumps(
+                {"choices": [{"message": {"role": "assistant", "content": "ignored-verdict"}}]}
+            ).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+            del format, args
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    return server, f"http://{host}:{port}/v1"
+
+
+def _run_dir(dataset: Path, result: dict[str, object]) -> Path:
+    logs = str(result.get("logs") or result.get("evidence_path") or "")
+    root = dataset / logs if logs else dataset / ".ageval" / "runs"
+    if root.is_file():
+        return root.parent
+    if (root / "result.json").is_file():
+        return root
+    runs = dataset / ".ageval" / "runs"
+    found = sorted(p for p in runs.rglob("result.json"))
+    assert found, f"no result.json under {runs}"
+    return found[-1].parent
+
+
+def test_lock_mixed_acp_and_openai_http_on_judge_fixture() -> None:
+    env = os.environ.copy()
+    proc = _ageval(
+        env,
+        "lock",
+        str(FIXTURE),
+        "--task",
+        "judge-score",
+        "--profiles",
+        str(FIXTURE / "profiles.mixed.yaml"),
+        cwd=FIXTURE,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    data = json.loads(proc.stdout)
+    bindings = data["extension_bindings"]
+    assert bindings["solver"]["slots"]["executor"]["plugin"] == "acp"
+    assert bindings["judge"]["slots"]["executor"]["plugin"] == "openai-http"
+    overlay = data["job_overlay"]["agent_profiles"]
+    assert overlay["solver"]["api_key"] != overlay["judge"]["api_key"]
+    assert "sk-" not in json.dumps(data)
+
+
+def test_no_sdk_evaluator_has_no_observation_jsonl(tmp_path: Path) -> None:
+    dataset = Path(
+        shutil.copytree(FIXTURE, tmp_path / "no-sdk", ignore=shutil.ignore_patterns(".ageval"))
+    )
+    (dataset / "tasks" / "judge-score" / "evaluator.py").write_text(
+        "from pathlib import Path\n"
+        "import json\n"
+        "def evaluate(inputs):\n"
+        "    data = json.loads(Path(inputs['artifacts']['result']).read_text())\n"
+        "    ok = data.get('ok') is True\n"
+        "    return {'status': 'PASS' if ok else 'FAIL', 'score': 1.0 if ok else 0.0}\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.pop("AGEVAL_OFFLINE_AGENT", None)
+    env["SOLVER_API_KEY"] = "ci-solver-locator"
+    env["JUDGE_API_KEY"] = "ci-judge-locator"
+    env["SOLVER_BASE_URL"] = "http://127.0.0.1:9/v1"
+    env["JUDGE_BASE_URL"] = "http://127.0.0.1:9/v1"
+    ran = _ageval(env, "run", str(dataset), "--task", "judge-score", cwd=dataset)
+    assert ran.returncode == 0, ran.stderr or ran.stdout
+    result = json.loads(ran.stdout)
+    run_dir = _run_dir(dataset, result)
+    assert result["status"] == "PASS"
+    assert not (run_dir / "evaluation" / "observation.jsonl").exists()
+    assert (run_dir / "result.json").is_file()
+
+
+def test_opt_in_judge_writes_observation_not_trajectory(tmp_path: Path) -> None:
+    dataset = Path(
+        shutil.copytree(FIXTURE, tmp_path / "eval-judge", ignore=shutil.ignore_patterns(".ageval"))
+    )
+    server, base = _serve_judge()
+    env = os.environ.copy()
+    env.pop("AGEVAL_OFFLINE_AGENT", None)
+    env["SOLVER_API_KEY"] = "ci-solver-locator"
+    env["JUDGE_API_KEY"] = "ci-judge-locator"
+    env["SOLVER_BASE_URL"] = base
+    env["JUDGE_BASE_URL"] = base
+    try:
+        ran = _ageval(env, "run", str(dataset), "--task", "judge-score", cwd=dataset)
+        assert ran.returncode == 0, ran.stderr or ran.stdout
+        result = json.loads(ran.stdout)
+        assert result["status"] == "PASS"
+        assert result.get("metrics", {}).get("exact") == 1
+        run_dir = _run_dir(dataset, result)
+        obs = run_dir / "evaluation" / "observation.jsonl"
+        traj = run_dir / "trajectory.jsonl"
+        assert obs.is_file()
+        dumped_obs = obs.read_text(encoding="utf-8")
+        dumped_traj = traj.read_text(encoding="utf-8") if traj.is_file() else ""
+        assert GOLD not in dumped_obs
+        assert GOLD not in dumped_traj
+        rows = [json.loads(line) for line in dumped_obs.splitlines() if line.strip()]
+        assert rows
+        assert all(row.get("role") != "user" for row in rows)
+        assert any(row.get("profile_id") == "judge" for row in rows)
+        assert any(row.get("type") == "terminal" for row in rows)
+        assert "ignored-verdict" in dumped_obs
+        assert not (run_dir / "evaluation" / "evaluator_raw.json").exists()
+        result_doc = json.loads((run_dir / "result.json").read_text(encoding="utf-8"))
+        assert result_doc["status"] == "PASS"
+        assert "ignored-verdict" not in json.dumps(result_doc)
+    finally:
+        server.shutdown()

--- a/tests/attempt/test_eval_seal_phases.py
+++ b/tests/attempt/test_eval_seal_phases.py
@@ -199,6 +199,53 @@ async def test_seal_winner_writes_after_collect(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_record_seals_evaluate_invokes_to_observation_not_trajectory(
+    tmp_path: Path,
+) -> None:
+    import json
+
+    registry = ExtensionRegistry()
+    register_defaults(registry)
+    graph = resolve(BindingIntent(profile_id="solver"), registry)
+    ctx = _ctx(tmp_path, registry=registry, graph=graph)
+    agent = ctx.evidence.root / "agent" / "invocations" / "0001-solver"
+    agent.mkdir(parents=True)
+    (agent / "metadata.json").write_text(
+        '{"seq": 1, "status": "completed", "profile_id": "solver"}',
+        encoding="utf-8",
+    )
+    (agent / "final-response.json").write_text('{"content": "done"}', encoding="utf-8")
+    (agent / "request.json").write_text(
+        '{"messages": [{"content": "solve this"}]}',
+        encoding="utf-8",
+    )
+    (agent / "events.jsonl").write_text("", encoding="utf-8")
+    judge = ctx.evidence.root / "evaluation" / "invocations" / "0001-judge"
+    judge.mkdir(parents=True)
+    (judge / "metadata.json").write_text(
+        '{"seq": 1, "status": "completed", "profile_id": "judge"}',
+        encoding="utf-8",
+    )
+    (judge / "final-response.json").write_text('{"content": "1.0"}', encoding="utf-8")
+    (judge / "request.json").write_text(
+        '{"messages": [{"content": "hidden gold body"}]}',
+        encoding="utf-8",
+    )
+    (judge / "events.jsonl").write_text("", encoding="utf-8")
+    await record.run(ctx)
+    traj = (ctx.evidence.root / "trajectory.jsonl").read_text(encoding="utf-8")
+    obs = (ctx.evidence.root / "evaluation" / "observation.jsonl").read_text(encoding="utf-8")
+    assert "solve this" in traj
+    assert "hidden gold body" not in traj
+    assert "hidden gold body" not in obs
+    assert "1.0" in obs
+    assert '"profile_id": "judge"' in obs
+    assert not any(
+        json.loads(line).get("role") == "user" for line in obs.splitlines() if line.strip()
+    )
+
+
+@pytest.mark.asyncio
 async def test_collect_usage_extra_lands_on_terminal(tmp_path: Path) -> None:
     import json
 

--- a/tests/config/test_load_and_lock.py
+++ b/tests/config/test_load_and_lock.py
@@ -84,6 +84,47 @@ def test_payload_holds_no_secret_and_no_host_path() -> None:
     assert str(CONFIG_MIN.resolve()) not in blob
 
 
+def test_lock_binds_executor_per_profile_mixed_mechanisms(tmp_path: Path) -> None:
+    yaml = TASK_YAML.replace(
+        "agent_profiles:\n  - id: solver",
+        "agent_profiles:\n  - id: solver\n  - id: judge",
+    )
+    root = _standalone(tmp_path / "pkg", task_yaml=yaml, files=("run.py", "evaluator.py"))
+    locked = lock_standalone(
+        root,
+        "minimal",
+        job=job_document(
+            {
+                "solver": {**SOLVER, "api_key": "${SOLVER_API_KEY}"},
+                "judge": {
+                    "executor": "openai-http",
+                    "model": "gpt-4.1-mini",
+                    "api_key": "${JUDGE_API_KEY}",
+                    "base_url": "http://127.0.0.1:9/v1",
+                    "extensions": [{"plugin": "openai-http"}, {"plugin": "local"}],
+                },
+            }
+        ),
+    )
+    bindings = thaw(locked.extension_bindings)
+    assert bindings["solver"]["slots"]["executor"]["plugin"] == "acp"
+    assert bindings["judge"]["slots"]["executor"]["plugin"] == "openai-http"
+    assert bindings["solver"]["slots"]["environment"]["plugin"] == "local"
+    assert bindings["judge"]["slots"]["environment"]["plugin"] == "local"
+    overlay = thaw(locked.job_overlay)["agent_profiles"]
+    assert overlay["solver"]["api_key"] == "SOLVER_API_KEY"
+    assert overlay["judge"]["api_key"] == "JUDGE_API_KEY"
+    blob = str(locked.canonical_payload())
+    assert "sk-" not in blob
+
+
+def test_lock_does_not_require_undeclared_judge_profile() -> None:
+    locked = lock_task(CONFIG_MIN, "minimal")
+    ids = [str(row.get("id")) for row in thaw(locked.agent_profiles)]
+    assert ids == ["solver"]
+    assert "judge" not in (thaw(locked.extension_bindings) or {})
+
+
 # --- immutability ----------------------------------------------------------
 
 

--- a/tests/evidence/test_invocation_layout.py
+++ b/tests/evidence/test_invocation_layout.py
@@ -56,6 +56,23 @@ def test_minimal_fields_present(tmp_path: Path) -> None:
     final = json.loads((d / "final-response.json").read_text(encoding="utf-8"))
     assert final["structured_output"]["answer"] == 42
     assert (d / "stderr.txt").read_text(encoding="utf-8").startswith("diag")
+    assert h.relative_path.startswith("agent/invocations/")
+
+
+def test_evaluate_surface_lives_under_evaluation(tmp_path: Path) -> None:
+    store = AttemptEvidenceStore(root=tmp_path / "e", attempt_id="attempt_y")
+    agent = store.begin_invocation(profile_id="solver", executor_kind="acp", model="m")
+    judge = store.begin_invocation(
+        profile_id="judge",
+        executor_kind="openai-http",
+        model="g",
+        surface="evaluate",
+    )
+    assert agent.relative_path.startswith("agent/invocations/")
+    assert judge.relative_path.startswith("evaluation/invocations/")
+    assert store.list_invocations() == [agent.directory]
+    assert store.list_evaluation_invocations() == [judge.directory]
+    assert not (tmp_path / "e" / "agent" / "invocations" / judge.directory.name).exists()
 
 
 def test_append_supplement_after_seal(tmp_path: Path) -> None:

--- a/tests/evidence/test_slim.py
+++ b/tests/evidence/test_slim.py
@@ -56,6 +56,10 @@ def test_is_vendor_raw_rel() -> None:
     assert not is_vendor_raw_rel("result.json")
     assert not is_vendor_raw_rel("summary.json")
     assert not is_vendor_raw_rel("task-artifacts/out.txt")
+    assert not is_vendor_raw_rel("evaluation/observation.jsonl")
+    assert is_vendor_raw_rel("evaluation/events.jsonl")
+    assert is_vendor_raw_rel("evaluation/invocations/001/request.json")
+    assert is_vendor_raw_rel("evaluation/invocations/001/backend_raw/raw.json")
 
 
 def test_slim_deletes_vendor_raw_keeps_jsonl(tmp_path: Path) -> None:
@@ -75,6 +79,29 @@ def test_slim_deletes_vendor_raw_keeps_jsonl(tmp_path: Path) -> None:
     assert not (inv / "metadata.json").exists()
     assert not (root / "agent" / "events.jsonl").exists()
     assert not (root / "evaluation" / "evaluator_raw.json").exists()
+
+
+def test_slim_keeps_observation_jsonl_drops_eval_vendor_raw(tmp_path: Path) -> None:
+    root = tmp_path / "run"
+    root.mkdir()
+    eval_inv = root / "evaluation" / "invocations" / "0001-judge"
+    eval_inv.mkdir(parents=True)
+    (eval_inv / "request.json").write_text('{"messages":[{"content":"gold"}]}\n', encoding="utf-8")
+    (eval_inv / "events.jsonl").write_text("{}\n", encoding="utf-8")
+    (eval_inv / "backend_raw").mkdir()
+    (eval_inv / "backend_raw" / "raw.json").write_text("{}\n", encoding="utf-8")
+    (root / "evaluation" / "events.jsonl").write_text("{}\n", encoding="utf-8")
+    (root / "evaluation" / "evaluator_raw.json").write_text("{}\n", encoding="utf-8")
+    (root / "evaluation" / "observation.jsonl").write_text(
+        '{"type":"terminal","profile_id":"judge"}\n', encoding="utf-8"
+    )
+    slim_sealed_attempt(root)
+    assert (root / "evaluation" / "observation.jsonl").is_file()
+    assert not (root / "evaluation" / "evaluator_raw.json").exists()
+    assert not (root / "evaluation" / "events.jsonl").exists()
+    assert eval_inv.is_dir()
+    assert not (eval_inv / "request.json").exists()
+    assert not (eval_inv / "backend_raw").exists()
 
 
 @pytest.mark.asyncio
@@ -125,6 +152,12 @@ def test_archive_skips_vendor_raw_unless_flag(tmp_path: Path) -> None:
     (run_dir / "lock.json").write_text("{}\n", encoding="utf-8")
     (run_dir / "result.json").write_text("{}\n", encoding="utf-8")
     (run_dir / "trajectory.jsonl").write_text("{}\n", encoding="utf-8")
+    (run_dir / "evaluation").mkdir()
+    (run_dir / "evaluation" / "observation.jsonl").write_text("{}\n", encoding="utf-8")
+    (run_dir / "evaluation" / "evaluator_raw.json").write_text("{}\n", encoding="utf-8")
+    eval_inv = run_dir / "evaluation" / "invocations" / "001"
+    eval_inv.mkdir(parents=True)
+    (eval_inv / "request.json").write_text("{}\n", encoding="utf-8")
     inv = run_dir / "agent" / "invocations" / "001"
     inv.mkdir(parents=True)
     (inv / "request.json").write_text("{}\n", encoding="utf-8")
@@ -150,6 +183,11 @@ def test_archive_skips_vendor_raw_unless_flag(tmp_path: Path) -> None:
     fat_names = names(fat)
     assert f"{prefix}/trajectory.jsonl" in slim_names
     assert f"{prefix}/lock.json" in slim_names
+    assert f"{prefix}/evaluation/observation.jsonl" in slim_names
+    assert f"{prefix}/evaluation/evaluator_raw.json" not in slim_names
+    assert f"{prefix}/evaluation/invocations/001/request.json" not in slim_names
+    assert f"{prefix}/evaluation/evaluator_raw.json" in fat_names
+    assert f"{prefix}/evaluation/invocations/001/request.json" in fat_names
     assert not any("backend_raw" in n for n in slim_names)
     assert not any(n.endswith("/request.json") for n in slim_names)
     assert f"{prefix}/agent/invocations/001/request.json" in fat_names

--- a/tests/evidence/test_trajectory_fold.py
+++ b/tests/evidence/test_trajectory_fold.py
@@ -7,7 +7,11 @@ from pathlib import Path
 from typing import Any
 
 from ageval.evidence.schema import EVENT_SCHEMA_VERSION
-from ageval.evidence.trajectory import turn_rows, write_attempt_trajectory
+from ageval.evidence.trajectory import (
+    turn_rows,
+    write_attempt_trajectory,
+    write_evaluation_observation,
+)
 from ageval.plugins.contrib.acp.trajectory_map import acp_session_events_to_ageval
 
 
@@ -1004,3 +1008,36 @@ def test_write_attempt_keeps_invoke_order_across_profiles(tmp_path: Path) -> Non
     ]
     assert lines[2]["turn_index"] == 1
     assert lines[5]["turn_index"] == 2
+
+
+def test_evaluation_observation_omits_user_row(tmp_path: Path) -> None:
+    rows = turn_rows(
+        prompt="hidden gold body",
+        events=(
+            {
+                "schema": EVENT_SCHEMA_VERSION,
+                "seq": 1,
+                "source": "openai-http",
+                "kind": "text",
+                "channel": "assistant",
+                "text": "score 1",
+            },
+        ),
+        final_text="score 1",
+        structured=None,
+        usage={"prompt_tokens": 2, "completion_tokens": 1},
+        extra=None,
+        ok=True,
+        error=None,
+        metadata={"profile_id": "judge", "turn_index": 1, "executor_kind": "openai-http"},
+        include_user=False,
+    )
+    roles = [row.get("role") for row in rows if row.get("type") == "turn"]
+    assert "user" not in roles
+    assert any(row.get("type") == "terminal" for row in rows)
+    assert all("hidden gold body" not in json.dumps(row) for row in rows)
+    path = write_evaluation_observation(tmp_path / "run", [rows])
+    assert path == tmp_path / "run" / "evaluation" / "observation.jsonl"
+    dumped = path.read_text(encoding="utf-8")
+    assert "hidden gold body" not in dumped
+    assert '"role": "assistant"' in dumped

--- a/tests/fixtures/datasets/eval-judge-min/ageval.yaml
+++ b/tests/fixtures/datasets/eval-judge-min/ageval.yaml
@@ -1,0 +1,6 @@
+format: ageval.dataset/1
+dataset_id: test/eval-judge-min
+version: "0.1.0"
+description: Opt-in evaluator SDK invoke (LLM-as-judge) fixture
+tasks:
+  root: tasks

--- a/tests/fixtures/datasets/eval-judge-min/profiles.mixed.yaml
+++ b/tests/fixtures/datasets/eval-judge-min/profiles.mixed.yaml
@@ -1,0 +1,20 @@
+format: ageval.profiles/1
+environment: local
+agent_profiles:
+  solver:
+    executor: acp
+    model: entry-default
+    api_key: ${SOLVER_API_KEY}
+    options:
+      entry: codex
+    extensions:
+      - plugin: acp
+      - plugin: local
+  judge:
+    executor: openai-http
+    model: mock
+    api_key: ${JUDGE_API_KEY}
+    base_url: ${JUDGE_BASE_URL}
+    extensions:
+      - plugin: openai-http
+      - plugin: local

--- a/tests/fixtures/datasets/eval-judge-min/profiles.yaml
+++ b/tests/fixtures/datasets/eval-judge-min/profiles.yaml
@@ -1,0 +1,19 @@
+format: ageval.profiles/1
+environment: local
+agent_profiles:
+  solver:
+    executor: openai-http
+    model: mock
+    api_key: ${SOLVER_API_KEY}
+    base_url: ${SOLVER_BASE_URL}
+    extensions:
+      - plugin: openai-http
+      - plugin: local
+  judge:
+    executor: openai-http
+    model: mock
+    api_key: ${JUDGE_API_KEY}
+    base_url: ${JUDGE_BASE_URL}
+    extensions:
+      - plugin: openai-http
+      - plugin: local

--- a/tests/fixtures/datasets/eval-judge-min/tasks/judge-score/evaluation/expected.json
+++ b/tests/fixtures/datasets/eval-judge-min/tasks/judge-score/evaluation/expected.json
@@ -1,0 +1,1 @@
+{"label": "secret-gold-token-eval-judge"}

--- a/tests/fixtures/datasets/eval-judge-min/tasks/judge-score/evaluator.py
+++ b/tests/fixtures/datasets/eval-judge-min/tasks/judge-score/evaluator.py
@@ -1,0 +1,37 @@
+"""Opt-in judge invoke. Verdict still comes from this return value, not judge text."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+
+async def _invoke(agent: Any, prompt: str) -> Any:
+    async with agent.session("judge") as session:
+        return await session.invoke(prompt)
+
+
+def evaluate(inputs: dict[str, Any]) -> dict[str, Any]:
+    raw = (inputs.get("artifacts") or {}).get("result")
+    if not raw:
+        return {"status": "FAIL", "score": 0.0, "metrics": {"reason": "result_missing"}}
+    data = json.loads(Path(str(raw)).read_text(encoding="utf-8"))
+    gold = Path(str(inputs["evaluation_dir"])) / "expected.json"
+    gold_text = gold.read_text(encoding="utf-8") if gold.is_file() else ""
+    agent = inputs.get("agent")
+    judge_ok = False
+    if agent is not None:
+        prompt = (
+            "Hidden reference (must not appear as a user row in observation.jsonl):\n"
+            f"{gold_text}\nArtifact:\n{json.dumps(data)}\nReply with a score."
+        )
+        reply = asyncio.run(_invoke(agent, prompt))
+        judge_ok = bool(reply.get("ok"))
+    ok = data.get("ok") is True
+    return {
+        "status": "PASS" if ok else "FAIL",
+        "score": 1.0 if ok else 0.0,
+        "metrics": {"exact": 1 if ok else 0, "judge_ok": judge_ok},
+    }

--- a/tests/fixtures/datasets/eval-judge-min/tasks/judge-score/run.py
+++ b/tests/fixtures/datasets/eval-judge-min/tasks/judge-score/run.py
@@ -1,0 +1,10 @@
+"""Solver path: publish an artifact. Does not open a judge session."""
+
+from __future__ import annotations
+
+from ageval_sdk import RunContext, RunTerminal
+
+
+async def run(ctx: RunContext) -> RunTerminal:
+    ctx.publish_json("result", {"ok": True})
+    return RunTerminal.completed("ok")

--- a/tests/fixtures/datasets/eval-judge-min/tasks/judge-score/task.yaml
+++ b/tests/fixtures/datasets/eval-judge-min/tasks/judge-score/task.yaml
@@ -1,0 +1,20 @@
+format: ageval.task/1
+task_id: judge-score
+description: Solver publishes an artifact; evaluator may invoke a judge profile.
+parameters:
+  seed: 1
+  active_profile: solver
+agent_profiles:
+  - id: solver
+  - id: judge
+limits:
+  wall_time_seconds: 60
+  agent_invocations: 2
+artifacts:
+  publishable:
+    - id: result
+      path: artifacts/result.json
+evaluation:
+  inputs:
+    - artifact: result
+      target: artifacts/result.json

--- a/tests/helpers/agent_binding.py
+++ b/tests/helpers/agent_binding.py
@@ -73,9 +73,18 @@ class ScriptedExecutor:
 class ScriptedBinder(AgentBinder):
     """Binds one declared profile id to a fixed executor instance."""
 
-    def __init__(self, executor: Any, *, profile_id: str = "solver") -> None:
+    def __init__(
+        self,
+        executor: Any,
+        *,
+        profile_id: str = "solver",
+        extra_profiles: tuple[str, ...] = (),
+    ) -> None:
+        rows = ({"id": profile_id, "executor": ScriptedExecutor.kind},) + tuple(
+            {"id": name, "executor": ScriptedExecutor.kind} for name in extra_profiles
+        )
         super().__init__(
-            profiles=({"id": profile_id, "executor": ScriptedExecutor.kind},),
+            profiles=rows,
             services=ServiceTable(),
             registry=ExtensionRegistry(),
         )

--- a/tests/plugins/test_acp_timeout_events.py
+++ b/tests/plugins/test_acp_timeout_events.py
@@ -38,7 +38,9 @@ def _executor(**kwargs: object) -> AcpExecutor:
     )
 
 
-def _timeout_run(ex: AcpExecutor, client: _AgevalAcpClient, monkeypatch: object) -> None:
+def _timeout_run(
+    ex: AcpExecutor, client: _AgevalAcpClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(ex, "_ensure_session", lambda **_k: None)
     n = {"i": 0}
 
@@ -53,7 +55,7 @@ def _timeout_run(ex: AcpExecutor, client: _AgevalAcpClient, monkeypatch: object)
     monkeypatch.setattr(ex, "_run", fake_run)
 
 
-def test_timeout_returns_mapped_tool_events(monkeypatch: object) -> None:
+def test_timeout_returns_mapped_tool_events(monkeypatch: pytest.MonkeyPatch) -> None:
     ex = _executor()
     client = _AgevalAcpClient()
     ex._client = client
@@ -65,7 +67,7 @@ def test_timeout_returns_mapped_tool_events(monkeypatch: object) -> None:
     assert any(ev.get("phase") == "timeout" for ev in result.events)
 
 
-def test_timeout_writes_vendor_jsonl(monkeypatch: object, tmp_path: Path) -> None:
+def test_timeout_writes_vendor_jsonl(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     ex = _executor()
     client = _AgevalAcpClient()
     ex._client = client

--- a/tests/runtime/test_parent_agent.py
+++ b/tests/runtime/test_parent_agent.py
@@ -31,6 +31,7 @@ def _service(
     invoke_timeout_seconds: float = DEFAULT_INVOKE_TIMEOUT_SECONDS,
     evidence: bool = True,
     offline_env: str = "",
+    extra_profiles: tuple[str, ...] = (),
 ) -> tuple[ParentAgentService, ScriptedExecutor]:
     backend = executor or ScriptedExecutor()
     store = (
@@ -40,7 +41,7 @@ def _service(
     )
     service = ParentAgentService(
         attempt_id=ATTEMPT,
-        binder=ScriptedBinder(backend),
+        binder=ScriptedBinder(backend, extra_profiles=extra_profiles),
         agent_invocation_limit=limit,
         evidence_store=store,
         deadline_monotonic=deadline_monotonic,
@@ -128,6 +129,32 @@ def test_session_invokes_carry_turns_and_evidence(tmp_path: Path) -> None:
     assert service.invocations_completed == 2
     assert service.evidence_store is not None
     assert len(service.evidence_store.list_invocations()) == 2
+
+
+def test_seal_run_refuses_solver_and_keeps_judge_on_evaluate_surface(
+    tmp_path: Path,
+) -> None:
+    service, backend = _service(tmp_path, extra_profiles=("judge",))
+    solver = _open(service, "solver")
+    assert service.invoke(session_id=solver, prompt="solve")["ok"] is True
+    assert service.evidence_store is not None
+    assert len(service.evidence_store.list_invocations()) == 1
+    assert service.evidence_store.list_evaluation_invocations() == []
+
+    service.seal_run()
+    refused = service.open_session(profile_id="solver")
+    assert refused["error"] == "solver_writers_stopped"
+    closed = service.invoke(session_id=solver, prompt="after-gold")
+    assert closed["error"] == "session_closed"
+    assert backend.prompts == ["solve"]
+
+    judge = _open(service, "judge")
+    answer = service.invoke(session_id=judge, prompt="GOLD BODY must not be layer C user")
+    assert answer["ok"] is True
+    assert len(service.evidence_store.list_invocations()) == 1
+    eval_dirs = service.evidence_store.list_evaluation_invocations()
+    assert len(eval_dirs) == 1
+    assert "evaluation/invocations/" in str(eval_dirs[0])
 
 
 def test_unknown_profile_never_opens(tmp_path: Path) -> None:

--- a/tests/viewer/test_viewer_trials.py
+++ b/tests/viewer/test_viewer_trials.py
@@ -278,6 +278,45 @@ def test_trajectory_steps(tmp_path: Path) -> None:
     assert all(s.get("profile_id") == "main" for s in traj["steps"])
 
 
+def test_evaluation_observation_steps_not_on_trajectory(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = _seed_suite_run(db)
+    root = _write_evidence(db, "run_alpha_1", task_id="alpha")
+    gold = "secret-gold-token-eval-judge"
+    (root / "evaluation" / "observation.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "turn",
+                "role": "assistant",
+                "content": "score 1",
+                "turn_index": 1,
+                "profile_id": "judge",
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "type": "terminal",
+                "ok": True,
+                "turn_index": 1,
+                "profile_id": "judge",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    obs = trials.trial_evaluation_observation(db, job_id, "alpha", "run_alpha_1")
+    assert obs["step_count"] >= 2
+    assert all(s.get("role") != "user" for s in obs["steps"])
+    assert any(s.get("profile_id") == "judge" for s in obs["steps"])
+    assert gold not in json.dumps(obs)
+    traj = trials.trial_trajectory(db, job_id, "alpha", "run_alpha_1")
+    assert all(s.get("profile_id") != "judge" for s in traj["steps"])
+    (root / "evaluation" / "observation.jsonl").unlink()
+    gone = trials.trial_evaluation_observation(db, job_id, "alpha", "run_alpha_1")
+    assert gone["steps"] == []
+
+
 def test_trajectory_tool_call_and_observation_steps(tmp_path: Path) -> None:
     """Viewer fail-open parses tool_call / observation rows for the panel."""
     db = _clean_db(tmp_path)

--- a/website/content/docs/author/tutorial.en.mdx
+++ b/website/content/docs/author/tutorial.en.mdx
@@ -33,3 +33,5 @@ Do not write `harness:`, `provider:`, or `assurance`. The environment and ACP en
 uv run ageval lock examples/journeys --task hello
 uv run ageval run  examples/journeys --task hello
 ```
+
+Scoring defaults to a script against gold. For LLM-as-judge, add a role on the same `profiles.yaml` and `Agent.session` after gold lands — see [Write an evaluator](/docs/author/write-evaluator).

--- a/website/content/docs/author/tutorial.mdx
+++ b/website/content/docs/author/tutorial.mdx
@@ -48,3 +48,5 @@ uv run ageval run  examples/journeys --task hello
 ```
 
 ACP 缺 entry：先 `ageval executors -v`。详见 [ACP Profiles](/docs/agents/acp-profiles)。
+
+评测默认是脚本比对 gold。若要用 LLM-as-judge，在同一份 `profiles.yaml` 加角色，gold 进盒后再 `Agent.session`；写法见 [编写 Evaluator](/docs/author/write-evaluator)。

--- a/website/content/docs/author/write-evaluator.en.mdx
+++ b/website/content/docs/author/write-evaluator.en.mdx
@@ -35,3 +35,25 @@ evaluation:
 | `tmpfs_mb` | In-environment evaluator `/tmp` only; omit → 32 MiB. Declare a larger sandbox on the **task**, not under `limits` |
 
 The in-environment `evaluator.py` is launched by the exclusive-slot `evaluation_runtime` default winner via `host.exec`. PASS still binds only in the engine. Runtime and evaluation stay separate facts. See [Results and PASS](/docs/reference/results-and-pass).
+
+## Two scoring styles
+
+Default is a **deterministic script**: read published artifacts and gold under `evaluation/`, return `{status, score, metrics}`. No Agent call. No `evaluation/observation.jsonl`. Verifier stays `result.json` plus the file tree.
+
+Optional **LLM-as-judge**: add another role on the same job `profiles.yaml` (e.g. `judge`) and list that id on `task.yaml` `agent_profiles`. After gold is uploaded, `evaluator.py` may `Agent.session("judge").invoke(...)`. The dataset owns the prompt. `invoke` must not override `profile_id` / executor.
+
+```python
+def evaluate(inputs):
+    # inputs["agent"] is injected on a local box (parent socket); omit → script path
+    ...
+    return {"status": "PASS", "score": 1.0, "metrics": {}}
+```
+
+| Point | Note |
+| --- | --- |
+| PASS | Still this return value only. Judge prose / `observation.jsonl` is not a score |
+| Trace | Evaluate-phase steps go to `evaluation/observation.jsonl` (`user` rows omitted so gold stays out of evidence). Not merged into root `trajectory.jsonl` |
+| Budget | `limits.agent_invocations` must cover solver **and** judge |
+| Box | SDK session uses the parent Unix socket; the default projection into the evaluator process is `environment: local` |
+
+No `Agent.session` = today's script path. With observation.jsonl, Verifier reuses the Trajectory step cards; without it, the file tree. See [local Viewer](/docs/run/local-viewer).

--- a/website/content/docs/author/write-evaluator.mdx
+++ b/website/content/docs/author/write-evaluator.mdx
@@ -38,3 +38,27 @@ evaluation:
 | `tmpfs_mb` | 只改环境内 evaluator `/tmp`；省略 32 MiB。大 snapshot 在 **task** 上声明，不要写进 `limits` |
 
 环境内 `evaluator.py` 由独占槽 `evaluation_runtime` 的默认赢家经 `host.exec` 拉起；PASS 仍只经引擎 bind。读结果时 runtime 与 evaluation 是分开的事实。见 [结果与 PASS](/docs/reference/results-and-pass)。
+
+## 两种评测
+
+缺省是**确定性脚本**：读产物和 `evaluation/` 里的 gold，返回 `{status, score, metrics}`。不必调 Agent。没有 `evaluation/observation.jsonl`，Verifier 仍是 `result.json` 与文件树。
+
+可选 **LLM-as-judge**：同一份 job `profiles.yaml` 再写一个角色（如 `judge`），`task.yaml` 的 `agent_profiles` 列入同一 id。gold **已经** upload 之后，`evaluator.py` 可以 `Agent.session("judge").invoke(...)`。提示词归题包。`invoke` 不得改 `profile_id` / executor。
+
+```python
+def evaluate(inputs):
+    # inputs["agent"] 在本机盒子上会注入（parent socket）；没有就走脚本路径
+    ...
+    return {"status": "PASS", "score": 1.0, "metrics": {}}
+```
+
+约束：
+
+| 点 | 说明 |
+| --- | --- |
+| PASS | 仍只看这次返回值；judge 文本 / `observation.jsonl` 不是分数 |
+| 轨迹 | evaluate 相位的步写入 `evaluation/observation.jsonl`（省略 `user` 行，避免 gold 进 evidence）。不并进根 `trajectory.jsonl` |
+| 调用预算 | `limits.agent_invocations` 要覆盖 solver **和** judge |
+| 盒子 | SDK session 走 parent 的 Unix socket；当前默认在 `environment: local` 投影进 evaluator 进程 |
+
+不调 `Agent.session` = 今日脚本路径。Verifier 有 observation 时复用 Trajectory 那种步骤卡片；没有则保持文件树。见 [本地 Viewer](/docs/run/local-viewer)。

--- a/website/content/docs/author/write-run.en.mdx
+++ b/website/content/docs/author/write-run.en.mdx
@@ -10,7 +10,7 @@ description: The task loop lives in the dataset; call the agent through the SDK.
 | loop, roles, tools | PASS, host credentials, isolation |
 | SDK `session` / `invoke` | A vendor SDK as Core |
 
-`RunTerminal.completed` is **not** PASS. Scoring: [write evaluator](/docs/author/write-evaluator).
+`RunTerminal.completed` is **not** PASS. Scoring: [write evaluator](/docs/author/write-evaluator) (deterministic script, or optional LLM-as-judge after gold).
 
 ```python
 from ageval_sdk import RunContext, RunTerminal

--- a/website/content/docs/author/write-run.mdx
+++ b/website/content/docs/author/write-run.mdx
@@ -10,7 +10,7 @@ description: 业务 loop 写在题包里；用 SDK 调 agent。
 | loop、角色、handoff、本地 Tool | 最终 PASS、宿主凭据、自己提隔离 |
 | 经 SDK `session` / `invoke` | 把某家私有 SDK 当 Core |
 
-`RunTerminal.completed` **不等于** PASS。分数在 [写 evaluator](/docs/author/write-evaluator)。
+`RunTerminal.completed` **不等于** PASS。分数在 [写 evaluator](/docs/author/write-evaluator)（确定性脚本，或 gold 之后可选 LLM-as-judge）。
 
 ```python
 from ageval_sdk import RunContext, RunTerminal

--- a/website/content/docs/reference/results-and-pass.en.mdx
+++ b/website/content/docs/reference/results-and-pass.en.mdx
@@ -6,8 +6,8 @@ description: How to read Result; pass@k is a job metric, not suite PASS.
 ## Hard boundaries
 
 1. `run.py` completed **≠** PASS  
-2. Trajectory / tokens / agent self-report **≠** score  
-3. PASS / FAIL comes only from `evaluator.py`  
+2. Trajectory / tokens / agent self-report **≠** score (including `evaluation/observation.jsonl`)  
+3. PASS / FAIL comes only from the `evaluator.py` return value  
 4. Suite / job aggregates (including pass@k) **≠** suite-level PASS authority  
 
 ## On the terminal

--- a/website/content/docs/reference/results-and-pass.mdx
+++ b/website/content/docs/reference/results-and-pass.mdx
@@ -6,8 +6,8 @@ description: Result 怎么读；pass@k 是 job 指标，不是整包 PASS。
 ## 几条硬边界
 
 1. `run.py` 跑完 **≠** PASS  
-2. 轨迹 / token / agent 自述 **≠** 分数  
-3. PASS / FAIL 仅来自 `evaluator.py`  
+2. 轨迹 / token / agent 自述 **≠** 分数（含 `evaluation/observation.jsonl`）  
+3. PASS / FAIL 仅来自 `evaluator.py` 的返回值  
 4. suite / job 汇总（含 pass@k）**≠** 整包 PASS 权威  
 
 ## 终端上

--- a/website/content/docs/run/local-viewer.en.mdx
+++ b/website/content/docs/run/local-viewer.en.mdx
@@ -42,4 +42,6 @@ Timing comes from Attempt `phase_timing` (`prepare` / `run` / `evaluate` / `clea
 Trajectory steps follow the sealed file order: a thought, then the tools that thought invoked, then the next thought. When a sealed step (thought, `tool_call`, or final assistant) carries `elapsed_ms`, the step header shows that duration. Missing timing is omitted — Viewer does not invent it from file mtimes or the page clock.  
 Time / tokens / step duration are **hints**, not PASS. Trajectory is not scoring authority. Each **tool-call** row (and other long rows) can collapse; the observational PASS note has expand-all / collapse-all, matching the Hub Attempt page.
 
+**Verifier:** default is `result.json` plus the `evaluation/` tree. When `evaluation/observation.jsonl` exists (evaluate-phase SDK invoke, LLM-as-judge), that tab reuses the Trajectory step cards. The Agent Trajectory tab still reads only root `trajectory.jsonl`. Observation is not PASS.
+
 Viewer does **not** talk to Registry — see [Hub](/docs/share/hub). SPA details: `apps/viewer/README.md`.

--- a/website/content/docs/run/local-viewer.mdx
+++ b/website/content/docs/run/local-viewer.mdx
@@ -44,4 +44,6 @@ Timing 来自 Attempt `phase_timing`（prepare / run / evaluate / cleanup）；h
 轨迹按密封文件顺序展示：一段 thought，紧接着它调用的工具，再下一段 thought。密封行（thought / `tool_call` / 最终 assistant）若带 `elapsed_ms`，步骤头会显示该步耗时；没有就不画标签——Viewer 不会用文件 mtime 或页面时钟补造。  
 耗时、token、单步耗时 **只是参考**，不是 PASS。轨迹也不是评分依据。Trajectory 里每条 **tool-call**（以及过长行）可折叠；观测 PASS 条上有全部展开 / 全部收起，与 Hub Attempt 页一致。
 
+**Verifier**：缺省是 `result.json` + `evaluation/` 文件树。若有 `evaluation/observation.jsonl`（evaluate 相位 SDK invoke，LLM-as-judge），该页签复用 Trajectory 的步骤卡片；Agent 的 Trajectory 页仍只读根 `trajectory.jsonl`。观察不是 PASS。
+
 Viewer **不连** Registry。远程目录见 [Hub](/docs/share/hub)。改 SPA 看仓库 `apps/viewer/README.md`。


### PR DESCRIPTION
## Summary

Optional LLM-as-judge recording: after gold lands, `evaluator.py` may `Agent.session` a second profile. Those turns seal to `evaluation/observation.jsonl` (no `user` rows) for the Verifier tab. Deterministic script evaluators stay unchanged and produce no observation file. PASS still binds only from the evaluator return value.

## Approach

- Executor stays one exclusive winner **per profile graph**; `environment` remains Attempt-wide. Mixed ACP + `openai-http` already locked; this documents that and keeps Agent Service up through evaluate so a judge profile can invoke.
- Run-phase sessions are sealed at the end of `run`; solver profiles cannot invoke after gold. Evaluate-phase scratch lives under `evaluation/invocations/`, then folds through the existing collect → enrich path into `evaluation/observation.jsonl`.
- Slim/archive keep `observation.jsonl` and still drop `evaluator_raw.json`. Viewer and Hub Verifier reuse TrajectoryPanel when that file has layer-C steps; the Agent Trajectory tab still reads only root `trajectory.jsonl`.
- Opt-in fixture: `tests/fixtures/datasets/eval-judge-min`. No `Agent.session` = today's script path.

## Test plan

- [x] `uv run ruff format --check src tests` / `ruff check` / `pyright`
- [x] `uv run pytest --ignore=tests/registry` (python-core equivalent)
- [x] viewer and Hub `pnpm lint` + `pnpm build`
- [x] lock mixed ACP + openai-http per profile (`tests/config/test_load_and_lock.py`)
- [x] opt-in judge fixture writes `evaluation/observation.jsonl`; no-SDK copy does not (`tests/acceptance/test_eval_judge_observation.py`)
- [x] slim/archive keep observation, drop `evaluator_raw`
- [x] Viewer observation API does not mix judge rows into Agent trajectory

Closes #202