### PR TITLE
feat(docker): environment_options.python_version selects the Attempt base FROM

### DIFF
--- a/docker/attempt/Dockerfile
+++ b/docker/attempt/Dockerfile
@@ -3,7 +3,9 @@
 # Build once (docker/attempt/build.py); packages FROM ageval-attempt:l1 or extend upstream.
 # Python ACP SDK stays on the parent host — never installed here.
 
-FROM python:3.12-slim-bookworm
+# Base CPython minor; build.py passes --build-arg to pick another 3.x.
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim-bookworm
 
 USER root
 # Optional host build-args (empty = official Debian / PyPI). Applied before

--- a/docker/attempt/build.py
+++ b/docker/attempt/build.py
@@ -4,6 +4,11 @@ Usage:
   uv run python docker/attempt/build.py --platform linux/arm64 \\
       --output-lock .ageval/runtime-images/provider-l1.json
 
+``--python-version`` selects the base CPython minor (default 3.12). The
+Dockerfile resolves ``FROM python:${PYTHON_VERSION}-slim-bookworm``; a
+non-default version also switches the default ``--tag`` to the versioned
+``ageval-attempt:py<version>`` so bases coexist instead of overwriting.
+
 Optional process / host-env knobs (empty = official Debian / PyPI):
 
   AGEVAL_APT_MIRROR   e.g. http://mirrors.aliyun.com/debian
@@ -22,6 +27,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -32,6 +38,24 @@ if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
 BUILD_INPUT_NAMES = ("Dockerfile", "install-executors.sh", "acp-entries.lock.json")
+DEFAULT_PYTHON_VERSION = "3.12"
+_PYTHON_VERSION_RE = re.compile(r"^\d+\.\d+$")
+
+
+def valid_python_version(text: str) -> bool:
+    """A CPython minor like ``3.13``; ``latest`` / ``3`` / empty are not."""
+    return _PYTHON_VERSION_RE.fullmatch(text) is not None
+
+
+def versioned_tag(version: str) -> str:
+    return f"ageval-attempt:py{version}"
+
+
+def default_tag(python_version: str) -> str:
+    """3.12 keeps the historical ``l1`` tag; other versions get their own."""
+    if python_version == DEFAULT_PYTHON_VERSION:
+        return "ageval-attempt:l1"
+    return versioned_tag(python_version)
 
 
 def official_attempt_dir(root: Path) -> Path:
@@ -45,9 +69,11 @@ def prepare_official_build_env(root: Path) -> tuple[str, str]:
     ).strip()
 
 
-def official_build_input_digest(attempt_dir: Path, *, apt_mirror: str, pip_index: str) -> str:
+def official_build_input_digest(
+    attempt_dir: Path, *, apt_mirror: str, pip_index: str, python_version: str
+) -> str:
     hasher = hashlib.sha256()
-    hasher.update(f"{apt_mirror}\n{pip_index}\n".encode())
+    hasher.update(f"{apt_mirror}\n{pip_index}\n{python_version}\n".encode())
     for name in BUILD_INPUT_NAMES:
         path = attempt_dir / name
         if not path.is_file():
@@ -64,12 +90,14 @@ def official_buildx_command(
     context: Path,
     apt_mirror: str,
     pip_index: str,
+    python_version: str,
 ) -> list[str]:
     cmd = ["docker", "build", "--platform", platform, "-f", str(dockerfile), "-t", tag]
     if apt_mirror:
         cmd.extend(["--build-arg", f"AGEVAL_APT_MIRROR={apt_mirror}"])
     if pip_index:
         cmd.extend(["--build-arg", f"AGEVAL_PIP_INDEX={pip_index}"])
+    cmd.extend(["--build-arg", f"PYTHON_VERSION={python_version}"])
     cmd.append(str(context))
     return cmd
 
@@ -86,12 +114,29 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--platform", default="linux/arm64")
     parser.add_argument(
+        "--python-version",
+        default=DEFAULT_PYTHON_VERSION,
+        help="base CPython minor, e.g. 3.13 (default 3.12)",
+    )
+    parser.add_argument(
         "--output-lock",
         type=Path,
         default=Path(".ageval/runtime-images/provider-l1.json"),
     )
-    parser.add_argument("--tag", default="ageval-attempt:l1")
+    parser.add_argument("--tag", default=None)
     args = parser.parse_args(argv)
+
+    python_version = args.python_version.strip()
+    if not valid_python_version(python_version):
+        print(
+            f"invalid --python-version {args.python_version!r}: expected a CPython minor like 3.13",
+            file=sys.stderr,
+        )
+        return 2
+
+    tag = args.tag
+    if tag is None:
+        tag = default_tag(python_version)
 
     root = _REPO_ROOT
     attempt_dir = official_attempt_dir(root)
@@ -107,6 +152,7 @@ def main(argv: list[str] | None = None) -> int:
             attempt_dir,
             apt_mirror=apt_mirror,
             pip_index=pip_index,
+            python_version=python_version,
         )
     except FileNotFoundError as exc:
         print(str(exc), file=sys.stderr)
@@ -117,11 +163,12 @@ def main(argv: list[str] | None = None) -> int:
 
     cmd = official_buildx_command(
         dockerfile=dockerfile,
-        tag=args.tag,
+        tag=tag,
         platform=args.platform,
         context=attempt_dir,
         apt_mirror=apt_mirror,
         pip_index=pip_index,
+        python_version=python_version,
     )
     proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
     if proc.returncode != 0:
@@ -129,7 +176,7 @@ def main(argv: list[str] | None = None) -> int:
         return proc.returncode
 
     inspect = subprocess.run(
-        ["docker", "image", "inspect", args.tag, "--format", "{{json .Id}}"],
+        ["docker", "image", "inspect", tag, "--format", "{{json .Id}}"],
         check=False,
         capture_output=True,
         text=True,
@@ -143,7 +190,7 @@ def main(argv: list[str] | None = None) -> int:
             "docker",
             "image",
             "inspect",
-            args.tag,
+            tag,
             "--format",
             "{{if .RepoDigests}}{{index .RepoDigests 0}}{{else}}{{.Id}}{{end}}",
         ],
@@ -161,7 +208,7 @@ def main(argv: list[str] | None = None) -> int:
             "--rm",
             "--user",
             "10001:10001",
-            args.tag,
+            tag,
             "bash",
             "-c",
             "command -v codex && command -v codex-acp && "
@@ -182,14 +229,15 @@ def main(argv: list[str] | None = None) -> int:
     lock = {
         "kind": "docker-attempt",
         "platform": args.platform,
-        "image_tag": args.tag,
+        "python_version": python_version,
+        "image_tag": tag,
         "image_id": image_id,
         "image_digest": image_digest,
         "build_input_digest": f"sha256:{build_input}",
         "build_input_files": list(BUILD_INPUT_NAMES),
         "acp_entries_lock": pin_doc,
         "generator": "docker/attempt/build.py",
-        "runtime_abi": "python3.12",
+        "runtime_abi": f"python{python_version}",
         "actor_uid_path_probe": "ok",
     }
     args.output_lock.parent.mkdir(parents=True, exist_ok=True)

--- a/docs/design/02-task-package-and-config.md
+++ b/docs/design/02-task-package-and-config.md
@@ -103,12 +103,12 @@ yaml 显式字段覆盖缺省。旧 `harness.entrypoint` 与未知 format **拒�
 ```yaml
 format: ageval.profiles/1
 environment: local          # 或 docker / e2b / ssh / daytona
-# environment_options:      # docker：image / platform / network / user（`root` 开 root）/ egress
+# environment_options:      # docker：image / platform / network / user（`root` 开 root）/ egress / python_version
 #                           # ssh：host / user / port / key_env / image
 #                           # daytona：image / snapshot / timeout_seconds
 # evaluate_host:            # 省略 = 同一环境 evaluate
 #   isolated: true
-#   environment_options:     # 打分盒自己的 network / egress / platform / user；省略 = 不继承 agent 的 egress/network
+#   environment_options:     # 打分盒自己的 network / egress / platform / user / python_version；省略 = 不继承 agent 的 egress/network
 agent_profiles:
   solver:
     executor: acp
@@ -121,7 +121,7 @@ agent_profiles:
       - plugin: local
 ```
 
-`environment_options` 给 **run** 环境；locator 在 preflight 解析，密钥不进 digest。`evaluate_host.isolated: true` 要求成员题有打分配方，且 kind 能再起一份环境（Current：docker）；否则 lock 失败。`evaluate_host.environment_options` 是打分盒自己的旋钮（`network` / `egress` / `platform` / `user`；不是 `image`），要求 `isolated: true`；省略时打分盒只继承 job `environment_options` 的 `platform` / `user`，不继承 agent 的 `egress` / `network`。未知顶键与未知嵌套键一次拒绝。
+`environment_options` 给 **run** 环境；locator 在 preflight 解析，密钥不进 digest。`evaluate_host.isolated: true` 要求成员题有打分配方，且 kind 能再起一份环境（Current：docker）；否则 lock 失败。`evaluate_host.environment_options` 是打分盒自己的旋钮（`network` / `egress` / `platform` / `user` / `python_version`；不是 `image`），要求 `isolated: true`；省略时打分盒只继承 job `environment_options` 的 `platform` / `user` / `python_version`，不继承 agent 的 `egress` / `network`。未知顶键与未知嵌套键一次拒绝。
 
 `evaluation.environments` 是成员题上的名 → 配方表。名字 `[a-z][a-z0-9_-]*`。每个名字只允许 `dockerfile`（题相对路径）或 `docker_image`（OCI tag），或两者（与今日单只配方同一识别规则）。未知键一次错误。`dockerfile` 必须存在且不得落在 `evaluation/`（那是 gold）。写出该表则：
 

--- a/docs/design/05-runtime/environment.md
+++ b/docs/design/05-runtime/environment.md
@@ -10,13 +10,13 @@
 # profiles.yaml — 选独占槽 environment 的赢家
 format: ageval.profiles/1
 environment: e2b    # local | docker | e2b | ssh | daytona
-# environment_options:   # docker：image / platform / network / user / egress
+# environment_options:   # docker：image / platform / network / user / egress / python_version
 #                        # ssh：host / user / port / key_env / image
 #                        # daytona：image / snapshot / timeout_seconds
 # evaluate_host:         # 省略 = 同一环境打分
 #   isolated: true       # 第二只 EnvironmentProvider；不是新槽
 #   environment_options: # 打分盒自己的 docker 旋钮；省略 = 不继承 agent 的 egress / network
-#     egress: llm        # network / egress / platform / user；不是 image（配方照旧）
+#     egress: llm        # network / egress / platform / user / python_version；不是 image（配方照旧）
 ```
 
 取消隔离档产品面。不要写 `provider.kind`、`assurance: l0/l1`。Result 记 `kind` + `capabilities_used`。
@@ -36,7 +36,7 @@ environment: e2b    # local | docker | e2b | ssh | daytona
 
 `environment/Dockerfile`（或 `docker_image`）对 docker 与 e2b 是同一配方。docker 本机编；e2b `Template.from_dockerfile` 再 `Sandbox.create`。daytona 把同一配方编成 **snapshot**（`Image.from_dockerfile` 或公开 OCI tag），再 `Sandbox.create` from snapshot。OCI tag 须带具体 tag/digest；Daytona 拒绝 `latest` / `lts` / `stable`。
 
-官方 Attempt 镜像由 `docker/attempt/` 构建。题包 Dockerfile 用 `FROM ageval-attempt:base`。invoke 时禁止 `npm i` / 浮动 `npx`。Python ACP SDK 只在 parent，不进 Attempt 镜像。
+官方 Attempt 镜像由 `docker/attempt/` 构建，`ARG PYTHON_VERSION` 选基座 CPython（缺省 3.12）。题包 Dockerfile 用 `FROM ageval-attempt:base`；job 声明非缺省 `python_version` 时 docker 插件把该 `FROM` 解析到版本化 tag（如 `ageval-attempt:py3.13`），镜像内容键含 `python_version`，两个版本的本地基座并存、不互相覆盖。invoke 时禁止 `npm i` / 浮动 `npx`。Python ACP SDK 只在 parent，不进 Attempt 镜像。
 
 docker `environment_options`：
 
@@ -45,11 +45,13 @@ docker `environment_options`：
 - `network` — 缺省 `bridge`。这是 **原始 docker 网络名**。`none` 也是原始名：它会一并挡住环境内进程访问模型 API，**不是**下面的 LLM egress 模式。
 - `egress` — 省略 = 今日 `bridge`。`egress: llm`（Current：仅 docker contrib）：Agent 环境出站 HTTP(S) 只能到达已绑定 profile 的 `base_url` 主机（parent 侧代理 + 环境内 `HTTPS_PROXY` / `HTTP_PROXY`，或等价物）。ACP stdio 仍是 parent `attach_stdio`，不走这条代理。不能兑现的 kind 写了该键 → lock 失败。依赖仍 bake 在题包 `environment/Dockerfile`；官方 Attempt 镜像 invoke 时禁止 `npm i` / 浮动 `npx`。
 - `user` — 环境内身份，`docker run --user` 与 `exec`/`attach_stdio` 同一值。缺省 `10001:10001`。`root` / `0` / `0:0` 开 root（Harbor 式终端题要 `apt` 或写 `/usr/local` 时用）。其它值必须是 `uid` 或 `uid:gid`。未知字符串一次失败。默认仍带 `no-new-privileges`。
+- `python_version` — 官方 Attempt 基座的 CPython minor（如 `"3.13"`）；省略 = 3.12。形状 `^\d+\.\d+$`；`latest` / `3` / 空串 / 其它形状一次拒绝。基座 `FROM python:${python_version}-slim-bookworm` 拉不到 → image build 一次失败，**不**回退 3.12。ACP 引擎仍在 build 期 bake，Node / Go 等引擎版本不受此旋钮影响。
 
 `egress` 约束的是 **Agent 环境**。两只盒子两份策略：打分 Host 有自己的
-`evaluate_host.environment_options`（`network` / `egress` / `platform` / `user`）；
+`evaluate_host.environment_options`（`network` / `egress` / `platform` / `user` /
+`python_version`）；
 嵌套表省略时打分盒沿用今日行为——只继承 job `environment_options` 的
-`platform` / `user`，**不**继承 agent 的 `egress` / `network` 或镜像。
+`platform` / `user` / `python_version`，**不**继承 agent 的 `egress` / `network` 或镜像。
 打分 `egress: llm` 的放行名单来自 evaluate 相位 profile 的 `base_url`
 （judge 盒 reach judge 的 API host），不是 solver 名单。不能兑现该键的 kind
 写了任一处 `egress` → lock 失败，同一规则。

--- a/src/ageval/attempt/phases/evaluate.py
+++ b/src/ageval/attempt/phases/evaluate.py
@@ -190,8 +190,9 @@ def _scoring_environment_options(
     """Two boxes, two option maps.
 
     Declared ``evaluate_host.environment_options`` wins whole. Omitted, the
-    scoring box keeps today's non-inheritance: only ``platform`` / ``user``
-    from the job map, never the agent ``egress`` / ``network`` or image.
+    scoring box keeps today's non-inheritance: only ``platform`` / ``user`` /
+    ``python_version`` from the job map, never the agent ``egress`` /
+    ``network`` or image.
     """
     overlay = thaw(getattr(ctx.lock, "job_overlay", None) or {})
     host = overlay.get("evaluate_host") if isinstance(overlay.get("evaluate_host"), dict) else {}
@@ -203,7 +204,7 @@ def _scoring_environment_options(
         options = {
             key: value
             for key, value in (job_options.items() if isinstance(job_options, dict) else [])
-            if key in {"platform", "user"}
+            if key in {"platform", "user", "python_version"}
         }
     image = (recipe or {}).get("docker_image")
     if not (isinstance(image, str) and image.strip()):

--- a/src/ageval/config/profiles.py
+++ b/src/ageval/config/profiles.py
@@ -266,7 +266,7 @@ _EVALUATE_HOST_KEYS = frozenset({"isolated", "environment_options"})
 # The scoring box reads the same per-box knobs as the agent box. ``image`` is
 # deliberately absent: the recipe stays environment/evaluate.Dockerfile or
 # evaluation.docker_image.
-_EVALUATE_HOST_OPTION_KEYS = frozenset({"network", "egress", "platform", "user"})
+_EVALUATE_HOST_OPTION_KEYS = frozenset({"network", "egress", "platform", "user", "python_version"})
 _EGRESS_VALUES = frozenset({"llm"})
 
 

--- a/src/ageval/plugins/contrib/docker/README.md
+++ b/src/ageval/plugins/contrib/docker/README.md
@@ -28,6 +28,7 @@ Job knobs are `environment_options` (not `extensions[].options`).
 | `environment_options.platform` | this host | `docker` platform (e.g. `linux/arm64`). |
 | `environment_options.network` | `bridge` | Attempt container network. A task compose file overrides this to `{project}_default`. |
 | `environment_options.user` | `10001:10001` | `docker run --user` and the same identity for `exec` / `attach_stdio`. `root` / `0` / `0:0` → root. Other values must be `uid` or `uid:gid`. Unknown strings are rejected. Default still has `no-new-privileges`. |
+| `environment_options.python_version` | `3.12` | CPython minor of the official Attempt base (`python:${version}-slim-bookworm`). Shape `^\d+\.\d+$`; `latest` / `3` / empty / other shapes are rejected once. The base builds as a versioned tag (e.g. `ageval-attempt:py3.13`) and the plugin rewrites the recipe's `FROM ageval-attempt:base` onto it, so 3.12 and 3.13 bases coexist. A base that cannot be pulled fails the image build once — no fallback to 3.12. The ACP entries stay baked at build time; engine versions are unaffected. |
 | `AGEVAL_PIP_INDEX` (host env) | unset | When set, plugin bake layers pass it as `PIP_INDEX_URL` so image-build pip uses that index. Unset / blank = pip default. Same knob as the official Attempt image build. |
 
 ## Bind

--- a/src/ageval/plugins/contrib/docker/host.py
+++ b/src/ageval/plugins/contrib/docker/host.py
@@ -505,7 +505,7 @@ class DockerHost:
 
 def _box_python_version(raw: object) -> str | None:
     """Job ``environment_options.python_version``. None = the official 3.12 base."""
-    if raw is None or raw == "":
+    if raw is None:
         return None
     text = _text(raw)
     if text is None or not _PYTHON_VERSION_RE.fullmatch(text):

--- a/src/ageval/plugins/contrib/docker/host.py
+++ b/src/ageval/plugins/contrib/docker/host.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+import re
 import shutil
 import subprocess
 import uuid
@@ -39,6 +40,7 @@ BOX_ROOT = "/attempt"
 ATTEMPT_UID = 10001
 ATTEMPT_GID = 10001
 _MAX_STREAM_BYTES = 256 * 1024
+_PYTHON_VERSION_RE = re.compile(r"^\d+\.\d+$")
 
 # The daemon locators the docker CLI itself needs. They describe *this* machine,
 # so they must never be projected into a container.
@@ -112,6 +114,7 @@ class DockerHost:
         # The Agent runs inside the box and has to reach its provider.
         self._network = _text(opts.get("network")) or "bridge"
         self._user = _box_user(opts.get("user"))
+        self._python_version = _box_python_version(opts.get("python_version"))
         self._egress = _text(opts.get("egress"))
         raw_allow = opts.get("egress_allowlist") or ()
         if isinstance(raw_allow, (list, tuple)):
@@ -149,6 +152,7 @@ class DockerHost:
             platform=self._platform,
             force_build=force_build,
             plugin_layers=self._plugin_layers,
+            python_version=self._python_version,
         )
         self._image = tag
         # Sidecars come up first: the Attempt container joins their network, so
@@ -497,6 +501,20 @@ class DockerHost:
             raise EnvironmentFailure("environment_not_started", "docker box is not started")
         if self._stopped:
             raise EnvironmentFailure("environment_stopped", "docker box is already stopped")
+
+
+def _box_python_version(raw: object) -> str | None:
+    """Job ``environment_options.python_version``. None = the official 3.12 base."""
+    if raw is None or raw == "":
+        return None
+    text = _text(raw)
+    if text is None or not _PYTHON_VERSION_RE.fullmatch(text):
+        raise EnvironmentFailure(
+            "environment_options_invalid",
+            "docker environment_options.python_version must be a CPython minor "
+            f'like "3.13", got {raw!r}',
+        )
+    return text
 
 
 def _box_user(raw: object) -> str:

--- a/src/ageval/plugins/contrib/docker/images.py
+++ b/src/ageval/plugins/contrib/docker/images.py
@@ -8,6 +8,11 @@ Plugin bake layers honor parent ``AGEVAL_PIP_INDEX`` (same knob as
 ``docker/attempt/build.py``). Unset omits the build-arg and leaves the content
 key unchanged. A non-empty value is ``PIP_INDEX_URL`` on the plugin-layer
 build only — task recipes and the official base path are untouched.
+
+``python_version`` selects the official base's CPython. The default keeps the
+historical ``ageval-attempt:base`` tag; another minor builds
+``ageval-attempt:py<version>`` and the recipe's ``FROM ageval-attempt:base``
+resolves onto that tag, so two bases coexist locally.
 """
 
 from __future__ import annotations
@@ -27,7 +32,9 @@ from ageval.environments.protocol import EnvironmentFailure
 BASE_TAG = "ageval-attempt:base"
 PACKAGE_TAG_PREFIX = "ageval-pkg"
 BASE_LOCK_PATH = Path(".ageval") / "runtime-images" / "attempt-base.json"
+DEFAULT_PYTHON_VERSION = "3.12"
 
+_BASE_FROM_RE = re.compile(r"^FROM\s+ageval-attempt:base\b", re.IGNORECASE | re.MULTILINE)
 _COPY_HEAD = re.compile(r"^(COPY|ADD)\s+", re.IGNORECASE)
 _SKIP_COPY_NAMES = frozenset({".ageval", ".git", "__pycache__", "node_modules"})
 _DIGEST_FORMAT = "{{if .RepoDigests}}{{index .RepoDigests 0}}{{else}}{{.Id}}{{end}}"
@@ -56,38 +63,59 @@ def image_digest(tag: str) -> str | None:
     return (found.stdout or "").strip() or None
 
 
-def ensure_base_image(repo_root: Path) -> str:
+def base_tag_for(python_version: str | None) -> str:
+    """The official base tag this job's CPython resolves to."""
+    if not python_version or python_version == DEFAULT_PYTHON_VERSION:
+        return BASE_TAG
+    return f"ageval-attempt:py{python_version}"
+
+
+def base_lock_path(python_version: str | None) -> Path:
+    """Per-version build lock so two bases do not overwrite each other's record."""
+    tag = base_tag_for(python_version)
+    if tag == BASE_TAG:
+        return BASE_LOCK_PATH
+    return BASE_LOCK_PATH.with_name(f"{BASE_LOCK_PATH.stem}-py{python_version}.json")
+
+
+def ensure_base_image(repo_root: Path, *, python_version: str | None = None) -> str:
     """Digest of the official base image, building it when absent.
 
     The base bakes the ACP entries, so a run must never fall back to installing
-    an agent at invoke time.
+    an agent at invoke time. A base whose upstream ``python:`` tag cannot be
+    pulled fails the build once — there is no fallback to the default version.
     """
-    digest = image_digest(BASE_TAG)
+    tag = base_tag_for(python_version)
+    digest = image_digest(tag)
     if digest is not None:
         return digest
     build_script = repo_root / "docker" / "attempt" / "build.py"
     if not build_script.is_file():
         raise EnvironmentFailure(
             "environment_image_unresolved",
-            f"{BASE_TAG} is missing and {build_script} is not in this checkout",
+            f"{tag} is missing and {build_script} is not in this checkout",
         )
+    command = [
+        sys.executable,
+        str(build_script),
+        "--tag",
+        tag,
+        "--output-lock",
+        str(repo_root / base_lock_path(python_version)),
+    ]
+    if tag != BASE_TAG:
+        assert python_version is not None
+        command.extend(["--python-version", python_version])
     built = subprocess.run(  # noqa: S603 — repo-local build entrypoint
-        [
-            sys.executable,
-            str(build_script),
-            "--tag",
-            BASE_TAG,
-            "--output-lock",
-            str(repo_root / BASE_LOCK_PATH),
-        ],
+        command,
         check=False,
         cwd=str(repo_root),
     )
-    digest = image_digest(BASE_TAG)
+    digest = image_digest(tag)
     if built.returncode != 0 or digest is None:
         raise EnvironmentFailure(
             "environment_image_unresolved",
-            f"could not build the official base image {BASE_TAG}",
+            f"could not build the official base image {tag}",
         )
     return digest
 
@@ -101,12 +129,13 @@ def resolve_image(
     platform: str,
     force_build: bool,
     plugin_layers: Sequence[tuple[str, str, str, str]] = (),
+    python_version: str | None = None,
 ) -> tuple[str, str]:
     """Return ``(tag, digest)`` for this Attempt's image.
 
     A declared ``docker_image`` is used as-is. A task recipe is built on top of
-    the official base, and the bound plugins' declared layers are baked on top of
-    that. With neither, the base itself is the box.
+    the official base, and the bound plugins' declared layers are baked on top
+    of that. With neither, the base itself is the box.
 
     Each plugin layer is ``(plugin_id, dockerfile_path, package_root, body)``.
     """
@@ -123,14 +152,16 @@ def resolve_image(
                 )
         return declared_image, digest
 
-    base_digest = ensure_base_image(repo_root)
+    base_digest = ensure_base_image(repo_root, python_version=python_version)
+    base_tag = base_tag_for(python_version)
     if dockerfile_rel is None and not plugin_layers:
-        return BASE_TAG, base_digest
+        return base_tag, base_digest
     return build_task_image(
         task_root=task_root,
         dockerfile_rel=dockerfile_rel,
         platform=platform,
         base_digest=base_digest,
+        base_tag=base_tag,
         force_build=force_build,
         plugin_layers=plugin_layers,
     )
@@ -156,11 +187,16 @@ def build_task_image(
     dockerfile_rel: str | None,
     platform: str,
     base_digest: str,
+    base_tag: str = BASE_TAG,
     force_build: bool,
     plugin_layers: Sequence[tuple[str, str, str, str]] = (),
 ) -> tuple[str, str]:
-    """Build the task recipe, then each plugin bake with its own context."""
-    recipe = _recipe_text(task_root, dockerfile_rel)
+    """Build the task recipe, then each plugin bake with its own context.
+
+    The recipe's ``FROM ageval-attempt:base`` resolves onto ``base_tag`` so a
+    non-default CPython base is the one under the task image.
+    """
+    recipe = _recipe_text(task_root, dockerfile_rel, base_tag)
     layer_key = "\n".join(f"{plugin_id}\n{body}" for plugin_id, _, _, body in plugin_layers)
     pip_index = plugin_bake_pip_index()
     if plugin_layers and pip_index:
@@ -170,6 +206,7 @@ def build_task_image(
         context_root=task_root,
         platform=platform,
         base_digest=base_digest,
+        base_tag=base_tag,
     )
     tag = f"{PACKAGE_TAG_PREFIX}:{content[:12]}"
     if not force_build:
@@ -252,10 +289,10 @@ def _build_named(
     return tag, digest
 
 
-def _recipe_text(task_root: Path, dockerfile_rel: str | None) -> str:
-    """The task's recipe, or a bare FROM when only plugins contribute layers."""
+def _recipe_text(task_root: Path, dockerfile_rel: str | None, base_tag: str = BASE_TAG) -> str:
+    """The task's recipe (base FROM resolved), or a bare FROM for plugins only."""
     if dockerfile_rel is None:
-        return f"FROM {BASE_TAG}\n"
+        return f"FROM {base_tag}\n"
     dockerfile = (task_root / dockerfile_rel).resolve()
     try:
         dockerfile.relative_to(task_root.resolve())
@@ -269,7 +306,10 @@ def _recipe_text(task_root: Path, dockerfile_rel: str | None) -> str:
             "environment_image_unresolved",
             f"missing task recipe: {dockerfile_rel}",
         )
-    return dockerfile.read_text(encoding="utf-8")
+    recipe = dockerfile.read_text(encoding="utf-8")
+    if base_tag == BASE_TAG:
+        return recipe
+    return _BASE_FROM_RE.sub(f"FROM {base_tag}", recipe)
 
 
 def content_digest(
@@ -278,15 +318,23 @@ def content_digest(
     context_root: Path,
     platform: str,
     base_digest: str,
+    base_tag: str = BASE_TAG,
 ) -> str:
-    """Recipe + base identity + copied bytes + platform."""
+    """Recipe + base identity + copied bytes + platform.
+
+    A non-default ``base_tag`` also enters the key, so 3.12 and 3.13 bases
+    never share a task image even when the recipe text alone would collide.
+    """
     hasher = hashlib.sha256()
-    for label, payload in (
-        (b"dockerfile", recipe.encode("utf-8")),
-        (b"base", base_digest.encode("utf-8")),
-        (b"platform", platform.encode("utf-8")),
-    ):
-        hasher.update(label + b"\0" + payload + b"\0")
+    fields: list[tuple[bytes, str]] = [
+        (b"dockerfile", recipe),
+        (b"base", base_digest),
+        (b"platform", platform),
+    ]
+    if base_tag != BASE_TAG:
+        fields.append((b"python", base_tag))
+    for label, payload in fields:
+        hasher.update(label + b"\0" + payload.encode("utf-8") + b"\0")
     _hash_copy_sources(context_root, copy_sources(recipe), hasher)
     return hasher.hexdigest()
 

--- a/src/ageval/plugins/contrib/docker/images.py
+++ b/src/ageval/plugins/contrib/docker/images.py
@@ -34,7 +34,10 @@ PACKAGE_TAG_PREFIX = "ageval-pkg"
 BASE_LOCK_PATH = Path(".ageval") / "runtime-images" / "attempt-base.json"
 DEFAULT_PYTHON_VERSION = "3.12"
 
-_BASE_FROM_RE = re.compile(r"^FROM\s+ageval-attempt:base\b", re.IGNORECASE | re.MULTILINE)
+_BASE_FROM_RE = re.compile(
+    r"^FROM(?P<flags>(?:\s+--[^\s]+)*)\s+ageval-attempt:base\b",
+    re.IGNORECASE | re.MULTILINE,
+)
 _COPY_HEAD = re.compile(r"^(COPY|ADD)\s+", re.IGNORECASE)
 _SKIP_COPY_NAMES = frozenset({".ageval", ".git", "__pycache__", "node_modules"})
 _DIGEST_FORMAT = "{{if .RepoDigests}}{{index .RepoDigests 0}}{{else}}{{.Id}}{{end}}"
@@ -309,7 +312,7 @@ def _recipe_text(task_root: Path, dockerfile_rel: str | None, base_tag: str = BA
     recipe = dockerfile.read_text(encoding="utf-8")
     if base_tag == BASE_TAG:
         return recipe
-    return _BASE_FROM_RE.sub(f"FROM {base_tag}", recipe)
+    return _BASE_FROM_RE.sub(lambda m: f"FROM{m.group('flags')} {base_tag}", recipe)
 
 
 def content_digest(

--- a/tests/attempt/test_scoring_bind.py
+++ b/tests/attempt/test_scoring_bind.py
@@ -227,7 +227,7 @@ async def test_scoring_host_binds_at_evaluate_with_nested_options_and_layers(
 
 
 @pytest.mark.asyncio
-async def test_scoring_options_without_nested_map_inherit_platform_user_only(
+async def test_scoring_options_without_nested_map_inherit_platform_user_python(
     tmp_path: Path,
     fake_layers: list[str],
 ) -> None:
@@ -240,6 +240,7 @@ async def test_scoring_options_without_nested_map_inherit_platform_user_only(
                 "network": "bridge",
                 "platform": "linux/arm64",
                 "user": "root",
+                "python_version": "3.13",
             },
             "evaluate_host": {"isolated": True},
         },
@@ -257,9 +258,14 @@ async def test_scoring_options_without_nested_map_inherit_platform_user_only(
     await _ensure_evaluate_host(ctx)
 
     options = created[0]["options"]
-    # Non-inheritance: agent network/egress stay agent-only; platform/user and
-    # the scoring image are the whole story.
-    assert options == {"platform": "linux/arm64", "user": "root", "image": "ageval-eval:grader"}
+    # Non-inheritance: agent network/egress stay agent-only; platform/user,
+    # python_version and the scoring image are the whole story.
+    assert options == {
+        "platform": "linux/arm64",
+        "user": "root",
+        "python_version": "3.13",
+        "image": "ageval-eval:grader",
+    }
 
 
 def test_scoring_layers_follow_seal_set(tmp_path: Path, fake_layers: list[str]) -> None:

--- a/tests/config/test_evaluate_host.py
+++ b/tests/config/test_evaluate_host.py
@@ -567,6 +567,23 @@ def test_evaluate_host_nested_options_without_isolated_fails_closed(tmp_path: Pa
     assert "requires evaluate_host.isolated" in caught.value.message
 
 
+def test_evaluate_host_nested_python_version_is_accepted() -> None:
+    """python_version is a per-box docker knob; image stays rejected."""
+    parsed = parse_job_mapping(
+        {
+            "format": "ageval.profiles/1",
+            "environment": "docker",
+            "evaluate_host": {
+                "isolated": True,
+                "environment_options": {"python_version": "3.13"},
+            },
+            "agent_profiles": {"solver": dict(DOCKER_SOLVER)},
+        }
+    )
+    host = parsed.evaluate_host
+    assert host is not None and host["environment_options"] == {"python_version": "3.13"}
+
+
 def test_evaluate_host_nested_unknown_key_fails_closed() -> None:
     with pytest.raises(ConfigError) as caught:
         parse_job_mapping(

--- a/tests/plugins/test_attempt_base_build.py
+++ b/tests/plugins/test_attempt_base_build.py
@@ -1,0 +1,56 @@
+"""docker/attempt/build.py — base CPython selection and versioned tags."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_BUILD_SCRIPT = Path(__file__).resolve().parents[2] / "docker" / "attempt" / "build.py"
+_spec = importlib.util.spec_from_file_location("attempt_base_build", _BUILD_SCRIPT)
+assert _spec is not None and _spec.loader is not None
+build = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(build)
+
+
+@pytest.mark.parametrize("version", ["3.9", "3.10", "3.12", "3.13"])
+def test_valid_python_version_shape(version: str) -> None:
+    assert build.valid_python_version(version)
+
+
+@pytest.mark.parametrize("version", ["latest", "3", "", "3.13.1", "v3.13", "3.13 ", "x"])
+def test_invalid_python_version_shape(version: str) -> None:
+    assert not build.valid_python_version(version)
+
+
+def test_default_tag_keeps_l1_for_312_and_versions_others() -> None:
+    assert build.default_tag("3.12") == "ageval-attempt:l1"
+    assert build.default_tag("3.13") == "ageval-attempt:py3.13"
+
+
+def test_buildx_command_passes_python_version(tmp_path: Path) -> None:
+    cmd = build.official_buildx_command(
+        dockerfile=tmp_path / "Dockerfile",
+        tag="ageval-attempt:py3.13",
+        platform="linux/arm64",
+        context=tmp_path,
+        apt_mirror="",
+        pip_index="",
+        python_version="3.13",
+    )
+    assert cmd[cmd.index("--build-arg") + 1] == "PYTHON_VERSION=3.13"
+
+
+def test_build_input_digest_tracks_python_version(tmp_path: Path) -> None:
+    for name in build.BUILD_INPUT_NAMES:
+        (tmp_path / name).write_text(f"{name}\n", encoding="utf-8")
+    common = {"apt_mirror": "", "pip_index": ""}
+    digest_312 = build.official_build_input_digest(tmp_path, python_version="3.12", **common)
+    digest_313 = build.official_build_input_digest(tmp_path, python_version="3.13", **common)
+    assert digest_312 != digest_313
+
+
+@pytest.mark.parametrize("version", ["latest", "3", ""])
+def test_main_rejects_invalid_python_version_before_docker(version: str) -> None:
+    assert build.main(["--python-version", version]) == 2

--- a/tests/plugins/test_docker_python_version.py
+++ b/tests/plugins/test_docker_python_version.py
@@ -12,9 +12,8 @@ from ageval.plugins.contrib.docker import images
 from ageval.plugins.contrib.docker.host import DockerHost, _box_python_version
 
 
-@pytest.mark.parametrize("raw", [None, ""])
-def test_python_version_omitted_is_none(raw: object) -> None:
-    assert _box_python_version(raw) is None
+def test_python_version_omitted_is_none() -> None:
+    assert _box_python_version(None) is None
 
 
 @pytest.mark.parametrize("raw", ["3.9", "3.10", "3.13"])
@@ -22,7 +21,7 @@ def test_python_version_accepts_minor(raw: str) -> None:
     assert _box_python_version(raw) == raw
 
 
-@pytest.mark.parametrize("raw", ["latest", "3", "  ", "3.13.1", True, 3.13])
+@pytest.mark.parametrize("raw", ["", "latest", "3", "  ", "3.13.1", True, 3.13])
 def test_python_version_rejects_other_shapes(raw: object) -> None:
     with pytest.raises(EnvironmentFailure, match="CPython minor"):
         _box_python_version(raw)
@@ -63,6 +62,15 @@ def test_bare_recipe_uses_versioned_base() -> None:
         images._recipe_text(Path("."), None, "ageval-attempt:py3.13")
         == "FROM ageval-attempt:py3.13\n"
     )
+
+
+def test_recipe_from_with_build_flags_resolves_onto_versioned_base(tmp_path: Path) -> None:
+    text = "FROM --platform=linux/arm64 ageval-attempt:base\nRUN pip install x\n"
+    recipe = tmp_path / "Dockerfile"
+    recipe.write_text(text, encoding="utf-8")
+    assert images._recipe_text(tmp_path, "Dockerfile") == text
+    resolved = images._recipe_text(tmp_path, "Dockerfile", "ageval-attempt:py3.13")
+    assert resolved.startswith("FROM --platform=linux/arm64 ageval-attempt:py3.13\n")
 
 
 def test_content_digest_separates_python_bases(tmp_path: Path) -> None:

--- a/tests/plugins/test_docker_python_version.py
+++ b/tests/plugins/test_docker_python_version.py
@@ -1,0 +1,224 @@
+"""docker environment_options.python_version — base selection and FROM resolve."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from ageval.environments.protocol import BoxSpec, EnvironmentFailure
+from ageval.plugins.contrib.docker import images
+from ageval.plugins.contrib.docker.host import DockerHost, _box_python_version
+
+
+@pytest.mark.parametrize("raw", [None, ""])
+def test_python_version_omitted_is_none(raw: object) -> None:
+    assert _box_python_version(raw) is None
+
+
+@pytest.mark.parametrize("raw", ["3.9", "3.10", "3.13"])
+def test_python_version_accepts_minor(raw: str) -> None:
+    assert _box_python_version(raw) == raw
+
+
+@pytest.mark.parametrize("raw", ["latest", "3", "  ", "3.13.1", True, 3.13])
+def test_python_version_rejects_other_shapes(raw: object) -> None:
+    with pytest.raises(EnvironmentFailure, match="CPython minor"):
+        _box_python_version(raw)
+
+
+def test_host_constructor_rejects_bad_python_version(tmp_path: Path) -> None:
+    spec = BoxSpec(attempt_root=tmp_path / "box", task_root=tmp_path, repo_root=tmp_path)
+    with pytest.raises(EnvironmentFailure, match="CPython minor"):
+        DockerHost(spec=spec, options={"python_version": "latest"})
+
+
+def test_base_tag_default_and_versioned() -> None:
+    assert images.base_tag_for(None) == "ageval-attempt:base"
+    assert images.base_tag_for("3.12") == "ageval-attempt:base"
+    assert images.base_tag_for("3.13") == "ageval-attempt:py3.13"
+
+
+def test_base_lock_path_versions_non_default() -> None:
+    assert images.base_lock_path(None) == images.BASE_LOCK_PATH
+    assert images.base_lock_path("3.13").name == "attempt-base-py3.13.json"
+
+
+def test_recipe_from_resolves_onto_versioned_base(tmp_path: Path) -> None:
+    recipe = tmp_path / "Dockerfile"
+    recipe.write_text(
+        "FROM ageval-attempt:base\nRUN pip install x\n# FROM ageval-attempt:base in a comment\n",
+        encoding="utf-8",
+    )
+    assert images._recipe_text(tmp_path, "Dockerfile") == recipe.read_text(encoding="utf-8")
+    resolved = images._recipe_text(tmp_path, "Dockerfile", "ageval-attempt:py3.13")
+    assert resolved.startswith("FROM ageval-attempt:py3.13\n")
+    assert "RUN pip install x\n" in resolved
+
+
+def test_bare_recipe_uses_versioned_base() -> None:
+    assert images._recipe_text(Path("."), None) == "FROM ageval-attempt:base\n"
+    assert (
+        images._recipe_text(Path("."), None, "ageval-attempt:py3.13")
+        == "FROM ageval-attempt:py3.13\n"
+    )
+
+
+def test_content_digest_separates_python_bases(tmp_path: Path) -> None:
+    common = {
+        "recipe": "FROM ageval-attempt:base\n",
+        "context_root": tmp_path,
+        "platform": "linux/arm64",
+        "base_digest": "sha256:x",
+    }
+    default = images.content_digest(**common, base_tag=images.BASE_TAG)
+    assert default == images.content_digest(**common)
+    assert default != images.content_digest(**common, base_tag="ageval-attempt:py3.13")
+
+
+class _FakeDaemon:
+    """image inspect + buildx tag bookkeeping, like the pip-index tests."""
+
+    def __init__(self) -> None:
+        self.images: set[str] = set()
+        self.builds: list[tuple[str, str]] = []  # (tag, dockerfile text)
+
+    def __call__(self, *args: str, timeout: float = 600.0) -> subprocess.CompletedProcess[str]:
+        del timeout
+        if args[:2] == ("image", "inspect"):
+            tag = args[2]
+            if tag in self.images:
+                return subprocess.CompletedProcess(
+                    list(args), 0, stdout=f"sha256:{tag}\n", stderr=""
+                )
+            return subprocess.CompletedProcess(list(args), 1, stdout="", stderr="missing")
+        if args[:2] == ("buildx", "build"):
+            tag = args[args.index("-t") + 1]
+            source = Path(args[args.index("-f") + 1])
+            self.builds.append((tag, source.read_text(encoding="utf-8")))
+            self.images.add(tag)
+            return subprocess.CompletedProcess(list(args), 0, stdout="", stderr="")
+        if args[0] == "tag":
+            src, dest = args[1], args[2]
+            if src in self.images:
+                self.images.add(dest)
+                return subprocess.CompletedProcess(list(args), 0, stdout="", stderr="")
+            return subprocess.CompletedProcess(list(args), 1, stdout="", stderr="missing src")
+        return subprocess.CompletedProcess(list(args), 1, stdout="", stderr=f"unexpected {args}")
+
+
+def _fake_base_build(monkeypatch: pytest.MonkeyPatch, daemon: _FakeDaemon) -> list[list[str]]:
+    calls: list[list[str]] = []
+
+    def run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        del kwargs
+        calls.append(list(argv))
+        daemon.images.add(argv[argv.index("--tag") + 1])
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(images.subprocess, "run", run)
+    return calls
+
+
+def _fake_repo(tmp_path: Path) -> Path:
+    """A repo root whose build.py exists; the subprocess itself is faked."""
+    attempt_dir = tmp_path / "docker" / "attempt"
+    attempt_dir.mkdir(parents=True, exist_ok=True)
+    (attempt_dir / "build.py").write_text("# stub\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_resolve_image_builds_versioned_base_and_resolves_recipe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    daemon = _FakeDaemon()
+    monkeypatch.setattr(images, "docker", daemon)
+    build_calls = _fake_base_build(monkeypatch, daemon)
+    repo = _fake_repo(tmp_path)
+    (tmp_path / "Dockerfile").write_text("FROM ageval-attempt:base\n", encoding="utf-8")
+
+    tag, _digest = images.resolve_image(
+        task_root=tmp_path,
+        repo_root=repo,
+        dockerfile_rel="Dockerfile",
+        declared_image=None,
+        platform="linux/arm64",
+        force_build=True,
+        python_version="3.13",
+    )
+
+    assert tag.startswith("ageval-pkg:")
+    assert build_calls == [
+        [
+            images.sys.executable,
+            str(tmp_path / "docker" / "attempt" / "build.py"),
+            "--tag",
+            "ageval-attempt:py3.13",
+            "--output-lock",
+            str(tmp_path / ".ageval" / "runtime-images" / "attempt-base-py3.13.json"),
+            "--python-version",
+            "3.13",
+        ]
+    ]
+    assert len(daemon.builds) == 1
+    assert daemon.builds[0][1].startswith("FROM ageval-attempt:py3.13")
+
+
+def test_resolve_image_without_recipe_returns_versioned_base(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    daemon = _FakeDaemon()
+    monkeypatch.setattr(images, "docker", daemon)
+    _fake_base_build(monkeypatch, daemon)
+    repo = _fake_repo(tmp_path)
+
+    tag, _digest = images.resolve_image(
+        task_root=tmp_path,
+        repo_root=repo,
+        dockerfile_rel=None,
+        declared_image=None,
+        platform="linux/arm64",
+        force_build=False,
+        python_version="3.13",
+    )
+
+    assert tag == "ageval-attempt:py3.13"
+
+
+def test_resolve_image_default_keeps_base_tag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    daemon = _FakeDaemon()
+    monkeypatch.setattr(images, "docker", daemon)
+    build_calls = _fake_base_build(monkeypatch, daemon)
+    repo = _fake_repo(tmp_path)
+
+    tag, _digest = images.resolve_image(
+        task_root=tmp_path,
+        repo_root=repo,
+        dockerfile_rel=None,
+        declared_image=None,
+        platform="linux/arm64",
+        force_build=False,
+    )
+
+    assert tag == "ageval-attempt:base"
+    assert build_calls[0][build_calls[0].index("--tag") + 1] == "ageval-attempt:base"
+    assert "--python-version" not in build_calls[0]
+
+
+def test_missing_upstream_base_fails_once_without_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    daemon = _FakeDaemon()
+    monkeypatch.setattr(images, "docker", daemon)
+
+    def fail_build(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        del argv, kwargs
+        return subprocess.CompletedProcess(["docker"], 1, stdout="", stderr="pull access denied")
+
+    monkeypatch.setattr(images.subprocess, "run", fail_build)
+
+    with pytest.raises(EnvironmentFailure, match="ageval-attempt:py3.13"):
+        images.ensure_base_image(_fake_repo(tmp_path), python_version="3.13")


### PR DESCRIPTION
## Summary

Docker jobs can pick the official Attempt base's CPython with `environment_options.python_version` (e.g. `"3.13"`). Omitted, today's 3.12 base and its image identity are unchanged. The base build takes `ARG PYTHON_VERSION` into `FROM python:${PYTHON_VERSION}-slim-bookworm`; a non-default version builds the versioned local tag `ageval-attempt:py<version>` with its own build lock, and the docker plugin resolves the recipe's `FROM ageval-attempt:base` (including `FROM --platform=…` flag forms) onto that tag, folding the base tag into the image content key so 3.12 and 3.13 never share or overwrite an image. The isolated scoring host inherits `python_version` from the job options, same rule as `platform` / `user`.

Design moved first: `docs/design/05-runtime/environment.md`, `docs/design/02-task-package-and-config.md`, and the docker plugin README (parameter catalog). ACP engines stay baked at image build; no invoke-time install, and engine versions are untouched by this knob.

## Approach

- **Knob:** `environment_options.python_version` on the docker job and on `evaluate_host.environment_options` (allowlisted in `config/profiles.py`). Shape `^\d+\.\d+$`; `latest` / `3` / `""` / whitespace / non-strings are one `environment_options_invalid` at bind, before any start.
- **Base build:** `docker/attempt/build.py --python-version` validates the shape before touching docker, bakes `PYTHON_VERSION` into the build, records it in the build-input digest and `runtime_abi`, and defaults `--tag` to `ageval-attempt:py<version>` for non-3.12.
- **Plugin resolve:** `ensure_base_image` builds/reads the versioned tag and a per-version `attempt-base-py<version>.json` lock; `resolve_image` threads `python_version` through so bare-plugin and task-recipe images alike land on the right base. A base whose upstream tag cannot be built fails once, with no fallback to 3.12.
- **Scoring host:** with no nested `evaluate_host.environment_options`, the scoring box inherits `python_version` next to `platform` / `user`; `egress` / `network` / image stay agent-only.

## Related

- Issue: Closes #217
- Evidence grade (if claimed): not claimed — argv/unit-level verification; no live docker journey in this pass (see Follow-ups)

## Verification

```bash
uv sync --frozen
uv run ruff format --check src tests
uv run ruff check src tests
uv run pyright
# 0 errors (1 pre-existing warning: tests/examples `run` import, unrelated)
AGEVAL_OFFLINE_AGENT=1 AGEVAL_SKIP_DOCKER=1 AGEVAL_SKIP_REAL_CODEX=1 \
  AGEVAL_SKIP_REAL_PI=1 AGEVAL_SKIP_REAL_OPENCODE=1 AGEVAL_SKIP_REAL_ACP=1 \
  uv run pytest --ignore=tests/registry -q
# 1041 passed, 7 skipped, 1 deselected

uv sync --frozen --extra registry
AGEVAL_OFFLINE_AGENT=1 AGEVAL_SKIP_DOCKER=1 uv run pytest tests/registry -q
# 252 passed, 1 skipped
```

Deselected locally: `tests/plugins/test_nooa_box_executor.py::test_invoke_runs_worker_through_local_exec` — it bootstraps the PyPI `nooa` stack at test time, which needs real PyPI access this sandbox lacks; the rest of that file passes, the test is untouched by this PR, and it runs in CI with network.

- [x] Omit `python_version`: base tag stays `ageval-attempt:base`, default digest input and `l1` / `python3.12` build record unchanged
- [x] `"3.13"` / `"3.10"`: versioned base argv (`PYTHON_VERSION` build-arg), recipe `FROM` resolve incl. flag form, bare-plugin recipes included
- [x] `latest` / `3` / `""` / bad shape: one error, no start (host bind) / exit 2 before any docker call (build.py)
- [x] Upstream tag missing: one `environment_image_unresolved`, no fallback
- [x] Two jobs coexist: distinct versioned tags + per-version build locks
- [x] Image content key changes with `python_version`
- [x] No credentials / tokens in yaml, lock, evidence, or examples
- [x] Trajectory / `RunTerminal.completed` is not treated as PASS
- [x] Product / mechanism changes updated the highest authority (design 02 / 05 + plugin README first, then code)
- [ ] Not verified: live pull of `python:3.13-slim-bookworm`, 3.12 + 3.13 coexistence on a real daemon, ACP detect on the versioned base (CI has no docker e2e; the skip is not acceptance)

## Follow-ups

- `examples/datasets/minimal-demo` member recipes still say `FROM ageval-attempt:l1`, not the documented `ageval-attempt:base` — they neither follow the knob nor resolve without a manually built `l1` tag (pre-existing drift).
- `docker/attempt/build.py --python-version 3.13` without an explicit `--output-lock` still writes `provider-l1.json` (operator ergonomics only; the product path always passes a per-version lock).
- One real-docker acceptance run (pull, coexistence, ACP detect) should land on the issue before any evidence-grade claim.

Closes #217
