### PR TITLE
feat(runtime): live suite summary and evaluate-phase scoring bind

### DIFF
--- a/docs/design/02-task-package-and-config.md
+++ b/docs/design/02-task-package-and-config.md
@@ -108,6 +108,7 @@ environment: local          # 或 docker / e2b / ssh / daytona
 #                           # daytona：image / snapshot / timeout_seconds
 # evaluate_host:            # 省略 = 同一环境 evaluate
 #   isolated: true
+#   environment_options:     # 打分盒自己的 network / egress / platform / user；省略 = 不继承 agent 的 egress/network
 agent_profiles:
   solver:
     executor: acp
@@ -120,7 +121,7 @@ agent_profiles:
       - plugin: local
 ```
 
-`environment_options` 给 **run** 环境；locator 在 preflight 解析，密钥不进 digest。`evaluate_host.isolated: true` 要求成员题有打分配方，且 kind 能再起一份环境（Current：docker）；否则 lock 失败。未知顶键一次拒绝。
+`environment_options` 给 **run** 环境；locator 在 preflight 解析，密钥不进 digest。`evaluate_host.isolated: true` 要求成员题有打分配方，且 kind 能再起一份环境（Current：docker）；否则 lock 失败。`evaluate_host.environment_options` 是打分盒自己的旋钮（`network` / `egress` / `platform` / `user`；不是 `image`），要求 `isolated: true`；省略时打分盒只继承 job `environment_options` 的 `platform` / `user`，不继承 agent 的 `egress` / `network`。未知顶键与未知嵌套键一次拒绝。
 
 `evaluation.environments` 是成员题上的名 → 配方表。名字 `[a-z][a-z0-9_-]*`。每个名字只允许 `dockerfile`（题相对路径）或 `docker_image`（OCI tag），或两者（与今日单只配方同一识别规则）。未知键一次错误。`dockerfile` 必须存在且不得落在 `evaluation/`（那是 gold）。写出该表则：
 

--- a/docs/design/05-runtime/campaign-suite.md
+++ b/docs/design/05-runtime/campaign-suite.md
@@ -17,6 +17,19 @@ suite job
     task_refs[]     run_id / attempt_run_ids
 ```
 
+`summary.json` 在 suite 进行中就存在，是 **观测快照**：只统计已 settle 的 attempt，
+`status` 为 `running` / `cancelling`，`metrics.pass_rate` =
+`n_pass / (n_pass + n_fail + n_error)`（分母是已 settle 的任务，不是计划任务数）；
+`tasks[]` / `attempts[]` / `task_refs[]` 只列已 settle 的工作，未跑的 task id 不出现。
+它不是 suite PASS。suite 完成 / 取消时同一文件被按全计划 id 集重写为终值；
+`created_at` 在首次写入时锁定，resume 重写不改写它。`progress.json` 仍是
+slot / cancel 文档（计划数、in-flight、取消请求），两文件各管各的。
+
+Viewer Jobs 对进行中的 suite 显示 **一行**（suite_run_id 唯一），pass rate 取自该
+快照，Trials 显示 `settled / planned`；已 settle 的 run id 归属该 suite 行，
+不再以单题 job 重复出现。`ageval results upload-suite` 拒绝 `running` /
+`cancelling` 的快照——观测快照不是完备 suite，完备性门禁不变。
+
 Hub Leaderboard 吃的是 **suite** 上传（`ageval results upload-suite`），不是单 Attempt `results upload`。公开榜还要完备且绑定 release。draft / 不完备只上 Jobs。
 
 `--agent` 与 `--profiles` 互斥。`--model` 须配合 `--agent`（`lock` / `run` / `campaign`）。Campaign 不与 `run.py` 内 scheduler 合并。

--- a/docs/design/05-runtime/environment.md
+++ b/docs/design/05-runtime/environment.md
@@ -15,6 +15,8 @@ environment: e2b    # local | docker | e2b | ssh | daytona
 #                        # daytona：image / snapshot / timeout_seconds
 # evaluate_host:         # 省略 = 同一环境打分
 #   isolated: true       # 第二只 EnvironmentProvider；不是新槽
+#   environment_options: # 打分盒自己的 docker 旋钮；省略 = 不继承 agent 的 egress / network
+#     egress: llm        # network / egress / platform / user；不是 image（配方照旧）
 ```
 
 取消隔离档产品面。不要写 `provider.kind`、`assurance: l0/l1`。Result 记 `kind` + `capabilities_used`。
@@ -44,13 +46,20 @@ docker `environment_options`：
 - `egress` — 省略 = 今日 `bridge`。`egress: llm`（Current：仅 docker contrib）：Agent 环境出站 HTTP(S) 只能到达已绑定 profile 的 `base_url` 主机（parent 侧代理 + 环境内 `HTTPS_PROXY` / `HTTP_PROXY`，或等价物）。ACP stdio 仍是 parent `attach_stdio`，不走这条代理。不能兑现的 kind 写了该键 → lock 失败。依赖仍 bake 在题包 `environment/Dockerfile`；官方基座 invoke 时禁止 `npm i` / 浮动 `npx`。
 - `user` — 环境内身份，`docker run --user` 与 `exec`/`attach_stdio` 同一值。缺省 `10001:10001`。`root` / `0` / `0:0` 开 root（Harbor 式终端题要 `apt` 或写 `/usr/local` 时用）。其它值必须是 `uid` 或 `uid:gid`。未知字符串一次失败。默认仍带 `no-new-privileges`。
 
-`egress` 约束的是 **Agent 环境**。打分 Host 不继承该键，除非以后另开开关。
+`egress` 约束的是 **Agent 环境**。两只盒子两份策略：打分 Host 有自己的
+`evaluate_host.environment_options`（`network` / `egress` / `platform` / `user`）；
+嵌套表省略时打分盒沿用今日行为——只继承 job `environment_options` 的
+`platform` / `user`，**不**继承 agent 的 `egress` / `network` 或镜像。
+打分 `egress: llm` 的放行名单来自 evaluate 相位 profile 的 `base_url`
+（judge 盒 reach judge 的 API host），不是 solver 名单。不能兑现该键的 kind
+写了任一处 `egress` → lock 失败，同一规则。
 
 ## 第二份环境（evaluate，opt-in）
 
 `environment` 独占槽仍一份赢家。`evaluate_host.isolated: true` 时 Runtime 再 `start` **同一个赢家类** 的更多实例：
 
 - 单只配方：题包 `environment/evaluate.Dockerfile`，或 `evaluation.docker_image`。与 Agent 的 `environment/Dockerfile` 不是同一文件。Current 只要求 docker。
+- **构造时机：evaluate 相位。** run 密封（`seal_run`）之后才知道哪些 profile 属 evaluate 相位；打分盒实例在 evaluate 相位按 evaluate 相位 graph 联合的 `image_layers` 构造（见 [evaluation.md](evaluation.md)），composition 不再预建。cleanup 只停已构造 / 已启动的实例。
 - 名表：成员 `evaluation.environments.<name>.dockerfile` 或 `.docker_image`。每只一个 `BoxSpec.attempt_root`（evidence `eval-box/<name>`）。evaluate 开头不 start；第一次 `exec` / `session(environment=)` 才 start。写出名表则忽略单只配方。
 - work root **独立**。禁止把 Agent 的 bind-mount 或 live workspace symlink 进打分环境。
 - 不加入 Agent compose 网络。compose 侧车仍随 Agent `host.start()` 起来，寿命与 Agent 环境相同；不要拿侧车当打分镜像。

--- a/docs/design/05-runtime/evaluation.md
+++ b/docs/design/05-runtime/evaluation.md
@@ -82,6 +82,9 @@ job：
 # profiles.yaml — 省略 evaluate_host = 同一环境
 evaluate_host:
   isolated: true
+  # environment_options:      # 打分盒自己的网络策略；省略 = 不继承 agent 的 egress/network
+  #   egress: llm             # ACP judge 在打分盒里时放行其 API host
+  #   network: bridge
 ```
 
 lock：
@@ -89,9 +92,18 @@ lock：
 - `isolated: true` 必须能在成员题上落到配方：存在 `environment/evaluate.Dockerfile`，或 `evaluation.docker_image`（OCI tag）。两者都无 → lock 失败，不 start。
 - 配方文件 **不** 放 `evaluation/`（那是 gold）。
 - Current：`environment: docker`。local / 不能再起一份环境的 kind + `isolated: true` → lock 失败。
+- 嵌套 `environment_options` 要求 `isolated: true`；键允许 `network` / `egress` / `platform` / `user`（与盒子同一旋钮名，**不是** `image`）；`egress` 的 kind 门禁与 agent 同一规则；未知键一次错误，不映射。
 - 未知 `evaluate_host` 键、未知 `artifacts.publishable` 键：一次错误，不映射。
 
-runtime：第二实例由 composition 用同一 docker 赢家工厂构造（不同 `BoxSpec.attempt_root` + evaluate 配方）。`evaluation_runtime` 仍是独占槽默认引擎，parent 子进程跑 `evaluator.py`。isolated 时对 **未在 run 打开过的 ACP profile** 在打分环境上再跑 `after_environment_ready`（不要拿 solver 的 entry 去装打分镜像）。SDK 仍不得拥有 `host.start` / `host.upload`。
+runtime：打分盒实例在 **evaluate 相位**（writer 已密封）构造：composition 不再预建
+第二 EnvironmentProvider。构造时 `image_layers` 取 **evaluate 相位 profile graph**
+的联合（`bind_winner` 的赢家工厂仍是 Attempt 级 docker 插件；配方仍是 `_evaluate_box_spec`）——
+declare 了 `config.image_layers` 的 judge 插件由此 bake 进打分镜像，solver 独占的
+插件不进。无 `image_layers` 的插件（含 `acp`）不加东西；官方 ACP 引擎仍是 **配方**
+问题（`FROM` 官方 attempt 基座），不是 Core wrap。`evaluation_runtime` 仍是独占槽
+默认引擎，parent 子进程跑 `evaluator.py`。isolated 时对 **未在 run 打开过的 profile**
+（不限 executor kind）在打分环境上再跑 `after_environment_ready`；空链 no-op，
+不跑 `environment_setup`。SDK 仍不得拥有 `host.start` / `host.upload`。
 
 ## 命名打分 Host（`evaluation.environments`）
 

--- a/docs/design/05-runtime/evaluation.md
+++ b/docs/design/05-runtime/evaluation.md
@@ -97,7 +97,8 @@ lock：
 
 runtime：打分盒实例在 **evaluate 相位**（writer 已密封）构造：composition 不再预建
 第二 EnvironmentProvider。构造时 `image_layers` 取 **evaluate 相位 profile graph**
-的联合（`bind_winner` 的赢家工厂仍是 Attempt 级 docker 插件；配方仍是 `_evaluate_box_spec`）——
+的联合（`bind_winner` 的赢家工厂仍是 Attempt 级 docker 插件；`BoxSpec` 仍只装
+evaluate 配方与独立 attempt root）——
 declare 了 `config.image_layers` 的 judge 插件由此 bake 进打分镜像，solver 独占的
 插件不进。无 `image_layers` 的插件（含 `acp`）不加东西；官方 ACP 引擎仍是 **配方**
 问题（`FROM` 官方 attempt 基座），不是 Core wrap。`evaluation_runtime` 仍是独占槽

--- a/src/ageval/application/registry_ops/results_command.py
+++ b/src/ageval/application/registry_ops/results_command.py
@@ -127,6 +127,20 @@ def _task_rows_from_summary(summary: dict[str, Any]) -> list[dict[str, Any]]:
     return [t for t in raw if isinstance(t, dict)]
 
 
+def _refuse_in_progress_snapshot(
+    summary: dict[str, Any], suite_dir: Path, suite_run_id: str
+) -> None:
+    """A live ``running``/``cancelling`` snapshot is not a complete suite."""
+    snapshot_status = str(summary.get("status") or "").strip().lower()
+    if snapshot_status in {"running", "cancelling"}:
+        raise ConfigError(
+            "suite_in_progress",
+            f"suite {suite_run_id} is still {snapshot_status}; "
+            "an in-progress summary is an observational snapshot, not a complete suite",
+            location=str(suite_dir / "summary.json"),
+        )
+
+
 def _suite_metrics_and_refs(summary: dict[str, Any]) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Resolve metrics + task_refs, recomputing pass@k / n,c when recoverable (#60 A).
 
@@ -398,6 +412,7 @@ class ResultsCommands:
         root = resolve_dataset_root(dataset_root)
         suite_dir = _resolve_suite_dir(root, suite_run_id)
         summary = _load_suite_summary(suite_dir)
+        _refuse_in_progress_snapshot(summary, suite_dir, suite_run_id)
 
         metrics, task_refs = _suite_metrics_and_refs(summary)
         try:
@@ -571,6 +586,7 @@ class ResultsCommands:
         root = resolve_dataset_root(dataset_root)
         suite_dir = _resolve_suite_dir(root, suite_run_id)
         summary = _load_suite_summary(suite_dir)
+        _refuse_in_progress_snapshot(summary, suite_dir, suite_run_id)
         metrics, task_refs = _suite_metrics_and_refs(summary)
         tid = task_id.strip()
         hit: dict[str, Any] | None = None

--- a/src/ageval/application/run.py
+++ b/src/ageval/application/run.py
@@ -25,9 +25,7 @@ from ageval.evaluation.bind import AttemptResult, bind_result
 from ageval.evidence.locators import default_runs_root
 from ageval.evidence.store import (
     AGENT_BOX_REL,
-    EVALUATE_BOX_REL,
     AttemptEvidenceStore,
-    evaluate_box_rel,
 )
 from ageval.plugins.binding import bind_winner
 from ageval.plugins.bootstrap import ensure_bootstrapped
@@ -187,24 +185,6 @@ async def run_attempt(
     )
     services.register(ENVIRONMENT, host, plugin_id=graph.winners[ENVIRONMENT].plugin_id)
     await host.preflight()
-    evaluate_hosts = _bind_named_evaluate_hosts(
-        lock,
-        registry=registry,
-        graph=graph,
-        task_root=task_root,
-        evidence=evidence,
-    )
-    evaluate_host = (
-        None
-        if evaluate_hosts
-        else _bind_evaluate_host(
-            lock,
-            registry=registry,
-            graph=graph,
-            task_root=task_root,
-            attempt_root=evidence.path(EVALUATE_BOX_REL),
-        )
-    )
 
     ctx = AttemptCtx(
         run_id=run_ident.value,
@@ -216,8 +196,6 @@ async def run_attempt(
         registry=registry,
         services=services,
         host=host,
-        evaluate_host=evaluate_host,
-        evaluate_hosts=evaluate_hosts,
         evidence=evidence,
         cancellation=CancellationSignal(),
         task_root=task_root,
@@ -328,15 +306,9 @@ def _selected_profile_id(lock: LockedTaskConfig) -> str:
 
 def _plugin_image_layers(graph: ExtensionGraph) -> tuple[tuple[str, str, str, str], ...]:
     """Bake files the bound plugins declared, for kinds that build."""
-    from ageval.plugins.image_layers import layers_for_plugins
+    from ageval.plugins.image_layers import layers_for_graph
 
-    bound = {ref.plugin_id for ref in graph.winners.values()}
-    for chain in graph.chains.values():
-        bound.update(handler.plugin_id for handler in chain)
-    return tuple(
-        (layer.plugin_id, str(layer.dockerfile), str(layer.package_root), layer.body)
-        for layer in layers_for_plugins(frozenset(bound))
-    )
+    return layers_for_graph(graph)
 
 
 def _environment_options(lock: LockedTaskConfig) -> dict[str, Any]:
@@ -393,143 +365,20 @@ def _box_spec(
     )
 
 
-def _evaluate_isolated(lock: LockedTaskConfig) -> bool:
-    overlay = thaw(lock.job_overlay) if lock.job_overlay is not None else {}
-    host = overlay.get("evaluate_host") if isinstance(overlay, dict) else None
-    return bool(isinstance(host, dict) and host.get("isolated") is True)
-
-
-def _evaluate_host_options(lock: LockedTaskConfig) -> dict[str, Any]:
-    """Job options for the scoring box: no agent image, network, or egress."""
-    base = _environment_options(lock)
-    out = {key: value for key, value in base.items() if key in {"platform", "user"}}
-    image = thaw(lock.resolved_references).get("evaluation_docker_image")
-    if isinstance(image, str) and image.strip():
-        out["image"] = image.strip()
-    return out
-
-
-def _evaluate_box_spec(
-    lock: LockedTaskConfig,
-    *,
-    task_root: Path,
-    attempt_root: Path,
-) -> BoxSpec:
-    references = thaw(lock.resolved_references)
-    return BoxSpec(
-        attempt_root=attempt_root,
-        task_root=task_root,
-        repo_root=Path.cwd(),
-        dockerfile=references.get("environment_evaluate_dockerfile"),
-        compose_file=None,
-    )
-
-
-def _bind_evaluate_host(
-    lock: LockedTaskConfig,
-    *,
-    registry: Any,
-    graph: ExtensionGraph,
-    task_root: Path,
-    attempt_root: Path,
-) -> Any | None:
-    """Second EnvironmentProvider when isolated; otherwise None (same box)."""
-    if not _evaluate_isolated(lock):
-        return None
-    return bind_winner(
-        registry,
-        graph,
-        ENVIRONMENT,
-        spec=_evaluate_box_spec(lock, task_root=task_root, attempt_root=attempt_root),
-        plugin_layers=(),
-        options=_evaluate_host_options(lock),
-    )
-
-
-def _named_evaluate_recipes(lock: LockedTaskConfig) -> dict[str, dict[str, str]]:
-    raw = thaw(lock.resolved_references).get("evaluation_environments") or {}
-    if not isinstance(raw, dict):
-        return {}
-    out: dict[str, dict[str, str]] = {}
-    for name, recipe in raw.items():
-        if isinstance(name, str) and isinstance(recipe, dict):
-            out[name] = {str(key): str(value) for key, value in recipe.items()}
-    return out
-
-
-def _named_evaluate_host_options(lock: LockedTaskConfig, recipe: dict[str, str]) -> dict[str, Any]:
-    base = _environment_options(lock)
-    out = {key: value for key, value in base.items() if key in {"platform", "user"}}
-    image = recipe.get("docker_image")
-    if isinstance(image, str) and image.strip():
-        out["image"] = image.strip()
-    return out
-
-
-def _named_evaluate_box_spec(
-    lock: LockedTaskConfig,
-    *,
-    name: str,
-    recipe: dict[str, str],
-    task_root: Path,
-    attempt_root: Path,
-) -> BoxSpec:
-    del lock, name
-    dockerfile = recipe.get("dockerfile")
-    return BoxSpec(
-        attempt_root=attempt_root,
-        task_root=task_root,
-        repo_root=Path.cwd(),
-        dockerfile=dockerfile if isinstance(dockerfile, str) and dockerfile.strip() else None,
-        compose_file=None,
-    )
-
-
 def _bind_evaluate_session_target(ctx: AttemptCtx, agent_service: AgentServiceServer) -> None:
     """Let evaluate-phase session(environment=) rebind ACP onto a named host."""
     parent = getattr(agent_service, "service", None)
     if parent is None:
         return
-    names = frozenset(ctx.evaluate_hosts)
+    from ageval.attempt.phases.evaluate import bind_named_environment, named_evaluate_environments
+
+    names = frozenset(named_evaluate_environments(ctx))
     parent.evaluate_environment_names = names if names else None
     if not names:
         return
-    from ageval.attempt.phases.evaluate import bind_named_environment
-
     parent.evaluate_environment_binder = lambda name, profile_id=None: bind_named_environment(
         ctx, name, profile_id=profile_id
     )
-
-
-def _bind_named_evaluate_hosts(
-    lock: LockedTaskConfig,
-    *,
-    registry: Any,
-    graph: ExtensionGraph,
-    task_root: Path,
-    evidence: AttemptEvidenceStore,
-) -> dict[str, Any]:
-    """Construct named scoring hosts. Start happens on first exec / session."""
-    recipes = _named_evaluate_recipes(lock)
-    if not recipes:
-        return {}
-    out: dict[str, Any] = {}
-    for name, recipe in recipes.items():
-        out[name] = bind_winner(
-            registry,
-            graph,
-            ENVIRONMENT,
-            spec=_named_evaluate_box_spec(
-                lock,
-                name=name,
-                recipe=recipe,
-                task_root=task_root,
-                attempt_root=evidence.path(evaluate_box_rel(name)),
-            ),
-            plugin_layers=(),
-            options=_named_evaluate_host_options(lock, recipe),
-        )
-    return out
 
 
 def _agent_service(

--- a/src/ageval/application/run.py
+++ b/src/ageval/application/run.py
@@ -29,6 +29,7 @@ from ageval.evidence.store import (
 )
 from ageval.plugins.binding import bind_winner
 from ageval.plugins.bootstrap import ensure_bootstrapped
+from ageval.plugins.image_layers import layers_for_graph
 from ageval.plugins.protocol import ExtensionGraph
 from ageval.plugins.services import ServiceTable
 from ageval.plugins.slots import ENVIRONMENT
@@ -86,7 +87,7 @@ async def probe_attempt(
             task_root=locked.resolved.task_dir,
             attempt_root=Path(tempfile.mkdtemp(prefix="ageval-probe-")),
         ),
-        plugin_layers=_plugin_image_layers(graph),
+        plugin_layers=layers_for_graph(graph),
     )
     probe: dict[str, Any] = {
         "task_id": lock.task_id,
@@ -180,7 +181,7 @@ async def run_attempt(
             task_root=task_root,
             attempt_root=evidence.path(AGENT_BOX_REL),
         ),
-        plugin_layers=_plugin_image_layers(graph),
+        plugin_layers=layers_for_graph(graph),
         options=_agent_environment_options(lock, graph),
     )
     services.register(ENVIRONMENT, host, plugin_id=graph.winners[ENVIRONMENT].plugin_id)
@@ -302,13 +303,6 @@ def _selected_profile_id(lock: LockedTaskConfig) -> str:
     if isinstance(active, str) and active.strip():
         return active.strip()
     return str(rows[0].get("id"))
-
-
-def _plugin_image_layers(graph: ExtensionGraph) -> tuple[tuple[str, str, str, str], ...]:
-    """Bake files the bound plugins declared, for kinds that build."""
-    from ageval.plugins.image_layers import layers_for_graph
-
-    return layers_for_graph(graph)
 
 
 def _environment_options(lock: LockedTaskConfig) -> dict[str, Any]:

--- a/src/ageval/application/suite/suite_run.py
+++ b/src/ageval/application/suite/suite_run.py
@@ -585,6 +585,7 @@ def _settled_task_ids(plan: SuitePlan, attempts: list[dict[str, Any]]) -> list[s
     Mirrors the final summary's task-id union: resume-filter siblings that
     already settled stay listed.
     """
+    settled = {str(a.get("task_id") or "") for a in attempts}
     present: list[str] = []
     seen: set[str] = set()
 
@@ -595,9 +596,9 @@ def _settled_task_ids(plan: SuitePlan, attempts: list[dict[str, Any]]) -> list[s
 
     for tid in plan.task_ids:
         _add(tid)
-    for tid in (str(a.get("task_id") or "") for a in attempts):
+    for tid in settled:
         _add(tid)
-    return [tid for tid in present if any(str(a.get("task_id") or "") == tid for a in attempts)]
+    return [tid for tid in present if tid in settled]
 
 
 def _live_summary(

--- a/src/ageval/application/suite/suite_run.py
+++ b/src/ageval/application/suite/suite_run.py
@@ -25,6 +25,7 @@ from ageval.application.suite.suite_metrics import (
     aggregate_k_metrics,
     extend_slot_previous,
     flatten_legacy_tasks_as_attempts,
+    metrics_payload_from_k_agg,
     slot_key,
     task_refs_for_summary,
 )
@@ -469,37 +470,7 @@ def _task_row_from_rollup(t: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
-def _build_summary(
-    plan: SuitePlan,
-    attempts: list[dict[str, Any]],
-    *,
-    overrides: dict[str, Any] | None,
-    profiles_path: Path | str | None,
-) -> dict[str, Any]:
-    """Roll attempts → tasks + metrics; write identity fields (no k in fingerprint)."""
-    k_agg = aggregate_k_metrics(
-        attempts,
-        task_ids=plan.task_ids,
-        n_attempts=plan.n_attempts,
-    )
-    task_rows: list[dict[str, Any]] = list(k_agg.pop("task_rows"))
-    # Single shape for k==1 and k>1. Full samples live under ``attempts[]``.
-    tasks_out = [_task_row_from_rollup(t) for t in task_rows]
-    metrics = {
-        "pass_rate": k_agg["pass_rate"],
-        "mean_score": k_agg["mean_score"],
-        "n_tasks": k_agg["n_tasks"],
-        "n_pass": k_agg["n_pass"],
-        "n_fail": k_agg["n_fail"],
-        "n_error": k_agg["n_error"],
-        "missing_score_as": k_agg["missing_score_as"],
-        "n_attempts": plan.n_attempts,
-        "k_values": k_agg["k_values"],
-        "pass_at_k": k_agg["pass_at_k"],
-        "pass_power_k": k_agg["pass_power_k"],
-        "per_task": k_agg["per_task"],
-    }
-
+def _counts_and_exit_code(tasks_out: list[dict[str, Any]]) -> tuple[dict[str, int], int]:
     counts = {"pass": 0, "fail": 0, "error": 0, "skipped": 0}
     for row in tasks_out:
         st = str(row.get("status") or "").upper()
@@ -516,6 +487,35 @@ def _build_summary(
         exit_code = 1
     else:
         exit_code = 0
+    return counts, exit_code
+
+
+def _metrics_from_k_agg(k_agg: Mapping[str, Any], *, n_attempts: int) -> dict[str, Any]:
+    metrics = metrics_payload_from_k_agg(k_agg)
+    metrics["n_attempts"] = n_attempts
+    return metrics
+
+
+def _build_summary(
+    plan: SuitePlan,
+    attempts: list[dict[str, Any]],
+    *,
+    overrides: dict[str, Any] | None,
+    profiles_path: Path | str | None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    """Roll attempts → tasks + metrics; write identity fields (no k in fingerprint)."""
+    k_agg = aggregate_k_metrics(
+        attempts,
+        task_ids=plan.task_ids,
+        n_attempts=plan.n_attempts,
+    )
+    task_rows: list[dict[str, Any]] = list(k_agg.pop("task_rows"))
+    # Single shape for k==1 and k>1. Full samples live under ``attempts[]``.
+    tasks_out = [_task_row_from_rollup(t) for t in task_rows]
+    metrics = _metrics_from_k_agg(k_agg, n_attempts=plan.n_attempts)
+
+    counts, exit_code = _counts_and_exit_code(tasks_out)
 
     # Fingerprint from one row per task (prefer a PASS attempt's run_id).
     fp_rows: list[dict[str, Any]] = []
@@ -560,7 +560,8 @@ def _build_summary(
         # Observational aggregates (leaderboard / job stats); never suite PASS.
         "metrics": metrics,
         "exit_code": exit_code,
-        "created_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "created_at": created_at
+        or datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         "inflight_peak": get_inflight_peak(),
         "config_fingerprint": config_fields["config_fingerprint"],
         "config_homogeneous": config_fields["config_homogeneous"],
@@ -577,6 +578,72 @@ def _build_summary(
     if any(isinstance(a.get("previous"), list) and a["previous"] for a in attempts):
         summary["amended"] = True
     return summary
+
+
+def _settled_task_ids(plan: SuitePlan, attempts: list[dict[str, Any]]) -> list[str]:
+    """Ids with at least one settled attempt: plan order first, then discovered.
+
+    Mirrors the final summary's task-id union: resume-filter siblings that
+    already settled stay listed.
+    """
+    present: list[str] = []
+    seen: set[str] = set()
+
+    def _add(tid: str) -> None:
+        if tid and tid not in seen:
+            seen.add(tid)
+            present.append(tid)
+
+    for tid in plan.task_ids:
+        _add(tid)
+    for tid in (str(a.get("task_id") or "") for a in attempts):
+        _add(tid)
+    return [tid for tid in present if any(str(a.get("task_id") or "") == tid for a in attempts)]
+
+
+def _live_summary(
+    plan: SuitePlan,
+    attempts: list[dict[str, Any]],
+    *,
+    created_at: str,
+    status: str,
+) -> dict[str, Any]:
+    """In-progress observational snapshot over *settled* attempts only.
+
+    ``metrics.pass_rate`` counts only settled tasks; unrun planned ids appear
+    nowhere. No config fingerprint: the final document is the fingerprint
+    authority. ``status`` is ``running`` / ``cancelling`` — never a verdict.
+    """
+    settled_ids = _settled_task_ids(plan, attempts)
+    k_agg = aggregate_k_metrics(
+        attempts,
+        task_ids=settled_ids,
+        n_attempts=plan.n_attempts,
+    )
+    task_rows: list[dict[str, Any]] = list(k_agg.pop("task_rows"))
+    tasks_out = [_task_row_from_rollup(t) for t in task_rows]
+    metrics = _metrics_from_k_agg(k_agg, n_attempts=plan.n_attempts)
+    counts, exit_code = _counts_and_exit_code(tasks_out)
+    return {
+        "schema": "ageval.suite.summary/1",
+        "suite_run_id": plan.suite_run_id,
+        "dataset_id": plan.dataset_id,
+        "dataset_version": plan.dataset_version,
+        "max_concurrent_tasks": plan.max_concurrent_tasks,
+        "n_attempts": plan.n_attempts,
+        "task_ids": settled_ids,
+        "attempts": list(attempts),
+        "tasks": tasks_out,
+        "task_refs": task_refs_for_summary(tasks_out, attempts=attempts),
+        "counts": counts,
+        # Observational aggregates; a running snapshot is not suite PASS.
+        "metrics": metrics,
+        "exit_code": exit_code,
+        "status": status,
+        "created_at": created_at,
+        "inflight_peak": get_inflight_peak(),
+        "note": "suite in progress; observational snapshot of settled tasks",
+    }
 
 
 def _write_summary(plan: SuitePlan, summary: dict[str, Any]) -> dict[str, Any]:
@@ -725,6 +792,24 @@ async def execute_suite_run(
             with contextlib.suppress(Exception):
                 on_progress(event)
 
+    # ``created_at`` locks on the first write of this suite (resume keeps the
+    # original) and every later rewrite — live or final — reuses it.
+    created_at_cell: list[str] = []
+    if resume and isinstance(old_summary, dict):
+        prior_created = old_summary.get("created_at")
+        if isinstance(prior_created, str) and prior_created.strip():
+            created_at_cell.append(prior_created.strip())
+
+    def _write_live_summary(status: str) -> None:
+        """Rewrite summary.json from settled attempts (live observational view)."""
+        settled = [a for a in existing if not _is_cancelled_placeholder(a)] + list(new_results)
+        if not created_at_cell:
+            created_at_cell.append(datetime.now(UTC).isoformat().replace("+00:00", "Z"))
+        _write_summary(
+            plan,
+            _live_summary(plan, settled, created_at=created_at_cell[0], status=status),
+        )
+
     _write_suite_progress(
         plan,
         done=completed_count,
@@ -732,6 +817,7 @@ async def execute_suite_run(
         running=[],
         status="running" if todo else "complete",
     )
+    _write_live_summary("running" if todo else "complete")
     _emit(
         {
             "type": "suite_start",
@@ -842,6 +928,7 @@ async def execute_suite_run(
                     running=_running_snapshot(),
                     status=st,
                 )
+                _write_live_summary(st)
                 _emit(
                     {
                         "type": "unit_done",
@@ -952,6 +1039,7 @@ async def execute_suite_run(
         attempts,
         overrides=overrides,
         profiles_path=profiles_path,
+        created_at=created_at_cell[0] if created_at_cell else None,
     )
     if resume:
         summary["resumed"] = True
@@ -980,6 +1068,7 @@ async def execute_suite_run(
             }
         )
     else:
+        summary["status"] = "complete"
         _write_suite_progress(
             plan,
             done=completed_count,

--- a/src/ageval/application/suite/suite_run.py
+++ b/src/ageval/application/suite/suite_run.py
@@ -560,8 +560,7 @@ def _build_summary(
         # Observational aggregates (leaderboard / job stats); never suite PASS.
         "metrics": metrics,
         "exit_code": exit_code,
-        "created_at": created_at
-        or datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "created_at": created_at or datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         "inflight_peak": get_inflight_peak(),
         "config_fingerprint": config_fields["config_fingerprint"],
         "config_homogeneous": config_fields["config_homogeneous"],

--- a/src/ageval/attempt/phases/evaluate.py
+++ b/src/ageval/attempt/phases/evaluate.py
@@ -10,17 +10,20 @@ The ``evaluation_runtime`` winner returns raw; it does not bind PASS.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from ageval.attempt.ctx import AttemptCtx
 from ageval.attempt.emit import emit
+from ageval.config.errors import ConfigError
 from ageval.config.model import thaw
 from ageval.environments.protocol import (
     ARTIFACTS_PATH,
     EVALUATION_PATH,
     WORKSPACE_PATH,
+    BoxSpec,
     EnvironmentProvider,
 )
-from ageval.evidence.store import TASK_ARTIFACTS_REL
+from ageval.evidence.store import EVALUATE_BOX_REL, TASK_ARTIFACTS_REL, evaluate_box_rel
 from ageval.plugins.binding import bind_winner
 from ageval.plugins.slots import AFTER_EVALUATE, BEFORE_EVALUATE, ENVIRONMENT, EVALUATION_RUNTIME
 
@@ -71,7 +74,10 @@ async def ensure_named_host(ctx: AttemptCtx, name: str) -> EnvironmentProvider:
         raise RuntimeError(UNKNOWN_EVALUATE_ENVIRONMENT)
     host = ctx.evaluate_hosts.get(name)
     if host is None:
-        raise RuntimeError(UNKNOWN_EVALUATE_ENVIRONMENT)
+        host = _bind_named_scoring_host(ctx, name)
+        if host is None:
+            raise RuntimeError(UNKNOWN_EVALUATE_ENVIRONMENT)
+        ctx.evaluate_hosts[name] = host
     if name in ctx.started_evaluate_names:
         return host
     await host.preflight()
@@ -101,7 +107,14 @@ async def bind_named_environment(
 
 async def _ensure_evaluate_host(ctx: AttemptCtx) -> None:
     host = ctx.evaluate_host
-    if host is None or host is ctx.host:
+    if host is None:
+        # The scoring box binds here, not at composition: which profiles belong
+        # to the evaluate phase is only known once run has sealed.
+        host = _bind_singular_scoring_host(ctx)
+        if host is None:
+            return
+        ctx.evaluate_host = host
+    if host is ctx.host:
         return
     await host.preflight()
     await host.start(force_build=ctx.lock.force_build)
@@ -111,20 +124,156 @@ async def _ensure_evaluate_host(ctx: AttemptCtx) -> None:
     ctx.services.register(ENVIRONMENT, host, plugin_id=plugin_id)
 
 
+# --- scoring-box bind (evaluate-phase graphs) -------------------------------
+
+
+def _evaluate_phase_profile_ids(ctx: AttemptCtx) -> list[str]:
+    """Profiles not sealed by run: the roles evaluate may still open."""
+    parent = getattr(ctx.agent_service, "service", None) or ctx.agent_service
+    sealed = {str(item) for item in (getattr(parent, "_run_profile_ids", None) or ())}
+    ids: list[str] = []
+    for row in thaw(getattr(ctx.lock, "agent_profiles", None) or ()):
+        if not isinstance(row, dict):
+            continue
+        pid = str(row.get("id") or "")
+        if pid and pid not in sealed:
+            ids.append(pid)
+    return ids
+
+
+def _scoring_binder(ctx: AttemptCtx) -> Any:
+    parent = getattr(ctx.agent_service, "service", None) or ctx.agent_service
+    return getattr(parent, "binder", None)
+
+
+def _scoring_plugin_layers(ctx: AttemptCtx) -> tuple[tuple[str, str, str, str], ...]:
+    """Union image_layers over evaluate-phase profile graphs (solver excluded)."""
+    from ageval.plugins.image_layers import layers_for_graphs
+
+    binder = _scoring_binder(ctx)
+    if binder is None:
+        return ()
+    graphs = [binder.graph(pid) for pid in _evaluate_phase_profile_ids(ctx)]
+    return layers_for_graphs(graphs)
+
+
+def _scoring_egress_allowlist(ctx: AttemptCtx) -> list[str]:
+    """API hosts the evaluate-phase profiles need; judge box reaches judge hosts."""
+    from urllib.parse import urlparse
+
+    from ageval.config.env_refs import resolve_locked_base_url
+
+    sealed = set(_evaluate_phase_profile_ids(ctx))
+    hosts: list[str] = []
+    for row in thaw(getattr(ctx.lock, "agent_profiles", None) or ()):
+        if not isinstance(row, dict):
+            continue
+        pid = str(row.get("id") or "")
+        if not pid or pid not in sealed:
+            continue
+        raw = row.get("base_url")
+        try:
+            url = resolve_locked_base_url(raw if isinstance(raw, str) else None)
+        except ConfigError:
+            continue
+        if not url:
+            continue
+        host = urlparse(str(url)).hostname
+        if host:
+            hosts.append(host)
+    return sorted(set(hosts))
+
+
+def _scoring_environment_options(
+    ctx: AttemptCtx, recipe: dict[str, str] | None = None
+) -> dict[str, Any]:
+    """Two boxes, two option maps.
+
+    Declared ``evaluate_host.environment_options`` wins whole. Omitted, the
+    scoring box keeps today's non-inheritance: only ``platform`` / ``user``
+    from the job map, never the agent ``egress`` / ``network`` or image.
+    """
+    overlay = thaw(getattr(ctx.lock, "job_overlay", None) or {})
+    host = overlay.get("evaluate_host") if isinstance(overlay.get("evaluate_host"), dict) else {}
+    nested = host.get("environment_options")
+    if isinstance(nested, dict) and nested:
+        options: dict[str, Any] = dict(nested)
+    else:
+        job_options = overlay.get("environment_options")
+        options = {
+            key: value
+            for key, value in (job_options.items() if isinstance(job_options, dict) else [])
+            if key in {"platform", "user"}
+        }
+    image = (recipe or {}).get("docker_image")
+    if not (isinstance(image, str) and image.strip()):
+        refs = thaw(getattr(ctx.lock, "resolved_references", None) or {})
+        image = refs.get("evaluation_docker_image")
+    if isinstance(image, str) and image.strip():
+        options["image"] = image.strip()
+    if str(options.get("egress") or "") == "llm":
+        options["egress_allowlist"] = _scoring_egress_allowlist(ctx)
+    return options
+
+
+def _bind_singular_scoring_host(ctx: AttemptCtx) -> EnvironmentProvider | None:
+    """The one isolated scoring box: evaluate recipe + evaluate-phase layers."""
+    refs = thaw(getattr(ctx.lock, "resolved_references", None) or {})
+    has_recipe = bool(refs.get("environment_evaluate_dockerfile")) or bool(
+        refs.get("evaluation_docker_image")
+    )
+    if not has_recipe:
+        return None
+    return bind_winner(
+        ctx.registry,
+        ctx.bindings,
+        ENVIRONMENT,
+        spec=BoxSpec(
+            attempt_root=ctx.evidence.path(EVALUATE_BOX_REL),
+            task_root=ctx.task_root,
+            repo_root=Path.cwd(),
+            dockerfile=refs.get("environment_evaluate_dockerfile"),
+            compose_file=None,
+        ),
+        plugin_layers=_scoring_plugin_layers(ctx),
+        options=_scoring_environment_options(ctx),
+    )
+
+
+def _bind_named_scoring_host(ctx: AttemptCtx, name: str) -> EnvironmentProvider | None:
+    """One named scoring box from its member recipe, with evaluate-phase layers."""
+    recipe = named_evaluate_environments(ctx)[name]
+    dockerfile = recipe.get("dockerfile")
+    return bind_winner(
+        ctx.registry,
+        ctx.bindings,
+        ENVIRONMENT,
+        spec=BoxSpec(
+            attempt_root=ctx.evidence.path(evaluate_box_rel(name)),
+            task_root=ctx.task_root,
+            repo_root=Path.cwd(),
+            dockerfile=dockerfile if isinstance(dockerfile, str) and dockerfile.strip() else None,
+            compose_file=None,
+        ),
+        plugin_layers=_scoring_plugin_layers(ctx),
+        options=_scoring_environment_options(ctx, recipe),
+    )
+
+
 async def _prepare_evaluate_runtime(ctx: AttemptCtx) -> None:
-    """Probe/install ACP on the scoring host for profiles not used during run."""
+    """Probe/install runtime entries on the scoring host for profiles not used during run."""
     if ctx.evaluate_host is None or ctx.evaluate_host is ctx.host:
         return
-    await _prepare_acp_profiles(ctx)
+    await _prepare_evaluate_profiles(ctx)
 
 
 async def _prepare_named_runtime(ctx: AttemptCtx, name: str, profile_id: str | None = None) -> None:
     if not profile_id:
         return
-    await _prepare_acp_profiles(ctx, name=name, profile_id=profile_id)
+    await _prepare_evaluate_profiles(ctx, name=name, profile_id=profile_id)
 
 
-async def _prepare_acp_profiles(
+async def _prepare_evaluate_profiles(
     ctx: AttemptCtx,
     name: str | None = None,
     profile_id: str | None = None,
@@ -150,10 +299,9 @@ async def _prepare_acp_profiles(
             continue
         if profile_id is not None and pid != profile_id:
             continue
-        if str(row.get("executor") or "") != "acp":
-            continue
         if (name or "", pid) in already:
             continue
+        # Empty chains no-op: the slot runs whatever the profile's graph binds.
         await run_chain(binder.graph(pid), AFTER_ENVIRONMENT_READY, None, ctx=ctx)
         detail: dict[str, str] = {"profile_id": pid}
         if name:

--- a/src/ageval/config/load_and_lock.py
+++ b/src/ageval/config/load_and_lock.py
@@ -440,12 +440,28 @@ def _apply_evaluate_job(job: JobDocument, resolved_refs: dict[str, Any]) -> None
             )
     egress = job.environment_options.get("egress")
     if egress is None:
-        return
-    if job.environment not in _EGRESS_KINDS:
+        pass
+    elif job.environment not in _EGRESS_KINDS:
         raise ConfigError(
             ERROR_INVALID_SCHEMA,
             "environment_options.egress requires environment: docker",
             location="/environment_options/egress",
+        )
+    scoring_options = job.evaluate_host.get("environment_options")
+    if not scoring_options:
+        return
+    if not isolated:
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            "evaluate_host.environment_options requires evaluate_host.isolated: true",
+            location="/evaluate_host/environment_options",
+        )
+    scoring_egress = scoring_options.get("egress")
+    if scoring_egress is not None and job.environment not in _EGRESS_KINDS:
+        raise ConfigError(
+            ERROR_INVALID_SCHEMA,
+            "evaluate_host.environment_options.egress requires environment: docker",
+            location="/evaluate_host/environment_options/egress",
         )
 
 

--- a/src/ageval/config/profiles.py
+++ b/src/ageval/config/profiles.py
@@ -262,7 +262,11 @@ def parse_job_mapping(raw: Mapping[str, Any], *, location: str = "profiles.yaml"
     )
 
 
-_EVALUATE_HOST_KEYS = frozenset({"isolated"})
+_EVALUATE_HOST_KEYS = frozenset({"isolated", "environment_options"})
+# The scoring box reads the same per-box knobs as the agent box. ``image`` is
+# deliberately absent: the recipe stays environment/evaluate.Dockerfile or
+# evaluation.docker_image.
+_EVALUATE_HOST_OPTION_KEYS = frozenset({"network", "egress", "platform", "user"})
 _EGRESS_VALUES = frozenset({"llm"})
 
 
@@ -284,25 +288,51 @@ def _parse_evaluate_host(raw: Any, *, location: str) -> dict[str, Any]:
             location=location,
         )
     isolated = raw.get("isolated")
-    if isolated is None:
+    options_raw = raw.get("environment_options")
+    if isolated is None and options_raw is None:
         return {}
-    if not isinstance(isolated, bool):
-        raise ConfigError(
-            ERROR_INVALID_SCHEMA,
-            "evaluate_host.isolated must be a boolean",
-            location=f"{location}/isolated",
+    out: dict[str, Any] = {}
+    if isolated is not None:
+        if not isinstance(isolated, bool):
+            raise ConfigError(
+                ERROR_INVALID_SCHEMA,
+                "evaluate_host.isolated must be a boolean",
+                location=f"{location}/isolated",
+            )
+        out["isolated"] = isolated
+    if options_raw is not None:
+        if not isinstance(options_raw, Mapping):
+            raise ConfigError(
+                ERROR_INVALID_SCHEMA,
+                "evaluate_host.environment_options must be a mapping the box kind understands",
+                location=f"{location}/environment_options",
+            )
+        unknown_options = sorted(set(options_raw) - _EVALUATE_HOST_OPTION_KEYS)
+        if unknown_options:
+            raise ConfigError(
+                ERROR_INVALID_SCHEMA,
+                f"unknown evaluate_host.environment_options keys: {unknown_options}",
+                location=f"{location}/environment_options",
+            )
+        _validate_egress(
+            options_raw,
+            location=f"{location}/environment_options",
+            label="evaluate_host.environment_options.egress",
         )
-    return {"isolated": isolated}
+        out["environment_options"] = copy.deepcopy(dict(options_raw))
+    return out
 
 
-def _validate_egress(options: Mapping[str, Any], *, location: str) -> None:
+def _validate_egress(
+    options: Mapping[str, Any], *, location: str, label: str = "environment_options.egress"
+) -> None:
     if "egress" not in options:
         return
     egress = options.get("egress")
     if not isinstance(egress, str) or egress not in _EGRESS_VALUES:
         raise ConfigError(
             ERROR_INVALID_SCHEMA,
-            "environment_options.egress must be llm when set",
+            f"{label} must be llm when set",
             location=f"{location}/egress",
         )
 

--- a/src/ageval/plugins/image_layers.py
+++ b/src/ageval/plugins/image_layers.py
@@ -7,11 +7,16 @@ image it builds. That is why ``image_contribute`` left the timeline.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ageval.plugins.manifest import PluginManifest, load_manifest
 from ageval.plugins.store import load_index, resolve_package_root
+
+if TYPE_CHECKING:
+    from ageval.plugins.protocol import ExtensionGraph
 
 
 @dataclass(frozen=True, slots=True)
@@ -63,3 +68,34 @@ def _manifest(root: Path) -> PluginManifest | None:
     except PluginManifestError:
         # A broken install is reported where it is installed, not here.
         return None
+
+
+def graph_plugin_ids(graph: ExtensionGraph) -> frozenset[str]:
+    """Plugin ids a graph binds: exclusive winners plus every chain handler."""
+    bound = {ref.plugin_id for ref in graph.winners.values()}
+    for chain in graph.chains.values():
+        bound.update(handler.plugin_id for handler in chain)
+    return frozenset(bound)
+
+
+def layers_tuple(layers: Iterable[ImageLayer]) -> tuple[tuple[str, str, str, str], ...]:
+    """The factory-facing layer shape (plugin_id, dockerfile, package_root, body)."""
+    return tuple(
+        (layer.plugin_id, str(layer.dockerfile), str(layer.package_root), layer.body)
+        for layer in layers
+    )
+
+
+def layers_for_graph(graph: ExtensionGraph) -> tuple[tuple[str, str, str, str], ...]:
+    """Bake files declared by the plugins one graph binds, for kinds that build."""
+    return layers_tuple(layers_for_plugins(graph_plugin_ids(graph)))
+
+
+def layers_for_graphs(
+    graphs: Iterable[ExtensionGraph],
+) -> tuple[tuple[str, str, str, str], ...]:
+    """Union bake files over several graphs, ordered by plugin id."""
+    bound: set[str] = set()
+    for graph in graphs:
+        bound.update(graph_plugin_ids(graph))
+    return layers_tuple(layers_for_plugins(frozenset(bound)))

--- a/src/ageval/viewer/jobs.py
+++ b/src/ageval/viewer/jobs.py
@@ -305,9 +305,7 @@ def _job_row(
     return row
 
 
-def _merge_live_progress(
-    row: dict[str, Any], summary: dict[str, Any], *, suite_dir: Path
-) -> None:
+def _merge_live_progress(row: dict[str, Any], summary: dict[str, Any], *, suite_dir: Path) -> None:
     """Merge progress.json into a row backed by an in-progress summary snapshot.
 
     A live snapshot lists settled work only; ``progress.json`` still owns the

--- a/src/ageval/viewer/jobs.py
+++ b/src/ageval/viewer/jobs.py
@@ -318,7 +318,8 @@ def _merge_live_progress(row: dict[str, Any], summary: dict[str, Any], *, suite_
     progress = _load_progress(suite_dir)
     if progress is None:
         return
-    metrics = row.get("metrics") if isinstance(row.get("metrics"), dict) else {}
+    raw_metrics = row.get("metrics")
+    metrics = raw_metrics if isinstance(raw_metrics, dict) else {}
     row["progress"] = progress
     planned = int(progress.get("total") or 0)
     if planned:

--- a/src/ageval/viewer/jobs.py
+++ b/src/ageval/viewer/jobs.py
@@ -273,7 +273,7 @@ def _job_row(
 
     did, ver = dataset_identity(summary, location=str(suite_dir / "summary.json"))
     ref = dataset_ref(did, ver)
-    return {
+    row = {
         "job_id": str(summary.get("suite_run_id") or suite_dir.name),
         "job_name": str(summary.get("suite_run_id") or suite_dir.name),
         "source_kind": "suite",
@@ -301,6 +301,36 @@ def _job_row(
         "summary_path": str(suite_dir / "summary.json"),
         "note": summary.get("note") or "per-task evaluator verdicts only; no suite-level PASS",
     }
+    _merge_live_progress(row, summary, suite_dir=suite_dir)
+    return row
+
+
+def _merge_live_progress(
+    row: dict[str, Any], summary: dict[str, Any], *, suite_dir: Path
+) -> None:
+    """Merge progress.json into a row backed by an in-progress summary snapshot.
+
+    A live snapshot lists settled work only; ``progress.json`` still owns the
+    planned unit count. Final summaries are untouched.
+    """
+    status = str(summary.get("status") or "").strip().lower() or None
+    row["status"] = status
+    if status not in {"running", "cancelling"}:
+        return
+    progress = _load_progress(suite_dir)
+    if progress is None:
+        return
+    metrics = row.get("metrics") if isinstance(row.get("metrics"), dict) else {}
+    row["progress"] = progress
+    planned = int(progress.get("total") or 0)
+    if planned:
+        row["trials_total"] = planned
+        row["task_count"] = planned
+    row["trials_done"] = (
+        int(metrics.get("n_pass") or 0)
+        + int(metrics.get("n_fail") or 0)
+        + int(metrics.get("n_error") or 0)
+    )
 
 
 def _load_progress(suite_dir: Path) -> dict[str, Any] | None:

--- a/tests/application/test_suite_live_summary.py
+++ b/tests/application/test_suite_live_summary.py
@@ -1,0 +1,207 @@
+"""In-progress summary.json: an observational snapshot over settled tasks (#193).
+
+While the suite runs, ``summary.json`` is rewritten from settled attempts only;
+the same file is replaced by the final document on complete / cancel.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from ageval.application.registry_ops.results_command import ResultsCommands
+from ageval.application.suite.suite_run import (
+    execute_suite_run,
+    plan_suite_run,
+    request_suite_cancel,
+    suite_summary_path,
+)
+from ageval.config.errors import ConfigError
+
+REPO = Path(__file__).resolve().parents[2]
+SUITE = REPO / "tests" / "fixtures" / "datasets" / "suite-min"
+
+
+def _copy_fixture(tmp_path: Path) -> Path:
+    """Private dataset root: the fixture dir accumulates .ageval state when shared."""
+    db = tmp_path / "db"
+    db.mkdir()
+    for item in SUITE.iterdir():
+        if item.name == ".ageval":
+            continue
+        target = db / item.name
+        (shutil.copytree if item.is_dir() else shutil.copyfile)(item, target)
+    return db
+
+
+def _snapshotting_runner(suite_run_id: str, statuses: dict[str, str], *, prefix: str = "live"):
+    """Runner that records the on-disk summary.json seen when each unit starts.
+
+    Later units see every earlier unit settled; nothing else.
+    """
+    seen: dict[str, dict] = {}
+    n = {"n": 0}
+
+    async def run(root, task_id, *, overrides=None, profiles_path=None, **kwargs):  # noqa: ANN001
+        path = suite_summary_path(Path(root), suite_run_id)
+        if path.is_file():
+            seen[task_id] = json.loads(path.read_text(encoding="utf-8"))
+        n["n"] += 1
+        st = statuses[task_id]
+        run_id = f"sha256_dead_run_{prefix}_{task_id}_{n['n']}"
+        abs_run = Path(root) / ".ageval" / "runs" / run_id
+        abs_run.mkdir(parents=True, exist_ok=True)
+        score = 1.0 if st == "PASS" else (0.0 if st == "FAIL" else None)
+        code = 0 if st == "PASS" else (1 if st == "FAIL" else 2)
+        result = SimpleNamespace(
+            status=st, score=score, evidence_path=str(abs_run), logs=str(abs_run)
+        )
+        return code, result
+
+    run.seen = seen  # type: ignore[attr-defined]
+    return run
+
+
+@pytest.mark.asyncio
+async def test_live_summary_counts_settled_tasks_only(tmp_path: Path) -> None:
+    db = _copy_fixture(tmp_path)
+    plan = plan_suite_run(db, max_concurrent_tasks=1)
+    runner = _snapshotting_runner(
+        plan.suite_run_id,
+        {"alpha": "PASS", "beta": "ERROR", "delta-fail": "FAIL", "gamma": "PASS"},
+    )
+    summary = await execute_suite_run(plan, run_fn=runner)
+
+    seen = runner.seen  # type: ignore[attr-defined]
+    # alpha started first: nothing settled yet, but the snapshot exists.
+    assert seen["alpha"]["status"] == "running"
+    assert seen["alpha"]["dataset_id"] == "test/suite-min"
+    assert seen["alpha"]["dataset_version"] == "0.1.0"
+    assert seen["alpha"]["metrics"]["n_tasks"] == 0
+    # beta starts after alpha settled: denominator is settled tasks, not planned.
+    assert seen["beta"]["status"] == "running"
+    assert seen["beta"]["task_ids"] == ["alpha"]
+    assert [t["task_id"] for t in seen["beta"]["tasks"]] == ["alpha"]
+    assert seen["beta"]["metrics"]["pass_rate"] == 1.0
+    assert seen["beta"]["metrics"]["n_tasks"] == 1
+    # delta-fail starts after alpha(PASS) + beta(ERROR): pass rate over 2 settled.
+    assert seen["delta-fail"]["metrics"]["pass_rate"] == pytest.approx(1 / 2)
+    assert seen["delta-fail"]["metrics"]["n_error"] == 1
+    assert "beta" in [t["task_id"] for t in seen["delta-fail"]["tasks"]]
+    assert "gamma" not in seen["delta-fail"]["task_ids"]
+
+    # Final document: full planned id set, finished status, locked created_at.
+    disk = json.loads(Path(summary["summary_path"]).read_text(encoding="utf-8"))
+    assert disk["status"] == "complete"
+    assert disk["metrics"]["n_tasks"] == 4
+    assert disk["metrics"]["pass_rate"] == pytest.approx(2 / 4)
+    assert disk["created_at"] == seen["alpha"]["created_at"]
+
+
+@pytest.mark.asyncio
+async def test_resume_rewrites_snapshot_immediately_and_keeps_created_at(
+    tmp_path: Path,
+) -> None:
+    db = _copy_fixture(tmp_path)
+    plan = plan_suite_run(db, task_id="alpha")
+    first = await execute_suite_run(
+        plan,
+        run_fn=_snapshotting_runner(plan.suite_run_id, {"alpha": "PASS"}, prefix="r1"),
+    )
+    original_created = first["created_at"]
+
+    plan2 = plan_suite_run(db, suite_run_id=first["suite_run_id"])
+    runner = _snapshotting_runner(
+        plan2.suite_run_id,
+        {"alpha": "PASS", "beta": "PASS", "delta-fail": "FAIL", "gamma": "PASS"},
+        prefix="r2",
+    )
+    second = await execute_suite_run(plan2, run_fn=runner, resume=True)
+
+    seen = runner.seen  # type: ignore[attr-defined]
+    # First task of the resume sees the snapshot rewritten from settled work
+    # only — alpha — with the original created_at and a running status.
+    first_seen = next(iter(seen.values()))
+    assert first_seen["status"] == "running"
+    assert first_seen["task_ids"] == ["alpha"]
+    assert first_seen["created_at"] == original_created
+    disk = json.loads(Path(second["summary_path"]).read_text(encoding="utf-8"))
+    assert disk["status"] == "complete"
+    assert disk["metrics"]["n_tasks"] == 4
+    assert disk["created_at"] == original_created
+    assert disk["resumed"] is True
+
+
+@pytest.mark.asyncio
+async def test_cancelled_suite_writes_cancelled_status(tmp_path: Path) -> None:
+    db = _copy_fixture(tmp_path)
+    plan = plan_suite_run(db)
+    request_suite_cancel(db, plan.suite_run_id)
+    runner = _snapshotting_runner(plan.suite_run_id, {"alpha": "PASS"}, prefix="cx")
+    summary = await execute_suite_run(plan, run_fn=runner)
+
+    disk = json.loads(Path(summary["summary_path"]).read_text(encoding="utf-8"))
+    assert disk["status"] == "cancelled"
+    assert runner.seen == {}  # type: ignore[attr-defined]  # no unit ever started
+
+
+def _never_client(*args: object, **kwargs: object) -> object:
+    raise AssertionError("registry client must not be reached for this summary")
+
+
+def _seed_upload_db(tmp_path: Path, *, status: str | None) -> Path:
+    db = tmp_path / "db"
+    db.mkdir()
+    (db / "ageval.yaml").write_text(
+        "format: ageval.dataset/1\nid: test/db\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+    suite_dir = db / ".ageval" / "suite-runs" / "suite_up_001"
+    suite_dir.mkdir(parents=True)
+    summary: dict[str, object] = {
+        "schema": "ageval.suite.summary/1",
+        "suite_run_id": "suite_up_001",
+        "dataset_id": "test/db",
+        "dataset_version": "0.1.0",
+        "attempts": [
+            {"task_id": "a", "attempt_index": 0, "status": "PASS", "run_id": "a0"}
+        ],
+        "tasks": [{"task_id": "a", "status": "PASS", "score": 1.0, "run_id": "a0"}],
+        "metrics": {
+            "pass_rate": 1.0,
+            "mean_score": 1.0,
+            "n_tasks": 1,
+            "n_pass": 1,
+            "n_fail": 0,
+            "n_error": 0,
+            "missing_score_as": 0.0,
+        },
+        "exit_code": 0,
+    }
+    if status is not None:
+        summary["status"] = status
+    (suite_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2) + "\n", encoding="utf-8"
+    )
+    return db
+
+
+@pytest.mark.parametrize("status", ["running", "cancelling"])
+def test_upload_suite_refuses_live_snapshot(tmp_path: Path, status: str) -> None:
+    db = _seed_upload_db(tmp_path, status=status)
+    cmds = ResultsCommands(client_factory=_never_client)
+    with pytest.raises(ConfigError) as excinfo:
+        cmds.upload_suite_result(db, suite_run_id="suite_up_001")
+    assert excinfo.value.error_code == "suite_in_progress"
+
+
+def test_upload_suite_complete_summary_passes_status_gate(tmp_path: Path) -> None:
+    db = _seed_upload_db(tmp_path, status="complete")
+    cmds = ResultsCommands(client_factory=_never_client)
+    # The status gate passes; the upload then reaches the (refusing) client.
+    with pytest.raises(AssertionError, match="registry client"):
+        cmds.upload_suite_result(db, suite_run_id="suite_up_001")

--- a/tests/application/test_suite_live_summary.py
+++ b/tests/application/test_suite_live_summary.py
@@ -167,9 +167,7 @@ def _seed_upload_db(tmp_path: Path, *, status: str | None) -> Path:
         "suite_run_id": "suite_up_001",
         "dataset_id": "test/db",
         "dataset_version": "0.1.0",
-        "attempts": [
-            {"task_id": "a", "attempt_index": 0, "status": "PASS", "run_id": "a0"}
-        ],
+        "attempts": [{"task_id": "a", "attempt_index": 0, "status": "PASS", "run_id": "a0"}],
         "tasks": [{"task_id": "a", "status": "PASS", "score": 1.0, "run_id": "a0"}],
         "metrics": {
             "pass_rate": 1.0,
@@ -184,9 +182,7 @@ def _seed_upload_db(tmp_path: Path, *, status: str | None) -> Path:
     }
     if status is not None:
         summary["status"] = status
-    (suite_dir / "summary.json").write_text(
-        json.dumps(summary, indent=2) + "\n", encoding="utf-8"
-    )
+    (suite_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
     return db
 
 

--- a/tests/attempt/test_scoring_bind.py
+++ b/tests/attempt/test_scoring_bind.py
@@ -1,0 +1,389 @@
+"""Scoring-box bind at evaluate phase: layers, options, and the chain (#206).
+
+The scoring EnvironmentProvider is constructed after run seals, from the
+evaluate-phase profile graphs — not the solver graph, not an empty tuple.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from ageval.attempt.ctx import AttemptCtx
+from ageval.attempt.phases.evaluate import (
+    _ensure_evaluate_host,
+    _prepare_evaluate_profiles,
+    _scoring_environment_options,
+    _scoring_plugin_layers,
+    ensure_named_host,
+)
+from ageval.plugins.defaults import register_defaults
+from ageval.plugins.image_layers import ImageLayer
+from ageval.plugins.protocol import BindingIntent, ExplicitBinding, HandlerRef
+from ageval.plugins.registry import ExtensionRegistry
+from ageval.plugins.resolve import resolve
+from ageval.plugins.services import ServiceTable
+from ageval.plugins.slots import AFTER_ENVIRONMENT_READY, ENVIRONMENT, EVALUATION_RUNTIME, EXECUTOR
+from ageval.runtime.cancellation import CancellationSignal
+
+
+class RecordingHost:
+    def __init__(self, *, root: Path, kind: str = "docker") -> None:
+        self.kind = kind
+        self.root = root
+        self.started = False
+        self.preflighted = False
+
+    async def preflight(self) -> None:
+        self.preflighted = True
+
+    async def start(self, *, force_build: bool = False) -> None:
+        del force_build
+        self.started = True
+
+    async def stop(self, *, delete: bool) -> None:
+        del delete
+
+
+class RawPassRuntime:
+    async def evaluate(self, ctx: Any) -> dict[str, Any]:
+        del ctx
+        return {"status": "PASS", "score": 1}
+
+
+class StubGraph:
+    """The shape binder.graph(pid) really returns: executor + env winners, chains."""
+
+    def __init__(
+        self,
+        *,
+        executor_plugin: str,
+        chain_plugin_ids: tuple[str, ...] = (),
+    ) -> None:
+        self.winners = {
+            ENVIRONMENT: SimpleNamespace(plugin_id="fakebox"),
+            EXECUTOR: SimpleNamespace(plugin_id=executor_plugin),
+        }
+        self.chains = {
+            AFTER_ENVIRONMENT_READY: [SimpleNamespace(plugin_id=pid) for pid in chain_plugin_ids]
+        }
+
+    def chain(self, slot: str) -> list[Any]:
+        return self.chains.get(slot, [])
+
+
+def _registry(created: list[dict[str, Any]]) -> ExtensionRegistry:
+    registry = ExtensionRegistry()
+    register_defaults(registry)
+
+    def env_factory(*, spec: Any = None, options: Any = None, plugin_layers: Any = ()) -> Any:
+        host = RecordingHost(root=Path(spec.attempt_root))
+        created.append(
+            {
+                "spec": spec,
+                "options": dict(options or {}),
+                "layers": tuple(tuple(layer) for layer in plugin_layers),
+            }
+        )
+        return host
+
+    registry.exclusive(ENVIRONMENT, "fakebox", env_factory, source="test", is_factory=True)
+    registry.exclusive(
+        EVALUATION_RUNTIME,
+        "probe",
+        lambda **_kwargs: RawPassRuntime(),
+        source="test",
+        is_factory=True,
+    )
+    return registry
+
+
+def _ctx(
+    tmp_path: Path,
+    created: list[dict[str, Any]],
+    *,
+    lock: Any,
+    graphs: dict[str, StubGraph],
+    sealed: set[str],
+) -> AttemptCtx:
+    registry = _registry(created)
+    graph = resolve(
+        BindingIntent(
+            profile_id="solver",
+            extensions=[
+                ExplicitBinding(slot=ENVIRONMENT, plugin="fakebox"),
+                ExplicitBinding(slot=EVALUATION_RUNTIME, plugin="probe"),
+            ],
+        ),
+        registry,
+    )
+    ctx = AttemptCtx(
+        run_id="r",
+        trial_id="t",
+        attempt_id="a",
+        lock=lock,
+        profile_id="solver",
+        bindings=graph,
+        registry=registry,
+        services=ServiceTable(),
+        host=RecordingHost(root=tmp_path / "agent"),  # type: ignore[arg-type]
+        evidence=SimpleNamespace(path=lambda rel: tmp_path / "run" / rel),
+        cancellation=CancellationSignal(),
+        task_root=tmp_path,
+        dataset_root=tmp_path,
+    )
+    ctx.mark_writers_stopped()
+    ctx.phase = "evaluate"
+    ctx.agent_service = SimpleNamespace(
+        service=SimpleNamespace(
+            binder=SimpleNamespace(graph=lambda pid: graphs[pid]),
+            _run_profile_ids=sealed,
+        )
+    )
+    return ctx
+
+
+def _lock(*, overlay: dict[str, Any], refs: dict[str, Any]) -> SimpleNamespace:
+    return SimpleNamespace(
+        force_build=False,
+        resolved_references=refs,
+        job_overlay=overlay,
+        agent_profiles=[
+            {
+                "id": "solver",
+                "executor": "acp",
+                "model": "entry-default",
+                "base_url": "https://solver.example.com/v1",
+            },
+            {
+                "id": "judge",
+                "executor": "openai-http",
+                "model": "gpt-judge",
+                "base_url": "https://api.judge.example.com/v1",
+            },
+        ],
+    )
+
+
+@pytest.fixture()
+def fake_layers(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record requested plugin ids; only ``*-plugin`` ones declare image_layers."""
+    requested: list[str] = []
+
+    def fake(plugin_ids: frozenset[str]) -> tuple[ImageLayer, ...]:
+        requested.extend(sorted(plugin_ids))
+        declaring = sorted(pid for pid in plugin_ids if pid.endswith("-plugin"))
+        return tuple(
+            ImageLayer(plugin_id=pid, dockerfile=Path("D"), package_root=Path("."), body="X")
+            for pid in declaring
+        )
+
+    monkeypatch.setattr("ageval.plugins.image_layers.layers_for_plugins", fake)
+    return requested
+
+
+@pytest.mark.asyncio
+async def test_scoring_host_binds_at_evaluate_with_nested_options_and_layers(
+    tmp_path: Path,
+    fake_layers: list[str],
+) -> None:
+    created: list[dict[str, Any]] = []
+    lock = _lock(
+        overlay={
+            "environment": "docker",
+            "environment_options": {"egress": "llm", "user": "10001:10001"},
+            "evaluate_host": {
+                "isolated": True,
+                "environment_options": {"egress": "llm", "network": "bridge"},
+            },
+        },
+        refs={"environment_evaluate_dockerfile": "environment/evaluate.Dockerfile"},
+    )
+    graphs = {
+        "solver": StubGraph(executor_plugin="solver-exec", chain_plugin_ids=("solver-plugin",)),
+        "judge": StubGraph(executor_plugin="judge-exec", chain_plugin_ids=("judge-plugin",)),
+    }
+    ctx = _ctx(tmp_path, created, lock=lock, graphs=graphs, sealed={"solver"})
+
+    assert ctx.evaluate_host is None  # composition no longer pre-builds the box
+    await _ensure_evaluate_host(ctx)
+
+    assert len(created) == 1
+    bind = created[0]
+    # Two boxes, two option maps: the nested map wins whole, the agent egress
+    # key is not copied over, and the judge allowlist comes from judge hosts.
+    assert bind["options"] == {
+        "egress": "llm",
+        "network": "bridge",
+        "egress_allowlist": ["api.judge.example.com"],
+    }
+    assert "solver-plugin" not in fake_layers
+    assert "judge-plugin" in fake_layers
+    assert bind["layers"] == (("judge-plugin", "D", ".", "X"),)
+    assert ctx.evaluate_host is not None and ctx.evaluate_host.started
+
+
+@pytest.mark.asyncio
+async def test_scoring_options_without_nested_map_inherit_platform_user_only(
+    tmp_path: Path,
+    fake_layers: list[str],
+) -> None:
+    created: list[dict[str, Any]] = []
+    lock = _lock(
+        overlay={
+            "environment": "docker",
+            "environment_options": {
+                "egress": "llm",
+                "network": "bridge",
+                "platform": "linux/arm64",
+                "user": "root",
+            },
+            "evaluate_host": {"isolated": True},
+        },
+        refs={
+            "environment_evaluate_dockerfile": "environment/evaluate.Dockerfile",
+            "evaluation_docker_image": "ageval-eval:grader",
+        },
+    )
+    graphs = {
+        "solver": StubGraph(executor_plugin="solver-exec"),
+        "judge": StubGraph(executor_plugin="judge-exec"),
+    }
+    ctx = _ctx(tmp_path, created, lock=lock, graphs=graphs, sealed={"solver"})
+
+    await _ensure_evaluate_host(ctx)
+
+    options = created[0]["options"]
+    # Non-inheritance: agent network/egress stay agent-only; platform/user and
+    # the scoring image are the whole story.
+    assert options == {"platform": "linux/arm64", "user": "root", "image": "ageval-eval:grader"}
+
+
+def test_scoring_layers_follow_seal_set(tmp_path: Path, fake_layers: list[str]) -> None:
+    """Sealed solver plugins stay out; unsealed ones (incl. solver) bake in."""
+    lock = _lock(overlay={}, refs={})
+    graphs = {
+        "solver": StubGraph(executor_plugin="solver-exec", chain_plugin_ids=("solver-plugin",)),
+        "judge": StubGraph(executor_plugin="judge-exec", chain_plugin_ids=("judge-plugin",)),
+    }
+
+    sealed = _ctx(tmp_path, [], lock=lock, graphs=graphs, sealed={"solver"})
+    assert _scoring_plugin_layers(sealed) == (("judge-plugin", "D", ".", "X"),)
+    assert "solver-plugin" not in fake_layers
+
+    nobody = _ctx(tmp_path, [], lock=lock, graphs=graphs, sealed=set())
+    # Run invoked nobody: every declared profile may open at evaluate.
+    assert _scoring_plugin_layers(nobody) == (
+        ("judge-plugin", "D", ".", "X"),
+        ("solver-plugin", "D", ".", "X"),
+    )
+
+
+def test_scoring_options_named_recipe_image_wins(tmp_path: Path, fake_layers: list[str]) -> None:
+    lock = _lock(
+        overlay={
+            "environment": "docker",
+            "evaluate_host": {
+                "isolated": True,
+                "environment_options": {"network": "none"},
+            },
+        },
+        refs={"evaluation_docker_image": "ageval-eval:grader"},
+    )
+    ctx = _ctx(
+        tmp_path,
+        [],
+        lock=lock,
+        graphs={
+            "solver": StubGraph(executor_plugin="solver-exec"),
+            "judge": StubGraph(executor_plugin="judge-exec"),
+        },
+        sealed=set(),
+    )
+
+    options = _scoring_environment_options(ctx, {"docker_image": "audit:2", "dockerfile": "x"})
+    assert options["image"] == "audit:2"
+    assert options["network"] == "none"
+
+
+@pytest.mark.asyncio
+async def test_prepare_evaluate_profiles_runs_non_acp_chain(tmp_path: Path) -> None:
+    ran: list[str] = []
+
+    async def handler(ctx: Any, value: Any, nxt: Any) -> Any:
+        ran.append("judge")
+        return await nxt(value)
+
+    lock = _lock(overlay={}, refs={})
+    graphs = {
+        "solver": StubGraph(executor_plugin="solver-exec"),
+        "judge": StubGraph(executor_plugin="judge-exec"),
+    }
+    graphs["judge"].chains[AFTER_ENVIRONMENT_READY] = [
+        HandlerRef(
+            plugin_id="judge-hook",
+            handler=handler,
+            priority=0,
+            source="test",
+            slot=AFTER_ENVIRONMENT_READY,
+        )
+    ]
+    ctx = _ctx(tmp_path, [], lock=lock, graphs=graphs, sealed={"solver"})
+
+    await _prepare_evaluate_profiles(ctx)
+
+    assert ran == ["judge"]
+    facts = [f for f in ctx.phase_facts if f.name == "evaluate_runtime_prepared"]
+    assert [f.detail["profile_id"] for f in facts] == ["judge"]
+
+
+@pytest.mark.asyncio
+async def test_named_scoring_host_binds_lazily_with_layers(
+    tmp_path: Path, fake_layers: list[str]
+) -> None:
+    created: list[dict[str, Any]] = []
+    lock = _lock(
+        overlay={"environment": "docker", "evaluate_host": {"isolated": True}},
+        refs={
+            "evaluation_environments": {
+                "audit": {"dockerfile": "environment/evaluate/audit/Dockerfile"}
+            },
+        },
+    )
+    graphs = {
+        "solver": StubGraph(executor_plugin="solver-exec", chain_plugin_ids=("solver-plugin",)),
+        "judge": StubGraph(executor_plugin="judge-exec", chain_plugin_ids=("judge-plugin",)),
+    }
+    ctx = _ctx(tmp_path, created, lock=lock, graphs=graphs, sealed={"solver"})
+
+    host = await ensure_named_host(ctx, "audit")
+    assert host.started
+    assert created[0]["layers"] == (("judge-plugin", "D", ".", "X"),)
+    assert created[0]["spec"].dockerfile == "environment/evaluate/audit/Dockerfile"
+    again = await ensure_named_host(ctx, "audit")
+    assert again is host
+    assert len(created) == 1
+
+
+@pytest.mark.asyncio
+async def test_scoring_host_without_recipe_stays_none(tmp_path: Path) -> None:
+    created: list[dict[str, Any]] = []
+    lock = _lock(overlay={"environment": "docker"}, refs={})
+    ctx = _ctx(
+        tmp_path,
+        created,
+        lock=lock,
+        graphs={
+            "solver": StubGraph(executor_plugin="solver-exec"),
+            "judge": StubGraph(executor_plugin="judge-exec"),
+        },
+        sealed={"solver"},
+    )
+
+    await _ensure_evaluate_host(ctx)
+
+    assert ctx.evaluate_host is None
+    assert created == []

--- a/tests/attempt/test_scoring_bind.py
+++ b/tests/attempt/test_scoring_bind.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -67,7 +67,7 @@ class StubGraph:
             ENVIRONMENT: SimpleNamespace(plugin_id="fakebox"),
             EXECUTOR: SimpleNamespace(plugin_id=executor_plugin),
         }
-        self.chains = {
+        self.chains: dict[str, list[Any]] = {
             AFTER_ENVIRONMENT_READY: [SimpleNamespace(plugin_id=pid) for pid in chain_plugin_ids]
         }
 
@@ -359,7 +359,7 @@ async def test_named_scoring_host_binds_lazily_with_layers(
     }
     ctx = _ctx(tmp_path, created, lock=lock, graphs=graphs, sealed={"solver"})
 
-    host = await ensure_named_host(ctx, "audit")
+    host = cast(RecordingHost, await ensure_named_host(ctx, "audit"))
     assert host.started
     assert created[0]["layers"] == (("judge-plugin", "D", ".", "X"),)
     assert created[0]["spec"].dockerfile == "environment/evaluate/audit/Dockerfile"

--- a/tests/config/test_evaluate_host.py
+++ b/tests/config/test_evaluate_host.py
@@ -523,3 +523,97 @@ def test_unknown_egress_value_fails_closed() -> None:
         )
     assert caught.value.error_code == "invalid_schema"
     assert "egress" in caught.value.message
+
+
+def test_evaluate_host_nested_options_lock_and_project(tmp_path: Path) -> None:
+    root = _standalone(
+        tmp_path / "pkg",
+        files=("run.py", "evaluator.py", "environment/evaluate.Dockerfile"),
+    )
+    locked = _lock(
+        root,
+        job=job_document(
+            {"solver": dict(DOCKER_SOLVER)},
+            environment="docker",
+            environment_options={"egress": "llm"},
+            evaluate_host={
+                "isolated": True,
+                "environment_options": {"egress": "llm", "network": "bridge", "user": "root"},
+            },
+        ),
+    )
+    overlay = thaw(locked.job_overlay)
+    # Two boxes, two policies: the scoring map is its own document.
+    assert overlay["evaluate_host"]["environment_options"] == {
+        "egress": "llm",
+        "network": "bridge",
+        "user": "root",
+    }
+    assert overlay["environment_options"]["egress"] == "llm"
+
+
+def test_evaluate_host_nested_options_without_isolated_fails_closed(tmp_path: Path) -> None:
+    root = _standalone(tmp_path / "pkg", files=("run.py", "evaluator.py"))
+    with pytest.raises(ConfigError) as caught:
+        _lock(
+            root,
+            job=job_document(
+                {"solver": dict(DOCKER_SOLVER)},
+                environment="docker",
+                evaluate_host={"environment_options": {"network": "bridge"}},
+            ),
+        )
+    assert caught.value.error_code == "invalid_schema"
+    assert "requires evaluate_host.isolated" in caught.value.message
+
+
+def test_evaluate_host_nested_unknown_key_fails_closed() -> None:
+    with pytest.raises(ConfigError) as caught:
+        parse_job_mapping(
+            {
+                "format": "ageval.profiles/1",
+                "environment": "docker",
+                "evaluate_host": {
+                    "isolated": True,
+                    "environment_options": {"sidecar": True},
+                },
+                "agent_profiles": {"solver": dict(DOCKER_SOLVER)},
+            }
+        )
+    assert caught.value.error_code == "invalid_schema"
+    assert "unknown evaluate_host.environment_options keys" in caught.value.message
+
+
+def test_evaluate_host_nested_image_key_fails_closed() -> None:
+    """The recipe stays environment/evaluate.Dockerfile or evaluation.docker_image."""
+    with pytest.raises(ConfigError) as caught:
+        parse_job_mapping(
+            {
+                "format": "ageval.profiles/1",
+                "environment": "docker",
+                "evaluate_host": {
+                    "isolated": True,
+                    "environment_options": {"image": "evil:latest"},
+                },
+                "agent_profiles": {"solver": dict(DOCKER_SOLVER)},
+            }
+        )
+    assert caught.value.error_code == "invalid_schema"
+    assert "unknown evaluate_host.environment_options keys" in caught.value.message
+
+
+def test_evaluate_host_nested_bad_egress_fails_closed() -> None:
+    with pytest.raises(ConfigError) as caught:
+        parse_job_mapping(
+            {
+                "format": "ageval.profiles/1",
+                "environment": "docker",
+                "evaluate_host": {
+                    "isolated": True,
+                    "environment_options": {"egress": "open"},
+                },
+                "agent_profiles": {"solver": dict(DOCKER_SOLVER)},
+            }
+        )
+    assert caught.value.error_code == "invalid_schema"
+    assert "egress" in caught.value.message

--- a/tests/viewer/test_viewer_jobs_live.py
+++ b/tests/viewer/test_viewer_jobs_live.py
@@ -1,0 +1,192 @@
+"""Viewer Jobs on a live suite snapshot: one row, settled/planned trials (#193)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from ageval.viewer import jobs
+
+REPO = Path(__file__).resolve().parents[2]
+SUITE = REPO / "tests" / "fixtures" / "datasets" / "suite-min"
+
+
+def _seed_live_suite(db: Path, job_id: str = "suite_live_001") -> None:
+    """Settled alpha(PASS) + beta(ERROR); gamma/delta-fail still planned."""
+    suite_dir = db / ".ageval" / "suite-runs" / job_id
+    suite_dir.mkdir(parents=True, exist_ok=True)
+    summary = {
+        "schema": "ageval.suite.summary/1",
+        "suite_run_id": job_id,
+        "dataset_id": "test/suite-min",
+        "dataset_version": "0.1.0",
+        "created_at": "2026-08-30T10:00:00Z",
+        "task_ids": ["alpha", "beta"],
+        "attempts": [
+            {
+                "task_id": "alpha",
+                "attempt_index": 0,
+                "status": "PASS",
+                "score": 1.0,
+                "run_id": "run_live_a",
+                "phase": "terminal",
+            },
+            {
+                "task_id": "beta",
+                "attempt_index": 0,
+                "status": "ERROR",
+                "score": None,
+                "run_id": "run_live_b",
+                "phase": "terminal",
+            },
+        ],
+        "tasks": [
+            {"task_id": "alpha", "status": "PASS", "score": 1.0, "run_id": "run_live_a"},
+            {"task_id": "beta", "status": "ERROR", "score": None, "run_id": "run_live_b"},
+        ],
+        "task_refs": [
+            {"task_id": "alpha", "status": "PASS", "score": 1.0, "run_id": "run_live_a"},
+            {"task_id": "beta", "status": "ERROR", "score": None, "run_id": "run_live_b"},
+        ],
+        "metrics": {
+            "pass_rate": 0.5,
+            "mean_score": 0.5,
+            "n_tasks": 2,
+            "n_pass": 1,
+            "n_fail": 0,
+            "n_error": 1,
+            "missing_score_as": 0.0,
+        },
+        "exit_code": 2,
+        "status": "running",
+        "note": "suite in progress; observational snapshot of settled tasks",
+    }
+    (suite_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    progress = {
+        "schema": "ageval.suite.progress/1",
+        "suite_run_id": job_id,
+        "dataset_id": "test/suite-min",
+        "dataset_version": "0.1.0",
+        "status": "running",
+        "done": 2,
+        "total": 4,
+        "n_attempts": 1,
+        "running": [{"task_id": "gamma", "attempt_index": 0, "phase": "running"}],
+        "updated_at": "2026-08-30T10:05:00Z",
+        "cancel_requested": False,
+    }
+    (suite_dir / "progress.json").write_text(
+        json.dumps(progress, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def _clean_db(tmp_path: Path) -> Path:
+    db = tmp_path / "db"
+    shutil.copytree(SUITE, db, ignore=shutil.ignore_patterns(".ageval"))
+    return db
+
+
+def test_list_jobs_shows_one_running_suite_row(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    _seed_live_suite(db)
+
+    payload = jobs.list_jobs(db)
+    suite_rows = [i for i in payload["items"] if i["source_kind"] == "suite"]
+    assert len(suite_rows) == 1
+    row = suite_rows[0]
+    assert row["job_id"] == "suite_live_001"
+    assert row["status"] == "running"
+    assert row["pass_rate"] == 0.5
+    assert row["trials_done"] == 2
+    assert row["trials_total"] == 4
+    assert row["progress"]["total"] == 4
+
+    # Settled run ids are claimed by the suite row — no single-task job rows.
+    single_ids = {i["job_id"] for i in payload["items"] if i["source_kind"] == "single"}
+    assert "run_live_a" not in single_ids
+    assert "run_live_b" not in single_ids
+    assert payload["count"] == 1
+
+
+def test_list_jobs_unclaimed_attempt_still_listed_alongside(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    _seed_live_suite(db)
+    other = db / ".ageval" / "runs" / "run_outside"
+    other.mkdir(parents=True)
+    (other / "lock.json").write_text(
+        json.dumps({"task_id": "gamma", "dataset_id": "test/suite-min", "dataset_version": "0.1.0"})
+        + "\n",
+        encoding="utf-8",
+    )
+    (other / "result.json").write_text(
+        json.dumps(
+            {
+                "task_id": "gamma",
+                "status": "FAIL",
+                "score": 0.0,
+                "dataset_id": "test/suite-min",
+                "dataset_version": "0.1.0",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    payload = jobs.list_jobs(db)
+    single_ids = {i["job_id"] for i in payload["items"] if i["source_kind"] == "single"}
+    assert single_ids == {"run_outside"}
+
+
+def test_get_job_live_snapshot_lists_settled_tasks(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    _seed_live_suite(db)
+
+    payload = jobs.get_job(db, "suite_live_001")
+    assert payload["job"]["status"] == "running"
+    assert payload["job"]["trials_done"] == 2
+    assert payload["job"]["trials_total"] == 4
+    assert [t["task_id"] for t in payload["tasks"]] == ["alpha", "beta"]
+    assert payload["progress"]["status"] == "running"
+
+
+def test_final_suite_row_keeps_finished_shape(tmp_path: Path) -> None:
+    db = _clean_db(tmp_path)
+    job_id = "suite_done_001"
+    suite_dir = db / ".ageval" / "suite-runs" / job_id
+    suite_dir.mkdir(parents=True)
+    summary = {
+        "schema": "ageval.suite.summary/1",
+        "suite_run_id": job_id,
+        "dataset_id": "test/suite-min",
+        "dataset_version": "0.1.0",
+        "created_at": "2026-08-30T09:00:00Z",
+        "task_ids": ["alpha"],
+        "attempts": [
+            {"task_id": "alpha", "attempt_index": 0, "status": "PASS", "run_id": "run_done_a"}
+        ],
+        "tasks": [{"task_id": "alpha", "status": "PASS", "score": 1.0, "run_id": "run_done_a"}],
+        "task_refs": [
+            {"task_id": "alpha", "status": "PASS", "score": 1.0, "run_id": "run_done_a"}
+        ],
+        "metrics": {
+            "pass_rate": 1.0,
+            "mean_score": 1.0,
+            "n_tasks": 1,
+            "n_pass": 1,
+            "n_fail": 0,
+            "n_error": 0,
+            "missing_score_as": 0.0,
+        },
+        "exit_code": 0,
+        "status": "complete",
+        "note": "per-task evaluator verdicts only; no suite-level PASS",
+    }
+    (suite_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    payload = jobs.list_jobs(db)
+    row = next(i for i in payload["items"] if i["source_kind"] == "suite")
+    assert row["status"] == "complete"
+    assert row["trials_done"] == 1
+    assert row["trials_total"] == 1
+    assert "progress" not in row

--- a/tests/viewer/test_viewer_jobs_live.py
+++ b/tests/viewer/test_viewer_jobs_live.py
@@ -166,9 +166,7 @@ def test_final_suite_row_keeps_finished_shape(tmp_path: Path) -> None:
             {"task_id": "alpha", "attempt_index": 0, "status": "PASS", "run_id": "run_done_a"}
         ],
         "tasks": [{"task_id": "alpha", "status": "PASS", "score": 1.0, "run_id": "run_done_a"}],
-        "task_refs": [
-            {"task_id": "alpha", "status": "PASS", "score": 1.0, "run_id": "run_done_a"}
-        ],
+        "task_refs": [{"task_id": "alpha", "status": "PASS", "score": 1.0, "run_id": "run_done_a"}],
         "metrics": {
             "pass_rate": 1.0,
             "mean_score": 1.0,


### PR DESCRIPTION
## Summary

Two hardening slices on the canary line:

**Live suite summary (#193).** While `ageval run <dataset>` is in progress, `summary.json` is rewritten under the progress lock from **settled attempts only** — `status: running` (or `cancelling`), `metrics.pass_rate = n_pass / (n_pass + n_fail + n_error)` over settled tasks, and unrun task ids appear nowhere. `created_at` locks on the first write; resume keeps the original. The same file is rewritten with the finished value on complete / cancel. Viewer Jobs shows one suite row merging `progress.json` (trials `settled / planned`, claimed run ids), and `results upload-suite` (plus slot append) refuses a running snapshot.

**Scoring-box bind (#206).** The isolated scoring EnvironmentProvider is now constructed at **evaluate phase**, after run seals, instead of at composition. Its `image_layers` union the **evaluate-phase profile graphs** — a judge plugin that declares `config.image_layers` bakes into the scoring image, solver-only plugins stay out. `evaluate_host.environment_options` declares the scoring box's own `network` / `egress` / `platform` / `user` (two boxes, two policies; omitted = today's non-inheritance of agent `egress`/`network`). The scoring `egress: llm` allowlist comes from evaluate-phase `base_url`s, and `after_environment_ready` on the scoring host no longer filters on `executor == "acp"`.

Design moved first: `docs/design/05-runtime/campaign-suite.md`, `environment.md`, `evaluation.md`, `docs/design/02-task-package-and-config.md`.

## Related

- Issue: #193, #206
- Evidence grade (if claimed): not claimed — no new docker journey; offline unit/integration tests only

## Verification

```bash
uv sync --frozen
uv run ruff format --check src tests
uv run ruff check src tests
uv run pyright
AGEVAL_OFFLINE_AGENT=1 AGEVAL_SKIP_DOCKER=1 AGEVAL_SKIP_REAL_CODEX=1 \
  AGEVAL_SKIP_REAL_PI=1 AGEVAL_SKIP_REAL_OPENCODE=1 AGEVAL_SKIP_REAL_ACP=1 \
  uv run pytest --ignore=tests/registry -q
# 980 passed, 7 skipped

uv sync --frozen --extra registry
AGEVAL_OFFLINE_AGENT=1 AGEVAL_SKIP_DOCKER=1 uv run pytest tests/registry -q
# 249 passed, 1 skipped
```

- [x] No credentials / tokens in yaml, lock, evidence, or examples
- [x] Trajectory / `RunTerminal.completed` is not treated as PASS (live snapshot is observational; a running status upload fails closed)
- [x] Product / mechanism changes updated the highest authority (design docs first, then code)
- [x] Tests: live write (settled-only denominator, locked `created_at`), viewer one-row + claimed run ids, resume append, upload reject (#193); two-policy lock, unknown nested keys, layer union seal set, non-ACP chain, lazy named bind (#206)
- [x] Local python-core equivalent (ruff / pyright / pytest ignore registry) and python-registry equivalent

Not verified: real docker isolated run (`AGEVAL_SKIP_DOCKER=1`); CI has no docker e2e, and per repo rules those skips are not acceptance.
