### PR TITLE
feat(runtime): forward AGEVAL_PIP_INDEX to plugin bake layers

### DIFF
--- a/docker/attempt/build.py
+++ b/docker/attempt/build.py
@@ -8,6 +8,7 @@ Optional process / host-env knobs (empty = official Debian / PyPI):
 
   AGEVAL_APT_MIRROR   e.g. http://mirrors.aliyun.com/debian
   AGEVAL_PIP_INDEX    e.g. https://pypi.tuna.tsinghua.edu.cn/simple
+                      (plugin bake layers read the same knob)
 
 ``ageval run`` already loads Database / cwd / repo ``.env`` before prepare.
 This script loads the same host env files when the package is importable.

--- a/plugins/dsh/docker/Dockerfile.bake
+++ b/plugins/dsh/docker/Dockerfile.bake
@@ -6,9 +6,14 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+# Optional. Parent forwards AGEVAL_PIP_INDEX as this ARG. Empty = pip default.
+# Do not ENV an empty PIP_INDEX_URL — a blank value overrides pip's default index.
+ARG PIP_INDEX_URL=
+
 USER root
 # Pin official wheels at image build. No invoke-time pip / floating npx.
-RUN python3 -m pip install --no-cache-dir "deepseek-harness-sdk==0.1.0rc6"
+RUN if [ -z "${PIP_INDEX_URL}" ]; then unset PIP_INDEX_URL; fi; \
+    python3 -m pip install --no-cache-dir "deepseek-harness-sdk==0.1.0rc6"
 
 # Prefer non-root actor when base defines it.
 USER ageval

--- a/plugins/miniswe/docker/Dockerfile.bake
+++ b/plugins/miniswe/docker/Dockerfile.bake
@@ -2,5 +2,7 @@
 # ageval-attempt:base). This file is bake input for the environment winner.
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+# Optional. Parent forwards AGEVAL_PIP_INDEX as this ARG. Empty = pip default.
+ARG PIP_INDEX_URL=
 USER ageval
 WORKDIR /attempt/workspace

--- a/plugins/nooa/docker/Dockerfile.bake
+++ b/plugins/nooa/docker/Dockerfile.bake
@@ -6,9 +6,14 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+# Optional. Parent forwards AGEVAL_PIP_INDEX as this ARG. Empty = pip default.
+# Do not ENV an empty PIP_INDEX_URL — a blank value overrides pip's default index.
+ARG PIP_INDEX_URL=
+
 USER root
 # NVIDIA OO Agents (LiteLLM-backed). Bake needs network at image build time.
-RUN python3 -m pip install --no-cache-dir "nooa>=0.0.7"
+RUN if [ -z "${PIP_INDEX_URL}" ]; then unset PIP_INDEX_URL; fi; \
+    python3 -m pip install --no-cache-dir "nooa>=0.0.7"
 
 # Prefer non-root actor when base defines it.
 USER ageval

--- a/skills/ageval-plugin/references/authoring.md
+++ b/skills/ageval-plugin/references/authoring.md
@@ -93,6 +93,9 @@ image build. No invoke-time `npm i` / floating pip. Official ACP entries do not
 use this external chain.
 
 `${BASE_IMAGE}` is usually `ageval-attempt:base` (CPython 3.12).
+Declare `ARG PIP_INDEX_URL=` after `FROM` so a parent `AGEVAL_PIP_INDEX` is
+consumed. Empty means pip's default index. Do not `ENV` a blank `PIP_INDEX_URL`.
+A `RUN pip` should `unset PIP_INDEX_URL` when the ARG is empty.
 
 ## Hook shape
 

--- a/src/ageval/plugins/contrib/docker/README.md
+++ b/src/ageval/plugins/contrib/docker/README.md
@@ -28,6 +28,7 @@ Job knobs are `environment_options` (not `extensions[].options`).
 | `environment_options.platform` | this host | `docker` platform (e.g. `linux/arm64`). |
 | `environment_options.network` | `bridge` | Attempt container network. A task compose file overrides this to `{project}_default`. |
 | `environment_options.user` | `10001:10001` | `docker run --user` and the same identity for `exec` / `attach_stdio`. `root` / `0` / `0:0` → root. Other values must be `uid` or `uid:gid`. Unknown strings are rejected. Default still has `no-new-privileges`. |
+| `AGEVAL_PIP_INDEX` (host env) | unset | When set, plugin bake layers pass it as `PIP_INDEX_URL` so image-build pip uses that index. Unset / blank = pip default. Same knob as the official Attempt image build. |
 
 ## Bind
 

--- a/src/ageval/plugins/contrib/docker/images.py
+++ b/src/ageval/plugins/contrib/docker/images.py
@@ -3,12 +3,18 @@
 The cache key is the recipe plus what it copies, never the task id or the lock
 digest — two tasks with the same recipe share one image, and editing the recipe
 invalidates it.
+
+Plugin bake layers honor parent ``AGEVAL_PIP_INDEX`` (same knob as
+``docker/attempt/build.py``). Unset omits the build-arg and leaves the content
+key unchanged. A non-empty value is ``PIP_INDEX_URL`` on the plugin-layer
+build only — task recipes and the official base path are untouched.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import shlex
 import subprocess
@@ -130,6 +136,20 @@ def resolve_image(
     )
 
 
+def plugin_bake_pip_index() -> str:
+    """Parent ``AGEVAL_PIP_INDEX`` for plugin bake layers. Empty = pip default."""
+    return (os.environ.get("AGEVAL_PIP_INDEX") or "").strip()
+
+
+def plugin_layer_build_args(base_image: str) -> tuple[str, ...]:
+    """Build-args for one plugin ``Dockerfile.bake``. Unset index omits ``PIP_INDEX_URL``."""
+    args = [f"BASE_IMAGE={base_image}"]
+    pip_index = plugin_bake_pip_index()
+    if pip_index:
+        args.append(f"PIP_INDEX_URL={pip_index}")
+    return tuple(args)
+
+
 def build_task_image(
     *,
     task_root: Path,
@@ -142,6 +162,9 @@ def build_task_image(
     """Build the task recipe, then each plugin bake with its own context."""
     recipe = _recipe_text(task_root, dockerfile_rel)
     layer_key = "\n".join(f"{plugin_id}\n{body}" for plugin_id, _, _, body in plugin_layers)
+    pip_index = plugin_bake_pip_index()
+    if plugin_layers and pip_index:
+        layer_key = f"{layer_key}\npip_index={pip_index}"
     content = content_digest(
         recipe=recipe + "\n" + layer_key,
         context_root=task_root,
@@ -168,7 +191,7 @@ def build_task_image(
             context_root=Path(package_root),
             tag=f"{PACKAGE_TAG_PREFIX}:{content[:12]}-{plugin_id}",
             platform=platform,
-            build_args=(f"BASE_IMAGE={current}",),
+            build_args=plugin_layer_build_args(current),
         )
     tagged = docker("tag", current, tag)
     if tagged.returncode != 0:

--- a/tests/plugins/test_docker_bake_pip_index.py
+++ b/tests/plugins/test_docker_bake_pip_index.py
@@ -119,10 +119,14 @@ def test_build_argv_forwards_pip_index_only_on_plugin_layer(
     )
 
     recipe_argv, plugin_argv = fake.builds
+    recipe_tag = recipe_argv[recipe_argv.index("-t") + 1]
     assert "--build-arg" not in recipe_argv
-    joined = " ".join(plugin_argv)
-    assert f"--build-arg PIP_INDEX_URL={index}" in joined
-    assert "--build-arg BASE_IMAGE=" in joined
+    args = list(plugin_argv)
+    assert args.count("--build-arg") == 2
+    pip_at = args.index(f"PIP_INDEX_URL={index}")
+    base_at = args.index(f"BASE_IMAGE={recipe_tag}")
+    assert args[pip_at - 1] == "--build-arg"
+    assert args[base_at - 1] == "--build-arg"
 
 
 def test_pip_index_changes_plugin_layer_tag_not_recipe_only(
@@ -155,6 +159,11 @@ def test_contrib_bake_recipes_declare_pip_index_arg() -> None:
     root = Path(__file__).resolve().parents[2] / "plugins"
     bakes = sorted(root.glob("*/docker/Dockerfile.bake"))
     assert bakes, "expected contrib Dockerfile.bake files"
+    pip_bakes = []
     for bake in bakes:
         text = bake.read_text(encoding="utf-8")
         assert "ARG PIP_INDEX_URL=" in text, bake
+        if "pip install" in text:
+            pip_bakes.append(bake)
+            assert "unset PIP_INDEX_URL" in text, bake
+    assert pip_bakes, "expected at least one pip-installing bake recipe"

--- a/tests/plugins/test_docker_bake_pip_index.py
+++ b/tests/plugins/test_docker_bake_pip_index.py
@@ -149,3 +149,12 @@ def test_pip_index_changes_plugin_layer_tag_not_recipe_only(
 
     assert tag_unset != tag_set
     assert tag_recipe == tag_recipe_set
+
+
+def test_contrib_bake_recipes_declare_pip_index_arg() -> None:
+    root = Path(__file__).resolve().parents[2] / "plugins"
+    bakes = sorted(root.glob("*/docker/Dockerfile.bake"))
+    assert bakes, "expected contrib Dockerfile.bake files"
+    for bake in bakes:
+        text = bake.read_text(encoding="utf-8")
+        assert "ARG PIP_INDEX_URL=" in text, bake

--- a/tests/plugins/test_docker_bake_pip_index.py
+++ b/tests/plugins/test_docker_bake_pip_index.py
@@ -1,0 +1,151 @@
+"""Plugin bake layers forward AGEVAL_PIP_INDEX as PIP_INDEX_URL."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from ageval.plugins.contrib.docker import images
+
+
+class _FakeDaemon:
+    def __init__(self) -> None:
+        self.images: set[str] = set()
+        self.builds: list[tuple[str, ...]] = []
+
+    def __call__(self, *args: str, timeout: float = 600.0) -> subprocess.CompletedProcess[str]:
+        del timeout
+        if args[:2] == ("image", "inspect"):
+            tag = args[2]
+            if tag in self.images:
+                return subprocess.CompletedProcess(
+                    list(args), 0, stdout=f"sha256:{tag}\n", stderr=""
+                )
+            return subprocess.CompletedProcess(list(args), 1, stdout="", stderr="missing")
+        if args[:2] == ("buildx", "build"):
+            self.builds.append(args)
+            tag = args[args.index("-t") + 1]
+            self.images.add(tag)
+            return subprocess.CompletedProcess(list(args), 0, stdout="", stderr="")
+        if args[0] == "tag":
+            src, dest = args[1], args[2]
+            if src in self.images:
+                self.images.add(dest)
+                return subprocess.CompletedProcess(list(args), 0, stdout="", stderr="")
+            return subprocess.CompletedProcess(list(args), 1, stdout="", stderr="missing src")
+        return subprocess.CompletedProcess(list(args), 1, stdout="", stderr=f"unexpected {args}")
+
+
+def _plugin_tree(tmp_path: Path) -> tuple[Path, tuple[tuple[str, str, str, str], ...]]:
+    task_root = tmp_path / "task"
+    task_root.mkdir()
+    (task_root / "Dockerfile").write_text("FROM ageval-attempt:base\n", encoding="utf-8")
+    plugin = tmp_path / "plugin"
+    plugin.mkdir()
+    bake = plugin / "Dockerfile.bake"
+    bake.write_text(
+        "ARG BASE_IMAGE\nFROM ${BASE_IMAGE}\nARG PIP_INDEX_URL=\n",
+        encoding="utf-8",
+    )
+    body = bake.read_text(encoding="utf-8")
+    layers = (("nooa", str(bake), str(plugin), body),)
+    return task_root, layers
+
+
+def test_plugin_bake_pip_index_empty_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGEVAL_PIP_INDEX", raising=False)
+    assert images.plugin_bake_pip_index() == ""
+    assert images.plugin_layer_build_args("ageval-pkg:base") == ("BASE_IMAGE=ageval-pkg:base",)
+
+
+def test_plugin_bake_pip_index_strips_and_forwards(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGEVAL_PIP_INDEX", "  https://pypi.tuna.tsinghua.edu.cn/simple  ")
+    assert images.plugin_bake_pip_index() == "https://pypi.tuna.tsinghua.edu.cn/simple"
+    assert images.plugin_layer_build_args("ageval-pkg:base") == (
+        "BASE_IMAGE=ageval-pkg:base",
+        "PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple",
+    )
+
+
+def test_whitespace_only_index_is_omitted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGEVAL_PIP_INDEX", "   ")
+    assert images.plugin_bake_pip_index() == ""
+    assert "PIP_INDEX_URL" not in " ".join(images.plugin_layer_build_args("ageval-pkg:base"))
+
+
+def test_build_argv_omits_pip_index_when_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AGEVAL_PIP_INDEX", raising=False)
+    fake = _FakeDaemon()
+    monkeypatch.setattr(images, "docker", fake)
+    task_root, layers = _plugin_tree(tmp_path)
+
+    images.build_task_image(
+        task_root=task_root,
+        dockerfile_rel="Dockerfile",
+        platform="linux/arm64",
+        base_digest="sha256:base",
+        force_build=True,
+        plugin_layers=layers,
+    )
+
+    assert len(fake.builds) == 2
+    recipe_argv, plugin_argv = fake.builds
+    recipe_tag = recipe_argv[recipe_argv.index("-t") + 1]
+    assert "--build-arg" not in recipe_argv
+    assert "PIP_INDEX_URL" not in " ".join(plugin_argv)
+    assert f"BASE_IMAGE={recipe_tag}" in plugin_argv
+
+
+def test_build_argv_forwards_pip_index_only_on_plugin_layer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    index = "https://pypi.tuna.tsinghua.edu.cn/simple"
+    monkeypatch.setenv("AGEVAL_PIP_INDEX", index)
+    fake = _FakeDaemon()
+    monkeypatch.setattr(images, "docker", fake)
+    task_root, layers = _plugin_tree(tmp_path)
+
+    images.build_task_image(
+        task_root=task_root,
+        dockerfile_rel="Dockerfile",
+        platform="linux/arm64",
+        base_digest="sha256:base",
+        force_build=True,
+        plugin_layers=layers,
+    )
+
+    recipe_argv, plugin_argv = fake.builds
+    assert "--build-arg" not in recipe_argv
+    joined = " ".join(plugin_argv)
+    assert f"--build-arg PIP_INDEX_URL={index}" in joined
+    assert "--build-arg BASE_IMAGE=" in joined
+
+
+def test_pip_index_changes_plugin_layer_tag_not_recipe_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = _FakeDaemon()
+    monkeypatch.setattr(images, "docker", fake)
+    task_root, layers = _plugin_tree(tmp_path)
+    kwargs = {
+        "task_root": task_root,
+        "dockerfile_rel": "Dockerfile",
+        "platform": "linux/arm64",
+        "base_digest": "sha256:base",
+        "force_build": True,
+    }
+
+    monkeypatch.delenv("AGEVAL_PIP_INDEX", raising=False)
+    tag_unset, _ = images.build_task_image(plugin_layers=layers, **kwargs)
+    tag_recipe, _ = images.build_task_image(plugin_layers=(), **kwargs)
+
+    monkeypatch.setenv("AGEVAL_PIP_INDEX", "https://pypi.tuna.tsinghua.edu.cn/simple")
+    tag_set, _ = images.build_task_image(plugin_layers=layers, **kwargs)
+    tag_recipe_set, _ = images.build_task_image(plugin_layers=(), **kwargs)
+
+    assert tag_unset != tag_set
+    assert tag_recipe == tag_recipe_set


### PR DESCRIPTION
## Summary

Plugin bake layers (`Dockerfile.bake` on top of the official Attempt image) now honor the same parent `AGEVAL_PIP_INDEX` knob the official base already uses. Unset / blank is pip's default index and omits the build-arg. When set, docker contrib passes `--build-arg PIP_INDEX_URL=…` only on plugin-layer `buildx` (task recipes and `docker/attempt/build.py` are unchanged) and folds that value into the plugin-layer content key so a cached `ageval-pkg:*` tag is not reused across indexes.

Contrib bake recipes declare `ARG PIP_INDEX_URL=`. Pip-installing recipes (`nooa`, `dsh`) `unset` an empty ARG before `pip install` so a blank value does not override pip's default — the same gotcha the official Attempt Dockerfile already documents. `miniswe` declares the ARG so a forwarded build-arg is consumed.

Issue #214 is the delivery spec; the knob already exists for the official base. No new YAML field, no APT passthrough, no default mirror.

## Related

- Issue: Closes #214
- Evidence grade (if claimed): not claimed — argv unit tests only; no live bake journey

## Verification

```bash
uv sync --frozen
uv run ruff format --check src tests
uv run ruff check src tests
uv run pyright
# 0 errors (1 pre-existing warning: tests/examples `run` import, unrelated)
uv run python scripts/check_builtin_plugins.py
uv run python scripts/check_builtin_agents.py
AGEVAL_OFFLINE_AGENT=1 AGEVAL_SKIP_DOCKER=1 AGEVAL_SKIP_REAL_CODEX=1 \
  AGEVAL_SKIP_REAL_PI=1 AGEVAL_SKIP_REAL_OPENCODE=1 AGEVAL_SKIP_REAL_ACP=1 \
  uv run pytest --ignore=tests/registry -q
# 1002 passed, 7 skipped

uv sync --frozen --extra registry
AGEVAL_OFFLINE_AGENT=1 AGEVAL_SKIP_DOCKER=1 uv run pytest tests/registry -q
# 252 passed, 1 skipped
```

- [x] Unset / blank `AGEVAL_PIP_INDEX`: plugin-layer argv has no `PIP_INDEX_URL` build-arg; recipe-only tags unchanged when the env is set
- [x] Set `AGEVAL_PIP_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple`: consecutive `--build-arg PIP_INDEX_URL=…` on the plugin layer only; plugin-layer tag changes with the index
- [x] Contrib bake files declare `ARG PIP_INDEX_URL=`; pip-installing recipes unset empty ARG
- [ ] Not verified: live plugin-layer bake against a mirror (CI has no docker e2e; `AGEVAL_SKIP_DOCKER=1`)

## Checklist

- [x] No credentials / tokens in yaml, lock, evidence, or examples
- [x] Trajectory / `RunTerminal.completed` is not treated as PASS
- [x] Product / mechanism changes updated the highest authority (issue #214 is the spec; official-base knob already in `docker/attempt/build.py`; no design-doc change)
- [x] Regression or public smoke exists; a fixture alone is not `runnable-mvp`

## Follow-ups

- Editing contrib `Dockerfile.bake` invalidates existing `ageval-pkg:*` tags for those plugins even when `AGEVAL_PIP_INDEX` is unset (accepted in the issue). One rebake after upgrade.
- Plugin bake does not copy official `trusted-host` / `sitecustomize`. HTTPS tuna is fine; HTTP mirrors may still differ from the official base path.
- Fixture `tests/fixtures/plugins/host-probe/docker/Dockerfile.bake` does not declare the ARG (unused-arg warning only if the env is set during a real bake of that fixture).

Closes #214