### PR TITLE
feat(acp): bake the bound ACP entry onto the task image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ apps/* / services/* README  ← SPA / 服务开发细节；非产品教程权威
 
 - Coding-agent **Target inlet**：`executor: acp` + `- plugin: acp` / `options.entry`；parent **唯一** ACP JSON-RPC client → evidence。
 - Vendor 私有格式翻译在 **进程外** ACP entry（Mode 1 shim / Mode 2 原生 / Mode 3 厂商包）；**禁止**在 ageval 内再写第二套 vendor stdout scrape。
-- **官方 Attempt 镜像** `docker/attempt` 在 **build 期** 写入镜像 最低 entry 的 engine + ACP 入口（Mode 1 **同时装 engine 和 adapter**：codex/claude/**pi** + 各自 adapter）；禁止 invoke 时 `npm i` / floating `npx`。Python ACP SDK **只在 parent**，不进 Attempt 镜像。
+- **官方 Attempt 镜像** `docker/attempt` 在 **build 期** 写入镜像 最低 entry 的 engine + ACP 入口（Mode 1 **同时装 engine 和 adapter**：codex/claude/**pi** + 各自 adapter）。题包配方再叠 ACP `image_layers`，只 bake 绑定的 `options.entry`；禁止 invoke 时 `npm i` / floating `npx`。Python ACP SDK **只在 parent**，不进 Attempt 镜像。
 - Pi：官方 registry **`pi-acp`**（npm `pi-acp`，桥 `pi --mode rpc`）；勿与反向桥 `pi-shell-acp` 混淆。
 - **可见性**：mount + `docker exec -u/-w` + UID/GID（只在 docker contrib）。**Permission**：batch 默认 ACP auto-approve，**不**提权、**不**突破未投影路径；evidence 记录 decision。
 - 权威：[docs/design/05-runtime/agent-service.md](docs/design/05-runtime/agent-service.md)。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -298,7 +298,7 @@ environment phase
   before_environment
   host.start
   upload data/ → /attempt/workspace
-  after_environment_ready      # ACP name+pin+stdio initialize, else install
+  after_environment_ready      # ACP probe; skip install when bake matches
   environment_setup            # setup.sh (defaults)
   after_environment
 
@@ -391,7 +391,8 @@ Phase detail: [docs/design/05-runtime/lifecycle.md](docs/design/05-runtime/lifec
 | `environment: ssh` A/B | `plugins/contrib/ssh` | A has no image; B has a remote tag |
 | ACP coding-agent | `plugins/contrib/acp` | Sole coding-agent inlet; `attach_stdio` |
 | Other Agent backends | `openai-http` / `anthropic-http` / external `nooa` `dsh` | Not vendor stdout scrape |
-| Official base image | `docker/attempt/` | Bake ACP entries at build; no `npm i` at invoke |
+| Official base image | `docker/attempt/` | Bake every shipped ACP entry at build; no `npm i` at invoke |
+| ACP task image layer | `plugins/contrib/acp` | `config.image_layers` bakes the bound `options.entry` onto the task recipe |
 | Registry HTTP | `services/registry/` | Handlers do not touch `state.meta` directly |
 
 ## Failure and Privacy Boundary

--- a/docs/design/00-overview-and-product.md
+++ b/docs/design/00-overview-and-product.md
@@ -148,7 +148,7 @@ Agent / `run.py` 阶段 **不得** `upload` `evaluation/`。evaluate phase 开�
 
 ### US12 — 云上已有 image：连上 + 探测再装 agent
 
-`environment: ssh`。**A** 无 `image`：环境=整机，`attach_stdio` = `ssh -T -- argv`。**B** 有已有 tag：`start` 远端 `docker run`，`attach_stdio` = `ssh -- docker exec -i`。两种 agent 都在云上。ACP 挂 `after_environment_ready`：名字 + 钉死包版本 + stdio `initialize`，不对再按 entry `install_command` 装。
+`environment: ssh`。**A** 无 `image`：环境=整机，`attach_stdio` = `ssh -T -- argv`。**B** 有已有 tag：`start` 远端 `docker run`，`attach_stdio` = `ssh -- docker exec -i`。两种 agent 都在云上。ACP 挂 `after_environment_ready`：名字 + 钉死包版本 + stdio `initialize`；docker bake 已匹配则跳过安装，不对再按 entry `install_command` 装。
 
 ## 红线
 
@@ -188,7 +188,7 @@ gold 隔离是**时间切**：不 mount，evaluate 再 upload。这是默认，�
 - Agent 后端：独占槽 `executor`。环境：独占槽 `environment`。扩展只有 exclusive 与 chain。
 - 题包根：**dataset**，format `ageval.dataset/1`。CLI：`ageval lock` / `ageval.yaml`。
 - gold：同一环境；evaluate 开头再 upload。
-- ACP：`after_environment_ready` 探名字 + 钉死包版本 + stdio `initialize`，不对再按 entry `install_command` 装。
+- ACP：docker 在 `host.start()` 用插件 `image_layers` bake 绑定的 `options.entry`；`after_environment_ready` 探名字 + 钉死包版本 + stdio `initialize`，已匹配则跳过，不对再按 entry `install_command` 装。
 - ssh：A 整机 / B 远端已有容器。inject：`service: environment`。
 
 ## 审查问题（实现时对照）

--- a/docs/design/01-ageval-core.md
+++ b/docs/design/01-ageval-core.md
@@ -103,7 +103,7 @@ async def run(ctx) -> None:
     await emit(ctx, "after_environment")
 ```
 
-- `after_environment_ready`：环境已开、`environment_setup` 之前。HOME overlay、env inject、**ACP 探测再装**挂这里。按 `options.entry` 探名字 + 钉死包版本 + 一次 stdio `initialize`；齐了就跳过；不对再按 entry 的 `install_command` `exec`。失败 = environment 相位失败。不把安装写进 task `setup.sh`。
+- `after_environment_ready`：环境已开、`environment_setup` 之前。HOME overlay、env inject、**ACP 探测**挂这里。按 `options.entry` 探名字 + 钉死包版本 + 一次 stdio `initialize`；docker bake 已匹配则跳过 `install_command`；不对再按 entry 的 `install_command` `exec`。失败 = environment 相位失败。不把安装写进 task `setup.sh`。invoke 不是装引擎的 happy path。
 - `environment_setup`：默认插件若存在 `environment/setup.sh`（或 yaml 覆盖的 entry）则 `host.exec`。本题依赖，不是 agent CLI。
 - bake / `image_layers` 消化在 `host.start()` 内部（docker build / e2b template），不是 attempt 上的独立 phase。`kind: ssh` 且 skip_build 时无 bake。
 

--- a/docs/design/05-runtime/agent-service.md
+++ b/docs/design/05-runtime/agent-service.md
@@ -95,7 +95,7 @@ Agent Service **跨 evaluate 保持**（或 reopen）：`evaluator.py` 才能 `A
 - `evaluator.py` 与 `run.py` 一样是 **parent 子进程**。`AGEVAL_AGENT_SERVICE_SOCK` 是本机 unix 路径，不 bind-mount 进容器。
 - evaluate 相位的 `Agent.session`（judge 等 **未** 在 run 用过的 profile）走同一 Parent Agent Service。ACP `attach_stdio` 打 **打分 Host**（environment 服务 rebound 到当时的打分实例），不是 Agent Host。solver 仍密封。
 - 有 `evaluation.environments` 时，`session(profile_id, environment=<name>)` 只在 evaluate 相位（`seal_run` 之后）把 environment 服务绑到那只命名 Host（懒 start + **对该 profile** 跑 `after_environment_ready`）。未知名、run 相位点名、或 ACP 省略名字一次失败，不 start。省略 `environment=` = 无名表时的那只打分 Host。`openai-http` / `anthropic-http` 忽略 `environment=`。
-- isolated 打分环境 start 之后，对上述 ACP profile 再跑 `after_environment_ready`（probe / 按 entry `install_command`）。不要把 solver 的 ACP 配方装进打分镜像。
+- isolated 打分环境 start 之后，对上述 ACP profile 再跑 `after_environment_ready`（probe；bake 已匹配则跳过 `install_command`）。不要把 solver 的 ACP 配方装进打分镜像。
 - Agent 容器 **没有** docker daemon socket。ACP / `attempt` / `run.py` 仍然不见 `container_id`。
 
 observe 这些 invoke：`evaluation/observation.jsonl`（省略 `user` 行）。不是 PASS。
@@ -171,9 +171,9 @@ kind 名是 `anthropic-http`（api-client，Anthropic Messages）。与 `openai-
 0. **lock overlay（Attempt HOME，不拷宿主）。** lock 已有 `model` / `api_key` locator / 可选 `base_url`。箱子 `start` 之后、`attach_stdio` 之前，ACP contrib 按 **entry** 写成该引擎自己的配置文件（Pi：`.pi/agent/models.json` + `settings.json`；OpenCode：`.config/opencode/opencode.json`；Codex：`.codex/config.toml`（Attempt 已隔离，写 `sandbox_mode = danger-full-access`，禁止再套一层 bwrap）；Claude Code：`.claude/settings.json`）。`entry-default` 不写。locator **值**不进文件（Pi `$ENV`、OpenCode `{env:NAME}`）。**禁止**从宿主 `~/.pi` / `~/.config` 拷 catalog。local / docker / e2b 同一条 Attempt HOME。Claude Code 同时把 lock 的 `model` 投影进 attach env（`ANTHROPIC_MODEL`；有 `base_url` 时再写 `ANTHROPIC_DEFAULT_*` / `CLAUDE_CODE_SUBAGENT_MODEL`）。Codex ACP 默认 `workspace-write`（bwrap）；Attempt 里投影 `INITIAL_AGENT_MODE=agent-full-access`，并写 `.codex/models.json` + `model_catalog_json`（slug 等于 `model`）。grok-build 仍 argv `--model`。
 1. 读 `options.entry`（如 `pi`）→ 需要哪些环境内二进制（`pi`、`pi-acp`、…）以及 entry 表钉死的包版本。
 2. `host.exec` 探测三件事：名字（`which`）、钉死的 npm 包版本（`npm ls -g pkg@pin`）、一次便宜的 stdio JSON-RPC `initialize`（不是 `session/prompt`）。同名但协议不是 stdio ACP（例如只开 TCP 的旧 `opencode`）算未命中。
-3. **三件都齐就跳过。** 任一不对再按 **ACP entry 自己的** `install_command` `exec`，装完再探一次。失败 = environment 相位失败。不把「怎么装 opencode」下放到 environment 插件。
+3. **三件都齐就跳过。** docker 上题包配方已叠 ACP `image_layers`、且 pin + stdio `initialize` 命中时，不跑 `install_command`。local / 未 bake 的云 snapshot 等面，任一不对再按 **ACP entry 自己的** `install_command` `exec`，装完再探一次。失败 = environment 相位失败。不把「怎么装 opencode」下放到 environment 插件。invoke 禁止把 `npm i` / 浮动 `npx` 当 happy path。
 4. 不把安装写进 task `setup.sh`。`setup.sh` 只本题依赖。
-5. docker 官方 Attempt 镜像已 bake 且版本+stdio 对得上时，探测命中；云上瘦镜像或 snapshot 里是错版本/错协议才会走到安装。invoke 禁止 `npm i` / 浮动 `npx`。
+5. **build 期 bake（docker）。** ACP 插件声明 `config.image_layers`（`docker/Dockerfile.bake`），合同与 miniswe / dsh / nooa 相同：`ARG BASE_IMAGE` / `FROM ${BASE_IMAGE}`，缺 Node 才装 Node，再 `npm install -g` lock 绑定 `options.entry` 在 `acp_entries.json` 里钉死的 engine + ACP 包。只 bake **当前绑定的 entry**，不把五份 entry 写进每张题图。内容键已含插件层正文（`src/ageval/plugins/contrib/docker/images.py`）：同配方 + 同 entry + 同 platform 复用；同配方换 entry → 新层；换 `model` 不进内容键。题包已 `FROM ageval-attempt:base` 时叠层幂等（pin 已在基座则同 pin）。无浮动 `npx`。
 
 Python ACP SDK 只在 parent，不进 Attempt 镜像。
 
@@ -183,4 +183,4 @@ batch 默认 auto-approve，不提权、不突破未投影路径。decision 进 
 
 Pi：官方 registry `pi-acp`（npm `pi-acp`，桥 `pi --mode rpc`）。勿与反向桥 `pi-shell-acp` 混淆。
 
-官方 Attempt 镜像 `docker/attempt` 在 **build 期** 写入镜像 最低 entry 的 engine + ACP 入口（Mode 1 同时装 engine 和 adapter：codex/claude/**pi** + 各自 adapter）。
+官方 Attempt 镜像 `docker/attempt` 在 **build 期** 写入镜像 最低 entry 的 engine + ACP 入口（Mode 1 同时装 engine 和 adapter：codex/claude/**pi** + 各自 adapter）。题包配方不是这份基座时（例如 `FROM ubuntu:24.04`），由 ACP `image_layers` 在题图上再 bake **绑定的** `options.entry`；不要为此改写题包 `FROM`，也不要在 invoke 后再 `npm i`。

--- a/docs/design/05-runtime/environment.md
+++ b/docs/design/05-runtime/environment.md
@@ -36,7 +36,7 @@ environment: e2b    # local | docker | e2b | ssh | daytona
 
 `environment/Dockerfile`（或 `docker_image`）对 docker 与 e2b 是同一配方。docker 本机编；e2b `Template.from_dockerfile` 再 `Sandbox.create`。daytona 把同一配方编成 **snapshot**（`Image.from_dockerfile` 或公开 OCI tag），再 `Sandbox.create` from snapshot。OCI tag 须带具体 tag/digest；Daytona 拒绝 `latest` / `lts` / `stable`。
 
-官方 Attempt 镜像由 `docker/attempt/` 构建，`ARG PYTHON_VERSION` 选基座 CPython（缺省 3.12）。题包 Dockerfile 用 `FROM ageval-attempt:base`；job 声明非缺省 `python_version` 时 docker 插件把该 `FROM` 解析到版本化 tag（如 `ageval-attempt:py3.13`），镜像内容键含 `python_version`，两个版本的本地基座并存、不互相覆盖。invoke 时禁止 `npm i` / 浮动 `npx`。Python ACP SDK 只在 parent，不进 Attempt 镜像。
+官方 Attempt 镜像由 `docker/attempt/` 构建，`ARG PYTHON_VERSION` 选基座 CPython（缺省 3.12）。题包 Dockerfile 用 `FROM ageval-attempt:base`；job 声明非缺省 `python_version` 时 docker 插件把该 `FROM` 解析到版本化 tag（如 `ageval-attempt:py3.13`），镜像内容键含 `python_version`，两个版本的本地基座并存、不互相覆盖。题包也可以 `FROM ubuntu:24.04`（或其它发行版）：docker 按配方构建，再叠绑定插件的 `image_layers`。ACP 只 bake lock 的 `options.entry`（钉死包来自 `acp_entries.json`），不改写题包 `FROM`，也不把全部 ACP entry 写进每张题图。官方基座配方仍然有效；叠层在 pin 已存在时幂等。invoke 时禁止 `npm i` / 浮动 `npx`。Python ACP SDK 只在 parent，不进 Attempt 镜像。
 
 docker `environment_options`：
 
@@ -110,7 +110,7 @@ Locator：`DAYTONA_API_KEY`（接受 `daytona_api_key`）。缺钥或缺 SDK imp
 
 ssh A / B 由 `environment_options.image` 是否为空决定。host/user/`key_env` 是 locator，preflight 解析，不进 lock 明文密钥。
 
-ACP 挂 `after_environment_ready`：名字 + 钉死包版本 + 一次 stdio `initialize`，不对再按 ACP entry 的 `install_command` 装。云镜像已 bake 且版本/协议对得上时探测命中，不得再装一遍。同名但不是 stdio ACP 的二进制不算命中。
+ACP 挂 `after_environment_ready`：名字 + 钉死包版本 + 一次 stdio `initialize`。docker bake 已匹配 pin + stdio `initialize` 时跳过 `install_command`；不对再按 ACP entry 的 `install_command` 装。云镜像 / 官方基座已 bake 且版本/协议对得上时探测命中，不得再装一遍。同名但不是 stdio ACP 的二进制不算命中。
 
 ## locality
 

--- a/docs/design/05-runtime/evaluation.md
+++ b/docs/design/05-runtime/evaluation.md
@@ -101,8 +101,10 @@ runtime：打分盒实例在 **evaluate 相位**（writer 已密封）构造：c
 的联合（`bind_winner` 的赢家工厂仍是 Attempt 级 docker 插件；`BoxSpec` 仍只装
 evaluate 配方与独立 attempt root）——
 declare 了 `config.image_layers` 的 judge 插件由此 bake 进打分镜像，solver 独占的
-插件不进。无 `image_layers` 的插件（含 `acp`）不加东西；官方 ACP 引擎仍是 **配方**
-问题（`FROM` 官方 attempt 基座），不是 Core wrap。`evaluation_runtime` 仍是独占槽
+插件不进。无 `image_layers` 的插件不加东西。ACP 若出现在 evaluate 相位 graph（例如
+ACP judge）则只 bake 该 graph 绑定的 `options.entry`；solver 的 ACP 层不进打分镜像。
+官方 ACP 引擎仍可走 **配方**（`FROM` 官方 attempt 基座）；非基座配方由 ACP 插件层
+补绑定 entry，不是 Core wrap。`evaluation_runtime` 仍是独占槽
 默认引擎，parent 子进程跑 `evaluator.py`。isolated 时对 **未在 run 打开过的 profile**
 （不限 executor kind）在打分环境上再跑 `after_environment_ready`；空链 no-op，
 不跑 `environment_setup`。SDK 仍不得拥有 `host.start` / `host.upload`。

--- a/docs/design/05-runtime/lifecycle.md
+++ b/docs/design/05-runtime/lifecycle.md
@@ -20,7 +20,7 @@ created
 
 ## 相位
 
-1. **environment** — `host.start`，upload `data/`，链 `after_environment_ready`（ACP 探测再装；齐了跳过）、`environment_setup`（`setup.sh`，末槽，不是 provision phase）。
+1. **environment** — `host.start`（docker 在此消化 `image_layers`，含 ACP 绑定 entry），upload `data/`，链 `after_environment_ready`（ACP 探测；bake 已匹配则跳过安装）、`environment_setup`（`setup.sh`，末槽，不是 provision phase）。
 2. **run** — 子进程调 `run.py`。Agent invoke 走 parent socket。结束时停 Agent Service 并 `mark_writers_stopped`。
 3. **evaluate** — 停 writer 之后 upload `evaluation/`，环境内跑 `evaluator.py`，`bind_evaluation`。
 4. **record** — collect/enrich → 引擎写 `trajectory.jsonl`。

--- a/docs/design/08-conversion-security-testing.md
+++ b/docs/design/08-conversion-security-testing.md
@@ -6,6 +6,6 @@
 
 测试面是公开 CLI + 真实 kind。无凭证 skip 该 job，不标完成。禁止 FakeHost / `executor: mock`。默认 CI skip 真 ACP/E2B/SSH，不得提供 mock 绿路径。`AGEVAL_SKIP_REAL_ACP=1` 只表示 CI 没跑这条。
 
-官方 Attempt 镜像由 `docker/attempt/` 构建（题包 `FROM ageval-attempt:base`）。`FROM` 此基座不是上游 runtime：钉死 checkout 实际 import 的版本，在 **image build** 门禁，不要靠运行时 `apt`/`pip`/`npm i` 当默认等价路径。Core **不会**隐式 COPY `shared/` 进镜像。
+官方 Attempt 镜像由 `docker/attempt/` 构建（题包 `FROM ageval-attempt:base`）。非基座配方（例如 `FROM ubuntu:24.04`）由绑定插件的 `image_layers` 在题图上补依赖；ACP 只 bake 当前 `options.entry`。`FROM` 此基座不是上游 runtime：钉死 checkout 实际 import 的版本，在 **image build** 门禁，不要靠运行时 `apt`/`pip`/`npm i` 当默认等价路径。Core **不会**隐式 COPY `shared/` 进镜像。
 
 lock 成功、Hub 上架、改 import 契约 **都不**升级证据等级。

--- a/docs/design/11-extension-plugins.md
+++ b/docs/design/11-extension-plugins.md
@@ -74,7 +74,7 @@ agent_profiles:
     extensions: [ssh, acp]
 ```
 
-外置包实例见 `plugins/nooa/plugin.yaml`：`slots.exclusive` / `slots.chain`，`host_requires`，`config.image_layers`（给 environment 赢家 bake，**不是**时间线槽）。
+外置包实例见 `plugins/nooa/plugin.yaml`：`slots.exclusive` / `slots.chain`，`host_requires`，`config.image_layers`（给 environment 赢家 bake，**不是**时间线槽）。first-party `acp` 同样声明 `config.image_layers`：只 bake 该 graph 绑定的 `options.entry`（钉死包来自 `acp_entries.json`），不把全部 ACP entry 写进每张题图。
 
 `description` 可选。一段功能说明；Hub 插件详情把它画在 Install (CLI) 上方。缺省不展示。空字符串 / 非字符串则拒绝。Hub 渲染 Markdown 链接（`[text](https://…)`）；其它块级语法不展示。
 
@@ -90,7 +90,7 @@ agent_profiles:
 
 独占槽默认赢家（Current）：`environment` 由 job `environment:` 选出（缺省常见 local 或 docker，以 profiles 为准）；`executor` 由 **各** `agent_profiles.*.executor` 选出（coding-agent 默认 acp；judge 行可以是 `openai-http` 或 `anthropic-http`）；`evaluation_runtime` / `trajectory_seal` 由引擎 `plugin_id: default` 赢（parent `evaluator.py` / 轨迹文件 writer）。缺默认注册 → lock 失败，不能进入运行。lock 记录 **per-profile** executor 绑定。
 
-链默认：`after_environment_ready`（ACP 探测安装 + HOME overlay）；`environment_setup`（`setup.sh`，引擎 defaults）。
+链默认：`after_environment_ready`（ACP 探测；bake 已匹配则跳过安装 + HOME overlay）；`environment_setup`（`setup.sh`，引擎 defaults）。
 
 ## 解析
 

--- a/services/registry/builtin_plugins.json
+++ b/services/registry/builtin_plugins.json
@@ -36,7 +36,7 @@
   },
   {
     "plugin_id": "acp",
-    "description": "Coding-agent executor: parent is the only [ACP](https://agentclientprotocol.com) JSON-RPC client (`executor: acp` + `options.entry`). Vendor CLIs stay behind a process-out ACP entry (native, shim, or vendor package). Injects `environment.attach_stdio`. Official Attempt images bake entries at build time; invoke does not `npm i`.",
+    "description": "Coding-agent executor: parent is the only [ACP](https://agentclientprotocol.com) JSON-RPC client (`executor: acp` + `options.entry`). Vendor CLIs stay behind a process-out ACP entry (native, shim, or vendor package). Injects `environment.attach_stdio`. Official Attempt images bake every shipped entry at build time. Task recipes also stack ``config.image_layers`` for the bound ``options.entry``. Invoke does not ``npm i``.",
     "host_requires": [],
     "exclusive": ["executor"],
     "chain": ["after_environment_ready", "trajectory_collect"]

--- a/skills/ageval-plugin/references/authoring.md
+++ b/skills/ageval-plugin/references/authoring.md
@@ -88,9 +88,10 @@ not import the Core-touching factory.
 ## Image layers (docker bake)
 
 Not a timeline slot. The environment winner reads `config.image_layers` at `host.start()`.
-`executor:` alone does not bake. Context = installed plugin root. Pin wheels at
-image build. No invoke-time `npm i` / floating pip. Official ACP entries do not
-use this external chain.
+`executor:` alone does not bake. Context = installed plugin root (first-party
+contribs use the package next to the plugin). Pin wheels / npm at image build.
+No invoke-time `npm i` / floating pip. First-party ACP uses the same contract
+and bakes only the bound `options.entry` (pins from `acp_entries.json`).
 
 `${BASE_IMAGE}` is usually `ageval-attempt:base` (CPython 3.12).
 Declare `ARG PIP_INDEX_URL=` after `FROM` so a parent `AGEVAL_PIP_INDEX` is

--- a/src/ageval/plugins/contrib/acp/README.md
+++ b/src/ageval/plugins/contrib/acp/README.md
@@ -20,8 +20,8 @@ scrape in this repo.
 | --- | --- |
 | export | exclusive `executor` |
 | inject | `environment`: `attach_stdio` |
-| chain | `after_environment_ready` (probe the box; install the entry only if missing — official images already bake pi / Codex / Claude + adapters), `trajectory_collect` |
-| bake | — (official Attempt image; invoke does not `npm i`) |
+| chain | `after_environment_ready` (probe the box; skip `install_command` when the bake already matches pin + stdio `initialize`), `trajectory_collect` |
+| bake | `docker/Dockerfile.bake` — bound `options.entry` only (pins from `acp_entries.json`). Official Attempt images still bake every shipped entry. Invoke does not `npm i`. |
 
 Missing `attach_stdio` fails at **lock**, not mid-invoke.
 

--- a/src/ageval/plugins/contrib/acp/__init__.py
+++ b/src/ageval/plugins/contrib/acp/__init__.py
@@ -1,7 +1,8 @@
 """ACP first-party contrib: parent client, entry registry, executor SPI.
 
 Not an external ``plugins/acp`` package and not installed via ``ageval plugin
-install``. Official entries stay bake-in on ``docker/attempt``.
+install``. Official Attempt images bake every shipped entry; task recipes
+also stack ``config.image_layers`` for the bound ``options.entry``.
 """
 
 from __future__ import annotations

--- a/src/ageval/plugins/contrib/acp/bake.py
+++ b/src/ageval/plugins/contrib/acp/bake.py
@@ -1,0 +1,89 @@
+"""Render the ACP plugin bake Dockerfile for one bound ``options.entry``.
+
+Pins and detect names stay in ``acp_entries.json``. The template is a
+Dockerfile; this module only substitutes the bound entry. No floating ``npx``.
+"""
+
+from __future__ import annotations
+
+from ageval.plugins.contrib.acp.registry import AcpEntryDescriptor, get_entry
+from ageval.plugins.errors import ExtensionMaterializeError
+
+PACKAGES_MARKER = "__ACP_ENTRY_PACKAGES__"
+DETECT_MARKER = "__ACP_DETECT_BINARIES__"
+
+_CODEX_NATIVE_RUN = r"""
+# Codex ACP vendors a nested @openai/codex; the platform native must sit next to it.
+RUN set -eu; \
+    case "$(uname -m)" in \
+      aarch64|arm64) pkg="@openai/codex-linux-arm64"; tag="linux-arm64" ;; \
+      x86_64|amd64) pkg="@openai/codex-linux-x64"; tag="linux-x64" ;; \
+      *) echo "unsupported uname -m $(uname -m) for Codex native binary" >&2; exit 1 ;; \
+    esac; \
+    while IFS= read -r -d '' pkgjson; do \
+      dir="$(dirname "${pkgjson}")"; \
+      ver="$(node -p "require('${pkgjson}').version")"; \
+      (cd "${dir}" && npm install --omit=dev --no-package-lock --no-fund --no-audit \
+        "${pkg}@npm:@openai/codex@${ver}-${tag}"); \
+    done < <(find /usr/lib/node_modules -path '*/@openai/codex/package.json' -print0)
+"""
+
+
+def render_bake_body(template: str, entry_id: str) -> str:
+    """Fill the bake template with the pinned packages for *entry_id*."""
+    descriptor = get_entry(entry_id)
+    if descriptor is None:
+        raise ExtensionMaterializeError(
+            f"unknown acp entry: {entry_id!r}",
+            kind="extension_materialize_failed",
+        )
+    if PACKAGES_MARKER not in template or DETECT_MARKER not in template:
+        raise ExtensionMaterializeError(
+            "acp bake template missing package or detect marker",
+            kind="extension_materialize_failed",
+        )
+    packages = _npm_packages(descriptor.install_command)
+    detect = _detect_verify(descriptor)
+    body = template.replace(PACKAGES_MARKER, packages).replace(DETECT_MARKER, detect)
+    if descriptor.entry_id == "codex":
+        body = body.rstrip() + "\n" + _CODEX_NATIVE_RUN.lstrip("\n")
+    return body
+
+
+def _npm_packages(install_command: str) -> str:
+    text = install_command.strip()
+    prefix = "npm install -g "
+    if not text.startswith(prefix):
+        raise ExtensionMaterializeError(
+            "acp install_command must be npm install -g <pinned packages>",
+            kind="extension_materialize_failed",
+        )
+    packages = text[len(prefix) :].strip()
+    tokens = packages.split()
+    if not tokens or "npx" in tokens or any(tok.endswith("@latest") for tok in tokens):
+        raise ExtensionMaterializeError(
+            "acp install_command rejects floating npx / latest",
+            kind="extension_materialize_failed",
+        )
+    return packages
+
+
+def _detect_verify(descriptor: AcpEntryDescriptor) -> str:
+    names: list[str] = []
+    if descriptor.integration_mode == 1 and descriptor.engine_detect_commands:
+        names.append(descriptor.engine_detect_commands[0])
+    if descriptor.acp_detect_commands:
+        names.append(descriptor.acp_detect_commands[0])
+    seen: set[str] = set()
+    out: list[str] = []
+    for name in names:
+        token = name.strip().split()[0] if name.strip() else ""
+        if token and token not in seen:
+            seen.add(token)
+            out.append(token)
+    if not out:
+        raise ExtensionMaterializeError(
+            f"acp entry {descriptor.entry_id!r} declares no detect commands",
+            kind="extension_materialize_failed",
+        )
+    return " && ".join(f"command -v {name}" for name in out)

--- a/src/ageval/plugins/contrib/acp/bake.py
+++ b/src/ageval/plugins/contrib/acp/bake.py
@@ -6,7 +6,8 @@ Dockerfile; this module only substitutes the bound entry. No floating ``npx``.
 
 from __future__ import annotations
 
-from ageval.plugins.contrib.acp.registry import AcpEntryDescriptor, get_entry
+from ageval.plugins.contrib.acp.hooks import _needed_commands
+from ageval.plugins.contrib.acp.registry import get_entry
 from ageval.plugins.errors import ExtensionMaterializeError
 
 PACKAGES_MARKER = "__ACP_ENTRY_PACKAGES__"
@@ -43,7 +44,13 @@ def render_bake_body(template: str, entry_id: str) -> str:
             kind="extension_materialize_failed",
         )
     packages = _npm_packages(descriptor.install_command)
-    detect = _detect_verify(descriptor)
+    names = _needed_commands(descriptor)
+    if not names:
+        raise ExtensionMaterializeError(
+            f"acp entry {descriptor.entry_id!r} declares no detect commands",
+            kind="extension_materialize_failed",
+        )
+    detect = " && ".join(f"command -v {name}" for name in names)
     body = template.replace(PACKAGES_MARKER, packages).replace(DETECT_MARKER, detect)
     if descriptor.entry_id == "codex":
         body = body.rstrip() + "\n" + _CODEX_NATIVE_RUN.lstrip("\n")
@@ -66,24 +73,3 @@ def _npm_packages(install_command: str) -> str:
             kind="extension_materialize_failed",
         )
     return packages
-
-
-def _detect_verify(descriptor: AcpEntryDescriptor) -> str:
-    names: list[str] = []
-    if descriptor.integration_mode == 1 and descriptor.engine_detect_commands:
-        names.append(descriptor.engine_detect_commands[0])
-    if descriptor.acp_detect_commands:
-        names.append(descriptor.acp_detect_commands[0])
-    seen: set[str] = set()
-    out: list[str] = []
-    for name in names:
-        token = name.strip().split()[0] if name.strip() else ""
-        if token and token not in seen:
-            seen.add(token)
-            out.append(token)
-    if not out:
-        raise ExtensionMaterializeError(
-            f"acp entry {descriptor.entry_id!r} declares no detect commands",
-            kind="extension_materialize_failed",
-        )
-    return " && ".join(f"command -v {name}" for name in out)

--- a/src/ageval/plugins/contrib/acp/docker/Dockerfile.bake
+++ b/src/ageval/plugins/contrib/acp/docker/Dockerfile.bake
@@ -1,0 +1,29 @@
+# Bake the lock-bound ACP entry onto the task image.
+# Pins come from acp_entries.json (renderer fills the markers). No floating npx.
+# Build context = this plugin package root.
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Node only when the recipe did not already ship npm (official Attempt base has it).
+RUN set -eu; \
+    if ! command -v npm >/dev/null 2>&1; then \
+      export DEBIAN_FRONTEND=noninteractive; \
+      if ! command -v apt-get >/dev/null 2>&1; then \
+        echo "npm missing and no apt-get on this base" >&2; \
+        exit 1; \
+      fi; \
+      apt-get update; \
+      apt-get install -y --no-install-recommends ca-certificates curl gnupg; \
+      curl -fsSL https://deb.nodesource.com/setup_22.x | bash -; \
+      apt-get install -y --no-install-recommends nodejs; \
+      rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# Pinned engine + ACP packages for options.entry.
+RUN npm install -g __ACP_ENTRY_PACKAGES__ \
+    && npm cache clean --force
+
+# Detect commands the probe will look for (first name of each family).
+RUN __ACP_DETECT_BINARIES__

--- a/src/ageval/plugins/contrib/acp/hooks.py
+++ b/src/ageval/plugins/contrib/acp/hooks.py
@@ -1,9 +1,9 @@
 """ACP ``after_environment_ready`` hook: probe the box, install only if missing.
 
-The recipe comes from ``acp_entries.json``. A hit is the binary name, the pinned
-npm version, and one cheap stdio ``initialize``. Bake that already matches
-skips install. A same-named binary that speaks TCP ACP (or the wrong pin) does
-not.
+The recipe comes from ``acp_entries.json``. A hit is the binary name and one
+cheap stdio ``initialize``. Docker already baked the bound ``options.entry``
+into the task image at ``host.start()``; a matching bake skips
+``install_command``. A same-named binary that speaks TCP ACP does not.
 """
 
 from __future__ import annotations

--- a/src/ageval/plugins/contrib/acp/plugin.yaml
+++ b/src/ageval/plugins/contrib/acp/plugin.yaml
@@ -5,8 +5,9 @@ description: >
   Coding-agent executor: parent is the only [ACP](https://agentclientprotocol.com)
   JSON-RPC client (`executor: acp` + `options.entry`). Vendor CLIs stay
   behind a process-out ACP entry (native, shim, or vendor package). Injects
-  `environment.attach_stdio`. Official Attempt images bake entries at
-  build time; invoke does not `npm i`.
+  `environment.attach_stdio`. Official Attempt images bake every shipped
+  entry at build time. Task recipes also stack ``config.image_layers`` for
+  the bound ``options.entry``. Invoke does not ``npm i``.
 slots:
   exclusive:
     - id: executor
@@ -22,3 +23,5 @@ slots:
 inject:
   - service: environment
     capabilities: [attach_stdio]
+config:
+  image_layers: docker/Dockerfile.bake

--- a/src/ageval/plugins/contrib/docker/README.md
+++ b/src/ageval/plugins/contrib/docker/README.md
@@ -4,7 +4,9 @@ First-party exclusive-slot winner for `environment: docker`.
 
 The Attempt runs in a container built from the task's own recipe (plus
 plugin `image_layers` when declared). The official Attempt image bakes
-coding-agent ACP entries at **build** time; invoke does not `npm i`.
+every shipped ACP entry at **build** time. A task recipe that is not that
+base still gets the bound `options.entry` from the ACP plugin layer.
+Invoke does not `npm i`.
 Container id, `docker exec -u/-w`, and UID/GID stay in this package.
 ACP / `run.py` / Core never see `container_id`.
 

--- a/src/ageval/plugins/contrib/docker/images.py
+++ b/src/ageval/plugins/contrib/docker/images.py
@@ -24,6 +24,7 @@ import re
 import shlex
 import subprocess
 import sys
+import tempfile
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 
@@ -224,10 +225,9 @@ def build_task_image(
         platform=platform,
         build_args=(),
     )
-    for plugin_id, dockerfile, package_root, _body in plugin_layers:
+    for plugin_id, _dockerfile, package_root, body in plugin_layers:
         current, _ = _build_named(
-            recipe=None,
-            dockerfile=Path(dockerfile),
+            recipe=body,
             context_root=Path(package_root),
             tag=f"{PACKAGE_TAG_PREFIX}:{content[:12]}-{plugin_id}",
             platform=platform,
@@ -260,8 +260,14 @@ def _build_named(
     generated: Path | None = None
     file_arg = dockerfile
     if recipe is not None:
-        generated = context_root / f".ageval-image-{tag.split(':')[-1]}.Dockerfile"
-        generated.write_text(recipe, encoding="utf-8")
+        handle = tempfile.NamedTemporaryFile(
+            "w", suffix=".Dockerfile", delete=False, encoding="utf-8"
+        )
+        try:
+            handle.write(recipe)
+        finally:
+            handle.close()
+        generated = Path(handle.name)
         file_arg = generated
     assert file_arg is not None
     args = [

--- a/src/ageval/plugins/contrib/docker/images.py
+++ b/src/ageval/plugins/contrib/docker/images.py
@@ -260,14 +260,11 @@ def _build_named(
     generated: Path | None = None
     file_arg = dockerfile
     if recipe is not None:
-        handle = tempfile.NamedTemporaryFile(
+        with tempfile.NamedTemporaryFile(
             "w", suffix=".Dockerfile", delete=False, encoding="utf-8"
-        )
-        try:
+        ) as handle:
             handle.write(recipe)
-        finally:
-            handle.close()
-        generated = Path(handle.name)
+            generated = Path(handle.name)
         file_arg = generated
     assert file_arg is not None
     args = [

--- a/src/ageval/plugins/image_layers.py
+++ b/src/ageval/plugins/image_layers.py
@@ -1,22 +1,29 @@
-"""Dockerfile fragments installed plugins contribute to an Attempt image.
+"""Dockerfile fragments bound plugins contribute to an Attempt image.
 
 A layer list is not a slot. Nothing runs at a point in the timeline here: the
 environment winner reads what the bound plugins declared and folds it into the
 image it builds. That is why ``image_contribute`` left the timeline.
+
+Installed Hub packages come from the plugin index. First-party contribs
+(``src/ageval/plugins/contrib/``) are resolved from this checkout / wheel.
+ACP's layer body is the bound ``options.entry`` so the docker content key
+changes when the entry changes and not when only ``model`` does.
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ageval.plugins.manifest import PluginManifest, load_manifest
 from ageval.plugins.store import load_index, resolve_package_root
 
 if TYPE_CHECKING:
     from ageval.plugins.protocol import ExtensionGraph
+
+_CONTRIB_ROOT = Path(__file__).resolve().parent / "contrib"
 
 
 @dataclass(frozen=True, slots=True)
@@ -30,19 +37,17 @@ class ImageLayer:
 
 
 def layers_for_plugins(plugin_ids: frozenset[str]) -> tuple[ImageLayer, ...]:
-    """Bake files declared by the installed plugins among *plugin_ids*.
+    """Bake files declared by the bound plugins among *plugin_ids*.
 
     Ordered by plugin id so the image key does not depend on resolve order.
     """
     if not plugin_ids:
         return ()
-    index = load_index()
     found: list[ImageLayer] = []
     for plugin_id in sorted(plugin_ids):
-        entry = index.find(plugin_id)
-        if entry is None:
+        root, resolved_id = _package_root(plugin_id)
+        if root is None:
             continue
-        root = resolve_package_root(entry)
         manifest = _manifest(root)
         if manifest is None or manifest.image_layers is None:
             continue
@@ -51,13 +56,34 @@ def layers_for_plugins(plugin_ids: frozenset[str]) -> tuple[ImageLayer, ...]:
             continue
         found.append(
             ImageLayer(
-                plugin_id=entry.plugin_id,
+                plugin_id=resolved_id,
                 dockerfile=fragment,
                 package_root=root,
                 body=fragment.read_text("utf-8"),
             )
         )
     return tuple(found)
+
+
+def _package_root(plugin_id: str) -> tuple[Path | None, str]:
+    """Installed package root, else first-party contrib next to this module."""
+    entry = load_index().find(plugin_id)
+    if entry is not None:
+        return resolve_package_root(entry), entry.plugin_id
+    bundled = _bundled_contrib_root(plugin_id)
+    if bundled is None:
+        return None, plugin_id
+    return bundled, plugin_id
+
+
+def _bundled_contrib_root(plugin_id: str) -> Path | None:
+    name = plugin_id.replace("-", "_")
+    if not name.isidentifier():
+        return None
+    root = _CONTRIB_ROOT / name
+    if (root / "plugin.yaml").is_file():
+        return root
+    return None
 
 
 def _manifest(root: Path) -> PluginManifest | None:
@@ -78,6 +104,52 @@ def graph_plugin_ids(graph: ExtensionGraph) -> frozenset[str]:
     return frozenset(bound)
 
 
+def graph_plugin_options(graph: ExtensionGraph) -> dict[str, dict[str, Any]]:
+    """Per-plugin options on a graph (exclusive winner, then chain handlers)."""
+    found: dict[str, dict[str, Any]] = {}
+    for winner in graph.winners.values():
+        if winner.options:
+            found[winner.plugin_id] = dict(winner.options)
+    for handlers in graph.chains.values():
+        for handler in handlers:
+            if handler.options:
+                found[handler.plugin_id] = {
+                    **found.get(handler.plugin_id, {}),
+                    **dict(handler.options),
+                }
+    return found
+
+
+def _apply_bound_options(
+    layers: Iterable[ImageLayer],
+    options_by_plugin: Mapping[str, Mapping[str, Any]],
+) -> tuple[ImageLayer, ...]:
+    """Fill ACP's bake body with the bound ``options.entry`` pins."""
+    from ageval.plugins.contrib.acp.bake import render_bake_body
+    from ageval.plugins.errors import ExtensionMaterializeError
+
+    out: list[ImageLayer] = []
+    for layer in layers:
+        if layer.plugin_id != "acp":
+            out.append(layer)
+            continue
+        entry = str((options_by_plugin.get("acp") or {}).get("entry") or "").strip()
+        if not entry:
+            raise ExtensionMaterializeError(
+                "acp_entry_required",
+                kind="extension_materialize_failed",
+            )
+        out.append(
+            ImageLayer(
+                plugin_id=layer.plugin_id,
+                dockerfile=layer.dockerfile,
+                package_root=layer.package_root,
+                body=render_bake_body(layer.body, entry),
+            )
+        )
+    return tuple(out)
+
+
 def layers_tuple(layers: Iterable[ImageLayer]) -> tuple[tuple[str, str, str, str], ...]:
     """The factory-facing layer shape (plugin_id, dockerfile, package_root, body)."""
     return tuple(
@@ -88,7 +160,9 @@ def layers_tuple(layers: Iterable[ImageLayer]) -> tuple[tuple[str, str, str, str
 
 def layers_for_graph(graph: ExtensionGraph) -> tuple[tuple[str, str, str, str], ...]:
     """Bake files declared by the plugins one graph binds, for kinds that build."""
-    return layers_tuple(layers_for_plugins(graph_plugin_ids(graph)))
+    options = graph_plugin_options(graph)
+    layers = _apply_bound_options(layers_for_plugins(graph_plugin_ids(graph)), options)
+    return layers_tuple(layers)
 
 
 def layers_for_graphs(
@@ -96,6 +170,10 @@ def layers_for_graphs(
 ) -> tuple[tuple[str, str, str, str], ...]:
     """Union bake files over several graphs, ordered by plugin id."""
     bound: set[str] = set()
+    options: dict[str, dict[str, Any]] = {}
     for graph in graphs:
         bound.update(graph_plugin_ids(graph))
-    return layers_tuple(layers_for_plugins(frozenset(bound)))
+        for plugin_id, opts in graph_plugin_options(graph).items():
+            options[plugin_id] = {**options.get(plugin_id, {}), **dict(opts)}
+    layers = _apply_bound_options(layers_for_plugins(frozenset(bound)), options)
+    return layers_tuple(layers)

--- a/tests/attempt/test_scoring_bind.py
+++ b/tests/attempt/test_scoring_bind.py
@@ -64,11 +64,13 @@ class StubGraph:
         chain_plugin_ids: tuple[str, ...] = (),
     ) -> None:
         self.winners = {
-            ENVIRONMENT: SimpleNamespace(plugin_id="fakebox"),
-            EXECUTOR: SimpleNamespace(plugin_id=executor_plugin),
+            ENVIRONMENT: SimpleNamespace(plugin_id="fakebox", options=None),
+            EXECUTOR: SimpleNamespace(plugin_id=executor_plugin, options=None),
         }
         self.chains: dict[str, list[Any]] = {
-            AFTER_ENVIRONMENT_READY: [SimpleNamespace(plugin_id=pid) for pid in chain_plugin_ids]
+            AFTER_ENVIRONMENT_READY: [
+                SimpleNamespace(plugin_id=pid, options=None) for pid in chain_plugin_ids
+            ]
         }
 
     def chain(self, slot: str) -> list[Any]:

--- a/tests/plugins/test_acp_image_layers.py
+++ b/tests/plugins/test_acp_image_layers.py
@@ -1,0 +1,199 @@
+"""ACP plugin image_layers: bound entry body, content key, no model."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from ageval.plugins.contrib.acp.bake import render_bake_body
+from ageval.plugins.contrib.acp.registry import get_entry
+from ageval.plugins.contrib.docker import images
+from ageval.plugins.errors import ExtensionMaterializeError
+from ageval.plugins.image_layers import (
+    layers_for_graph,
+    layers_for_plugins,
+)
+from ageval.plugins.protocol import ExtensionGraph, HandlerRef, WinnerRef
+from ageval.plugins.slots import AFTER_ENVIRONMENT_READY, EXECUTOR
+
+_TEMPLATE = (
+    Path(__file__).resolve().parents[2]
+    / "src/ageval/plugins/contrib/acp/docker/Dockerfile.bake"
+)
+
+
+def _template() -> str:
+    return _TEMPLATE.read_text(encoding="utf-8")
+
+
+def _graph(entry: str) -> ExtensionGraph:
+    options = {"entry": entry}
+    return ExtensionGraph(
+        profile_id="solver",
+        winners={
+            EXECUTOR: WinnerRef(
+                plugin_id="acp",
+                impl=object(),
+                priority=100,
+                source="test",
+                slot=EXECUTOR,
+                options=options,
+            ),
+        },
+        chains={
+            AFTER_ENVIRONMENT_READY: [
+                HandlerRef(
+                    plugin_id="acp",
+                    handler=object(),
+                    priority=100,
+                    source="test",
+                    slot=AFTER_ENVIRONMENT_READY,
+                    options=options,
+                )
+            ],
+        },
+    )
+
+
+class _FakeDaemon:
+    def __init__(self) -> None:
+        self.images: set[str] = set()
+        self.builds: list[tuple[str, str]] = []
+
+    def __call__(self, *args: str, timeout: float = 600.0) -> subprocess.CompletedProcess[str]:
+        del timeout
+        if args[:2] == ("image", "inspect"):
+            tag = args[2]
+            if tag in self.images:
+                return subprocess.CompletedProcess(
+                    list(args), 0, stdout=f"sha256:{tag}\n", stderr=""
+                )
+            return subprocess.CompletedProcess(list(args), 1, stdout="", stderr="missing")
+        if args[:2] == ("buildx", "build"):
+            tag = args[args.index("-t") + 1]
+            source = Path(args[args.index("-f") + 1])
+            self.builds.append((tag, source.read_text(encoding="utf-8")))
+            self.images.add(tag)
+            return subprocess.CompletedProcess(list(args), 0, stdout="", stderr="")
+        if args[0] == "tag":
+            src, dest = args[1], args[2]
+            if src in self.images:
+                self.images.add(dest)
+                return subprocess.CompletedProcess(list(args), 0, stdout="", stderr="")
+            return subprocess.CompletedProcess(list(args), 1, stdout="", stderr="missing src")
+        return subprocess.CompletedProcess(list(args), 1, stdout="", stderr=f"unexpected {args}")
+
+
+def test_bake_template_uses_base_image_arg() -> None:
+    text = _template()
+    assert "ARG BASE_IMAGE" in text
+    assert "FROM ${BASE_IMAGE}" in text
+    assert all("npx" not in line.split() for line in text.splitlines() if line and not line.lstrip().startswith("#"))
+    assert "__ACP_ENTRY_PACKAGES__" in text
+
+
+def test_render_opencode_bakes_pinned_detect_commands() -> None:
+    desc = get_entry("opencode")
+    assert desc is not None
+    body = render_bake_body(_template(), "opencode")
+    assert "opencode-ai@1.18.12" in body
+    assert "command -v opencode" in body
+    assert "__ACP_ENTRY_PACKAGES__" not in body
+    assert all("npx" not in line.split() for line in body.splitlines() if line and not line.lstrip().startswith("#"))
+    assert "pi-acp@" not in body
+
+
+def test_render_pi_vs_opencode_bodies_differ() -> None:
+    pi = render_bake_body(_template(), "pi")
+    opencode = render_bake_body(_template(), "opencode")
+    assert pi != opencode
+    assert "pi-acp@0.0.33" in pi
+    assert "@earendil-works/pi-coding-agent@0.83.0" in pi
+    assert "command -v pi" in pi
+    assert "command -v pi-acp" in pi
+    assert "opencode-ai@" not in pi
+
+
+def test_render_unknown_entry_fails_closed() -> None:
+    with pytest.raises(ExtensionMaterializeError, match="unknown acp entry"):
+        render_bake_body(_template(), "not-an-entry")
+
+
+def test_bundled_acp_declares_image_layers() -> None:
+    layers = layers_for_plugins(frozenset({"acp"}))
+    assert len(layers) == 1
+    layer = layers[0]
+    assert layer.plugin_id == "acp"
+    assert layer.dockerfile.name == "Dockerfile.bake"
+    assert "__ACP_ENTRY_PACKAGES__" in layer.body
+
+
+def test_layers_for_graph_fills_bound_entry() -> None:
+    rows = layers_for_graph(_graph("opencode"))
+    assert len(rows) == 1
+    plugin_id, _dockerfile, _root, body = rows[0]
+    assert plugin_id == "acp"
+    assert "opencode-ai@1.18.12" in body
+    assert "__ACP_ENTRY_PACKAGES__" not in body
+
+
+def test_layers_for_graph_requires_entry() -> None:
+    graph = ExtensionGraph(
+        profile_id="solver",
+        winners={
+            EXECUTOR: WinnerRef(
+                plugin_id="acp",
+                impl=object(),
+                priority=100,
+                source="test",
+                slot=EXECUTOR,
+            ),
+        },
+    )
+    with pytest.raises(ExtensionMaterializeError, match="acp_entry_required"):
+        layers_for_graph(graph)
+
+
+def test_same_recipe_different_entry_two_content_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AGEVAL_PIP_INDEX", raising=False)
+    fake = _FakeDaemon()
+    monkeypatch.setattr(images, "docker", fake)
+    task = tmp_path / "task"
+    task.mkdir()
+    (task / "Dockerfile").write_text("FROM ubuntu:24.04\n", encoding="utf-8")
+    plugin = tmp_path / "plugin"
+    plugin.mkdir()
+    kwargs = {
+        "task_root": task,
+        "dockerfile_rel": "Dockerfile",
+        "platform": "linux/arm64",
+        "base_digest": "sha256:base",
+        "force_build": True,
+    }
+    open_body = render_bake_body(_template(), "opencode")
+    pi_body = render_bake_body(_template(), "pi")
+    bake = plugin / "Dockerfile.bake"
+    bake.write_text(open_body, encoding="utf-8")
+
+    tag_open, _ = images.build_task_image(
+        plugin_layers=(("acp", str(bake), str(plugin), open_body),),
+        **kwargs,
+    )
+    tag_pi, _ = images.build_task_image(
+        plugin_layers=(("acp", str(bake), str(plugin), pi_body),),
+        **kwargs,
+    )
+    tag_open_again, _ = images.build_task_image(
+        plugin_layers=(("acp", str(bake), str(plugin), open_body),),
+        **kwargs,
+    )
+
+    assert tag_open != tag_pi
+    assert tag_open == tag_open_again
+    plugin_bodies = [text for tag, text in fake.builds if tag.endswith("-acp")]
+    assert any("opencode-ai@1.18.12" in text for text in plugin_bodies)
+    assert any("pi-acp@0.0.33" in text for text in plugin_bodies)

--- a/tests/plugins/test_acp_image_layers.py
+++ b/tests/plugins/test_acp_image_layers.py
@@ -19,8 +19,7 @@ from ageval.plugins.protocol import ExtensionGraph, HandlerRef, WinnerRef
 from ageval.plugins.slots import AFTER_ENVIRONMENT_READY, EXECUTOR
 
 _TEMPLATE = (
-    Path(__file__).resolve().parents[2]
-    / "src/ageval/plugins/contrib/acp/docker/Dockerfile.bake"
+    Path(__file__).resolve().parents[2] / "src/ageval/plugins/contrib/acp/docker/Dockerfile.bake"
 )
 
 
@@ -28,8 +27,8 @@ def _template() -> str:
     return _TEMPLATE.read_text(encoding="utf-8")
 
 
-def _graph(entry: str) -> ExtensionGraph:
-    options = {"entry": entry}
+def _graph(entry: str, extra_options: dict[str, str] | None = None) -> ExtensionGraph:
+    options = {"entry": entry, **(extra_options or {})}
     return ExtensionGraph(
         profile_id="solver",
         winners={
@@ -90,7 +89,11 @@ def test_bake_template_uses_base_image_arg() -> None:
     text = _template()
     assert "ARG BASE_IMAGE" in text
     assert "FROM ${BASE_IMAGE}" in text
-    assert all("npx" not in line.split() for line in text.splitlines() if line and not line.lstrip().startswith("#"))
+    assert all(
+        "npx" not in line.split()
+        for line in text.splitlines()
+        if line and not line.lstrip().startswith("#")
+    )
     assert "__ACP_ENTRY_PACKAGES__" in text
 
 
@@ -101,7 +104,11 @@ def test_render_opencode_bakes_pinned_detect_commands() -> None:
     assert "opencode-ai@1.18.12" in body
     assert "command -v opencode" in body
     assert "__ACP_ENTRY_PACKAGES__" not in body
-    assert all("npx" not in line.split() for line in body.splitlines() if line and not line.lstrip().startswith("#"))
+    assert all(
+        "npx" not in line.split()
+        for line in body.splitlines()
+        if line and not line.lstrip().startswith("#")
+    )
     assert "pi-acp@" not in body
 
 
@@ -137,6 +144,13 @@ def test_layers_for_graph_fills_bound_entry() -> None:
     assert plugin_id == "acp"
     assert "opencode-ai@1.18.12" in body
     assert "__ACP_ENTRY_PACKAGES__" not in body
+
+
+def test_model_option_does_not_change_layer_body() -> None:
+    plain = layers_for_graph(_graph("opencode"))
+    with_model = layers_for_graph(_graph("opencode", {"model": "gpt-5.4-mini"}))
+    assert plain[0][3] == with_model[0][3]
+    assert "gpt-5.4-mini" not in with_model[0][3]
 
 
 def test_layers_for_graph_requires_entry() -> None:

--- a/website/content/docs/agents/environments.en.mdx
+++ b/website/content/docs/agents/environments.en.mdx
@@ -3,7 +3,7 @@ title: Environments
 description: Host, Docker, e2b, ssh, daytona on one ACP chain.
 ---
 
-Set the environment in `profiles.yaml` with `environment:`. ACP only needs `attach_stdio`. Do not write `plugin_id: docker`. Changing the environment does not change ACP. `exec` is a one-shot method on the same service, not a second environment.
+Set the environment in `profiles.yaml` with `environment:`. ACP only needs `attach_stdio`. Do not write `plugin_id: docker`. Changing the environment does not change ACP. `exec` is a one-shot method on the same service, not a second environment. On docker, `host.start()` bakes the bound `options.entry` onto the task image; `after_environment_ready` skips `npm i` when that bake already matches. Switching `model` does not rebuild; switching `entry` does.
 
 | Environment | Opens | To actually run |
 | --- | --- | --- |

--- a/website/content/docs/agents/environments.mdx
+++ b/website/content/docs/agents/environments.mdx
@@ -3,7 +3,7 @@ title: 环境
 description: 本机、Docker、e2b、ssh、daytona，同一条 ACP 链。
 ---
 
-环境写在 `profiles.yaml` 的 `environment:`。ACP 只要 `attach_stdio`，不写 `plugin_id: docker`。换环境不必改 ACP。`exec` 是同一服务上的一次性命令，不是第二种环境。
+环境写在 `profiles.yaml` 的 `environment:`。ACP 只要 `attach_stdio`，不写 `plugin_id: docker`。换环境不必改 ACP。`exec` 是同一服务上的一次性命令，不是第二种环境。docker 在 `host.start()` 把绑定的 `options.entry` bake 进题图；`after_environment_ready` 探测命中则不再 `npm i`。换 `model` 不重建镜像，换 `entry` 会。
 
 | 环境 | 怎么开 | 真跑条件 |
 | --- | --- | --- |

--- a/website/content/docs/run/plugins.en.mdx
+++ b/website/content/docs/run/plugins.en.mdx
@@ -48,7 +48,8 @@ agent_profiles:
 
 `executor:` selects the Agent for this profiles file. Plugin options live on that
 plugin's `extensions` row. Docker image layers are written when the environment
-starts. ACP `entry` lives on `- plugin: acp` / `options.entry`.
+starts. ACP `entry` lives on `- plugin: acp` / `options.entry` and is baked
+into the task image; switching model does not rebuild.
 
 ```bash
 ageval run examples/datasets/minimal-demo --task terminal-jsonl-agg \

--- a/website/content/docs/run/plugins.mdx
+++ b/website/content/docs/run/plugins.mdx
@@ -44,7 +44,7 @@ agent_profiles:
           method: "run"
 ```
 
-`executor:` 选出这份配置里的 Agent。插件自己的选项写在该插件的 `extensions` 行上。docker 的镜像层由环境在启动时写入。ACP 的 `entry` 写在 `- plugin: acp` / `options.entry`。
+`executor:` 选出这份配置里的 Agent。插件自己的选项写在该插件的 `extensions` 行上。docker 的镜像层由环境在启动时写入。ACP 的 `entry` 写在 `- plugin: acp` / `options.entry`；该 entry 会 bake 进题图，换模型不重建。
 
 用另一份 profiles 切换，不必改 dataset：
 


### PR DESCRIPTION
## Summary
ACP now declares `config.image_layers` and bakes only the lock-bound `options.entry` onto the task image at `host.start()`. `FROM ubuntu:24.04` recipes get the pinned engine without rewriting `FROM` or installing at invoke; official `ageval-attempt:base` recipes stay valid (same pin is idempotent).

## Approach
- Plugin bake file: `ARG BASE_IMAGE` / `FROM ${BASE_IMAGE}`, install Node only if `npm` is missing, then `npm install -g` the pins from `acp_entries.json`.
- Layer **body** includes that entry, so the existing docker content key reuses the same recipe+entry+platform and builds a new image when the entry changes. `model` is not in the key.
- `after_environment_ready` is unchanged except the documented skip: probe hit (binaries + stdio `initialize`) does not run `install_command`.
- No new CLI flag or `AGEVAL_*`. Default omit still means the old official-base path plus this extra layer.

## Test plan
- [x] `ruff format --check` / `ruff check` / `check_builtin_plugins`
- [x] `pytest --ignore=tests/registry` (python-core equivalent, `AGEVAL_SKIP_DOCKER=1` and offline agent). One public offline `ageval run` hit a 180s timeout on the **first** ACP layer bake (npm); rerun with the image cached passed in ~1s.
- [x] `pytest tests/registry` (python-registry equivalent)
- [x] `pnpm --dir website build`
- [x] Fake-docker tests: ubuntu recipe + `opencode` body has detect commands; `pi` vs `opencode` are two tags; same entry + extra `model` does not change the layer body
- [ ] Real daemon: `FROM ubuntu:24.04` + `entry: opencode` has `command -v opencode` **before** start; `acp_runtime_install` fact absent
- [ ] `FROM ageval-attempt:base` still locks and runs; bake does not break existing pins
- [ ] Trajectory / `RunTerminal.completed` still not PASS; no secrets in yaml / lock / evidence

Closes #220